### PR TITLE
ci: Add GitHub action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: devkitpro/devkitppc:latest
+    env:
+      WINEPREFIX: ${{github.workspace}}/.wine
+    steps:
+    - name: Install devkitPro
+      run: |
+        sudo dpkg --add-architecture i386
+        sudo apt-get update
+        sudo apt-get -y install build-essential wine32
+        sudo chown $(whoami) "$GITHUB_WORKSPACE"
+    - uses: actions/checkout@v3
+    - name: Download compilers
+      run: |
+        curl -L https://cdn.discordapp.com/attachments/727918646525165659/917185027656286218/GC_WII_COMPILERS.zip \
+          | bsdtar -xvf- -C tools --exclude Wii
+        mv tools/GC tools/mwcc_compiler
+    - name: make
+      run: GENERATE_MAP=1 make -j$(nproc)

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ ifeq ($(WINDOWS),1)
   WINE :=
 else
   WINE ?= wine
+  # Disable wine debug output for cleanliness
+  export WINEDEBUG ?= -all
+  # Default devkitPPC path
+  DEVKITPPC ?= /opt/devkitpro/devkitPPC
 endif
 AS      := $(DEVKITPPC)/bin/powerpc-eabi-as
 CPP     := cpp -P
@@ -119,7 +123,7 @@ $(LDSCRIPT): ldscript.lcf
 	@echo Converting $< to $@
 	$(QUIET) $(ELF2DOL) $< $@
 ifeq ($(GENERATE_MAP),1)
-	$(QUIET) $(PYTHON) tools/calcprogress.py $@
+	$(QUIET) $(PYTHON) tools/calcprogress.py $(DOL) $(MAP)
 endif
 
 clean:

--- a/tools/calcprogress.py
+++ b/tools/calcprogress.py
@@ -31,9 +31,6 @@ import math
 #                                             #
 ###############################################
 
-DOL_PATH = "baserom.dol"
-MAP_PATH = "build/ssbm.us.1.2/GALE01.map"
-
 MEM1_HI = 0x81700000 
 MEM1_LO = 0x80003100
 
@@ -78,7 +75,7 @@ SECTION_DATA = 1
 
 if __name__ == "__main__":
     # Sum up DOL section sizes
-    dol_handle = open(DOL_PATH, "rb")
+    dol_handle = open(sys.argv[1], "rb")
 
     # Seek to virtual addresses
     dol_handle.seek(0x48)
@@ -120,7 +117,7 @@ if __name__ == "__main__":
         dol_code_size += i
 
     # Open map file
-    mapfile = open(MAP_PATH, "r")
+    mapfile = open(sys.argv[2], "r")
     symbols = mapfile.readlines()
 
     decomp_code_size = 0


### PR DESCRIPTION
Builds the whole repo & runs calcprogress on every commit / pull request.

Successful build: https://github.com/encounter/melee/runs/5892809678

calcprogress.py was modified slightly to use the passed-in dol & map file instead of using hardcoded values.

Additionally, on *nix, DEVKITPPC is set to its default location (unless overridden) and Wine debug output is silenced.