### PR TITLE
Convert Special attributes in Fighter struct to a union.

### DIFF
--- a/src/melee/ft/chara/ftMars/ftMars.c
+++ b/src/melee/ft/chara/ftMars/ftMars.c
@@ -6,7 +6,7 @@ void ftMars_OnDeath(HSD_GObj* gobj) {
     Fighter* ft = gobj->user_data;
     func_80074A4C(gobj, 0, 0);
     func_80074A4C(gobj, 1, 0);
-    ft->x222C = 0;
+    ft->sa.mars.x222C = 0;
 }
 
 // 801362B0 00132E90

--- a/src/melee/ft/chara/ftMars/ftMarsSpecialS.c
+++ b/src/melee/ft/chara/ftMars/ftMarsSpecialS.c
@@ -33,8 +33,8 @@ void func_801374A0(HSD_GObj* gobj) {
     s32 unused1, unused2;
 
     ft->x80_self_vel.x = ft->x80_self_vel.x / attr->x14;
-    if ((s32)ft->x222C == 0) {
-        ft->x222C = 1;
+    if ((s32)ft->sa.mars.x222C == 0) {
+        ft->sa.mars.x222C = 1;
         ft->x80_self_vel.y = attr->x1C;
     } else {
         ft->x80_self_vel.y = 0.0f;
@@ -137,7 +137,7 @@ void func_801376E8(HSD_GObj* gobj) {
 // https://decomp.me/scratch/fpZ5r
 void func_80137748(HSD_GObj* gobj) {
     Fighter* ft = gobj->user_data;
-    ft->x222C = 0;
+    ft->sa.mars.x222C = 0;
     // Air_SetAsGrounded2
     func_8007D7FC(ft);
     // ActionStateChange
@@ -238,7 +238,7 @@ void func_801379D0(HSD_GObj* gobj) {
     Fighter* ft = gobj->user_data;
     s32 thing;
 
-    ft->x222C = 0;
+    ft->sa.mars.x222C = 0;
     func_8007D7FC(ft);
     switch (ft->x10) {
         case 0x167:
@@ -383,7 +383,7 @@ void func_80137CBC(HSD_GObj* gobj) {
 void func_80137D60(HSD_GObj* gobj) {
     Fighter* ft = gobj->user_data;
     s32 thing;
-    ft->x222C = 0;
+    ft->sa.mars.x222C = 0;
     // // Air_SetAsGrounded2
     func_8007D7FC(ft);
     switch (ft->x10) {
@@ -521,7 +521,7 @@ void func_8013809C(HSD_GObj* gobj) {
     Fighter* ft = gobj->user_data;
     s32 thing;
 
-    ft->x222C = 0;
+    ft->sa.mars.x222C = 0;
     // Air_SetAsGrounded2
     func_8007D7FC(ft);
     switch (ft->x10) {

--- a/src/melee/ft/chara/ftclink.c
+++ b/src/melee/ft/chara/ftclink.c
@@ -8,13 +8,13 @@ void ftCLink_OnDeath(HSD_GObj* gobj)
     func_80074A4C(gobj, 0, 0);
     func_80074A4C(gobj, 1, 0);
     func_80074A4C(gobj, 2, 0);
-    ft->x222C = 0;
-    ft->x2234 = 0;
-    ft->x2238 = 0;
-    ft->x223C = 0;
-    ft->x2240 = 0;
-    ft->x2238 = 0;
-    ft->x2244 = 0;
+    ft->sa.clink.x222C = 0;
+    ft->sa.clink.x2234 = 0;
+    ft->sa.clink.x2238 = 0;
+    ft->sa.clink.x223C = 0;
+    ft->sa.clink.x2240 = 0;
+    ft->sa.clink.x2238 = 0;
+    ft->sa.clink.x2244 = 0;
 }
 
 void ftCLink_OnLoad(HSD_GObj* gobj)
@@ -179,7 +179,7 @@ BOOL func_8014920C(HSD_GObj* gobj)
     if (temp_r0 != 0x156 && temp_r0 != 0x157) {
         return TRUE;
     }
-    if (ft->x2244 == 0) {
+    if (ft->sa.clink.x2244 == 0) {
         return TRUE;
     }
     return FALSE;
@@ -200,8 +200,8 @@ void func_801492C4(HSD_GObj* gobj)
     }
 
     ft = gobj->user_data;
-    if (ft != NULL && ft->x2244 != 0) {
-        ft->x2244 = 0;
+    if (ft != NULL && ft->sa.clink.x2244 != 0) {
+        ft->sa.clink.x2244 = 0;
     };
 
     if (gobj == NULL) {

--- a/src/melee/ft/chara/ftclink.h
+++ b/src/melee/ft/chara/ftclink.h
@@ -35,9 +35,9 @@ inline void checkFighter2244(HSD_GObj* gobj)
     }
 
     ft = gobj->user_data;
-    if (ft != NULL && ft->x2244 != 0) {
-        func_802C8C34(ft->x2244);
-        ft->x2244 = 0;
+    if (ft != NULL && ft->sa.clink.x2244 != 0) {
+        func_802C8C34(ft->sa.clink.x2244);
+        ft->sa.clink.x2244 = 0;
     }
 
     if (gobj == NULL) {

--- a/src/melee/ft/chara/ftclink_2.c
+++ b/src/melee/ft/chara/ftclink_2.c
@@ -11,10 +11,10 @@ void func_80149354(HSD_GObj* gobj)
 
     ft = ft2 = gobj->user_data;
 
-    if (ft->x2200_ftcmd_var1 == 1 && ft->x2244 == 0) {
+    if (ft->x2200_ftcmd_var1 == 1 && ft->sa.clink.x2244 == 0) {
         temp_r3 = func_802C8B28(gobj, &ft->xB0_pos, func_8007500C(ft2, 0x1F),
                                 ft->x2C_facing_direction);
-        ft->x2244 = (u32) temp_r3;
+        ft->sa.clink.x2244 = (u32) temp_r3;
         if (temp_r3 != NULL) {
             ft->cb.x21E4_callback_OnDeath2 = func_800EAF58;
             ft->cb.x21DC_callback_OnTakeDamage = func_800EAF58;

--- a/src/melee/ft/chara/ftdrmario.c
+++ b/src/melee/ft/chara/ftdrmario.c
@@ -4,10 +4,10 @@ void ftDrMario_OnDeath(HSD_GObj* gobj)
 {
     Fighter* ft = (Fighter*)gobj->user_data;
     func_80074A4C(gobj, 0, 0);
-    ft->x2234 = 0;
-    ft->x2238 = 0;
-    ft->x223C = 0;
-    ft->x2240 = 0;
+    ft->sa.mario.x2234 = 0;
+    ft->sa.mario.x2238 = 0;
+    ft->sa.mario.x223C = 0;
+    ft->sa.mario.x2240 = 0;
 }
 
 void ftDrMario_OnLoad(HSD_GObj* gobj)
@@ -108,9 +108,9 @@ void func_801497CC(HSD_GObj* gobj)
 
     if (gobj != NULL) {
         ft = gobj->user_data;
-        if (ft != NULL && ft->x2240 != 0) {
-            func_802C0DBC(ft->x2240);
-            ft->x2240 = 0;
+        if (ft != NULL && ft->sa.mario.x2240 != 0) {
+            func_802C0DBC(ft->sa.mario.x2240);
+            ft->sa.mario.x2240 = 0;
         }
     }
 
@@ -139,7 +139,7 @@ BOOL func_80149844(HSD_GObj* gobj)
     if (tmp != 0x155 && tmp != 0x156) {
         return TRUE;
     }
-    if (ft->x2240 == 0) {
+    if (ft->sa.mario.x2240 == 0) {
         return TRUE;
     }
     return FALSE;
@@ -151,8 +151,8 @@ void func_801498A0(HSD_GObj* gobj)
 
     if (gobj != NULL) {
         ft = gobj->user_data;
-        if (ft != NULL && ft->x2240 != 0) {
-            ft->x2240 = 0;
+        if (ft != NULL && ft->sa.mario.x2240 != 0) {
+            ft->sa.mario.x2240 = 0;
         }
     }
     if (gobj != NULL) {

--- a/src/melee/ft/chara/ftdrmario_2.c
+++ b/src/melee/ft/chara/ftdrmario_2.c
@@ -8,11 +8,11 @@ void func_80149954(HSD_GObj* gobj)
     int unused2[3];
 
     ft = gobj->user_data;
-    if (ft->x2200_ftcmd_var0 == 1 && ft->x2240 == 0U) {
+    if (ft->x2200_ftcmd_var0 == 1 && ft->sa.mario.x2240 == 0U) {
         func_8000B1CC(ft->x5E8_fighterBones->x0_jobj, 0, &sp18);
         tmp = func_800E0D1C(gobj);
         tmp = func_802C0850(gobj, &sp18, tmp, 0x31, ft->x2C_facing_direction);
-        ft->x2240 = tmp;
+        ft->sa.mario.x2240 = tmp;
         if (tmp != 0) {
             ft->cb.x21E4_callback_OnDeath2 = func_80149540;
             ft->cb.x21DC_callback_OnTakeDamage = func_80149540;
@@ -23,9 +23,9 @@ void func_80149954(HSD_GObj* gobj)
     if (func_8006F238(gobj) == 0) {
         if (gobj != NULL) {
             ft = gobj->user_data;
-            if (ft != NULL && ft->x2240 != 0) {
-                func_802C0DBC(ft->x2240);
-                ft->x2240 = 0;
+            if (ft != NULL && ft->sa.mario.x2240 != 0) {
+                func_802C0DBC(ft->sa.mario.x2240);
+                ft->sa.mario.x2240 = 0;
             }
         }
         if (gobj != NULL) {

--- a/src/melee/ft/chara/ftemblem.c
+++ b/src/melee/ft/chara/ftemblem.c
@@ -6,7 +6,7 @@ void ftRoy_OnDeath(HSD_GObj* gobj)
     func_80074A4C(gobj, 0, 0);
     func_80074A4C(gobj, 1, 0);
     func_80074A4C(gobj, 2, -1);
-    ft->x222C = 0;
+    ft->sa.mars.x222C = 0;
 }
 
 void func_8014EF60(HSD_GObj* gobj, s32 arg1)

--- a/src/melee/ft/chara/ftfalco.c
+++ b/src/melee/ft/chara/ftfalco.c
@@ -5,7 +5,7 @@
 void ftFalco_OnDeath(HSD_GObj* gobj)
 {
     Fighter* ft = gobj->user_data;
-    ft->x222C = 0;
+    ft->sa.fox.x222C = 0;
     func_80074A4C(gobj, 0, 0);
 }
 

--- a/src/melee/ft/chara/ftfox.c
+++ b/src/melee/ft/chara/ftfox.c
@@ -4,14 +4,14 @@ BOOL func_800E5534(HSD_GObj* gobj)
 {
     Fighter* ft = (Fighter*)gobj->user_data;
     
-    return ft->x222C ? TRUE : FALSE;
+    return ft->sa.fox.x222C ? TRUE : FALSE;
 }
 
 void ftFox_OnDeath(HSD_GObj* gobj)
 {
     Fighter* ft = (Fighter*)gobj->user_data;
     
-    ft->x222C = 0;
+    ft->sa.fox.x222C = 0;
     func_80074A4C(gobj, 0, 0);
 }
 

--- a/src/melee/ft/chara/ftganon.c
+++ b/src/melee/ft/chara/ftganon.c
@@ -5,8 +5,8 @@ void ftGanon_OnDeath(HSD_GObj* gobj)
     Fighter* ft = gobj->user_data;
     func_80074A4C(gobj, 0, 0);
     func_80074A4C(gobj, 1, -1);
-    ft->x2230 = 0;
-    ft->x222C = 0;
+    ft->sa.falcon.x2230 = 0;
+    ft->sa.falcon.x222C = 0;
 }
 
 void func_8014EC58(HSD_GObj* gobj, s32 arg1)

--- a/src/melee/ft/chara/ftkoopa.c
+++ b/src/melee/ft/chara/ftkoopa.c
@@ -21,7 +21,7 @@ void ftKoopa_OnDeath(HSD_GObj* gobj) {
     
     func_80074A4C(gobj, 0, 0);
 
-    ftVars = (ftKoopaVars*)&ft->x222C;
+    ftVars = (ftKoopaVars*)&ft->sa.koopa.x222C;
     
     ft->dmg.x18B0 = koopaAttr->x0;
     ftVars->x0 = koopaAttr->x10;

--- a/src/melee/ft/chara/ftmario.c
+++ b/src/melee/ft/chara/ftmario.c
@@ -10,12 +10,12 @@ extern s32 lbl_803C5A20[];
 void ftMario_OnDeath(HSD_GObj* gobj) {
     Fighter* ft = gobj->user_data;
     func_80074A4C(gobj, 0, 0);
-    ft->x222C = 9;
-    ft->x2230 = 9;
-    ft->x2234 = 0;
-    ft->x2238 = 0;
-    ft->x223C = 0;
-    ft->x2240 = 0;
+    ft->sa.mario.x222C = 9;
+    ft->sa.mario.x2230 = 9;
+    ft->sa.mario.x2234 = 0;
+    ft->sa.mario.x2238 = 0;
+    ft->sa.mario.x223C = 0;
+    ft->sa.mario.x2240 = 0;
 }
 
 void func_800E0920(Fighter* ft) {

--- a/src/melee/ft/chara/ftmewtwo.c
+++ b/src/melee/ft/chara/ftmewtwo.c
@@ -3,9 +3,9 @@
 void ftMewtwo_OnDeath(HSD_GObj* gobj) {
     Fighter* ft = (Fighter*)gobj->user_data;
     func_80074A4C(gobj, 0, 0);
-    ft->x222C = 0;
-    ft->x2230 = 0;
-    ft->x2234 = 0;
-    ft->x2238 = 0;
-    ft->x223C = 0;
+    ft->sa.mewtwo.x222C = 0;
+    ft->sa.mewtwo.x2230 = 0;
+    ft->sa.mewtwo.x2234 = 0;
+    ft->sa.mewtwo.x2238 = 0;
+    ft->sa.mewtwo.x223C = 0;
 }

--- a/src/melee/ft/chara/ftness.c
+++ b/src/melee/ft/chara/ftness.c
@@ -4,11 +4,11 @@ void ftNess_OnDeath(HSD_GObj* gobj, s32 arg1)
 {
     Fighter* ft = gobj->user_data;
     func_80074A4C(gobj, 0, 0);
-    ft->x2240 = 0;
-    ft->x2244 = 0;
-    ft->x2248 = 0;
-    ft->x222C = 0;
-    ft->x224C = 0;
+    ft->sa.ness.x2240 = 0;
+    ft->sa.ness.x2244 = 0;
+    ft->sa.ness.x2248 = 0;
+    ft->sa.ness.x222C = 0;
+    ft->sa.ness.x224C = 0;
 }
 
 void ftNess_OnLoad(HSD_GObj* gobj) {

--- a/src/melee/ft/chara/ftpeach.c
+++ b/src/melee/ft/chara/ftpeach.c
@@ -13,13 +13,13 @@ void ftPeach_OnDeath(HSD_GObj* gobj)
     Fighter* ft;
 
     ft = gobj->user_data;
-    ft->x222C = 1;
-    ft->x2234 = -1;
-    ft->x2240 = 0;
-    ft->x223C = 0;
-    ft->x2238 = 0;
-    ft->x2244 = 0;
-    ft->x2248 = 0;
+    ft->sa.peach.x222C = 1;
+    ft->sa.peach.x2234 = -1;
+    ft->sa.peach.x2240 = 0;
+    ft->sa.peach.x223C = 0;
+    ft->sa.peach.x2238 = 0;
+    ft->sa.peach.x2244 = 0;
+    ft->sa.peach.x2248 = 0;
     func_80074A4C(gobj, 0, 0);
     func_80074A4C(gobj, 2, 0);
     func_80074A4C(gobj, 3, -1);

--- a/src/melee/ft/fighter.h
+++ b/src/melee/ft/fighter.h
@@ -250,7 +250,165 @@ enum {
     GA_Air = 1,
 };
 
+// --------------------------------------------------------------------------------
+// UNION DEFS FOR FIGHTER STRUCTS. TODO: Maybe move these to per-fighter
+// header includes or something.
+// --------------------------------------------------------------------------------
+struct SpecialAttrs_Mario {
+    /* 0x222C */ u32 x222C;
+    /* 0x2230 */ u32 x2230;
+    /* 0x2234 */ u32 x2234;
+    /* 0x2238 */ u32 x2238;
+    /* 0x223C */ u32 x223C;
+    /* 0x2240 */ u32 x2240;
+    char filler0[0xFC];
+};
 
+struct SpecialAttrs_Fox {
+    /* 0x222C */ u32 x222C;
+    char filler0[0x110];
+};
+
+struct SpecialAttrs_Falcon {
+    /* 0x222C */ u32 x222C;
+    /* 0x2230 */ u32 x2230;
+    char filler0[0x10C];
+};
+
+struct SpecialAttrs_DK {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Kirby {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Koopa {
+    /* 0x222C */ u32 x222C;
+    char filler0[0x110];
+};
+
+struct SpecialAttrs_Link {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Shiek {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Ness {
+    /* 0x222C */ u32 x222C;
+    /* 0x2230 */ u32 x2230;
+    /* 0x2234 */ u32 x2234;
+    /* 0x2238 */ u32 x2238;
+    /* 0x223C */ u32 x223C;
+    /* 0x2240 */ u32 x2240;
+    /* 0x2244 */ u32 x2244;
+    /* 0x2248 */ u32 x2248;
+    /* 0x224C */ u32 x224C;
+    char filler0[0xF0];
+};
+
+struct SpecialAttrs_Peach {
+    /* 0x222C */ u32 x222C;
+    /* 0x2230 */ u32 x2230;
+    /* 0x2234 */ u32 x2234;
+    /* 0x2238 */ u32 x2238;
+    /* 0x223C */ u32 x223C;
+    /* 0x2240 */ u32 x2240;
+    /* 0x2244 */ u32 x2244;
+    /* 0x2248 */ u32 x2248;
+    char filler0[0xF4];
+};
+
+struct SpecialAttrs_Popo {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Nana {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Pikachu {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Samus {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Yoshi {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Jigglypuff {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Mewtwo {
+    /* 0x222C */ u32 x222C;
+    /* 0x2230 */ u32 x2230;
+    /* 0x2234 */ u32 x2234;
+    /* 0x2238 */ u32 x2238;
+    /* 0x223C */ u32 x223C;
+    char filler0[0x100];
+};
+
+struct SpecialAttrs_Luigi {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Mars {
+    /* 0x222C */ u32 x222C;
+    char filler0[0x110];
+};
+
+struct SpecialAttrs_Zelda {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_CLink {
+    /* 0x222C */ u32 x222C;
+    /* 0x2230 */ u32 x2230;
+    /* 0x2234 */ u32 x2234;
+    /* 0x2238 */ u32 x2238;
+    /* 0x223C */ u32 x223C;
+    /* 0x2240 */ u32 x2240;
+    /* 0x2244 */ u32 x2244;
+    char filler0[0xF8];
+};
+
+struct SpecialAttrs_Pichu {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Gaw {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Masterhand {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Crazyhand {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Boy {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Girl {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Gigabowser {
+    char filler0[0x114];
+};
+
+struct SpecialAttrs_Sandbag {
+    char filler0[0x114];
+};
 
 typedef struct _Fighter {
     /* 0x0 */ HSD_GObj *x0_fighter;
@@ -785,16 +943,41 @@ typedef struct _Fighter {
                  
     /* 0x222A */ UnkFlagStruct x222A_flag;
     u8 filler_x222B;
-    /* 0x222C */ u32 x222C;
-    /* 0x2230 */ u32 x2230;
-    /* 0x2234 */ u32 x2234;
-    /* 0x2238 */ u32 x2238;
-    /* 0x223C */ u32 x223C;
-    /* 0x2240 */ u32 x2240;
-    /* 0x2244 */ u32 x2244;
-    /* 0x2248 */ u32 x2248;
-    /* 0x224C */ u32 x224C;
-    u8 filler_x224C[0x2340-0x2250];
+    union { 
+        struct SpecialAttrs_Mario mario;
+        struct SpecialAttrs_Fox fox;
+        struct SpecialAttrs_Falcon falcon;
+        struct SpecialAttrs_DK dk;
+        struct SpecialAttrs_Kirby kirby;
+        struct SpecialAttrs_Koopa koopa;
+        struct SpecialAttrs_Link link;
+        struct SpecialAttrs_Shiek shiek;
+        struct SpecialAttrs_Ness ness;
+        struct SpecialAttrs_Peach peach;
+        struct SpecialAttrs_Popo popo;
+        struct SpecialAttrs_Nana nana;
+        struct SpecialAttrs_Pikachu pikachu;
+        struct SpecialAttrs_Samus samus;
+        struct SpecialAttrs_Yoshi yoshi;
+        struct SpecialAttrs_Jigglypuff jigglypuff;
+        struct SpecialAttrs_Mewtwo mewtwo;
+        struct SpecialAttrs_Luigi luigi;
+        struct SpecialAttrs_Mars mars;
+        struct SpecialAttrs_Zelda zelda;
+        struct SpecialAttrs_CLink clink;
+        // Mario SpecialAttrs struct is used for DrMario
+        // Fox SpecialAttrs struct is used for Falco
+        struct SpecialAttrs_Pichu pichu;
+        struct SpecialAttrs_Gaw gaw;
+        // Cpt Falcon SpecialAttrs struct is used for Ganondorf
+        // Mars (Marth) struct is used for Emblem (Roy)
+        struct SpecialAttrs_Masterhand masterhand;
+        struct SpecialAttrs_Crazyhand crazyhand;
+        struct SpecialAttrs_Boy boy;
+        struct SpecialAttrs_Girl girl;
+        struct SpecialAttrs_Gigabowser gigabowser;
+        struct SpecialAttrs_Sandbag sandbag;
+    } sa;
     /* 0x2340 */ u32 x2340_stateVar1;
     /* 0x2344 */ u32 x2344_stateVar2;
     /* 0x2348 */ u32 x2348_stateVar3;


### PR DESCRIPTION
Based on how these members are accessed, these members probably need to be accessed via a union. Luckily, I have determined the range between 222C and 2340 (possibly up to this) is very favorable to union accesses, and the DOL still matches when I converted all known accesses to these.