### PR TITLE
Correct comment on sine/cosine approx functions

### DIFF
--- a/src/melee/lb/lbvector.c
+++ b/src/melee/lb/lbvector.c
@@ -134,7 +134,8 @@ float lbvector_AngleXY(Vec* a, Vec* b)
     return 0.0f;
 }
 
-// Taylor series approximations of sin and cos
+// Approximations of sine/cosine which are the best quintic approximations for the x range (-pi,pi). They can be derived by using the Gran-Schmidt Procedure,
+// which is described in the following paper: https://math.berkeley.edu/~arash/54/notes/6_4.pdf
 
 static float sin(float angle)
 {


### PR DESCRIPTION
This PR corrects the comment about the sine/cosine functions. They're actually approximations derived through the Gran-Schmidt procedure, not the Taylor series.