### PR TITLE
Use portable bash shebang for asmdiff

### DIFF
--- a/asmdiff.sh
+++ b/asmdiff.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 OBJDUMP="$DEVKITPPC/bin/powerpc-eabi-objdump -D -bbinary -EB -mpowerpc -M gekko"
 OPTIONS="--start-address=$(($1)) --stop-address=$(($1 + $2))"


### PR DESCRIPTION
Some systems do not put the bash executable in /bin/bash;
`/usr/bin/env bash` is generally considered more portable