### PR TITLE
Enable inline_auto, fix FObj match, and mark GObj_GXReorder as dont_inline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ LDFLAGS := -fp hard -nodefaults
 ifeq ($(GENERATE_MAP),1)
   LDFLAGS += -map $(MAP)
 endif
-CFLAGS  = -Cpp_exceptions off -proc gekko -fp hard -fp_contract on -O4,p -enum int -nodefaults $(INCLUDES)
+CFLAGS  = -Cpp_exceptions off -proc gekko -fp hard -fp_contract on -O4,p -enum int -nodefaults -inline auto $(INCLUDES)
 
 $(EPILOGUE_DIR)/src/melee/lb/lbtime.o: CC_EPI := $(CC)
 $(EPILOGUE_DIR)/src/sysdolphin/baselib/dobj.o: CC_EPI := $(CC)

--- a/src/sysdolphin/baselib/fobj.c
+++ b/src/sysdolphin/baselib/fobj.c
@@ -20,44 +20,12 @@ void HSD_FObjRemove(HSD_FObj* fobj)
     HSD_FObjFree(fobj);
 }
 
-inline HSD_FObj *HSD_FObjGetNext(struct _HSD_FObj *fobj) {
-    return fobj->next;
-}
-
-inline void *HSD_FObjRemoveAll_Inlined(struct _HSD_FObj *fobj) {
-    if (!fobj)
+void HSD_FObjRemoveAll(HSD_FObj* fobj) 
+{
+    if (fobj == NULL)
         return;
     HSD_FObjRemoveAll(fobj->next);
     HSD_FObjRemove(fobj);
-}
-
-void HSD_FObjRemoveAll(HSD_FObj* fobj)
-{
-    HSD_FObj* t1;
-    HSD_FObj* t2;
-    HSD_FObj* t3;
-
-    if (fobj)
-    {
-        t3 = HSD_FObjGetNext(fobj);
-        if (t3)
-        {
-            t2 = HSD_FObjGetNext(t3);
-            if (t2)
-            {
-                HSD_FObjRemoveAll_Inlined(t2->next);
-                if (t2) {
-                    HSD_FObjFree(t2);
-                }
-            }
-            if (t3) {
-                HSD_FObjFree(t3);
-            }
-        }
-        if (fobj) {
-            HSD_FObjFree(fobj);
-        }
-    }
 }
 
 u8 HSD_FObjSetState(HSD_FObj* fobj, u8 state)

--- a/src/sysdolphin/baselib/gobjgxlink.c
+++ b/src/sysdolphin/baselib/gobjgxlink.c
@@ -8,6 +8,8 @@ extern HSD_GObjLibInitData lbl_804CE380;
 extern char lbl_804084F0[13]; //"gobjgxlink.c"
 extern char lbl_80408500[43]; //"gx_link <= HSD_GObjLibInitData.gx_link_max"
 
+#pragma push
+#pragma dont_inline on
 void GObj_GXReorder(HSD_GObj* gobj, HSD_GObj* hiprio_gobj)
 {
     u32 link = gobj->gx_link;
@@ -27,6 +29,7 @@ void GObj_GXReorder(HSD_GObj* gobj, HSD_GObj* hiprio_gobj)
         lbl_804D7820[gobj->gx_link] = gobj;
     }
 }
+#pragma pop
 
 void GObj_SetupGXLink(HSD_GObj* gobj, void (*render_cb)(HSD_GObj*, s32), u8 gx_link, u32 priority)
 {


### PR DESCRIPTION
This fixes the fake match in FObj from the weird unrolled loop.

Marks GObj_GXReorder as dont_inline since otherwise it gets inlined into GObj_SetupGXLink.