### PR TITLE
Remove negative sized padding

### DIFF
--- a/src/melee/ft/fighter.c
+++ b/src/melee/ft/fighter.c
@@ -1020,7 +1020,7 @@ void Fighter_ActionStateChange_800693AC(HSD_GObj* fighterObj, s32 new_action_sta
     }
 
     if ((arg2 & 0x100) == 0) {
-        fighter->x1198 = 0;
+        fighter->x1064_thrownHitbox.x134 = 0;
     }
 
     if ((arg2 & 4) == 0) {

--- a/src/melee/ft/fighter.h
+++ b/src/melee/ft/fighter.h
@@ -814,8 +814,6 @@ typedef struct _Fighter {
     /* 0x914 */ Hitbox x914[4];
     u8 filler_xDF4[0x1064 - 0xDF4];
     /* 0x1064 */ ftHit x1064_thrownHitbox;
-    u8 filler_x1064[0x1198 - 0x1064 - sizeof(ftHit)];
-    /* 0x1198 */ s32 x1198;
     u8 filler_x1198[0x1828 - 0x119C];
     /* 0x1828 */ s32 x1828;
     struct dmg                                                 // 0x182c


### PR DESCRIPTION
sizeof(ftHit) is 0x138
`0x1198 - 0x1064 - 0x138 == -4`

`x1064_thrownHitbox` should be from 0x1064 to 0x119C, but there's a filler and something at 0x1198.

```
    ft->x1064_thrownHitbox.filler_x0[0] = sizeof(ftHit);
    ft->filler_x1064[0] = sizeof(ft->filler_x1064);
    ft->x1198 = 1;
```
compiles to:
```
+  145848:      38 00 00 38     li      r0,56
+  14584c:      38 60 00 fc     li      r3,252
+  145850:      98 04 10 64     stb     r0,4196(r4)
+  145854:      38 00 00 01     li      r0,1
+  145858:      98 64 11 9c     stb     r3,4508(r4)
+  14585c:      90 04 11 98     stw     r0,4504(r4)
```
which is to say:
```
ft->x1064 = 0x38
ft->x119C = 0xFC
ft->x1198 = 1
```
the first size being 0x38 instead of 0x138 is because its truncated to u8
0xFC is the same as -4
and the last write is to an element later in the struct, but with a lower offset?
```
    ft->x1064_thrownHitbox.x134 = 0;
    ft->x1198 = 1;
```
compiles to:
```
+  145848:      38 60 00 00     li      r3,0
+  14584c:      38 00 00 01     li      r0,1
+  145850:      90 64 11 98     stw     r3,4504(r4)
+  145854:      90 04 11 98     stw     r0,4504(r4)
```
so these two struct elements have the same offset.

I would expect a compiler error like this one, but it seems like it's broken for expressions containing sizeof:
```
#     817:      u8 filler_qwer[-4];
#   Error:                       ^
#   illegal constant expression
```