### PR TITLE
[Drafts] won't compile, contains individual decompiled functions

### DIFF
--- a/src/drafts.c
+++ b/src/drafts.c
@@ -1,0 +1,14 @@
+// Contains drafts for individual functions.
+// This file is not supposed to compile, it just contains a list of decompiled functions
+// that you can pick from when you decompile the module they belong to.
+
+// https://decomp.me/scratch/VBrFf
+// melee/ft/code_8008521C.s
+#include "melee/ft/fighter.h"
+void func_800C88A0(Fighter* f) {
+    f->x2226_5 = 0;
+    f->x2226_6 = 0;
+    f->x2134 = 0;
+    f->x2030 = 0;
+    f->x2226_8 = 0;
+}


### PR DESCRIPTION
This is meant to serve as a set of individual decompiled functions that you can cherry pick from when you decompile a .s that contains these functions. As of now it only contains one simple function. All functions match on decomp.me unless specified otherwise.