### PR TITLE
don't have to rerun frank on untouched files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ $(EPILOGUE_DIR)/%.o: %.c $(BUILD_DIR)/%.o
 	@echo Frank is fixing $<
 	$(QUIET) $(CC_EPI) $(CFLAGS) -c -o $@ $<
 	$(QUIET) $(PYTHON) $(FRANK) $(word 2,$^) $@ $(word 2,$^)
+	$(QUIET) touch $@
 	
 endif
 


### PR DESCRIPTION
Before:
```
D:\code\game_decomps\melee>make
Frank is fixing src/melee/lb/lblanguage.c
Frank is fixing src/melee/lb/lbcommand.c
Frank is fixing src/melee/lb/lbvector.c
Frank is fixing src/melee/lb/lbtime.c
Frank is fixing src/melee/lb/lbfile.c
Frank is fixing src/melee/lb/lbarchive.c
Frank is fixing src/melee/ft/chara/ftpeach.c
Frank is fixing src/melee/gr/stage.c
Frank is fixing src/sysdolphin/baselib/tobj.c
Frank is fixing src/sysdolphin/baselib/aobj.c
Frank is fixing src/sysdolphin/baselib/fobj.c
Frank is fixing src/sysdolphin/baselib/robj.c
Frank is fixing src/sysdolphin/baselib/wobj.c
Frank is fixing src/sysdolphin/baselib/texp.c
Frank is fixing src/sysdolphin/baselib/list.c
Frank is fixing src/sysdolphin/baselib/archive.c
Frank is fixing src/sysdolphin/baselib/displayfunc.c
Frank is fixing src/sysdolphin/baselib/controller.c
Frank is fixing src/sysdolphin/baselib/dobj.c
Frank is fixing src/sysdolphin/baselib/shadow.c
Frank is fixing src/sysdolphin/baselib/class.c
Frank is fixing src/sysdolphin/baselib/pobj.c
Frank is fixing src/sysdolphin/baselib/id.c
Frank is fixing src/sysdolphin/baselib/lobj.c
Frank is fixing src/sysdolphin/baselib/gobjgxlink.c
Frank is fixing src/sysdolphin/baselib/gobjuserdata.c
Frank is fixing src/sysdolphin/baselib/random.c
Frank is fixing src/sysdolphin/baselib/cobj.c
Frank is fixing src/sysdolphin/baselib/mobj.c
Linking ELF build/ssbm.us.1.2/main.elf
Converting build/ssbm.us.1.2/main.elf to build/ssbm.us.1.2/main.dol
build/ssbm.us.1.2/main.dol: OK
```
After:
```
D:\code\game_decomps\melee>make
build/ssbm.us.1.2/main.dol: OK
```