### PR TITLE
Switch to using the 1.3.2 linker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ O_FILES := $(INIT_O_FILES) $(EXTAB_O_FILES) $(EXTABINDEX_O_FILES) $(TEXT_O_FILES
 #-------------------------------------------------------------------------------
 
 MWCC_VERSION := 1.0
+MWCC_LD_VERSION := 1.3.2
 
 # Programs
 ifeq ($(WINDOWS),1)
@@ -48,7 +49,7 @@ endif
 AS      := $(DEVKITPPC)/bin/powerpc-eabi-as
 CPP     := cpp -P
 CC      := $(WINE) tools/mwcc_compiler/$(MWCC_VERSION)/mwcceppc.exe
-LD      := $(WINE) tools/mwcc_compiler/$(MWCC_VERSION)/mwldeppc.exe
+LD      := $(WINE) tools/mwcc_compiler/$(MWCC_LD_VERSION)/mwldeppc.exe
 ELF2DOL := tools/elf2dol
 SHA1SUM := sha1sum
 PYTHON  := python3

--- a/asm/extabindex.s
+++ b/asm/extabindex.s
@@ -1,6 +1,7 @@
 .section extabindex_, "wa"  # 0x800056C0 - 0x80005940
 
 	.incbin "baserom.dol", 0x3B3FC0, 0x258
+
 .global lbl_80005918
 lbl_80005918:
 	.incbin "baserom.dol", 0x3B4218, 0x28

--- a/asm/sdata.s
+++ b/asm/sdata.s
@@ -4010,8 +4010,8 @@ lbl_804D5B30:
 lbl_804D5B38:
     .asciz "jobj"
     .balign 4
-.global lbl_804D5B40
-lbl_804D5B40:
+.global fragmentID
+fragmentID:
 	.incbin "baserom.dol", 0x430B60, 0x8
 .global lbl_804D5B48
 lbl_804D5B48:

--- a/src/runtime/__init_cpp_exceptions.c
+++ b/src/runtime/__init_cpp_exceptions.c
@@ -1,7 +1,7 @@
 #include "include/dolphin/types.h"
 
 extern const void* lbl_80005918; //info
-extern s32 lbl_804D5B40; //fragmentID
+extern s32 fragmentID; //fragmentID
 
 extern s32 __register_fragment(struct __eti_init_info *, char*);
 extern void __unregister_fragment(s32);
@@ -15,9 +15,9 @@ extern asm char* GetR2(void)
 
 extern void __fini_cpp_exceptions(void)
 {
-	if (lbl_804D5B40 != -2) {
-		__unregister_fragment(lbl_804D5B40);
-		lbl_804D5B40 = -2;
+	if (fragmentID != -2) {
+		__unregister_fragment(fragmentID);
+		fragmentID = -2;
 	}
 }
 
@@ -28,7 +28,7 @@ extern asm void __init_cpp_exceptions(void)
 /* 80322F5C 0031FB3C  7C 08 02 A6 */	mflr r0
 /* 80322F60 0031FB40  90 01 00 04 */	stw r0, 4(r1)
 /* 80322F64 0031FB44  94 21 FF F8 */	stwu r1, -8(r1)
-/* 80322F68 0031FB48  80 0D A4 A0 */	lwz r0, lbl_804D5B40(r13)
+/* 80322F68 0031FB48  80 0D A4 A0 */	lwz r0, fragmentID(r13)
 /* 80322F6C 0031FB4C  2C 00 FF FE */	cmpwi r0, -2
 /* 80322F70 0031FB50  40 82 00 1C */	bne lbl_80322F8C
 /* 80322F74 0031FB54  4B FF FF AD */	bl GetR2
@@ -36,7 +36,7 @@ extern asm void __init_cpp_exceptions(void)
 /* 80322F7C 0031FB5C  7C 64 1B 78 */	mr r4, r3
 /* 80322F80 0031FB60  38 65 59 18 */	addi r3, r5, lbl_80005918@l
 /* 80322F84 0031FB64  4B FF F8 0D */	bl __register_fragment
-/* 80322F88 0031FB68  90 6D A4 A0 */	stw r3, lbl_804D5B40(r13)
+/* 80322F88 0031FB68  90 6D A4 A0 */	stw r3, fragmentID(r13)
 lbl_80322F8C:
 /* 80322F8C 0031FB6C  80 01 00 0C */	lwz r0, 0xc(r1)
 /* 80322F90 0031FB70  38 21 00 08 */	addi r1, r1, 8


### PR DESCRIPTION
Switches to the 1.3.2 linker, since it's faster - while not as fast as 2.7 and not as finnicky to get changed to, and won't lead to my grandchildren being the ones that have to finish the decomp.