### PR TITLE
futureproof makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ build/
 
 # IDE
 .vscode/
+build.bat
+clean.bat

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,8 @@ tools:
 	$(MAKE) -C tools
 
 $(ELF): $(O_FILES) $(LDSCRIPT)
-	 $(LD) $(LDFLAGS) -lcf $(LDSCRIPT) $(O_FILES) -o $@
+	@echo $(O_FILES) > build/o_files
+	$(LD) $(LDFLAGS) -o $@ -lcf $(LDSCRIPT) @build/o_files
 
 $(BUILD_DIR)/%.o: %.s
 	$(AS) $(ASFLAGS) -o $@ $<


### PR DESCRIPTION
prevents a really long string from being printed to console. this prevents errors if too many source files are in a repository.