### PR TITLE
Add another possible shell uname for checking Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 ifneq ($(findstring MINGW,$(shell uname)),)
   WINDOWS := 1
 endif
+ifneq ($(findstring MSYS,$(shell uname)),)
+  WINDOWS := 1
+endif
 
 #-------------------------------------------------------------------------------
 # Files


### PR DESCRIPTION
Other name wasn't cutting it. Checking MSYS caught my terminal and set the WINDOWS flag as expected.