### PR TITLE
Minor fixes for mips_to_c decompilation

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -9130,6 +9130,6 @@ void func_80390A70();
 void efLib_PauseAll(struct _HSD_GObj*);
 void efLib_ResumeAll(struct _HSD_GObj*);
 s32 func_80096CC8(struct _HSD_GObj*);
-void ef_Spawn(...);
+void ef_Spawn(s32, ...);
 
 #endif

--- a/include/functions.h
+++ b/include/functions.h
@@ -1,3 +1,6 @@
+#ifndef _functions_h_
+#define _functions_h_
+
 #include <dolphin/types.h>
 #include <dolphin/mtx/mtxtypes.h>
 
@@ -9128,3 +9131,5 @@ void efLib_PauseAll(struct _HSD_GObj*);
 void efLib_ResumeAll(struct _HSD_GObj*);
 s32 func_80096CC8(struct _HSD_GObj*);
 void ef_Spawn(...);
+
+#endif

--- a/src/melee/ft/fighter.h
+++ b/src/melee/ft/fighter.h
@@ -507,7 +507,7 @@ typedef struct _Fighter {
     /* 0x914 */ Hitbox x914[4];
     u8 filler_xDF4[0x1064 - 0xDF4];
     /* 0x1064 */ ftHit x1064_thrownHitbox;
-    u8 filler_x1064[0x1828 - 0x1064 - sizeof(ftHit)];
+    u8 filler_x1064[0x1828 - 0x1064 - 0x138 /* sizeof(ftHit) */];
     /* 0x1828 */ s32 x1828;
     struct dmg                                                 // 0x182c
     {                                                          //

--- a/src/sysdolphin/baselib/jobj.h
+++ b/src/sysdolphin/baselib/jobj.h
@@ -166,7 +166,7 @@ inline void HSD_JObjSetTranslate(HSD_JObj* jobj, Vec* translate)
     }
 }
 
-inline HSD_JObjSetScale(HSD_JObj* jobj, Vec* vec)
+inline void HSD_JObjSetScale(HSD_JObj* jobj, Vec* vec)
 {
     if (jobj == NULL) {
         __assert("jobj.h", 760, "scale");


### PR DESCRIPTION
The decompilation pass in mips_to_c is a bit stricter than MWCC - this fixes the headers so they can be used as context without modification