### PR TITLE
Rename known OnDeath fighter functions

### DIFF
--- a/asm/melee/ft/chara/ftclink.s
+++ b/asm/melee/ft/chara/ftclink.s
@@ -65,8 +65,8 @@ lbl_80148C48:
 /* 80148C5C 0014583C  7C 08 03 A6 */	mtlr r0
 /* 80148C60 00145840  4E 80 00 20 */	blr 
 
-.global func_80148C64
-func_80148C64:
+.global ftCLink_OnDeath
+ftCLink_OnDeath:
 /* 80148C64 00145844  7C 08 02 A6 */	mflr r0
 /* 80148C68 00145848  38 80 00 00 */	li r4, 0
 /* 80148C6C 0014584C  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftcrazyhand.s
+++ b/asm/melee/ft/chara/ftcrazyhand.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_80155E18
-func_80155E18:
+.global ftCrazyhand_OnDeath
+ftCrazyhand_OnDeath:
 /* 80155E18 001529F8  4E 80 00 20 */	blr 
 
 .global ftCrazyhand_OnLoad

--- a/asm/melee/ft/chara/ftemblem.s
+++ b/asm/melee/ft/chara/ftemblem.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_8014EEF8
-func_8014EEF8:
+.global ftRoy_OnDeath
+ftRoy_OnDeath:
 /* 8014EEF8 0014BAD8  7C 08 02 A6 */	mflr r0
 /* 8014EEFC 0014BADC  38 80 00 00 */	li r4, 0
 /* 8014EF00 0014BAE0  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftfalco.s
+++ b/asm/melee/ft/chara/ftfalco.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_80149ACC
-func_80149ACC:
+.global ftFalco_OnDeath
+ftFalco_OnDeath:
 /* 80149ACC 001466AC  7C 08 02 A6 */	mflr r0
 /* 80149AD0 001466B0  38 A0 00 00 */	li r5, 0
 /* 80149AD4 001466B4  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftfalcon.s
+++ b/asm/melee/ft/chara/ftfalcon.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_800E2888
-func_800E2888:
+.global ftCFalcon_OnDeath
+ftCFalcon_OnDeath:
 /* 800E2888 000DF468  7C 08 02 A6 */	mflr r0
 /* 800E288C 000DF46C  38 80 00 00 */	li r4, 0
 /* 800E2890 000DF470  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftgamewatch.s
+++ b/asm/melee/ft/chara/ftgamewatch.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_8014A250
-func_8014A250:
+.global ftGameWatch_OnDeath
+ftGameWatch_OnDeath:
 /* 8014A250 00146E30  7C 08 02 A6 */	mflr r0
 /* 8014A254 00146E34  38 80 00 00 */	li r4, 0
 /* 8014A258 00146E38  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftganon.s
+++ b/asm/melee/ft/chara/ftganon.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_8014EBFC
-func_8014EBFC:
+.global ftGanon_OnDeath
+ftGanon_OnDeath:
 /* 8014EBFC 0014B7DC  7C 08 02 A6 */	mflr r0
 /* 8014EC00 0014B7E0  38 80 00 00 */	li r4, 0
 /* 8014EC04 0014B7E4  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftgigakoopa.s
+++ b/asm/melee/ft/chara/ftgigakoopa.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_8014F640
-func_8014F640:
+.global ftGKoopa_OnDeath
+ftGKoopa_OnDeath:
 /* 8014F640 0014C220  7C 08 02 A6 */	mflr r0
 /* 8014F644 0014C224  38 80 00 00 */	li r4, 0
 /* 8014F648 0014C228  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/fticeclimber.s
+++ b/asm/melee/ft/chara/fticeclimber.s
@@ -204,8 +204,8 @@ lbl_8011EF84:
 /* 8011EFE0 0011BBC0  7C 08 03 A6 */	mtlr r0
 /* 8011EFE4 0011BBC4  4E 80 00 20 */	blr 
 
-.global func_8011EFE8
-func_8011EFE8:
+.global ftPopo_OnDeath
+ftPopo_OnDeath:
 /* 8011EFE8 0011BBC8  7C 08 02 A6 */	mflr r0
 /* 8011EFEC 0011BBCC  38 80 00 00 */	li r4, 0
 /* 8011EFF0 0011BBD0  90 01 00 04 */	stw r0, 4(r1)
@@ -4767,8 +4767,8 @@ ftNana_OnLoad:
 /* 80122F20 0011FB00  7C 08 03 A6 */	mtlr r0
 /* 80122F24 0011FB04  4E 80 00 20 */	blr 
 
-.global func_80122F28
-func_80122F28:
+.global ftNana_OnDeath
+ftNana_OnDeath:
 /* 80122F28 0011FB08  7C 08 02 A6 */	mflr r0
 /* 80122F2C 0011FB0C  38 80 00 00 */	li r4, 0
 /* 80122F30 0011FB10  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftkirby.s
+++ b/asm/melee/ft/chara/ftkirby.s
@@ -45,8 +45,8 @@ lbl_800EE5B0:
 /* 800EE5B8 000EB198  42 00 FF 88 */	bdnz lbl_800EE540
 /* 800EE5BC 000EB19C  4E 80 00 20 */	blr 
 
-.global func_800EE5C0
-func_800EE5C0:
+.global ftKirby_OnDeath
+ftKirby_OnDeath:
 /* 800EE5C0 000EB1A0  7C 08 02 A6 */	mflr r0
 /* 800EE5C4 000EB1A4  38 80 00 00 */	li r4, 0
 /* 800EE5C8 000EB1A8  90 01 00 04 */	stw r0, 4(r1)
@@ -35739,8 +35739,8 @@ func_8010D6D0:
 /* 8010D738 0010A318  7C 08 03 A6 */	mtlr r0
 /* 8010D73C 0010A31C  4E 80 00 20 */	blr 
 
-.global func_8010D740
-func_8010D740:
+.global ftDonkey_OnDeath
+ftDonkey_OnDeath:
 /* 8010D740 0010A320  7C 08 02 A6 */	mflr r0
 /* 8010D744 0010A324  38 A0 00 00 */	li r5, 0
 /* 8010D748 0010A328  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftkoopa.s
+++ b/asm/melee/ft/chara/ftkoopa.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_80132A0C
-func_80132A0C:
+.global ftKoopa_OnDeath
+ftKoopa_OnDeath:
 /* 80132A0C 0012F5EC  7C 08 02 A6 */	mflr r0
 /* 80132A10 0012F5F0  38 80 00 00 */	li r4, 0
 /* 80132A14 0012F5F4  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftlink.s
+++ b/asm/melee/ft/chara/ftlink.s
@@ -14,8 +14,8 @@ lbl_800EAD7C:
 /* 800EAD7C 000E795C  38 60 00 00 */	li r3, 0
 /* 800EAD80 000E7960  4E 80 00 20 */	blr 
 
-.global func_800EAD84
-func_800EAD84:
+.global ftLink_OnDeath
+ftLink_OnDeath:
 /* 800EAD84 000E7964  7C 08 02 A6 */	mflr r0
 /* 800EAD88 000E7968  38 80 00 00 */	li r4, 0
 /* 800EAD8C 000E796C  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftluigi.s
+++ b/asm/melee/ft/chara/ftluigi.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_801422E8
-func_801422E8:
+.global ftLuigi_OnDeath
+ftLuigi_OnDeath:
 /* 801422E8 0013EEC8  7C 08 02 A6 */	mflr r0
 /* 801422EC 0013EECC  38 80 00 00 */	li r4, 0
 /* 801422F0 0013EED0  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftmario.s
+++ b/asm/melee/ft/chara/ftmario.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_800E08CC
-func_800E08CC:
+.global ftMario_OnDeath
+ftMario_OnDeath:
 /* 800E08CC 000DD4AC  7C 08 02 A6 */	mflr r0
 /* 800E08D0 000DD4B0  38 80 00 00 */	li r4, 0
 /* 800E08D4 000DD4B4  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftmars.s
+++ b/asm/melee/ft/chara/ftmars.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_80136258
-func_80136258:
+.global ftMars_OnDeath
+ftMars_OnDeath:
 /* 80136258 00132E38  7C 08 02 A6 */	mflr r0
 /* 8013625C 00132E3C  38 80 00 00 */	li r4, 0
 /* 80136260 00132E40  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftmasterhand.s
+++ b/asm/melee/ft/chara/ftmasterhand.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_8014FC68
-func_8014FC68:
+.global ftMasterhand_OnDeath
+ftMasterhand_OnDeath:
 /* 8014FC68 0014C848  4E 80 00 20 */	blr 
 
 .global ftMasterhand_OnLoad

--- a/asm/melee/ft/chara/ftpichu.s
+++ b/asm/melee/ft/chara/ftpichu.s
@@ -35,8 +35,8 @@ ftPichu_OnLoad:
 /* 80149EA4 00146A84  7C 08 03 A6 */	mtlr r0
 /* 80149EA8 00146A88  4E 80 00 20 */	blr 
 
-.global func_80149EAC
-func_80149EAC:
+.global ftPichu_OnDeath
+ftPichu_OnDeath:
 /* 80149EAC 00146A8C  7C 08 02 A6 */	mflr r0
 /* 80149EB0 00146A90  38 80 00 00 */	li r4, 0
 /* 80149EB4 00146A94  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftpikachu.s
+++ b/asm/melee/ft/chara/ftpikachu.s
@@ -60,8 +60,8 @@ lbl_8012441C:
 /* 8012446C 0012104C  7C 08 03 A6 */	mtlr r0
 /* 80124470 00121050  4E 80 00 20 */	blr 
 
-.global func_80124474
-func_80124474:
+.global ftPikachu_OnDeath
+ftPikachu_OnDeath:
 /* 80124474 00121054  7C 08 02 A6 */	mflr r0
 /* 80124478 00121058  38 80 00 00 */	li r4, 0
 /* 8012447C 0012105C  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftpurin.s
+++ b/asm/melee/ft/chara/ftpurin.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_8013C318
-func_8013C318:
+.global ftPurin_OnDeath
+ftPurin_OnDeath:
 /* 8013C318 00138EF8  7C 08 02 A6 */	mflr r0
 /* 8013C31C 00138EFC  38 80 00 00 */	li r4, 0
 /* 8013C320 00138F00  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftsamus.s
+++ b/asm/melee/ft/chara/ftsamus.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_8012832C
-func_8012832C:
+.global ftSamus_OnDeath
+ftSamus_OnDeath:
 /* 8012832C 00124F0C  7C 08 02 A6 */	mflr r0
 /* 80128330 00124F10  38 80 00 00 */	li r4, 0
 /* 80128334 00124F14  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftseak.s
+++ b/asm/melee/ft/chara/ftseak.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_80110094
-func_80110094:
+.global ftSeak_OnDeath
+ftSeak_OnDeath:
 /* 80110094 0010CC74  7C 08 02 A6 */	mflr r0
 /* 80110098 0010CC78  38 80 00 00 */	li r4, 0
 /* 8011009C 0010CC7C  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftyoshi.s
+++ b/asm/melee/ft/chara/ftyoshi.s
@@ -185,8 +185,8 @@ func_8012B918:
 /* 8012B958 00128538  7C 08 03 A6 */	mtlr r0
 /* 8012B95C 0012853C  4E 80 00 20 */	blr 
 
-.global func_8012B960
-func_8012B960:
+.global ftYoshi_OnDeath
+ftYoshi_OnDeath:
 /* 8012B960 00128540  7C 08 02 A6 */	mflr r0
 /* 8012B964 00128544  38 80 00 00 */	li r4, 0
 /* 8012B968 00128548  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftzakoboy.s
+++ b/asm/melee/ft/chara/ftzakoboy.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_8014F1F0
-func_8014F1F0:
+.global ftZakoBoy_OnDeath
+ftZakoBoy_OnDeath:
 /* 8014F1F0 0014BDD0  7C 08 02 A6 */	mflr r0
 /* 8014F1F4 0014BDD4  38 80 00 00 */	li r4, 0
 /* 8014F1F8 0014BDD8  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftzakogirl.s
+++ b/asm/melee/ft/chara/ftzakogirl.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_8014F418
-func_8014F418:
+.global ftZakoGirl_OnDeath
+ftZakoGirl_OnDeath:
 /* 8014F418 0014BFF8  7C 08 02 A6 */	mflr r0
 /* 8014F41C 0014BFFC  38 80 00 00 */	li r4, 0
 /* 8014F420 0014C000  90 01 00 04 */	stw r0, 4(r1)

--- a/asm/melee/ft/chara/ftzelda.s
+++ b/asm/melee/ft/chara/ftzelda.s
@@ -2,8 +2,8 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-.global func_801392DC
-func_801392DC:
+.global ftZelda_OnDeath
+ftZelda_OnDeath:
 /* 801392DC 00135EBC  7C 08 02 A6 */	mflr r0
 /* 801392E0 00135EC0  38 80 00 00 */	li r4, 0
 /* 801392E4 00135EC4  90 01 00 04 */	stw r0, 4(r1)

--- a/src/melee/ft/chara/ftdrmario.c
+++ b/src/melee/ft/chara/ftdrmario.c
@@ -1,6 +1,6 @@
 #include "ftdrmario.h"
 
-void func_8014949C(HSD_GObj* gobj) {
+void ftDrMario_OnDeath(HSD_GObj* gobj) {
     Fighter* ft = (Fighter*)gobj->user_data;
     func_80074A4C(gobj, 0, 0);
     ft->x2234 = 0;

--- a/src/melee/ft/chara/ftdrmario.h
+++ b/src/melee/ft/chara/ftdrmario.h
@@ -9,6 +9,6 @@
 
 #include "melee/ft/fighter.h"
 
-void func_8014949C(HSD_GObj* gobj);
+void ftDrMario_OnDeath(HSD_GObj* gobj);
 
 #endif

--- a/src/melee/ft/chara/ftfox.c
+++ b/src/melee/ft/chara/ftfox.c
@@ -7,7 +7,7 @@ BOOL func_800E5534(HSD_GObj* gobj)
     return ft->x222C ? TRUE : FALSE;
 }
 
-void func_800E5554(HSD_GObj* gobj)
+void ftFox_OnDeath(HSD_GObj* gobj)
 {
     Fighter* ft = (Fighter*)gobj->user_data;
     

--- a/src/melee/ft/chara/ftfox.h
+++ b/src/melee/ft/chara/ftfox.h
@@ -18,7 +18,7 @@ typedef struct _ftFoxAttributes {
 } ftFoxAttributes;
 
 BOOL func_800E5534(HSD_GObj* gobj);
-void func_800E5554(HSD_GObj* gobj);
+void ftFox_OnDeath(HSD_GObj* gobj);
 void func_800E5588(HSD_GObj* gobj);
 void func_800E55A8(HSD_GObj* gobj, s32 arg1);
 void func_800E5688(HSD_GObj* gobj);

--- a/src/melee/ft/chara/ftmewtwo.c
+++ b/src/melee/ft/chara/ftmewtwo.c
@@ -1,6 +1,6 @@
 #include "ftmewtwo.h"
 
-void func_80144DFC(HSD_GObj* gobj) {
+void ftMewtwo_OnDeath(HSD_GObj* gobj) {
     Fighter* ft = (Fighter*)gobj->user_data;
     func_80074A4C(gobj, 0, 0);
     ft->x222C = 0;

--- a/src/melee/ft/chara/ftmewtwo.h
+++ b/src/melee/ft/chara/ftmewtwo.h
@@ -9,6 +9,6 @@
 
 #include "melee/ft/fighter.h"
 
-void func_80144DFC(HSD_GObj* gobj);
+void ftMewtwo_OnDeath(HSD_GObj* gobj);
 
 #endif

--- a/src/melee/ft/chara/ftness.c
+++ b/src/melee/ft/chara/ftness.c
@@ -2,7 +2,7 @@
 
 extern f32 lbl_804D96B0;
 
-void func_801147C0(HSD_GObj* gobj, s32 arg1)
+void ftNess_OnDeath(HSD_GObj* gobj, s32 arg1)
 {
     Fighter* ft = gobj->user_data;
     func_80074A4C(gobj, 0, 0);

--- a/src/melee/ft/chara/ftness.h
+++ b/src/melee/ft/chara/ftness.h
@@ -17,7 +17,7 @@ typedef struct _ftNessAttributes {
     u8 data2[0xD9 - 0x98];
 } ftNessAttributes;
 
-void func_801147C0(HSD_GObj* gobj, s32 arg1);
+void ftNess_OnDeath(HSD_GObj* gobj, s32 arg1);
 void ftNess_OnLoad(HSD_GObj* gobj);
 void func_801148F8(HSD_GObj* gobj);
 void func_8011493C(HSD_GObj* gobj);

--- a/src/melee/ft/chara/ftpeach.c
+++ b/src/melee/ft/chara/ftpeach.c
@@ -6,7 +6,7 @@ typedef struct _PairStruct {
     u8 padding[0xB8];
 } PairStruct;
 
-void func_8011B51C(HSD_GObj* gobj) 
+void ftPeach_OnDeath(HSD_GObj* gobj)
 {
     Fighter* ft;
 

--- a/src/melee/ft/chara/ftpeach.h
+++ b/src/melee/ft/chara/ftpeach.h
@@ -15,6 +15,6 @@
 #define ITEM_PEACH_TOAD 104
 #define ITEM_PEACH_TOAD_SPORE 111
 
-void func_8011B51C(HSD_GObj* gobj);
+void ftPeach_OnDeath(HSD_GObj* gobj);
 
 #endif


### PR DESCRIPTION
Renamed all OnDeath callbacks in the ft_OnDeath table, in the style of existing ftSandbag_OnDeath and ft*_OnLoad functions