### PR TITLE
Standardize `Fighter*` variable names to `fp`

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -1452,7 +1452,7 @@ void func_8008031C();
 // ? func_80080474(?);
 // ? func_80080484(?);
 // ? func_800804A0(?);
-f32 func_800804EC(struct _Fighter *); // DataOffset_PlayerScale_MultiplyBySomething, returns fighter->x40*fighter->x34
+f32 func_800804EC(struct _Fighter *); // DataOffset_PlayerScale_MultiplyBySomething, returns fp->x40*fp->x34
 void func_800804FC();
 // ? func_8008051C(?);
 // ? func_800805C8(?);

--- a/src/melee/ft/chara/ftCLink/ftclink.c
+++ b/src/melee/ft/chara/ftCLink/ftclink.c
@@ -4,46 +4,46 @@
 
 void ftCLink_OnDeath(HSD_GObj* gobj)
 {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     func_80074A4C(gobj, 0, 0);
     func_80074A4C(gobj, 1, 0);
     func_80074A4C(gobj, 2, 0);
-    ft->sa.clink.x222C = 0;
-    ft->sa.clink.x2234 = 0;
-    ft->sa.clink.x2238 = 0;
-    ft->sa.clink.x223C = 0;
-    ft->sa.clink.x2240 = 0;
-    ft->sa.clink.x2238 = 0;
-    ft->sa.clink.x2244 = 0;
+    fp->sa.clink.x222C = 0;
+    fp->sa.clink.x2234 = 0;
+    fp->sa.clink.x2238 = 0;
+    fp->sa.clink.x223C = 0;
+    fp->sa.clink.x2240 = 0;
+    fp->sa.clink.x2238 = 0;
+    fp->sa.clink.x2244 = 0;
 }
 
 void ftCLink_OnLoad(HSD_GObj* gobj)
 {
     int unused[2];
 
-    Fighter* ft = gobj->user_data;
-    ftData* ftdata = ft->x10C_ftData;
+    Fighter* fp = gobj->user_data;
+    ftData* ftdata = fp->x10C_ftData;
     CLinkAttributes* attrs = (void*) ftdata->ext_attr;
     void** items = ftdata->x48_items;
 
-    ft->x2224_flag.bits.b7 = 1;
-    attrs->x54 = func_8001E8F8(func_80085E50(ft, 0x48));
-    ftLink_OnLoadForCLink(ft);
-    attrs = ft->x2D4_specialAttributes;
+    fp->x2224_flag.bits.b7 = 1;
+    attrs->x54 = func_8001E8F8(func_80085E50(fp, 0x48));
+    ftLink_OnLoadForCLink(fp);
+    attrs = fp->x2D4_specialAttributes;
     func_8026B3F8(items[0], attrs->x48);
     func_8026B3F8(items[1], attrs->x2C);
     func_8026B3F8(items[2], attrs->xBC);
     func_8026B3F8(items[3], attrs->xC);
     func_8026B3F8(items[4], attrs->x10);
     func_8026B3F8(items[5], It_Kind_CLink_Milk);
-    func_800753D4(ft, *lbl_804D6540[ft->x4_fighterKind], items[6]);
+    func_800753D4(fp, *lbl_804D6540[fp->x4_fighterKind], items[6]);
 }
 
 void ftCLink_OnItemPickupExt(HSD_GObj* gobj, s32 arg1)
 {
     int unused;
-    Fighter* ft = gobj->user_data;
-    if (func_8026B2B4(ft->x1974_heldItem) == 1) {
+    Fighter* fp = gobj->user_data;
+    if (func_8026B2B4(fp->x1974_heldItem) == 1) {
         func_80074A4C(gobj, 1, 1);
     }
     func_80074A4C(gobj, 2, 1);
@@ -63,8 +63,8 @@ void ftCLink_OnItemVisible(HSD_GObj* gobj)
 void ftCLink_OnItemDropExt(HSD_GObj* gobj, s32 arg1)
 {
     int unused;
-    Fighter* ft = gobj->user_data;
-    if (func_8026B2B4(ft->x1974_heldItem) == 1) {
+    Fighter* fp = gobj->user_data;
+    if (func_8026B2B4(fp->x1974_heldItem) == 1) {
         func_80074A4C(gobj, 1, 0);
     }
     func_80074A4C(gobj, 2, 0);
@@ -77,7 +77,7 @@ void ftCLink_OnItemPickup(HSD_GObj* fighterObj, BOOL bool) {
 
 void ftCLink_OnItemDrop(HSD_GObj* gobj, BOOL bool1)
 {
-    Fighter* link = getFighter(gobj);
+    Fighter* fp = getFighter(gobj);
     Fighter_OnItemDrop(gobj, bool1, 1, 1);
 }
 
@@ -98,17 +98,17 @@ void ftCLink_OnKnockbackExit(HSD_GObj* gobj)
 
 void func_80149114(HSD_GObj* gobj)
 {
-    Fighter* ft = gobj->user_data;
-    CLinkAttributes* temp_r4 = (void*) ft->x10C_ftData->ext_attr;
-    f32 ftmp = func_80092ED8(ft->x19A4, temp_r4, temp_r4->xD8);
-    ft->xEC_ground_vel = ftmp * p_ftCommonData->x294;
-    if (ft->x19AC < 0.0f) {
-        ftmp = ft->xEC_ground_vel;
+    Fighter* fp = gobj->user_data;
+    CLinkAttributes* temp_r4 = (void*) fp->x10C_ftData->ext_attr;
+    f32 ftmp = func_80092ED8(fp->x19A4, temp_r4, temp_r4->xD8);
+    fp->xEC_ground_vel = ftmp * p_ftCommonData->x294;
+    if (fp->x19AC < 0.0f) {
+        ftmp = fp->xEC_ground_vel;
     } else {
-        ftmp = -ft->xEC_ground_vel;
+        ftmp = -fp->xEC_ground_vel;
     }
-    ft->xEC_ground_vel = ftmp;
-    func_80088148(ft, 0x111DA, 0x7F, 0x40);
+    fp->xEC_ground_vel = ftmp;
+    func_80088148(fp, 0x111DA, 0x7F, 0x40);
 }
 
 void func_8014919C(HSD_GObj* gobj)
@@ -116,33 +116,33 @@ void func_8014919C(HSD_GObj* gobj)
     CLinkAttributes* attrs;
     s32 unused[2];
 
-    Fighter* ft = gobj->user_data;
-    if (ft->x5F8 == 0) {
-        attrs = (void*) ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    if (fp->x5F8 == 0) {
+        attrs = (void*) fp->x2D4_specialAttributes;
         func_8007B1B8(gobj, &attrs->xC4, func_80149114);
-        ft->x221B_flag.bits.b3 = 1;
-        ft->x221B_flag.bits.b4 = 1;
-        ft->x221B_flag.bits.b2 = 1;
+        fp->x221B_flag.bits.b3 = 1;
+        fp->x221B_flag.bits.b4 = 1;
+        fp->x221B_flag.bits.b2 = 1;
     }
 }
 
 BOOL func_8014920C(HSD_GObj* gobj)
 {
     s32 temp_r0;
-    Fighter* ft;
+    Fighter* fp;
 
     if (gobj == NULL) {
         return TRUE;
     }
-    ft = gobj->user_data;
-    if (ft == NULL) {
+    fp = gobj->user_data;
+    if (fp == NULL) {
         return TRUE;
     }
-    temp_r0 = ft->x10_action_state_index;
+    temp_r0 = fp->x10_action_state_index;
     if (temp_r0 != 0x156 && temp_r0 != 0x157) {
         return TRUE;
     }
-    if (ft->sa.clink.x2244 == 0) {
+    if (fp->sa.clink.x2244 == 0) {
         return TRUE;
     }
     return FALSE;
@@ -156,15 +156,15 @@ void func_80149268(HSD_GObj* gobj)
 
 void func_801492C4(HSD_GObj* gobj)
 {
-    Fighter* ft;
+    Fighter* fp;
 
     if (gobj == NULL) {
         return;
     }
 
-    ft = gobj->user_data;
-    if (ft != NULL && ft->sa.clink.x2244 != 0) {
-        ft->sa.clink.x2244 = 0;
+    fp = gobj->user_data;
+    if (fp != NULL && fp->sa.clink.x2244 != 0) {
+        fp->sa.clink.x2244 = 0;
     };
 
     if (gobj == NULL) {
@@ -174,12 +174,12 @@ void func_801492C4(HSD_GObj* gobj)
 
 u32 func_801492F4(HSD_GObj* gobj)
 {
-    Fighter* ft;
+    Fighter* fp;
 
     if (gobj != NULL) {
-        ft = gobj->user_data;
-        if (ft != NULL) {
-            return ft->x2204_ftcmd_var1;
+        fp = gobj->user_data;
+        if (fp != NULL) {
+            return fp->x2204_ftcmd_var1;
         }
     }
     return 0;
@@ -187,7 +187,7 @@ u32 func_801492F4(HSD_GObj* gobj)
 
 void func_80149318(HSD_GObj* gobj)
 {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     func_800DEAE8(gobj, 0x156, 0x157);
-    ft->x2204_ftcmd_var1 = 0;
+    fp->x2204_ftcmd_var1 = 0;
 }

--- a/src/melee/ft/chara/ftCLink/ftclink.h
+++ b/src/melee/ft/chara/ftCLink/ftclink.h
@@ -28,16 +28,16 @@ void ftCLink_OnItemDrop(HSD_GObj*, BOOL);
 
 inline void checkFighter2244(HSD_GObj* gobj)
 {
-    Fighter* ft;
+    Fighter* fp;
 
     if (gobj == NULL) {
         return;
     }
 
-    ft = gobj->user_data;
-    if (ft != NULL && ft->sa.clink.x2244 != 0) {
-        func_802C8C34(ft->sa.clink.x2244);
-        ft->sa.clink.x2244 = 0;
+    fp = gobj->user_data;
+    if (fp != NULL && fp->sa.clink.x2244 != 0) {
+        func_802C8C34(fp->sa.clink.x2244);
+        fp->sa.clink.x2244 = 0;
     }
 
     if (gobj == NULL) {

--- a/src/melee/ft/chara/ftCLink/ftclink_2.c
+++ b/src/melee/ft/chara/ftCLink/ftclink_2.c
@@ -5,19 +5,19 @@ extern void func_800EAF58(HSD_GObj*);
 void func_80149354(HSD_GObj* gobj)
 {
     void* temp_r3;
-    Fighter* ft;
+    Fighter* fp;
     Fighter* ft2;
     int unused[4];
 
-    ft = ft2 = gobj->user_data;
+    fp = ft2 = gobj->user_data;
 
-    if (ft->x2204_ftcmd_var1 == 1 && ft->sa.clink.x2244 == 0) {
-        temp_r3 = func_802C8B28(gobj, &ft->xB0_pos, func_8007500C(ft2, 0x1F),
-                                ft->x2C_facing_direction);
-        ft->sa.clink.x2244 = (u32) temp_r3;
+    if (fp->x2204_ftcmd_var1 == 1 && fp->sa.clink.x2244 == 0) {
+        temp_r3 = func_802C8B28(gobj, &fp->xB0_pos, func_8007500C(ft2, 0x1F),
+                                fp->x2C_facing_direction);
+        fp->sa.clink.x2244 = (u32) temp_r3;
         if (temp_r3 != NULL) {
-            ft->cb.x21E4_callback_OnDeath2 = func_800EAF58;
-            ft->cb.x21DC_callback_OnTakeDamage = func_800EAF58;
+            fp->cb.x21E4_callback_OnDeath2 = func_800EAF58;
+            fp->cb.x21DC_callback_OnTakeDamage = func_800EAF58;
         }
     } else if (ft2->x2204_ftcmd_var1 == 2) {
         func_80149268(gobj);

--- a/src/melee/ft/chara/ftCaptain/ftCaptain.c
+++ b/src/melee/ft/chara/ftCaptain/ftCaptain.c
@@ -50,8 +50,8 @@ void ftCFalcon_OnItemDrop(HSD_GObj* gobj, BOOL bool1)
 
 // ftCaptain_OnLoadForGanon
 // https://decomp.me/scratch/9AwRw
-void ftCaptain_OnLoadForGanon(Fighter* fighter) {
-    PUSH_ATTRS(fighter, ftCaptainAttributes);
+void ftCaptain_OnLoadForGanon(Fighter* fp) {
+    PUSH_ATTRS(fp, ftCaptainAttributes);
 }
 
 // func_800E2AEC
@@ -59,13 +59,13 @@ void ftCaptain_OnLoadForGanon(Fighter* fighter) {
 // https://decomp.me/scratch/aZ4Wn
 void ftCaptain_OnLoad(HSD_GObj* fighter_gobj)
 {
-    Fighter* fighter;
+    Fighter* fp;
     ftCaptainAttributes *sA2;
 
-    fighter = (Fighter*)fighter_gobj->user_data;
-    fighter->x2224_flag.bits.b7 = 1;
+    fp = (Fighter*)fighter_gobj->user_data;
+    fp->x2224_flag.bits.b7 = 1;
 
-    PUSH_ATTRS(fighter, ftCaptainAttributes);
+    PUSH_ATTRS(fp, ftCaptainAttributes);
 }
 
 // ftCFalcon_LoadSpecialAttrs

--- a/src/melee/ft/chara/ftCrazyHand/ftcrazyhand.c
+++ b/src/melee/ft/chara/ftCrazyHand/ftcrazyhand.c
@@ -8,45 +8,45 @@ void ftCrazyhand_OnLoad(HSD_GObj* fighterObj) {
     ftData* ftdata;
     ftCrazyHandAttributes* ftData_attr;
     void** items;
-    Fighter* ft;
+    Fighter* fp;
 
     
-    ft = fighterObj->user_data;
-    ftdata = ft->x10C_ftData;
+    fp = fighterObj->user_data;
+    ftdata = fp->x10C_ftData;
     ftData_attr = ftdata->ext_attr;
     items = ftdata->x48_items;
 
-    PUSH_ATTRS(ft, ftCrazyHandAttributes);
+    PUSH_ATTRS(fp, ftCrazyHandAttributes);
     
     func_8015BDB4(fighterObj);
     func_8026B3F8(items[0], 0x7F);
     func_8026B3F8(items[1], 0x80);
     func_8026B3F8(items[2], 0x81);
-    ft->x2229_b5_no_normal_motion = 1;
-    ft->x2229_b6 = 1;
-    ft->x2229_b7 = 1;
-    ft->x222A_flag.bits.b0 = 1;
-    ft->x222A_flag.bits.b1 = 1;
-    ft->x2229_b3 = 1;
-    ft->xB0_pos.x = ftData_attr->x18;
-    ft->xB0_pos.y = ftData_attr->x1C;
-    ft->xB0_pos.z = 0.0f;
-    ft->x2368 = 0;
-    ft->x236C = 0; 
-    ft->x2370 = 0;
-    ft->x2374 = 0;
-    ft->x2378 = -1;
-    ft->x237C = -1;
-    ft->x2380 = -1;
-    ft->x235C = 0.0f;
-    ft->x2360 = 0;
-    ft->sa.masterhand.x222C = func_8015C244(fighterObj, &ft->xB0_pos);
-    ft->sa.masterhand.x2238 = 1.0f;
-    ft->sa.masterhand.x224C = 0;
-    ft->sa.masterhand.x2250 = 0x159; 
-    ft->sa.masterhand.x2254 = 0;
-    ft->x1A98 = 1;
-    func_8015BD24(ft->x1A98, &ft->sa.masterhand.x223C, ft->sa.crazyhand.x2238, ftData_attr->x0, ftData_attr->x8, ftData_attr->x4);
+    fp->x2229_b5_no_normal_motion = 1;
+    fp->x2229_b6 = 1;
+    fp->x2229_b7 = 1;
+    fp->x222A_flag.bits.b0 = 1;
+    fp->x222A_flag.bits.b1 = 1;
+    fp->x2229_b3 = 1;
+    fp->xB0_pos.x = ftData_attr->x18;
+    fp->xB0_pos.y = ftData_attr->x1C;
+    fp->xB0_pos.z = 0.0f;
+    fp->x2368 = 0;
+    fp->x236C = 0; 
+    fp->x2370 = 0;
+    fp->x2374 = 0;
+    fp->x2378 = -1;
+    fp->x237C = -1;
+    fp->x2380 = -1;
+    fp->x235C = 0.0f;
+    fp->x2360 = 0;
+    fp->sa.masterhand.x222C = func_8015C244(fighterObj, &fp->xB0_pos);
+    fp->sa.masterhand.x2238 = 1.0f;
+    fp->sa.masterhand.x224C = 0;
+    fp->sa.masterhand.x2250 = 0x159; 
+    fp->sa.masterhand.x2254 = 0;
+    fp->x1A98 = 1;
+    func_8015BD24(fp->x1A98, &fp->sa.masterhand.x223C, fp->sa.crazyhand.x2238, ftData_attr->x0, ftData_attr->x8, ftData_attr->x4);
 }
 
 

--- a/src/melee/ft/chara/ftDonkey/ftdonkey1.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey1.c
@@ -10,12 +10,12 @@ s32 ftDonkey_800DF938(HSD_GObj* fighterObj) {
 
 void ftDonkey_800DF980(HSD_GObj* fighterObj) {
     s32 unused[2]; /// getFighter inlines not working
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     ftDonkeyAttributes* donkey_attr;
-    if (fighter->xE0_ground_or_air == GA_Air) {
-        func_8007D7FC(fighter);
+    if (fp->xE0_ground_or_air == GA_Air) {
+        func_8007D7FC(fp);
     }
-    donkey_attr = getFtSpecialAttrs2CC(fighter);
+    donkey_attr = getFtSpecialAttrs2CC(fp);
     Fighter_ActionStateChange_800693AC(fighterObj, donkey_attr->action_state, 0, NULL, 0.0f, 1.0f, 0.0f);
 }
 

--- a/src/melee/ft/chara/ftDonkey/ftdonkey4.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey4.c
@@ -9,7 +9,7 @@ s32 ftDonkey_800E0134(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_800E017C(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs2CC(fighter);
+    Fighter* fp = getFighterPlus(fighterObj);
+    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs2CC(fp);
     func_800C9840(fighterObj, donkey_attr->action_state + 4, 0, 0.0f, donkey_attr->cargo_hold.x20_TURN_SPEED, 0.0f);
 }

--- a/src/melee/ft/chara/ftDonkey/ftdonkey5.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey5.c
@@ -8,8 +8,8 @@ void ftDonkey_800E01BC(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_800E0200(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    if (fighter->x2340_stateVar1 && !func_80094EA4(fighterObj)) {
+    Fighter* fp = getFighter(fighterObj);
+    if (fp->x2340_stateVar1 && !func_80094EA4(fighterObj)) {
         s32 result = ftDonkey_800E0378(fighterObj);
         if (result) return;
     }
@@ -24,11 +24,11 @@ void ftDonkey_800E0274(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_800E0294(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs2CC(fighter);
+    Fighter* fp = getFighterPlus(fighterObj);
+    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs2CC(fp);
     Fighter_ActionStateChange_800693AC(fighterObj, donkey_attr->action_state + 6, 1, NULL, 0.0f, 1.0, 0.0f);
     ftAnim_SetAnimRate(fighterObj, 0.0f);
-    if (fighter->xE0_ground_or_air == GA_Ground) {
-        func_8007D5D4(fighter);
+    if (fp->xE0_ground_or_air == GA_Ground) {
+        func_8007D5D4(fp);
     }
 }

--- a/src/melee/ft/chara/ftDonkey/ftdonkey6.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey6.c
@@ -23,10 +23,10 @@ s32 ftDonkey_800E0378(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_800E03C0(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
+    Fighter* fp = getFighterPlus(fighterObj);
     ftDonkeyAttributes* donkey_attr;
-    func_8007D5D4(fighter);
-    donkey_attr = getFtSpecialAttrs2CC(fighter);
+    func_8007D5D4(fp);
+    donkey_attr = getFtSpecialAttrs2CC(fp);
     Fighter_ActionStateChange_800693AC(fighterObj, donkey_attr->action_state + 7, 0, NULL, 0.0f, 1.0, 0.0f);
     ftAnim_SetAnimRate(fighterObj, 0.0f);
     func_800CB110(fighterObj, 1, 1.0f);

--- a/src/melee/ft/chara/ftDonkey/ftdonkey7.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey7.c
@@ -14,22 +14,22 @@ void ftDonkey_800E0484(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_800E04A4(HSD_GObj* fighterObj, s32 arg1) {
-    Fighter* fighter = fighterObj->user_data;
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs2CC(fighter);
+    Fighter* fp = fighterObj->user_data;
+    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs2CC(fp);
     ftDonkeyAttributes* donkey_attr2;
-    fighter->x2344_stateVar2_s32 = arg1;
-    fighter->x2340_stateVar1 = 0;
-    fighter->x2348_stateVar3_f32 = donkey_attr->cargo_hold.x24_JUMP_STARTUP_LAG;
-    donkey_attr2 = getFtSpecialAttrs2CC(fighter);
+    fp->x2344_stateVar2_s32 = arg1;
+    fp->x2340_stateVar1 = 0;
+    fp->x2348_stateVar3_f32 = donkey_attr->cargo_hold.x24_JUMP_STARTUP_LAG;
+    donkey_attr2 = getFtSpecialAttrs2CC(fp);
     
     Fighter_ActionStateChange_800693AC(fighterObj, donkey_attr2->action_state + 5, 0, NULL, 0.0f, 1.0f, 0.0f);
     ftAnim_SetAnimRate(fighterObj, 0.0f);
 }
 
 void ftDonkey_800E0518(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    if (fighter->x2348_stateVar3_f32 <= 0.0f) {
+    Fighter* fp = getFighter(fighterObj);
+    if (fp->x2348_stateVar3_f32 <= 0.0f) {
         ftDonkey_800E03C0(fighterObj);
     }
-    fighter->x2348_stateVar3_f32 -= 1.0f;
+    fp->x2348_stateVar3_f32 -= 1.0f;
 }

--- a/src/melee/ft/chara/ftDonkey/ftdonkey8.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey8.c
@@ -17,18 +17,18 @@ void ftDonkey_800E05C4(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_800E05E4(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs2CC(fighter);
-    fighter->x2344_f32 = donkey_attr->cargo_hold.x28_LANDING_LAG;
-    donkey_attr = getFtSpecialAttrs2CC(fighter);
-    func_800D5AEC(fighterObj, donkey_attr->action_state + 8, 1, 0, fighter, 0.0f, 1.0f);
+    Fighter* fp = fighterObj->user_data;
+    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs2CC(fp);
+    fp->x2344_f32 = donkey_attr->cargo_hold.x28_LANDING_LAG;
+    donkey_attr = getFtSpecialAttrs2CC(fp);
+    func_800D5AEC(fighterObj, donkey_attr->action_state + 8, 1, 0, fp, 0.0f, 1.0f);
     ftAnim_SetAnimRate(fighterObj, 0.0f);
 }
 
 void ftDonkey_800E0648(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    if (fighter->x2344_f32 <= 0.0f) {
+    Fighter* fp = fighterObj->user_data;
+    if (fp->x2344_f32 <= 0.0f) {
         ftDonkey_800DF980(fighterObj);
     }
-    fighter->x2344_f32 -= 1.0f;
+    fp->x2344_f32 -= 1.0f;
 }

--- a/src/melee/ft/chara/ftDonkey/ftdonkey9.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey9.c
@@ -10,39 +10,39 @@ void ftDonkey_800E06B8(HSD_GObj* fighterObj) {
 
 void ftDonkey_800E06D8(HSD_GObj* fighterObj) {
     Vec vec;
-    Fighter* fighter = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
     if (ftDonkey_800E0750(fighterObj)) {
         ftDonkey_800E07B0(fighterObj);
     } else {
         vec.x = vec.y = vec.z = 0.0f;
-        func_8026ABD8(fighter->x1974_heldItem, &vec, 1.0f);
+        func_8026ABD8(fp->x1974_heldItem, &vec, 1.0f);
         func_8008E908(fighterObj, 0.0f);  
     }
 }
 
 BOOL ftDonkey_800E0750(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
     
-    if (func_8008E984(fighter)) {
+    if (func_8008E984(fp)) {
         return 1;
     }
-    if (func_8008D8E8(scaleBy154_8008D8D8(fighter->dmg.x1850_forceApplied)) < 3) {
+    if (func_8008D8E8(scaleBy154_8008D8D8(fp->dmg.x1850_forceApplied)) < 3) {
         return 1;
     }
     return 0;
 }
 
 void ftDonkey_800E07B0(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    ftDonkeyAttributes* donkey_attr = fighter->x2CC;
+    Fighter* fp = fighterObj->user_data;
+    ftDonkeyAttributes* donkey_attr = fp->x2CC;
     func_8008DCE0(fighterObj, donkey_attr->action_state + 9, 0.0f);
 }
  
 void ftDonkey_800E07E4(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     func_8008F744(fighterObj);
-    if (!fighter->x221C_flag.bits.b6) {
-        if (fighter->xE0_ground_or_air == GA_Air) {
+    if (!fp->x221C_flag.bits.b6) {
+        if (fp->xE0_ground_or_air == GA_Air) {
             ftDonkey_800E0294(fighterObj);
         } else {
             ftDonkey_800DF980(fighterObj); 
@@ -55,12 +55,12 @@ void ftDonkey_800E0848(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_800E0868(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    if (fighter->xE0_ground_or_air == GA_Ground) {
+    Fighter* fp = getFighter(fighterObj);
+    if (fp->xE0_ground_or_air == GA_Ground) {
         if (!func_80082708(fighterObj)) {
-            func_8007D5D4(fighter);
+            func_8007D5D4(fp);
         }
     } else if (func_80081D0C(fighterObj)) {
-        func_8007D7FC(fighter);
+        func_8007D7FC(fp);
     }
 }

--- a/src/melee/ft/chara/ftDonkey/ftdonkey_SpecialHi.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey_SpecialHi.c
@@ -1,44 +1,44 @@
 #include <ftdonkey.h>
 
 void ftDonkey_SetCallbacks_SpecialHi(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    fighter->cb.x21DC_callback_OnTakeDamage = &ftDonkey_8010D774;
-    fighter->cb.x21E4_callback_OnDeath2 = &ftDonkey_8010D774;
-    fighter->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-    fighter->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    Fighter* fp = fighterObj->user_data;
+    fp->cb.x21DC_callback_OnTakeDamage = &ftDonkey_8010D774;
+    fp->cb.x21E4_callback_OnDeath2 = &ftDonkey_8010D774;
+    fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
 }
 
 void ftDonkey_SpecialHi_StartAction(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fighter); 
+    Fighter* fp = getFighterPlus(fighterObj);
+    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp); 
     Fighter_ActionStateChange_800693AC(fighterObj, 0x17D, 0, NULL, 0.0f, 1.0f, 0.0f);
     ftDonkey_SetCallbacks_SpecialHi(fighterObj);
-    fighter->x220C_ftcmd_var3 = 0;
-    fighter->x2208_ftcmd_var2 = 0;
-    fighter->x2204_ftcmd_var1 = 0;
-    fighter->x2200_ftcmd_var0 = 0;
-    func_8007CC78(fighter, donkey_attr->SpecialHi.x54_GROUNDED_HORIZONTAL_VELOCITY);
-    fighter->x80_self_vel.x = fighter->xEC_ground_vel;
-    fighter->x80_self_vel.y = 0.0f;
-    fighter->x1968_jumpsUsed = fighter->x110_attr.x168_MaxJumps;
+    fp->x220C_ftcmd_var3 = 0;
+    fp->x2208_ftcmd_var2 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    func_8007CC78(fp, donkey_attr->SpecialHi.x54_GROUNDED_HORIZONTAL_VELOCITY);
+    fp->x80_self_vel.x = fp->xEC_ground_vel;
+    fp->x80_self_vel.y = 0.0f;
+    fp->x1968_jumpsUsed = fp->x110_attr.x168_MaxJumps;
     func_8006EBA4(fighterObj);
-    ef_Spawn(0x4CA, fighterObj, fighter->x5E8_fighterBones[0].x0_jobj);
+    ef_Spawn(0x4CA, fighterObj, fp->x5E8_fighterBones[0].x0_jobj);
 }
 
 void ftDonkey_SpecialAirHi_StartAction(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fighter); 
+    Fighter* fp = getFighterPlus(fighterObj);
+    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp); 
     Fighter_ActionStateChange_800693AC(fighterObj, 0x17E, 0, NULL, 0.0f, 1.0f, 0.0f);
     ftDonkey_SetCallbacks_SpecialHi(fighterObj);
-    fighter->x220C_ftcmd_var3 = 0;
-    fighter->x2208_ftcmd_var2 = 0;
-    fighter->x2204_ftcmd_var1 = 0;
-    fighter->x2200_ftcmd_var0 = 0;
-    func_8007D440(fighter, donkey_attr->SpecialHi.x54_GROUNDED_HORIZONTAL_VELOCITY);
-    fighter->x80_self_vel.y = donkey_attr->SpecialHi.x4C_AERIAL_VERTICAL_VELOCITY;
-    fighter->x1968_jumpsUsed = fighter->x110_attr.x168_MaxJumps;
+    fp->x220C_ftcmd_var3 = 0;
+    fp->x2208_ftcmd_var2 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    func_8007D440(fp, donkey_attr->SpecialHi.x54_GROUNDED_HORIZONTAL_VELOCITY);
+    fp->x80_self_vel.y = donkey_attr->SpecialHi.x4C_AERIAL_VERTICAL_VELOCITY;
+    fp->x1968_jumpsUsed = fp->x110_attr.x168_MaxJumps;
     func_8006EBA4(fighterObj);
-    ef_Spawn(0x4CA, fighterObj, fighter->x5E8_fighterBones[0].x0_jobj);
+    ef_Spawn(0x4CA, fighterObj, fp->x5E8_fighterBones[0].x0_jobj);
 }
 
 void ftDonkey_8010FCD4(HSD_GObj* fighterObj) {
@@ -48,11 +48,11 @@ void ftDonkey_8010FCD4(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_8010FD10(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
-    ftDonkeyAttributes* donkey_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = getFighterPlus(fighterObj);
+    ftDonkeyAttributes* donkey_attr = fp->x2D4_specialAttributes;
     
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
-        func_8007D60C(fighter);
+        func_8007D60C(fp);
         if (donkey_attr->SpecialHi.x64_LANDING_LAG == 0.0f) {
             func_800CC730(fighterObj); 
         } else {
@@ -66,56 +66,56 @@ void ftDonkey_8010FD9C(HSD_GObj* fighterObj) {}
 void ftDonkey_8010FDA0(HSD_GObj* fighterObj) {}
 
 void ftDonkey_8010FDA4(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fighter); 
-    func_8007CADC(fighter, 0.0f, donkey_attr->SpecialHi.x5C_GROUNDED_MOBILITY, donkey_attr->SpecialHi.x54_GROUNDED_HORIZONTAL_VELOCITY);
+    Fighter* fp = getFighter(fighterObj);
+    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp); 
+    func_8007CADC(fp, 0.0f, donkey_attr->SpecialHi.x5C_GROUNDED_MOBILITY, donkey_attr->SpecialHi.x54_GROUNDED_HORIZONTAL_VELOCITY);
     func_8007CB74(fighterObj);
 }
 
 void ftDonkey_8010FDEC(HSD_GObj* fighterObj) {
     s32 unused[2];  /// get inline break the regalloc, this seems cleanest
-    Fighter* fighter = fighterObj->user_data;
-    ftDonkeyAttributes* donkey_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftDonkeyAttributes* donkey_attr = fp->x2D4_specialAttributes;
     f32 gravity_scalar;
 
-    if (fighter->x2200_ftcmd_var0) {
+    if (fp->x2200_ftcmd_var0) {
         gravity_scalar = 1.0f;
     } else {
         gravity_scalar = donkey_attr->SpecialHi.x50_AERIAL_GRAVITY;
     }
-    func_8007D494(fighter, gravity_scalar * fighter->x110_attr.x16C_Gravity, fighter->x110_attr.x170_TerminalVelocity);
-    func_8007D344(fighter, 0.0f, donkey_attr->SpecialHi.x60_AERIAL_MOBILITY, donkey_attr->SpecialHi.x58_AERIAL_HORIZONTAL_VELOCITY);
+    func_8007D494(fp, gravity_scalar * fp->x110_attr.x16C_Gravity, fp->x110_attr.x170_TerminalVelocity);
+    func_8007D344(fp, 0.0f, donkey_attr->SpecialHi.x60_AERIAL_MOBILITY, donkey_attr->SpecialHi.x58_AERIAL_HORIZONTAL_VELOCITY);
 }
 
 void ftDonkey_8010FE60(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fighter); 
+    Fighter* fp = getFighter(fighterObj);
+    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp); 
     if (!func_80082708(fighterObj)) {
-        func_8007D60C(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x17E, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        func_8007D60C(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x17E, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftDonkey_SetCallbacks_SpecialHi(fighterObj);
-        func_8007D440(fighter, donkey_attr->SpecialHi.x58_AERIAL_HORIZONTAL_VELOCITY);
+        func_8007D440(fp, donkey_attr->SpecialHi.x58_AERIAL_HORIZONTAL_VELOCITY);
     } 
 }
 
 void ftDonkey_8010FF14(HSD_GObj* fighterObj) {
     s32 unused[2]; /// get inline break the regalloc, this seems cleanest
-    Fighter* fighter = fighterObj->user_data;
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fighter); 
+    Fighter* fp = fighterObj->user_data;
+    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp); 
     
-    if (fighter->x80_self_vel.y >= 0.0f) {
+    if (fp->x80_self_vel.y >= 0.0f) {
         if (func_80081D0C(fighterObj)) {
-            func_8007D7FC(fighter);
-            Fighter_ActionStateChange_800693AC(fighterObj, 0x17D, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+            func_8007D7FC(fp);
+            Fighter_ActionStateChange_800693AC(fighterObj, 0x17D, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
             ftDonkey_SetCallbacks_SpecialHi(fighterObj);
-            func_8007CC78(fighter, donkey_attr->SpecialHi.x54_GROUNDED_HORIZONTAL_VELOCITY);
+            func_8007CC78(fp, donkey_attr->SpecialHi.x54_GROUNDED_HORIZONTAL_VELOCITY);
         }
     } else {
         if (EnvColl_CheckGroundAndLedge(fighterObj, 0)) {
-            func_8007D7FC(fighter);
-            Fighter_ActionStateChange_800693AC(fighterObj, 0x17D, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+            func_8007D7FC(fp);
+            Fighter_ActionStateChange_800693AC(fighterObj, 0x17D, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
             ftDonkey_SetCallbacks_SpecialHi(fighterObj);
-            func_8007CC78(fighter, donkey_attr->SpecialHi.x54_GROUNDED_HORIZONTAL_VELOCITY);
+            func_8007CC78(fp, donkey_attr->SpecialHi.x54_GROUNDED_HORIZONTAL_VELOCITY);
         } else if (func_80081298(fighterObj)) {
             func_80081370(fighterObj);
         }

--- a/src/melee/ft/chara/ftDonkey/ftdonkey_SpecialLw.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey_SpecialLw.c
@@ -1,8 +1,8 @@
 #include <ftdonkey.h>
 
 void ftDonkey_SpecialLw_StartAction(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    fighter->x2340_stateVar1 = 0;
+    Fighter* fp = getFighter(fighterObj);
+    fp->x2340_stateVar1 = 0;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x17F, 0, NULL, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(fighterObj);
 }
@@ -27,10 +27,10 @@ void ftDonkey_8010DD38(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_8010DD74(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
-        if (fighter->x2340_stateVar1) {
-            fighter->x2340_stateVar1 = 0;
+        if (fp->x2340_stateVar1) {
+            fp->x2340_stateVar1 = 0;
             ftDonkey_8010DE88(fighterObj);
         } else {
             ftDonkey_8010DFF8(fighterObj);
@@ -39,9 +39,9 @@ void ftDonkey_8010DD74(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_8010DDDC(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    if (fighter->input.x668 & 0x200) {
-        fighter->x2340_stateVar1 = 1;
+    Fighter* fp = fighterObj->user_data;
+    if (fp->input.x668 & 0x200) {
+        fp->x2340_stateVar1 = 1;
     }
 }
 
@@ -61,22 +61,22 @@ void ftDonkey_8010DE54(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_8010DE88_inner(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
-    if (!fighter->x2219_flag.bits.b0) {
-        efAsync_Spawn(fighterObj, &fighter->x60C, 1, 0x4CC, fighter->x5E8_fighterBones[0].x0_jobj);
-        fighter->x2219_flag.bits.b0 = 1;
+    Fighter* fp = getFighterPlus(fighterObj);
+    if (!fp->x2219_flag.bits.b0) {
+        efAsync_Spawn(fighterObj, &fp->x60C, 1, 0x4CC, fp->x5E8_fighterBones[0].x0_jobj);
+        fp->x2219_flag.bits.b0 = 1;
     }
-    fighter->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-    fighter->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
 }
 
 void ftDonkey_8010DE88(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    fighter->cb.x21EC_callback = &ftDonkey_8010DE54;
-    fighter->x2210_ThrowFlags.flags = 0;
+    Fighter* fp = fighterObj->user_data;
+    fp->cb.x21EC_callback = &ftDonkey_8010DE54;
+    fp->x2210_ThrowFlags.flags = 0;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x180, 0, NULL, 0.0f, 1.0f, 0.0f);
     ftDonkey_8010DE88_inner(fighterObj);
-    fighter->cb.x21BC_callback_Accessory4 = &ftDonkey_8010DB3C;
+    fp->cb.x21BC_callback_Accessory4 = &ftDonkey_8010DB3C;
 }
 
 void ftDonkey_8010DF5C(HSD_GObj* fighterObj) {
@@ -121,23 +121,23 @@ void ftDonkey_8010E090(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_8010E0CC(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    if (!fighter->x2219_flag.bits.b0) {
-        ef_Spawn(0x4C6, fighterObj, fighter->x5E8_fighterBones[1].x0_jobj);
-        fighter->x2219_flag.bits.b0 = 1;
+    Fighter* fp = getFighter(fighterObj);
+    if (!fp->x2219_flag.bits.b0) {
+        ef_Spawn(0x4C6, fighterObj, fp->x5E8_fighterBones[1].x0_jobj);
+        fp->x2219_flag.bits.b0 = 1;
     }
-    fighter->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-    fighter->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
-    fighter->cb.x21BC_callback_Accessory4 = 0;
+    fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    fp->cb.x21BC_callback_Accessory4 = 0;
 }
 
 void ftDonkey_8010E148(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    if (!fighter->x2219_flag.bits.b0) {
-        ef_Spawn(0x4C7, fighterObj, fighter->x5E8_fighterBones[1].x0_jobj);
-        fighter->x2219_flag.bits.b0 = 1;
+    Fighter* fp = getFighter(fighterObj);
+    if (!fp->x2219_flag.bits.b0) {
+        ef_Spawn(0x4C7, fighterObj, fp->x5E8_fighterBones[1].x0_jobj);
+        fp->x2219_flag.bits.b0 = 1;
     }
-    fighter->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-    fighter->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
-    fighter->cb.x21BC_callback_Accessory4 = 0;
+    fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    fp->cb.x21BC_callback_Accessory4 = 0;
 }

--- a/src/melee/ft/chara/ftDonkey/ftdonkey_SpecialN.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey_SpecialN.c
@@ -1,68 +1,68 @@
 #include <ftdonkey.h>
 
 void ftDonkey_SetCallbacks_SpecialN(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    fighter->cb.x21DC_callback_OnTakeDamage = &ftDonkey_8010D774;
-    fighter->cb.x21E4_callback_OnDeath2 = &ftDonkey_8010D774;
-    fighter->cb.x21F0_callback = &ftDonkey_DestroyAllEffects;
-    fighter->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-    fighter->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    Fighter* fp = fighterObj->user_data;
+    fp->cb.x21DC_callback_OnTakeDamage = &ftDonkey_8010D774;
+    fp->cb.x21E4_callback_OnDeath2 = &ftDonkey_8010D774;
+    fp->cb.x21F0_callback = &ftDonkey_DestroyAllEffects;
+    fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
 }
 
 void ftDonkey_UpdateDKVelocityAfterPunch(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fighter); 
-    fighter->xEC_ground_vel = fighter->x2C_facing_direction * (donkey_attr->SpecialN.x34_PUNCH_HORIZONTAL_VEL * fighter->x234C_stateVar4_s32);
+    Fighter* fp = fighterObj->user_data;
+    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp); 
+    fp->xEC_ground_vel = fp->x2C_facing_direction * (donkey_attr->SpecialN.x34_PUNCH_HORIZONTAL_VEL * fp->x234C_stateVar4_s32);
 }
 
 void ftDonkey_SpecialN_StartAction(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fighter); 
-    if ( fighter->sa.dk.x222C == donkey_attr->SpecialN.x2C_MAX_ARM_SWINGS) {
+    Fighter* fp = getFighter(fighterObj);
+    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp); 
+    if ( fp->sa.dk.x222C == donkey_attr->SpecialN.x2C_MAX_ARM_SWINGS) {
         Fighter_ActionStateChange_800693AC(fighterObj, 0x175, 0, NULL, 0.0f, 1.0f, 0.0f);
-        fighter->x2348_stateVar3 = 1;
-        fighter->x234C_stateVar4 = fighter->sa.dk.x222C;
-        fighter->sa.dk.x222C = 0;
+        fp->x2348_stateVar3 = 1;
+        fp->x234C_stateVar4 = fp->sa.dk.x222C;
+        fp->sa.dk.x222C = 0;
     } else {
         Fighter_ActionStateChange_800693AC(fighterObj, 0x171, 0, NULL, 0.0f, 1.0f, 0.0f);
-        fighter->x2348_stateVar3 = 0;
-        fighter->x234C_stateVar4 = 0;
+        fp->x2348_stateVar3 = 0;
+        fp->x234C_stateVar4 = 0;
     }
-    fighter->x220C_ftcmd_var3 = 0;
-    fighter->x2208_ftcmd_var2 = 0;
-    fighter->x2204_ftcmd_var1 = 0;
-    fighter->x2200_ftcmd_var0 = 0;
-    fighter->x2340_stateVar1 = 0;
-    fighter->x2344_stateVar2 = 0;
-    fighter->x2354_stateVar6 = -1; 
-    fighter->x2350_stateVar5_s32 = -1;
-    func_8007D7FC(fighter);
-    fighter->x80_self_vel.y = 0.0f;
+    fp->x220C_ftcmd_var3 = 0;
+    fp->x2208_ftcmd_var2 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2340_stateVar1 = 0;
+    fp->x2344_stateVar2 = 0;
+    fp->x2354_stateVar6 = -1; 
+    fp->x2350_stateVar5_s32 = -1;
+    func_8007D7FC(fp);
+    fp->x80_self_vel.y = 0.0f;
     ftDonkey_SetCallbacks_SpecialN(fighterObj);
     func_8006EBA4(fighterObj);
 }
 
 void ftDonkey_SpecialAirN_StartAction(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fighter); 
-    if (fighter->sa.dk.x222C == donkey_attr->SpecialN.x2C_MAX_ARM_SWINGS) {
+    Fighter* fp = getFighter(fighterObj);
+    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp); 
+    if (fp->sa.dk.x222C == donkey_attr->SpecialN.x2C_MAX_ARM_SWINGS) {
         Fighter_ActionStateChange_800693AC(fighterObj, 0x17A, 0, NULL, 0.0f, 1.0f, 0.0f);
-        fighter->x2348_stateVar3 = 1;
-        fighter->x234C_stateVar4 = fighter->sa.dk.x222C;
-        fighter->sa.dk.x222C = 0;
+        fp->x2348_stateVar3 = 1;
+        fp->x234C_stateVar4 = fp->sa.dk.x222C;
+        fp->sa.dk.x222C = 0;
     } else {
         Fighter_ActionStateChange_800693AC(fighterObj, 0x176, 0, NULL, 0.0f, 1.0f, 0.0f);
-        fighter->x2348_stateVar3 = 0;
-        fighter->x234C_stateVar4 = 0;
+        fp->x2348_stateVar3 = 0;
+        fp->x234C_stateVar4 = 0;
     }
-    fighter->x220C_ftcmd_var3 = 0;
-    fighter->x2208_ftcmd_var2 = 0;
-    fighter->x2204_ftcmd_var1 = 0;
-    fighter->x2200_ftcmd_var0 = 0;
-    fighter->x2340_stateVar1 = 0;
-    fighter->x2344_stateVar2 = 0;
-    fighter->x2354_stateVar6 = -1; 
-    fighter->x2350_stateVar5_s32 = -1;
+    fp->x220C_ftcmd_var3 = 0;
+    fp->x2208_ftcmd_var2 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2340_stateVar1 = 0;
+    fp->x2344_stateVar2 = 0;
+    fp->x2354_stateVar6 = -1; 
+    fp->x2350_stateVar5_s32 = -1;
 
     ftDonkey_SetCallbacks_SpecialN(fighterObj);
     func_8006EBA4(fighterObj);
@@ -76,21 +76,21 @@ void ftDonkey_8010E7B4(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_NullCallbacks(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    fighter->cb.x21F0_callback = 0;
-    fighter->cb.x21D4_callback_EnterHitlag = 0;
-    fighter->cb.x21D8_callback_ExitHitlag = 0;
+    Fighter* fp = getFighter(fighterObj);
+    fp->cb.x21F0_callback = 0;
+    fp->cb.x21D4_callback_EnterHitlag = 0;
+    fp->cb.x21D8_callback_ExitHitlag = 0;
 }
 
 
 void ftDonkey_8010E840(HSD_GObj *fighterObj)
 {
-    Fighter *fighter = getFighter(fighterObj);
-    ftDonkeyAttributes* donkey_attr = fighter->x2D4_specialAttributes;
-    if (0.0f == fighter->x894_currentAnimFrame) {
-        fighter->sa.dk.x222C += 1;
-        if (fighter->sa.dk.x222C >= donkey_attr->SpecialN.x2C_MAX_ARM_SWINGS) {
-            Fighter *fighter2 = fighter;
+    Fighter *fp = getFighter(fighterObj);
+    ftDonkeyAttributes* donkey_attr = fp->x2D4_specialAttributes;
+    if (0.0f == fp->x894_currentAnimFrame) {
+        fp->sa.dk.x222C += 1;
+        if (fp->sa.dk.x222C >= donkey_attr->SpecialN.x2C_MAX_ARM_SWINGS) {
+            Fighter *fighter2 = fp;
             func_800BFFD0(fighter2, 0x39, 0);
             fighter2->sa.dk.x222C = donkey_attr->SpecialN.x2C_MAX_ARM_SWINGS;
             ftDonkey_NullCallbacks(fighterObj);
@@ -107,72 +107,72 @@ void ftDonkey_8010E8E0(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_8010E930(HSD_GObj* fighterObj) {
-    Fighter *fighter = getFighter(fighterObj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fighter); 
+    Fighter *fp = getFighter(fighterObj);
+    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp); 
     
-    if (fighter->x2200_ftcmd_var0) {
-        if (fighter->x2348_stateVar3_s32 == 0) {
-            fighter->x2348_stateVar3_s32++;
+    if (fp->x2200_ftcmd_var0) {
+        if (fp->x2348_stateVar3_s32 == 0) {
+            fp->x2348_stateVar3_s32++;
         }
     }
-    if (fighter->x2348_stateVar3_s32 == 1) {
-        fighter->x2348_stateVar3_s32++;
-        if (fighter->xE0_ground_or_air == GA_Air) {
-            ef_Spawn(0x4C9, fighterObj, fighter->x5E8_fighterBones[0].x0_jobj, &fighter->x2C_facing_direction);
+    if (fp->x2348_stateVar3_s32 == 1) {
+        fp->x2348_stateVar3_s32++;
+        if (fp->xE0_ground_or_air == GA_Air) {
+            ef_Spawn(0x4C9, fighterObj, fp->x5E8_fighterBones[0].x0_jobj, &fp->x2C_facing_direction);
         } else {
-            ef_Spawn(0x4C8, fighterObj, fighter->x5E8_fighterBones[0].x0_jobj, &fighter->x2C_facing_direction);
+            ef_Spawn(0x4C8, fighterObj, fp->x5E8_fighterBones[0].x0_jobj, &fp->x2C_facing_direction);
         }
     }
-    if (fighter->x914[0].x0) {
-        if (fighter->x2344_stateVar2_s32 == 0) {
-            fighter->x2344_stateVar2_s32 = 1;
+    if (fp->x914[0].x0) {
+        if (fp->x2344_stateVar2_s32 == 0) {
+            fp->x2344_stateVar2_s32 = 1;
         }
-        if (fighter->x2350_stateVar5_s32 == -1) {
-            fighter->x2350_stateVar5_s32 = fighter->x914[0].xC; 
+        if (fp->x2350_stateVar5_s32 == -1) {
+            fp->x2350_stateVar5_s32 = fp->x914[0].xC; 
         }
-        func_8007ABD0(&fighter->x914[0], fighter->x2350_stateVar5_s32 + (fighter->x234C_stateVar4_s32 * donkey_attr->SpecialN.x30_DAMAGE_PER_SWING), fighterObj);
-        if (fighter->x2354_stateVar6_s32 == -1) {
-            fighter->x2354_stateVar6_s32 = fighter->x914[1].xC;
+        func_8007ABD0(&fp->x914[0], fp->x2350_stateVar5_s32 + (fp->x234C_stateVar4_s32 * donkey_attr->SpecialN.x30_DAMAGE_PER_SWING), fighterObj);
+        if (fp->x2354_stateVar6_s32 == -1) {
+            fp->x2354_stateVar6_s32 = fp->x914[1].xC;
         }
-        func_8007ABD0(&fighter->x914[1], fighter->x2354_stateVar6_s32 + (fighter->x234C_stateVar4_s32 * donkey_attr->SpecialN.x30_DAMAGE_PER_SWING), fighterObj);
+        func_8007ABD0(&fp->x914[1], fp->x2354_stateVar6_s32 + (fp->x234C_stateVar4_s32 * donkey_attr->SpecialN.x30_DAMAGE_PER_SWING), fighterObj);
     }
-    if (fighter->x2344_stateVar2_s32 == 1) {
-        fighter->x2344_stateVar2_s32 = 2;
+    if (fp->x2344_stateVar2_s32 == 1) {
+        fp->x2344_stateVar2_s32 = 2;
         ftDonkey_UpdateDKVelocityAfterPunch(fighterObj);
     }
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
-        fighter->sa.dk.x222C = 0;
+        fp->sa.dk.x222C = 0;
         ftDonkey_NullCallbacks(fighterObj);
         func_8008A2BC(fighterObj);
     }
 }
 
 void ftDonkey_8010EB0C(HSD_GObj* fighterObj) {
-    Fighter *fighter = getFighter(fighterObj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fighter); 
+    Fighter *fp = getFighter(fighterObj);
+    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp); 
     
-    if (fighter->x2200_ftcmd_var0) {
-        if (fighter->x2348_stateVar3_s32 == 0) {
-            fighter->x2348_stateVar3_s32++;
+    if (fp->x2200_ftcmd_var0) {
+        if (fp->x2348_stateVar3_s32 == 0) {
+            fp->x2348_stateVar3_s32++;
         }
     }
-    if (fighter->x2348_stateVar3_s32 == 1) {
-        fighter->x2348_stateVar3_s32++;
-        if (fighter->xE0_ground_or_air == GA_Air) {
-            ef_Spawn(0x4C9, fighterObj, fighter->x5E8_fighterBones[0].x0_jobj, &fighter->x2C_facing_direction);
+    if (fp->x2348_stateVar3_s32 == 1) {
+        fp->x2348_stateVar3_s32++;
+        if (fp->xE0_ground_or_air == GA_Air) {
+            ef_Spawn(0x4C9, fighterObj, fp->x5E8_fighterBones[0].x0_jobj, &fp->x2C_facing_direction);
         } else {
-            ef_Spawn(0x4C8, fighterObj, fighter->x5E8_fighterBones[0].x0_jobj, &fighter->x2C_facing_direction);
+            ef_Spawn(0x4C8, fighterObj, fp->x5E8_fighterBones[0].x0_jobj, &fp->x2C_facing_direction);
         }
     }
-    if (fighter->x914[0].x0 && (fighter->x2344_stateVar2_s32 == 0)) {
-        fighter->x2344_stateVar2_s32 = 1;
+    if (fp->x914[0].x0 && (fp->x2344_stateVar2_s32 == 0)) {
+        fp->x2344_stateVar2_s32 = 1;
     }
-    if (fighter->x2344_stateVar2_s32 == 1) {
-        fighter->x2344_stateVar2_s32 = 2;
+    if (fp->x2344_stateVar2_s32 == 1) {
+        fp->x2344_stateVar2_s32 = 2;
         ftDonkey_UpdateDKVelocityAfterPunch(fighterObj);
     }
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
-        fighter->sa.dk.x222C = 0;
+        fp->sa.dk.x222C = 0;
         ftDonkey_NullCallbacks(fighterObj);
         func_8008A2BC(fighterObj);
     }
@@ -186,15 +186,15 @@ void ftDonkey_8010EC5C(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_8010ECE8(HSD_GObj* fighterObj) {
-    Fighter *fighter = getFighter(fighterObj);
-    ftDonkeyAttributes* donkey_attr = fighter->x2D4_specialAttributes;
+    Fighter *fp = getFighter(fighterObj);
+    ftDonkeyAttributes* donkey_attr = fp->x2D4_specialAttributes;
     
-    if (fighter->x894_currentAnimFrame == 0.0f) {
-        fighter->sa.dk.x222C += 1;
-        if (fighter->sa.dk.x222C >= donkey_attr->SpecialN.x2C_MAX_ARM_SWINGS) {
-            Fighter *fighter2 = fighter;
+    if (fp->x894_currentAnimFrame == 0.0f) {
+        fp->sa.dk.x222C += 1;
+        if (fp->sa.dk.x222C >= donkey_attr->SpecialN.x2C_MAX_ARM_SWINGS) {
+            Fighter *fighter2 = fp;
             func_800BFFD0(fighter2, 0x39, 0);
-            fighter->sa.dk.x222C = donkey_attr->SpecialN.x2C_MAX_ARM_SWINGS;
+            fp->sa.dk.x222C = donkey_attr->SpecialN.x2C_MAX_ARM_SWINGS;
             ftDonkey_NullCallbacks(fighterObj);
             func_800CC730(fighterObj);
         }
@@ -210,36 +210,36 @@ void ftDonkey_8010ED88(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_8010EDD8(HSD_GObj* fighterObj) {
-    Fighter *fighter = getFighterPlus(fighterObj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fighter); 
+    Fighter *fp = getFighterPlus(fighterObj);
+    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp); 
     
-    if (fighter->x2200_ftcmd_var0) {
-        if (fighter->x2348_stateVar3_s32 == 0) {
-            fighter->x2348_stateVar3_s32++;
+    if (fp->x2200_ftcmd_var0) {
+        if (fp->x2348_stateVar3_s32 == 0) {
+            fp->x2348_stateVar3_s32++;
         }
     }
-    if (fighter->x2348_stateVar3_s32 == 1) {
-        fighter->x2348_stateVar3_s32++;
-        if (fighter->xE0_ground_or_air == GA_Air) {
-            ef_Spawn(0x4C9, fighterObj, fighter->x5E8_fighterBones[0].x0_jobj, &fighter->x2C_facing_direction);
+    if (fp->x2348_stateVar3_s32 == 1) {
+        fp->x2348_stateVar3_s32++;
+        if (fp->xE0_ground_or_air == GA_Air) {
+            ef_Spawn(0x4C9, fighterObj, fp->x5E8_fighterBones[0].x0_jobj, &fp->x2C_facing_direction);
         } else {
-            ef_Spawn(0x4C8, fighterObj, fighter->x5E8_fighterBones[0].x0_jobj, &fighter->x2C_facing_direction);
+            ef_Spawn(0x4C8, fighterObj, fp->x5E8_fighterBones[0].x0_jobj, &fp->x2C_facing_direction);
         }
     }
-    if (fighter->x914[0].x0) {
+    if (fp->x914[0].x0) {
 
-        if (fighter->x2350_stateVar5_s32 == -1) {
-            fighter->x2350_stateVar5_s32 = fighter->x914[0].xC; 
+        if (fp->x2350_stateVar5_s32 == -1) {
+            fp->x2350_stateVar5_s32 = fp->x914[0].xC; 
         }
-        func_8007ABD0(&fighter->x914[0], fighter->x2350_stateVar5_s32 + (fighter->x234C_stateVar4_s32 * donkey_attr->SpecialN.x30_DAMAGE_PER_SWING), fighterObj);
-        if (fighter->x2354_stateVar6_s32 == -1) {
-            fighter->x2354_stateVar6_s32 = fighter->x914[1].xC;
+        func_8007ABD0(&fp->x914[0], fp->x2350_stateVar5_s32 + (fp->x234C_stateVar4_s32 * donkey_attr->SpecialN.x30_DAMAGE_PER_SWING), fighterObj);
+        if (fp->x2354_stateVar6_s32 == -1) {
+            fp->x2354_stateVar6_s32 = fp->x914[1].xC;
         }
-        func_8007ABD0(&fighter->x914[1], fighter->x2354_stateVar6_s32 + (fighter->x234C_stateVar4_s32 * donkey_attr->SpecialN.x30_DAMAGE_PER_SWING), fighterObj);
+        func_8007ABD0(&fp->x914[1], fp->x2354_stateVar6_s32 + (fp->x234C_stateVar4_s32 * donkey_attr->SpecialN.x30_DAMAGE_PER_SWING), fighterObj);
     }
 
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
-        fighter->sa.dk.x222C = 0;
+        fp->sa.dk.x222C = 0;
         ftDonkey_NullCallbacks(fighterObj);
         if (donkey_attr->SpecialN.x38_LANDING_LAG == 0.0f) {
             func_800CC730(fighterObj);
@@ -250,26 +250,26 @@ void ftDonkey_8010EDD8(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_8010EF7C(HSD_GObj* fighterObj) {
-    Fighter *fighter = getFighterPlus(fighterObj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fighter); 
+    Fighter *fp = getFighterPlus(fighterObj);
+    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp); 
     
-    if (fighter->x2200_ftcmd_var0) {
-        if (fighter->x2348_stateVar3_s32 == 0) {
-            fighter->x2348_stateVar3_s32++;
+    if (fp->x2200_ftcmd_var0) {
+        if (fp->x2348_stateVar3_s32 == 0) {
+            fp->x2348_stateVar3_s32++;
         }
     }
     
-    if (fighter->x2348_stateVar3_s32 == 1) {
-        fighter->x2348_stateVar3_s32++;
-        if (fighter->xE0_ground_or_air == GA_Air) {
-            ef_Spawn(0x4C9, fighterObj, fighter->x5E8_fighterBones[0].x0_jobj, &fighter->x2C_facing_direction);
+    if (fp->x2348_stateVar3_s32 == 1) {
+        fp->x2348_stateVar3_s32++;
+        if (fp->xE0_ground_or_air == GA_Air) {
+            ef_Spawn(0x4C9, fighterObj, fp->x5E8_fighterBones[0].x0_jobj, &fp->x2C_facing_direction);
         } else {
-            ef_Spawn(0x4C8, fighterObj, fighter->x5E8_fighterBones[0].x0_jobj, &fighter->x2C_facing_direction);
+            ef_Spawn(0x4C8, fighterObj, fp->x5E8_fighterBones[0].x0_jobj, &fp->x2C_facing_direction);
         }
     }
     
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
-        fighter->sa.dk.x222C = 0;
+        fp->sa.dk.x222C = 0;
         ftDonkey_NullCallbacks(fighterObj);
         if (donkey_attr->SpecialN.x38_LANDING_LAG == 0.0f) {
             func_800CC730(fighterObj);
@@ -283,19 +283,19 @@ void ftDonkey_8010F094(HSD_GObj* fighterObj) {}
 
 void ftDonkey_8010F098(HSD_GObj* fighterObj) {
     s32 unused[2]; 
-    Fighter* fighter = getFighterPlus(fighterObj);
+    Fighter* fp = getFighterPlus(fighterObj);
     if (!func_8009917C(fighterObj)) {
-        if ((fighter->input.x668 & 0x200)) {
+        if ((fp->input.x668 & 0x200)) {
             Fighter_ActionStateChange_800693AC(fighterObj, 0x174, 0, NULL, 0.0f, 1.0f, 0.0f);
-            fighter->x234C_stateVar4_s32 = fighter->sa.dk.x222C;
-            fighter->sa.dk.x222C = 0;
+            fp->x234C_stateVar4_s32 = fp->sa.dk.x222C;
+            fp->sa.dk.x222C = 0;
             ftDonkey_SetCallbacks_SpecialN(fighterObj);
             func_8006EBA4(fighterObj);
         }
-        if ((fighter->input.x668 & 0x80000000)) {
-            fighter->x2340_stateVar1 = 1;
+        if ((fp->input.x668 & 0x80000000)) {
+            fp->x2340_stateVar1 = 1;
         }
-        if ((fighter->x894_currentAnimFrame == 0.0f) && (fighter->x2340_stateVar1)) {
+        if ((fp->x894_currentAnimFrame == 0.0f) && (fp->x2340_stateVar1)) {
             Fighter_ActionStateChange_800693AC(fighterObj, 0x173, 0, NULL, 0.0f, 1.0f, 0.0f);
             ftDonkey_SetCallbacks_SpecialN(fighterObj);
         }
@@ -312,18 +312,18 @@ void ftDonkey_8010F1E4(HSD_GObj* fighterObj) {}
 
 void ftDonkey_8010F1E8(HSD_GObj* fighterObj) {
     s32 unused[2]; 
-    Fighter* fighter = getFighterPlus(fighterObj);
-    if ((fighter->input.x668 & 0x200)) {
+    Fighter* fp = getFighterPlus(fighterObj);
+    if ((fp->input.x668 & 0x200)) {
         Fighter_ActionStateChange_800693AC(fighterObj, 0x179, 0, NULL, 0.0f, 1.0f, 0.0f);
-        fighter->x234C_stateVar4_s32 = fighter->sa.dk.x222C;
-        fighter->sa.dk.x222C = 0;
+        fp->x234C_stateVar4_s32 = fp->sa.dk.x222C;
+        fp->sa.dk.x222C = 0;
         ftDonkey_SetCallbacks_SpecialN(fighterObj);
         func_8006EBA4(fighterObj);
     }
-    if ((fighter->input.x668 & 0x80000000)) {
-        fighter->x2340_stateVar1 = 1;
+    if ((fp->input.x668 & 0x80000000)) {
+        fp->x2340_stateVar1 = 1;
     }
-    if ((fighter->x894_currentAnimFrame == 0.0f) && (fighter->x2340_stateVar1)) {
+    if ((fp->x894_currentAnimFrame == 0.0f) && (fp->x2340_stateVar1)) {
         Fighter_ActionStateChange_800693AC(fighterObj, 0x178, 0, NULL, 0.0f, 1.0f, 0.0f);
         ftDonkey_SetCallbacks_SpecialN(fighterObj);
     }
@@ -377,93 +377,93 @@ void ftDonkey_8010F448(HSD_GObj* fighterObj) {
 
 
 void ftDonkey_8010F468(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
+    Fighter* fp = getFighterPlus(fighterObj);
     if (!func_80082708(fighterObj)) {
-        func_8007D5D4(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x176, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        func_8007D5D4(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x176, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftDonkey_SetCallbacks_SpecialN(fighterObj);
     }
 }
 
 void ftDonkey_8010F50C(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
+    Fighter* fp = getFighterPlus(fighterObj);
     if (!func_80082708(fighterObj)) {
-        func_8007D5D4(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x177, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        func_8007D5D4(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x177, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftDonkey_SetCallbacks_SpecialN(fighterObj);
     }
 }
 
 void ftDonkey_8010F5B0(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
+    Fighter* fp = getFighterPlus(fighterObj);
     if (!func_80082708(fighterObj)) {
-        func_8007D5D4(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x178, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        func_8007D5D4(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x178, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftDonkey_SetCallbacks_SpecialN(fighterObj);
     }
 }
 
 void ftDonkey_8010F654(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
+    Fighter* fp = getFighterPlus(fighterObj);
     if (func_800827A0(fighterObj) == 0) {
-        func_8007D5D4(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x179, 0x0C4D508E, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        func_8007D5D4(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x179, 0x0C4D508E, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftDonkey_SetCallbacks_SpecialN(fighterObj);
     }
 }
 
 void ftDonkey_8010F6F8(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
+    Fighter* fp = getFighterPlus(fighterObj);
     if (func_800827A0(fighterObj) == 0) {
-        func_8007D5D4(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x17A, 0x0C4D508E, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        func_8007D5D4(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x17A, 0x0C4D508E, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftDonkey_SetCallbacks_SpecialN(fighterObj);
     }
 }
 
 void ftDonkey_8010F79C(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
+    Fighter* fp = getFighterPlus(fighterObj);
     if (func_80081D0C(fighterObj) == 1) {
-        func_8007D7FC(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x171, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        func_8007D7FC(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x171, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftDonkey_SetCallbacks_SpecialN(fighterObj);
     }
 }
 
 void ftDonkey_8010F840(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
+    Fighter* fp = getFighterPlus(fighterObj);
     if (func_80081D0C(fighterObj) == 1) {
-        func_8007D7FC(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x172, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        func_8007D7FC(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x172, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftDonkey_SetCallbacks_SpecialN(fighterObj);
     }
 }
 
 
 void ftDonkey_8010F8E4(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
+    Fighter* fp = getFighterPlus(fighterObj);
     if (func_80081D0C(fighterObj) == 1) {
-        func_8007D7FC(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x173, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        func_8007D7FC(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x173, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftDonkey_SetCallbacks_SpecialN(fighterObj);
     }
 }
 
 
 void ftDonkey_8010F988(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
+    Fighter* fp = getFighterPlus(fighterObj);
     if (func_80081D0C(fighterObj)) {
-        func_8007D7FC(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x174, 0x0C4D508E, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        func_8007D7FC(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x174, 0x0C4D508E, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftDonkey_SetCallbacks_SpecialN(fighterObj);
     }
 }
 
 void ftDonkey_8010FA2C(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
+    Fighter* fp = getFighterPlus(fighterObj);
     if (func_80081D0C(fighterObj)) {
-        func_8007D7FC(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x175, 0x0C4D508E, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        func_8007D7FC(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x175, 0x0C4D508E, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftDonkey_SetCallbacks_SpecialN(fighterObj);
     }
 }
@@ -473,7 +473,7 @@ void ftDonkey_DestroyAllEffects(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_DestroyAllEffectsPlus(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    fighter->sa.dk.x222C = 0;
+    Fighter* fp = fighterObj->user_data;
+    fp->sa.dk.x222C = 0;
     efLib_DestroyAll(fighterObj);
 }

--- a/src/melee/ft/chara/ftDonkey/ftdonkey_SpecialS.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey_SpecialS.c
@@ -1,22 +1,22 @@
 #include <ftdonkey.h>
 
 void ftDonkey_SpecialS_StartAction(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
+    Fighter* fp = getFighterPlus(fighterObj);
     Fighter_ActionStateChange_800693AC(fighterObj, 0x17B, 0, NULL, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(fighterObj);
     Fighter_UnsetCmdVar0(fighterObj);
-    fighter->cb.x21BC_callback_Accessory4 = &ftDonkey_8010E0CC;
+    fp->cb.x21BC_callback_Accessory4 = &ftDonkey_8010E0CC;
 }
 
 void ftDonkey_SpecialAirS_StartAction(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    ftDonkeyAttributes* donkey_attr = fighter->x2D4_specialAttributes;
-    fighter->x80_self_vel.x /= donkey_attr->SpecialS.x3C_MIN_STICK_X_MOMENTUM;
-    fighter->x80_self_vel.y = 0.0f;
+    Fighter* fp = getFighter(fighterObj);
+    ftDonkeyAttributes* donkey_attr = fp->x2D4_specialAttributes;
+    fp->x80_self_vel.x /= donkey_attr->SpecialS.x3C_MIN_STICK_X_MOMENTUM;
+    fp->x80_self_vel.y = 0.0f;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x17C, 0, NULL, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(fighterObj);
     Fighter_UnsetCmdVar0(fighterObj);
-    fighter->cb.x21BC_callback_Accessory4 = &ftDonkey_8010E148;
+    fp->cb.x21BC_callback_Accessory4 = &ftDonkey_8010E148;
 }
 
 void ftDonkey_8010E2BC(HSD_GObj* fighterObj) {
@@ -41,21 +41,21 @@ void ftDonkey_8010E33C(HSD_GObj* fighterObj) {
 
 void ftDonkey_8010E35C(HSD_GObj* fighterObj)
 {
-    Fighter *fighter = getFighter(fighterObj);
-    attr *ft_attr = &fighter->x110_attr;
-    ftDonkeyAttributes *donkey_attr = getFtSpecialAttrs(fighter);
-    if (fighter->x2200_ftcmd_var0) {
-        func_8007D494(fighter, donkey_attr->SpecialS.x44_AERIAL_GRAVITY, ft_attr->x170_TerminalVelocity);
+    Fighter *fp = getFighter(fighterObj);
+    attr *ft_attr = &fp->x110_attr;
+    ftDonkeyAttributes *donkey_attr = getFtSpecialAttrs(fp);
+    if (fp->x2200_ftcmd_var0) {
+        func_8007D494(fp, donkey_attr->SpecialS.x44_AERIAL_GRAVITY, ft_attr->x170_TerminalVelocity);
     }
-    func_8007CE94(fighter, donkey_attr->SpecialS.x40_MOMENTUM_TRANSITION_MODIFIER);
-    if (fighter->x2200_ftcmd_var0 != 0){
+    func_8007CE94(fp, donkey_attr->SpecialS.x40_MOMENTUM_TRANSITION_MODIFIER);
+    if (fp->x2200_ftcmd_var0 != 0){
         /// unused or removed code here
     }
 }
 
 void ftDonkey_8010E3BC(HSD_GObj* fighterObj) {
-    Fighter *fighter = getFighter(fighterObj);
-    if (fighter->x2200_ftcmd_var0) {
+    Fighter *fp = getFighter(fighterObj);
+    if (fp->x2200_ftcmd_var0) {
         if (!func_800827A0(fighterObj)) {
             ftDonkey_8010E464(fighterObj);
         }
@@ -71,21 +71,21 @@ void ftDonkey_8010E428(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_8010E464(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D5D4(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x17C, 0x0C4C508A, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
-    if (fighter->x2219_flag.bits.b0 == 1) {
-        fighter->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-        fighter->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    Fighter* fp = fighterObj->user_data;
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x17C, 0x0C4C508A, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
+    if (fp->x2219_flag.bits.b0 == 1) {
+        fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+        fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
     }
 }
 
 void ftDonkey_8010E4EC(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D7FC(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x17B, 0x0C4C508A, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
-    if (fighter->x2219_flag.bits.b0 == 1) {
-        fighter->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-        fighter->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    Fighter* fp = fighterObj->user_data;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x17B, 0x0C4C508A, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
+    if (fp->x2219_flag.bits.b0 == 1) {
+        fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+        fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
     }
 }

--- a/src/melee/ft/chara/ftDonkey/ftdonkey_callbacks.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey_callbacks.c
@@ -1,8 +1,8 @@
 #include <ftdonkey.h>
 
 void ftDonkey_OnDeath(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    fighter->sa.dk.x222C = 0;
+    Fighter* fp = fighterObj->user_data;
+    fp->sa.dk.x222C = 0;
     func_80074A4C(fighterObj, 0, 0);
 }
 
@@ -29,26 +29,26 @@ void ftDonkey_OnItemDrop(HSD_GObj* gobj, BOOL bool1)
 }
 
 void func_8010D96C(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    ftDonkeyAttributes* attr = fighter->x2D4_specialAttributes;
-    if (fighter->sa.dk.x222C == attr->SpecialN.x2C_MAX_ARM_SWINGS) {
-        func_800BFFD0(fighter, 0x39, 0);
+    Fighter* fp = fighterObj->user_data;
+    ftDonkeyAttributes* attr = fp->x2D4_specialAttributes;
+    if (fp->sa.dk.x222C == attr->SpecialN.x2C_MAX_ARM_SWINGS) {
+        func_800BFFD0(fp, 0x39, 0);
     }
 }
 
 
 void ftDonkey_OnLoad(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    ftData* ftdata = fighter->x10C_ftData;
+    Fighter* fp = fighterObj->user_data;
+    ftData* ftdata = fp->x10C_ftData;
     ftDonkeyAttributes* ftData_attr = ftdata->ext_attr;
     
-    ftData_attr->x8 = func_8001E8F8(func_80085E50(fighter, 0x128U));
-    ftData_attr->xC = func_8001E8F8(func_80085E50(fighter, 0x129U));
-    ftData_attr->x10 = func_8001E8F8(func_80085E50(fighter, 0x12AU));
-    PUSH_ATTRS(fighter, ftDonkeyAttributes);
+    ftData_attr->x8 = func_8001E8F8(func_80085E50(fp, 0x128U));
+    ftData_attr->xC = func_8001E8F8(func_80085E50(fp, 0x129U));
+    ftData_attr->x10 = func_8001E8F8(func_80085E50(fp, 0x12AU));
+    PUSH_ATTRS(fp, ftDonkeyAttributes);
     
-    fighter->x2222_flag.bits.b0 = 1;
-    fighter->x2CC = fighter->x2D4_specialAttributes;
+    fp->x2222_flag.bits.b0 = 1;
+    fp->x2CC = fp->x2D4_specialAttributes;
 }
 
 void ftDonkey_LoadSpecialAttrs(HSD_GObj* fighterObj) {
@@ -66,12 +66,12 @@ void ftDonkey_OnKnockbackExit(HSD_GObj* fighterObj) {
 void ftDonkey_8010DB3C(HSD_GObj* fighterObj) { 
     s32 unused[2]; /// can't remove with get inlines
     BOOL bool1;
-    Fighter* fighter = fighterObj->user_data;
-    ftDonkeyAttributes* donkey_attr = fighter->x2D4_specialAttributes;
-    CollData* colldata = &fighter->x6F0_collData; 
+    Fighter* fp = fighterObj->user_data;
+    ftDonkeyAttributes* donkey_attr = fp->x2D4_specialAttributes;
+    CollData* colldata = &fp->x6F0_collData; 
 
-    if (fighter->x2210_ThrowFlags.b3) {
-        fighter->x2210_ThrowFlags.b3 = 0;
+    if (fp->x2210_ThrowFlags.b3) {
+        fp->x2210_ThrowFlags.b3 = 0;
         bool1 = 1;
     } else {
         bool1 = 0;
@@ -84,12 +84,12 @@ void ftDonkey_8010DB3C(HSD_GObj* fighterObj) {
         for (i = 0; i < 4; i++) {
 
             f32 temp_f5 = (donkey_attr->SpecialLw.x68 * i) - (donkey_attr->SpecialLw.x68 * 1.5f);
-            f32 temp_f3 = donkey_attr->SpecialLw.x6C * fighter->x2C_facing_direction;
+            f32 temp_f3 = donkey_attr->SpecialLw.x6C * fp->x2C_facing_direction;
             f32 temp_f6 = temp_f5 + temp_f3;
 
             if (!func_80056C54(
                     colldata->x14C_groundIndex, 
-                    &fighter->xB0_pos, 
+                    &fp->xB0_pos, 
                     0, 
                     &vec_list[i], 
                     0, 
@@ -100,11 +100,11 @@ void ftDonkey_8010DB3C(HSD_GObj* fighterObj) {
                     donkey_attr->SpecialLw.x68
                 )) {
 
-                vec_list[i] = fighter->xB0_pos;
+                vec_list[i] = fp->xB0_pos;
             }
 
             vec_list[i].y += 2.0f; 
-            func_8007B8A8(&fighter->x914[i], &vec_list[i]);
+            func_8007B8A8(&fp->x914[i], &vec_list[i]);
         }
     }
 }

--- a/src/melee/ft/chara/ftDonkey/ftdonkey_walk.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey_walk.c
@@ -10,8 +10,8 @@ s32 ftDonkey_800DFA98(HSD_GObj* fighterObj) {
 }
 
 void ftDonkey_800DFAE4(HSD_GObj* fighterObj, f32 argf) {
-    Fighter* fighter = getFighter(fighterObj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs2CC(fighter);
+    Fighter* fp = getFighter(fighterObj);
+    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs2CC(fp);
     ftWalkCommon_800DFCA4(
         fighterObj, donkey_attr->action_state + 1, 0, 
         argf, 

--- a/src/melee/ft/chara/ftDrMario/ftdrmario.c
+++ b/src/melee/ft/chara/ftDrMario/ftdrmario.c
@@ -2,25 +2,25 @@
 
 void ftDrMario_OnDeath(HSD_GObj* gobj)
 {
-    Fighter* ft = (Fighter*)gobj->user_data;
+    Fighter* fp = (Fighter*)gobj->user_data;
     func_80074A4C(gobj, 0, 0);
-    ft->sa.mario.x2234_tornadoCharge = 0;
-    ft->sa.mario.x2238_isCapeBoost = FALSE;
-    ft->sa.mario.x223C_capeGObj = NULL;
-    ft->sa.mario.x2240 = 0;
+    fp->sa.mario.x2234_tornadoCharge = 0;
+    fp->sa.mario.x2238_isCapeBoost = FALSE;
+    fp->sa.mario.x223C_capeGObj = NULL;
+    fp->sa.mario.x2240 = 0;
 }
 
 void ftDrMario_OnLoad(HSD_GObj* gobj)
 {
-    Fighter* ft;
+    Fighter* fp;
     void** items;
     ftDrMarioAttributes* sa;
     int unused[2];
 
-    ft = gobj->user_data;
-    items = ft->x10C_ftData->x48_items;
-    ftMario_OnLoadForDrMario(ft);
-    sa = ft->x2D4_specialAttributes;
+    fp = gobj->user_data;
+    items = fp->x10C_ftData->x48_items;
+    ftMario_OnLoadForDrMario(fp);
+    sa = fp->x2D4_specialAttributes;
     func_8026B3F8(items[1], 0x31);
     func_8026B3F8(items[3], sa->x14);
 }
@@ -66,22 +66,22 @@ void ftDrMario_OnKnockbackExit(HSD_GObj* gobj)
 
 void func_801497CC(HSD_GObj* gobj)
 {
-    Fighter* ft;
+    Fighter* fp;
     int unused[2];
 
     if (gobj != NULL) {
-        ft = gobj->user_data;
-        if (ft != NULL && ft->sa.mario.x2240 != 0) {
-            func_802C0DBC(ft->sa.mario.x2240);
-            ft->sa.mario.x2240 = 0;
+        fp = gobj->user_data;
+        if (fp != NULL && fp->sa.mario.x2240 != 0) {
+            func_802C0DBC(fp->sa.mario.x2240);
+            fp->sa.mario.x2240 = 0;
         }
     }
 
     if (gobj != NULL) {
-        ft = gobj->user_data;
-        if (ft != NULL) {
-            ft->cb.x21DC_callback_OnTakeDamage = 0;
-            ft->cb.x21E4_callback_OnDeath2 = 0;
+        fp = gobj->user_data;
+        if (fp != NULL) {
+            fp->cb.x21DC_callback_OnTakeDamage = 0;
+            fp->cb.x21E4_callback_OnDeath2 = 0;
         }
     }
 }
@@ -89,20 +89,20 @@ void func_801497CC(HSD_GObj* gobj)
 BOOL func_80149844(HSD_GObj* gobj)
 {
     s32 tmp;
-    Fighter* ft;
+    Fighter* fp;
 
     if (gobj == NULL) {
         return TRUE;
     }
-    ft = gobj->user_data;
-    if (ft == NULL) {
+    fp = gobj->user_data;
+    if (fp == NULL) {
         return TRUE;
     }
-    tmp = ft->x10_action_state_index;
+    tmp = fp->x10_action_state_index;
     if (tmp != 0x155 && tmp != 0x156) {
         return TRUE;
     }
-    if (ft->sa.mario.x2240 == 0) {
+    if (fp->sa.mario.x2240 == 0) {
         return TRUE;
     }
     return FALSE;
@@ -110,31 +110,31 @@ BOOL func_80149844(HSD_GObj* gobj)
 
 void func_801498A0(HSD_GObj* gobj)
 {
-    Fighter* ft;
+    Fighter* fp;
 
     if (gobj != NULL) {
-        ft = gobj->user_data;
-        if (ft != NULL && ft->sa.mario.x2240 != 0) {
-            ft->sa.mario.x2240 = 0;
+        fp = gobj->user_data;
+        if (fp != NULL && fp->sa.mario.x2240 != 0) {
+            fp->sa.mario.x2240 = 0;
         }
     }
     if (gobj != NULL) {
-        ft = gobj->user_data;
-        if (ft != NULL) {
-            ft->cb.x21DC_callback_OnTakeDamage = 0;
-            ft->cb.x21E4_callback_OnDeath2 = 0;
+        fp = gobj->user_data;
+        if (fp != NULL) {
+            fp->cb.x21DC_callback_OnTakeDamage = 0;
+            fp->cb.x21E4_callback_OnDeath2 = 0;
         }
     }
 }
 
 u32 func_801498EC(HSD_GObj* gobj)
 {
-    Fighter* ft;
+    Fighter* fp;
 
     if (gobj != NULL) {
-        ft = gobj->user_data;
-        if (ft != NULL) {
-            return ft->x2204_ftcmd_var1;
+        fp = gobj->user_data;
+        if (fp != NULL) {
+            return fp->x2204_ftcmd_var1;
         }
     }
 
@@ -143,9 +143,9 @@ u32 func_801498EC(HSD_GObj* gobj)
 
 void func_80149910(HSD_GObj* gobj)
 {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
 
     func_800DEAE8(gobj, 0x155, 0x156);
-    ft->x2200_ftcmd_var0 = 1;
-    ft->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 1;
+    fp->x2204_ftcmd_var1 = 0;
 }

--- a/src/melee/ft/chara/ftDrMario/ftdrmario_2.c
+++ b/src/melee/ft/chara/ftDrMario/ftdrmario_2.c
@@ -3,36 +3,36 @@
 void func_80149954(HSD_GObj* gobj)
 {
     Vec3 sp18;
-    Fighter* ft;
+    Fighter* fp;
     u32 tmp;
     int unused2[3];
 
-    ft = gobj->user_data;
-    if (ft->x2200_ftcmd_var0 == 1 && ft->sa.mario.x2240 == 0U) {
-        func_8000B1CC(ft->x5E8_fighterBones->x0_jobj, 0, &sp18);
+    fp = gobj->user_data;
+    if (fp->x2200_ftcmd_var0 == 1 && fp->sa.mario.x2240 == 0U) {
+        func_8000B1CC(fp->x5E8_fighterBones->x0_jobj, 0, &sp18);
         tmp = ftMario_SpecialN_VitaminRandom(gobj);
-        tmp = func_802C0850(gobj, &sp18, tmp, 0x31, ft->x2C_facing_direction);
-        ft->sa.mario.x2240 = tmp;
+        tmp = func_802C0850(gobj, &sp18, tmp, 0x31, fp->x2C_facing_direction);
+        fp->sa.mario.x2240 = tmp;
         if (tmp != 0) {
-            ft->cb.x21E4_callback_OnDeath2 = func_80149540;
-            ft->cb.x21DC_callback_OnTakeDamage = func_80149540;
+            fp->cb.x21E4_callback_OnDeath2 = func_80149540;
+            fp->cb.x21DC_callback_OnTakeDamage = func_80149540;
         }
-    } else if (ft->x2200_ftcmd_var0 == 2) {
+    } else if (fp->x2200_ftcmd_var0 == 2) {
         func_801497CC(gobj);
     }
     if (ftAnim_IsFramesRemaining(gobj) == 0) {
         if (gobj != NULL) {
-            ft = gobj->user_data;
-            if (ft != NULL && ft->sa.mario.x2240 != 0) {
-                func_802C0DBC(ft->sa.mario.x2240);
-                ft->sa.mario.x2240 = 0;
+            fp = gobj->user_data;
+            if (fp != NULL && fp->sa.mario.x2240 != 0) {
+                func_802C0DBC(fp->sa.mario.x2240);
+                fp->sa.mario.x2240 = 0;
             }
         }
         if (gobj != NULL) {
-            ft = gobj->user_data;
-            if (ft != NULL) {
-                ft->cb.x21DC_callback_OnTakeDamage = 0;
-                ft->cb.x21E4_callback_OnDeath2 = 0;
+            fp = gobj->user_data;
+            if (fp != NULL) {
+                fp->cb.x21DC_callback_OnTakeDamage = 0;
+                fp->cb.x21E4_callback_OnDeath2 = 0;
             }
         }
         func_8008A2BC(gobj);

--- a/src/melee/ft/chara/ftEmblem/ftemblem.c
+++ b/src/melee/ft/chara/ftEmblem/ftemblem.c
@@ -2,11 +2,11 @@
 
 void ftRoy_OnDeath(HSD_GObj* gobj)
 {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     func_80074A4C(gobj, 0, 0);
     func_80074A4C(gobj, 1, 0);
     func_80074A4C(gobj, 2, -1);
-    ft->sa.mars.x222C = 0;
+    fp->sa.mars.x222C = 0;
 }
 
 void ftRoy_OnItemPickup(HSD_GObj* fighterObj, BOOL bool) {

--- a/src/melee/ft/chara/ftFalco/ftfalco.c
+++ b/src/melee/ft/chara/ftFalco/ftfalco.c
@@ -4,8 +4,8 @@
 
 void ftFalco_OnDeath(HSD_GObj* gobj)
 {
-    Fighter* ft = gobj->user_data;
-    ft->sa.fox.x222C_blasterGObj = 0;
+    Fighter* fp = gobj->user_data;
+    fp->sa.fox.x222C_blasterGObj = 0;
     func_80074A4C(gobj, 0, 0);
 }
 
@@ -30,16 +30,16 @@ void ftFalco_OnItemDrop(HSD_GObj* gobj, BOOL bool1)
 
 void ftFalco_OnLoad(HSD_GObj* gobj)
 {
-    Fighter* ft = gobj->user_data;
-    ftData* ftdata = ft->x10C_ftData;
+    Fighter* fp = gobj->user_data;
+    ftData* ftdata = fp->x10C_ftData;
     s32* sa2;
     void** items = ftdata->x48_items;
     int unused;
 
-    ft->x2224_flag.bits.b7 = 1;
-    ftFox_OnLoadForFalco(ft);
+    fp->x2224_flag.bits.b7 = 1;
+    ftFox_OnLoadForFalco(fp);
 
-    sa2 = ft->x2D4_specialAttributes;
+    sa2 = fp->x2D4_specialAttributes;
     func_8026B3F8(items[0], sa2[7]);
     func_8026B3F8(items[1], sa2[8]);
     func_8026B3F8(items[3], 0x39);

--- a/src/melee/ft/chara/ftFox/ftFox_SpecialN.c
+++ b/src/melee/ft/chara/ftFox/ftFox_SpecialN.c
@@ -3,7 +3,7 @@
 #define PI64 3.141592653589793
 
 // 0x800E5CB0
-// https://decomp.me/scratch/aumQK // Get Fox/Falco's Item Hold Bone Position for Blaster GFX - used in Fox's fighter code
+// https://decomp.me/scratch/aumQK // Get Fox/Falco's Item Hold Bone Position for Blaster GFX - used in Fox's fp code
 void ftFox_FtGetHoldJoint(HSD_GObj* fighter_gobj, Vec3* pos)
 {
     Vec3 sp14;

--- a/src/melee/ft/chara/ftFox/ftfox.c
+++ b/src/melee/ft/chara/ftFox/ftfox.c
@@ -2,16 +2,16 @@
 
 BOOL func_800E5534(HSD_GObj* gobj)
 {
-    Fighter* ft = (Fighter*)gobj->user_data;
+    Fighter* fp = (Fighter*)gobj->user_data;
     
-    return ft->sa.fox.x222C_blasterGObj ? TRUE : FALSE;
+    return fp->sa.fox.x222C_blasterGObj ? TRUE : FALSE;
 }
 
 void ftFox_OnDeath(HSD_GObj* gobj)
 {
-    Fighter* ft = (Fighter*)gobj->user_data;
+    Fighter* fp = (Fighter*)gobj->user_data;
     
-    ft->sa.fox.x222C_blasterGObj = 0;
+    fp->sa.fox.x222C_blasterGObj = 0;
     func_80074A4C(gobj, 0, 0);
 }
 
@@ -39,22 +39,22 @@ void ftFox_OnItemDrop(HSD_GObj* gobj, BOOL bool1)
     Fighter_OnItemDrop(gobj, bool1, 1, 1);
 }
 
-void ftFox_OnLoadForFalco(Fighter* ft) 
+void ftFox_OnLoadForFalco(Fighter* fp) 
 {
-    PUSH_ATTRS(ft, ftFoxAttributes);
+    PUSH_ATTRS(fp, ftFoxAttributes);
 }
 
 void ftFox_OnLoad(HSD_GObj* gobj) {
 
-    Fighter* ft = gobj->user_data;
-    void** item_list = ft->x10C_ftData->x48_items;
+    Fighter* fp = gobj->user_data;
+    void** item_list = fp->x10C_ftData->x48_items;
 
-    ft->x2224_flag.bits.b7 = 1;
+    fp->x2224_flag.bits.b7 = 1;
 
-    PUSH_ATTRS(ft, ftFoxAttributes);
+    PUSH_ATTRS(fp, ftFoxAttributes);
     
     {
-        ftFoxAttributes *fox_attr = ft->x2D4_specialAttributes;
+        ftFoxAttributes *fox_attr = fp->x2D4_specialAttributes;
         func_8026B3F8(item_list[0], fox_attr->x1C_FOX_BLASTER_SHOT_ITKIND);
         func_8026B3F8(item_list[1], fox_attr->x20_FOX_BLASTER_GUN_ITKIND);
         func_8026B3F8(item_list[2], It_Kind_Fox_Illusion);

--- a/src/melee/ft/chara/ftGameWatch/ftGameWatch_SpecialHi.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGameWatch_SpecialHi.c
@@ -3,8 +3,8 @@
 #define HALF_PI64 1.5707963267948966
 
 extern HSD_GObj* func_802C8038(HSD_GObj*, Vec3*, s32, s32, f32, f32);
-void ftGameWatch_ItemRescueEnterHitlag(HSD_GObj* fighter);
-void ftGameWatch_ItemRescueExitHitlag(HSD_GObj* fighter);
+void ftGameWatch_ItemRescueEnterHitlag(HSD_GObj* fp);
+void ftGameWatch_ItemRescueExitHitlag(HSD_GObj* fp);
 
 // 0x8014DEF0
 // https://decomp.me/scratch/6Vtu9 // Create Fire Rescue item

--- a/src/melee/ft/chara/ftGameWatch/ftGameWatch_SpecialS.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGameWatch_SpecialS.c
@@ -1,9 +1,9 @@
 #include <ftgamewatch.h>
 
-void ftGameWatch_ItemJudgementExitHitlag(HSD_GObj* fighter);
+void ftGameWatch_ItemJudgementExitHitlag(HSD_GObj* fp);
 extern void func_8028FAF4(HSD_GObj*, Vec3*);
 extern HSD_GObj* func_802C7774(f32, HSD_GObj*, Vec3*, s32, u32);
-void ftGameWatch_ItemJudgementEnterHitlag(HSD_GObj* fighter);
+void ftGameWatch_ItemJudgementEnterHitlag(HSD_GObj* fp);
 
 // 0x8014C46C 
 // https://decomp.me/scratch/ohXu0 // Create Judgement item

--- a/src/melee/ft/chara/ftGameWatch/ftgamewatch.c
+++ b/src/melee/ft/chara/ftGameWatch/ftgamewatch.c
@@ -2,7 +2,7 @@
 
 void ftGameWatch_OnDeath(HSD_GObj* fighter_gobj) 
 {
-    Fighter* fighter = fighter_gobj->user_data;
+    Fighter* fp = fighter_gobj->user_data;
     func_80074A4C(fighter_gobj, 0U, 0);
     func_80074A4C(fighter_gobj, 1U, -1);
     func_80074A4C(fighter_gobj, 2U, 0);
@@ -14,44 +14,44 @@ void ftGameWatch_OnDeath(HSD_GObj* fighter_gobj)
     func_80074A4C(fighter_gobj, 8U, -1);
     func_80074A4C(fighter_gobj, 9U, -1);
     func_80074A4C(fighter_gobj, 0xAU, -1);
-    fighter->sa.gaw.x222C_judgeVar1 = 1;
-    fighter->sa.gaw.x2230_judgeVar2 = 0;
-    fighter->sa.gaw.x2234 = 0;
-    fighter->sa.gaw.x223C_panicDamage = 0;
-    fighter->sa.gaw.x2240_chefVar1 = 1;
-    fighter->sa.gaw.x2244_chefVar2 = 3;
-    fighter->sa.gaw.x2248_manholeGObj = NULL;
-    fighter->sa.gaw.x224C_greenhouseGObj = NULL;
-    fighter->sa.gaw.x2250_manholeGObj2 = NULL;
-    fighter->sa.gaw.x2254_fireGObj = NULL;
-    fighter->sa.gaw.x2258_parachuteGObj = NULL;
-    fighter->sa.gaw.x225C_turtleGObj = NULL;
-    fighter->sa.gaw.x2260_sparkyGObj = NULL;
-    fighter->sa.gaw.x2264_judgementGObj = NULL;
-    fighter->sa.gaw.x2268_panicGObj = NULL;
-    fighter->sa.gaw.x226C_rescueGObj = NULL;
+    fp->sa.gaw.x222C_judgeVar1 = 1;
+    fp->sa.gaw.x2230_judgeVar2 = 0;
+    fp->sa.gaw.x2234 = 0;
+    fp->sa.gaw.x223C_panicDamage = 0;
+    fp->sa.gaw.x2240_chefVar1 = 1;
+    fp->sa.gaw.x2244_chefVar2 = 3;
+    fp->sa.gaw.x2248_manholeGObj = NULL;
+    fp->sa.gaw.x224C_greenhouseGObj = NULL;
+    fp->sa.gaw.x2250_manholeGObj2 = NULL;
+    fp->sa.gaw.x2254_fireGObj = NULL;
+    fp->sa.gaw.x2258_parachuteGObj = NULL;
+    fp->sa.gaw.x225C_turtleGObj = NULL;
+    fp->sa.gaw.x2260_sparkyGObj = NULL;
+    fp->sa.gaw.x2264_judgementGObj = NULL;
+    fp->sa.gaw.x2268_panicGObj = NULL;
+    fp->sa.gaw.x226C_rescueGObj = NULL;
 }
 
 void ftGameWatch_OnLoad(HSD_GObj* fighter_gobj) 
 {
-    Fighter* fighter = fighter_gobj->user_data;
-    void** items = fighter->x10C_ftData->x48_items;
+    Fighter* fp = fighter_gobj->user_data;
+    void** items = fp->x10C_ftData->x48_items;
 
-    fighter->x2222_flag.bits.b6 = 0;
-    fighter->x2223_flag.bits.b1 = 1;
-    fighter->x2224_flag.bits.b0 = 1;
+    fp->x2222_flag.bits.b6 = 0;
+    fp->x2223_flag.bits.b1 = 1;
+    fp->x2224_flag.bits.b0 = 1;
 
 
-    PUSH_ATTRS(fighter, ftGameWatchAttributes);
-    fighter->sa.gaw.x2238_panicCharge = GAMEWATCH_PANIC_EMPTY;
+    PUSH_ATTRS(fp, ftGameWatchAttributes);
+    fp->sa.gaw.x2238_panicCharge = GAMEWATCH_PANIC_EMPTY;
 
     {
         
-        ftGameWatchAttributes *attr = fighter->x2D4_specialAttributes;
-        fighter->x34_scale.z = attr->x0_GAMEWATCH_WIDTH;
-        fighter->x614 = attr->x14_GAMEWATCH_OUTLINE;
-        func_800BFB4C(fighter_gobj, &attr->x4_GAMEWATCH_COLOR[fighter->x619_costume_id]);
-        fighter->x5C8 = items[10];
+        ftGameWatchAttributes *attr = fp->x2D4_specialAttributes;
+        fp->x34_scale.z = attr->x0_GAMEWATCH_WIDTH;
+        fp->x614 = attr->x14_GAMEWATCH_OUTLINE;
+        func_800BFB4C(fighter_gobj, &attr->x4_GAMEWATCH_COLOR[fp->x619_costume_id]);
+        fp->x5C8 = items[10];
         
         func_8026B3F8(items[0], It_Kind_GameWatch_Greenhouse);
         func_8026B3F8(items[1], It_Kind_GameWatch_Manhole);
@@ -82,8 +82,8 @@ void ftGameWatch_OnDamage(HSD_GObj* fighter_gobj)
 
 void ftGameWatch_8014A538(HSD_GObj* fighter_gobj) 
 {
-    Fighter* fighter = getFighter(fighter_gobj);
-    if (fighter->xE0_ground_or_air == GA_Air) 
+    Fighter* fp = getFighter(fighter_gobj);
+    if (fp->xE0_ground_or_air == GA_Air) 
     {
         ftGameWatch_ItemGreenhouseRemove(fighter_gobj);
         ftGameWatch_ItemManholeOnDamage(fighter_gobj);

--- a/src/melee/ft/chara/ftGanon/ftganon.c
+++ b/src/melee/ft/chara/ftGanon/ftganon.c
@@ -2,11 +2,11 @@
 
 void ftGanon_OnDeath(HSD_GObj* gobj)
 {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     func_80074A4C(gobj, 0, 0);
     func_80074A4C(gobj, 1, -1);
-    ft->sa.captain.x2230_isSpecialSGFX = FALSE;
-    ft->sa.captain.x222C_isSpecialSStartGFX = FALSE;
+    fp->sa.captain.x2230_isSpecialSGFX = FALSE;
+    fp->sa.captain.x222C_isSpecialSStartGFX = FALSE;
 }
 
 void ftGanon_OnItemPickup(HSD_GObj* fighterObj, BOOL bool) {

--- a/src/melee/ft/chara/ftGigaKoopa/ftgigakoopa.c
+++ b/src/melee/ft/chara/ftGigaKoopa/ftgigakoopa.c
@@ -5,13 +5,13 @@
 
 void ftGKoopa_OnDeath(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* ft = fighterObj->user_data;
-    ftKoopaAttributes* koopaAttr = ft->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftKoopaAttributes* koopaAttr = fp->x2D4_specialAttributes;
 
     func_80074A4C(fighterObj, 0, 0);
-    ft->dmg.x18B0 = koopaAttr->x0;
-    ft->sa.gkoopa.x222C = koopaAttr->x10;
-    ft->sa.gkoopa.x2230 = koopaAttr->x18;
+    fp->dmg.x18B0 = koopaAttr->x0;
+    fp->sa.gkoopa.x222C = koopaAttr->x10;
+    fp->sa.gkoopa.x2230 = koopaAttr->x18;
 }
 
 #pragma peephole on
@@ -23,15 +23,15 @@ void func_8014F698(HSD_GObj* gobj)
 
 void ftGKoopa_OnLoad(HSD_GObj* gobj)
 {
-    Fighter* ft = gobj->user_data;
-    ftData* ftdata = ft->x10C_ftData;
+    Fighter* fp = gobj->user_data;
+    ftData* ftdata = fp->x10C_ftData;
     void** items = ftdata->x48_items;
 
-    ftKoopa_OnLoadForGKoopa(ft);
+    ftKoopa_OnLoadForGKoopa(fp);
     func_8026B3F8(items[0], It_Kind_Koopa_Flame);
 
-    ft->x2226_flag.bits.b1 = 1;
-    ft->x222A_flag.bits.b0 = 1;
+    fp->x2226_flag.bits.b1 = 1;
+    fp->x222A_flag.bits.b0 = 1;
 }
 
 void ftGKoopa_OnItemPickup(HSD_GObj* fighterObj, BOOL bool) {

--- a/src/melee/ft/chara/ftIceClimber/fticeclimber1.c
+++ b/src/melee/ft/chara/ftIceClimber/fticeclimber1.c
@@ -18,22 +18,22 @@ void ftIceClimber_OnItemDrop(HSD_GObj* gobj, BOOL bool1)
     Fighter_OnItemDrop(gobj, bool1, 1, 1);
 }
 
-void ftIceClimber_OnLoadForNana(Fighter* fighter) {
-    PUSH_ATTRS(fighter, ftIceClimberAttributes);
+void ftIceClimber_OnLoadForNana(Fighter* fp) {
+    PUSH_ATTRS(fp, ftIceClimberAttributes);
 }
 
 void ftIceClimber_OnLoad(HSD_GObj* fighterObj) {
 
     s32 unused;
-    Fighter* fighter = fighterObj->user_data;
-    void** item_list = fighter->x10C_ftData->x48_items;
-    fighter->x2222_flag.bits.b5 = 1; 
+    Fighter* fp = fighterObj->user_data;
+    void** item_list = fp->x10C_ftData->x48_items;
+    fp->x2222_flag.bits.b5 = 1; 
     
-    PUSH_ATTRS(fighter, ftIceClimberAttributes);
+    PUSH_ATTRS(fp, ftIceClimberAttributes);
 
     {
-        ftIceClimberAttributes* attr = fighter->x2D4_specialAttributes;
-        fighter->x40 = attr->x0;
+        ftIceClimberAttributes* attr = fp->x2D4_specialAttributes;
+        fp->x40 = attr->x0;
         func_8026B3F8(item_list[0], 0x6AU);
         func_8026B3F8(item_list[1], 0x6BU);
         func_8026B3F8(item_list[2], 0x71U);
@@ -42,16 +42,16 @@ void ftIceClimber_OnLoad(HSD_GObj* fighterObj) {
 }
 
 void ftIceClimber_OnDeath(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    ftIceClimberAttributes* attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftIceClimberAttributes* attr = fp->x2D4_specialAttributes;
     func_80074A4C(fighterObj, 0U, 0);
     func_80074A4C(fighterObj, 1U, 0);
-    fighter->sa.nana.x2234 = 0;
-    fighter->sa.nana.x222C = 0;
-    fighter->sa.nana.x2230.bits.b0 = 0;
-    fighter->sa.nana.x2238 = 0;
-    fighter->sa.nana.x224C = 0;
-    fighter->sa.nana.x2250 = 0.0f;
+    fp->sa.nana.x2234 = 0;
+    fp->sa.nana.x222C = 0;
+    fp->sa.nana.x2230.bits.b0 = 0;
+    fp->sa.nana.x2238 = 0;
+    fp->sa.nana.x224C = 0;
+    fp->sa.nana.x2250 = 0.0f;
 }
 
 void ftIceClimber_8011F060(HSD_GObj* fighterObj) {

--- a/src/melee/ft/chara/ftIceClimber/fticeclimber2_nana.c
+++ b/src/melee/ft/chara/ftIceClimber/fticeclimber2_nana.c
@@ -6,30 +6,30 @@ extern f32 lbl_804D9898;
 
 void ftNana_OnLoad(HSD_GObj* fighterObj) {
     s32 unused[4];
-    Fighter* fighter = fighterObj->user_data;
-    fighter->x2222_flag.bits.b4 = 1;
-    ftIceClimber_OnLoadForNana(fighter);
+    Fighter* fp = fighterObj->user_data;
+    fp->x2222_flag.bits.b4 = 1;
+    ftIceClimber_OnLoadForNana(fp);
 
     {
-        ftIceClimberAttributes* attr = fighter->x2D4_specialAttributes;
-        fighter->x40 = attr->xC4;
+        ftIceClimberAttributes* attr = fp->x2D4_specialAttributes;
+        fp->x40 = attr->xC4;
     }
 
 }
 
 void ftNana_OnDeath(HSD_GObj* fighterObj) {
     s32 unused;
-    Fighter* fighter = fighterObj->user_data;
-    ftIceClimberAttributes* attr = fighter->x2D4_specialAttributes;
-    fighter->dmg.x18B0 = attr->xC8;
+    Fighter* fp = fighterObj->user_data;
+    ftIceClimberAttributes* attr = fp->x2D4_specialAttributes;
+    fp->dmg.x18B0 = attr->xC8;
     func_80074A4C(fighterObj, 0U, 0);
     func_80074A4C(fighterObj, 1U, 0);
-    fighter->sa.nana.x2234 = 0;
-    fighter->sa.nana.x222C = 0;
-    fighter->sa.nana.x2230.bits.b0 = 0;
-    fighter->sa.nana.x2238 = 0;
-    fighter->sa.nana.x224C = 0;
-    fighter->sa.nana.x2250 = lbl_804D9898;
+    fp->sa.nana.x2234 = 0;
+    fp->sa.nana.x222C = 0;
+    fp->sa.nana.x2230.bits.b0 = 0;
+    fp->sa.nana.x2238 = 0;
+    fp->sa.nana.x224C = 0;
+    fp->sa.nana.x2250 = lbl_804D9898;
 }
 
 void ftNana_80122FAC(HSD_GObj* fighterObj) {

--- a/src/melee/ft/chara/ftKirby/ftkirby.c
+++ b/src/melee/ft/chara/ftKirby/ftkirby.c
@@ -59,32 +59,32 @@ void func_800EE528() {
 }
 
 void ftKirby_OnDeath(HSD_GObj* fighterObj) {
-    Fighter *fighter = fighterObj->user_data;
+    Fighter *fp = fighterObj->user_data;
     func_80074A4C(fighterObj, 0, 0);
     func_80074A4C(fighterObj, 1, 0);
-    fighter->sa.kirby.x222C = 0;
-    fighter->sa.kirby.x2230 = (s32) (HSD_Randi(5) + 1);
-    fighter->sa.kirby.x223C = 0;
-    fighter->sa.kirby.x2238 = 4;
-    fighter->sa.kirby.x2244 = 0;
-    fighter->sa.kirby.x228C = 0;
-    fighter->sa.kirby.x2290 = 0;
-    if (Player_GetFlagsBit1(fighter->xC_playerID) && Player_GetUnk4D(fighter->xC_playerID) != 4) {
-        func_800F1BAC(fighterObj, Player_GetUnk4D(fighter->xC_playerID), 0);
+    fp->sa.kirby.x222C = 0;
+    fp->sa.kirby.x2230 = (s32) (HSD_Randi(5) + 1);
+    fp->sa.kirby.x223C = 0;
+    fp->sa.kirby.x2238 = 4;
+    fp->sa.kirby.x2244 = 0;
+    fp->sa.kirby.x228C = 0;
+    fp->sa.kirby.x2290 = 0;
+    if (Player_GetFlagsBit1(fp->xC_playerID) && Player_GetUnk4D(fp->xC_playerID) != 4) {
+        func_800F1BAC(fighterObj, Player_GetUnk4D(fp->xC_playerID), 0);
     }
 }
 
 void ftKirby_OnLoad(HSD_GObj* fighterObj) {
 
 
-    Fighter* fighter = fighterObj->user_data;
-    void** item_list = fighter->x10C_ftData->x48_items;
+    Fighter* fp = fighterObj->user_data;
+    void** item_list = fp->x10C_ftData->x48_items;
 
-    PUSH_ATTRS(fighter, ftKirbyAttributes);
+    PUSH_ATTRS(fp, ftKirbyAttributes);
     
-    fighter->x2222_flag.bits.b1 = 1;
-    fighter->x2D0 = fighter->x2D4_specialAttributes;
-    fighter->sa.kirby.x2234.bits.b0 = Player_GetFlagsAEBit1(fighter->xC_playerID);
+    fp->x2222_flag.bits.b1 = 1;
+    fp->x2D0 = fp->x2D4_specialAttributes;
+    fp->sa.kirby.x2234.bits.b0 = Player_GetFlagsAEBit1(fp->xC_playerID);
     func_8026B3F8(item_list[0], 0x32);
     func_8026B3F8(item_list[1], 0x33);
     func_8026B3F8(item_list[2], 0x34);
@@ -94,51 +94,51 @@ void ftKirby_OnLoad(HSD_GObj* fighterObj) {
 }
 
 void ftKirby_800EE74C(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     func_800F5524(fighterObj);
     func_800F22D4(fighterObj);
     func_800F5318(fighterObj);
     func_800F9090(fighterObj);
     func_800F19AC(fighterObj);
     func_800F5D04(fighterObj, 0);
-    fighter->cb.x21E8_callback_OnDeath3 = 0;
+    fp->cb.x21E8_callback_OnDeath3 = 0;
 }
 
 void ftKirby_800EE7B8(HSD_GObj* fighterObj) {
-    Fighter* fighter= fighterObj->user_data;
+    Fighter* fp= fighterObj->user_data;
     func_800F5524(fighterObj);
     func_800F22D4(fighterObj);
     func_800F5318(fighterObj);
     func_800F9090(fighterObj);
     func_800F1A8C(fighterObj);
-    fighter->cb.x21E0_callback_OnDeath = 0;
+    fp->cb.x21E0_callback_OnDeath = 0;
 }
 
 //// Matching, but needs more data moved over for DOL match
 // void func_800EE818(HSD_GObj* fighterObj) {
 //     s32 unused[2];
-//     Fighter* fighter = getFighter(fighterObj);
-//     ftKirbyAttributes* attr = fighter->x2D4_specialAttributes;
-//     switch (fighter->sa.kirby.x2238) {
+//     Fighter* fp = getFighter(fighterObj);
+//     ftKirbyAttributes* attr = fp->x2D4_specialAttributes;
+//     switch (fp->sa.kirby.x2238) {
 //         case 3:
-//             if (fighter->sa.kirby.x22E8 == attr->x190) {
-//                 func_800BFFD0(fighter, 0x3A, 0);
+//             if (fp->sa.kirby.x22E8 == attr->x190) {
+//                 func_800BFFD0(fp, 0x3A, 0);
 //             }
 //             break;
 //         case 13:
-//             if (fighter->sa.kirby.x22D4 == attr->x168) {
-//                 func_800BFFD0(fighter, 0x36, 0);
+//             if (fp->sa.kirby.x22D4 == attr->x168) {
+//                 func_800BFFD0(fp, 0x36, 0);
 //             }
 //             break;
 //         case 16:
-//             if (fighter->sa.kirby.x22C8 == attr->x384) {
-//                 func_800BFFD0(fighter, 0x5D, 0);
+//             if (fp->sa.kirby.x22C8 == attr->x384) {
+//                 func_800BFFD0(fp, 0x5D, 0);
 //                 return;
 //             }
 //             break;
 //         case 7:
-//             if (fighter->sa.kirby.x22E0 == 6) {
-//                 func_800BFFD0(fighter, 0x57, 0);
+//             if (fp->sa.kirby.x22E0 == 6) {
+//                 func_800BFFD0(fp, 0x57, 0);
 //             }
 //             break;
 //     }

--- a/src/melee/ft/chara/ftKoopa/ftkoopa.c
+++ b/src/melee/ft/chara/ftKoopa/ftkoopa.c
@@ -11,17 +11,17 @@ extern const f32 lbl_804D9ADC; //1.0
 extern const f32 lbl_804D9AD8; //0.0
 
 void ftKoopa_OnDeath(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    ftKoopaAttributes* koopaAttr = ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    ftKoopaAttributes* koopaAttr = fp->x2D4_specialAttributes;
     ftKoopaVars* ftVars;
     f32 unk = 0.0;
     f32 unk1 = 0.0;
     
     func_80074A4C(gobj, 0, 0);
 
-    ftVars = (ftKoopaVars*)&ft->sa.koopa.x222C;
+    ftVars = (ftKoopaVars*)&fp->sa.koopa.x222C;
     
-    ft->dmg.x18B0 = koopaAttr->x0;
+    fp->dmg.x18B0 = koopaAttr->x0;
     ftVars->x0 = koopaAttr->x10;
     ftVars->x4 = koopaAttr->x18;
 }
@@ -31,24 +31,24 @@ void func_80132A64(HSD_GObj* gobj) {
     return;
 }
 
-void ftKoopa_OnLoadForGKoopa(Fighter* ft) {
-    PUSH_ATTRS(ft, ftKoopaAttributes);
+void ftKoopa_OnLoadForGKoopa(Fighter* fp) {
+    PUSH_ATTRS(fp, ftKoopaAttributes);
 }
 
 void ftKoopa_OnLoad(HSD_GObj* gobj) {
     ftData* ftDataInfo; 
     void** items;
-    Fighter* ft;
+    Fighter* fp;
     
-    ft = (Fighter*)gobj->user_data;
-    ftDataInfo = ft->x10C_ftData;
+    fp = (Fighter*)gobj->user_data;
+    ftDataInfo = fp->x10C_ftData;
     items = ftDataInfo->x48_items;
    
-    PUSH_ATTRS(ft, ftKoopaAttributes);  
+    PUSH_ATTRS(fp, ftKoopaAttributes);  
 
     func_8026B3F8(items[0], It_Kind_Koopa_Flame);
 
-    ft->x2226_flag.bits.b1 = 1;
+    fp->x2226_flag.bits.b1 = 1;
 }
 
 void func_80132B38(void) {
@@ -85,162 +85,162 @@ void ftKoopa_OnKnockbackExit(HSD_GObj *gobj) {
 }
 
 f32 func_80132DC0(HSD_GObj *gobj) {
-    Fighter *ft = gobj->user_data;
-    return ((ftKoopaAttributes*)ft->x2D4_specialAttributes)->x4C;
+    Fighter *fp = gobj->user_data;
+    return ((ftKoopaAttributes*)fp->x2D4_specialAttributes)->x4C;
 }
 
 f32 func_80132DD0(HSD_GObj *gobj) {
-    Fighter *ft = gobj->user_data;
-    return ((ftKoopaAttributes*)ft->x2D4_specialAttributes)->x48;
+    Fighter *fp = gobj->user_data;
+    return ((ftKoopaAttributes*)fp->x2D4_specialAttributes)->x48;
 }
 
 f32 func_80132DE0(HSD_GObj *gobj) {
-    Fighter *ft = gobj->user_data;
-    return ((ftKoopaAttributes*)ft->x2D4_specialAttributes)->x44;
+    Fighter *fp = gobj->user_data;
+    return ((ftKoopaAttributes*)fp->x2D4_specialAttributes)->x44;
 }
 
 f32 func_80132DF0(HSD_GObj *gobj) {
-    Fighter *ft = gobj->user_data;
-    return ((ftKoopaAttributes*)ft->x2D4_specialAttributes)->x40;
+    Fighter *fp = gobj->user_data;
+    return ((ftKoopaAttributes*)fp->x2D4_specialAttributes)->x40;
 }
 
 f32 func_80132E00(HSD_GObj *gobj) {
-    Fighter *ft = gobj->user_data;
-    return ((ftKoopaAttributes*)ft->x2D4_specialAttributes)->x3C;
+    Fighter *fp = gobj->user_data;
+    return ((ftKoopaAttributes*)fp->x2D4_specialAttributes)->x3C;
 }
 
 f32 func_80132E10(HSD_GObj *gobj) {
-    Fighter *ft = gobj->user_data;
-    return ((ftKoopaAttributes*)ft->x2D4_specialAttributes)->x34;
+    Fighter *fp = gobj->user_data;
+    return ((ftKoopaAttributes*)fp->x2D4_specialAttributes)->x34;
 }
 
 f32 func_80132E20(HSD_GObj *gobj) {
-    Fighter *ft = gobj->user_data;
-    return ((ftKoopaAttributes*)ft->x2D4_specialAttributes)->x38;
+    Fighter *fp = gobj->user_data;
+    return ((ftKoopaAttributes*)fp->x2D4_specialAttributes)->x38;
 }
 
 void func_80132E30(HSD_GObj *gobj) {
-    Fighter *ft;
+    Fighter *fp;
     HSD_GObj* temp;
     BOOL flag_set;
 
-    ft = gobj->user_data;
-    if (ft->x2210_ThrowFlags.b4 != 0) {
-        ft->x2210_ThrowFlags.b4 = 0;
+    fp = gobj->user_data;
+    if (fp->x2210_ThrowFlags.b4 != 0) {
+        fp->x2210_ThrowFlags.b4 = 0;
         flag_set = TRUE;
     } else {
         flag_set = FALSE;
     }
     if (flag_set != FALSE) {
-        ft->x2C_facing_direction = -ft->x2C_facing_direction;
-        ft->x234C_stateVar4 = 1;
+        fp->x2C_facing_direction = -fp->x2C_facing_direction;
+        fp->x234C_stateVar4 = 1;
     }
-    if ((u32) ft->x2200_ftcmd_var0 != 0) {
-        if (ft->x1A58_interactedFighter != 0) {
-            temp = ft->x1A58_interactedFighter;
-            func_8007E2F4(ft, 0);
+    if ((u32) fp->x2200_ftcmd_var0 != 0) {
+        if (fp->x1A58_interactedFighter != 0) {
+            temp = fp->x1A58_interactedFighter;
+            func_8007E2F4(fp, 0);
             func_800DE2A8(gobj, temp);
             func_800DE7C0(temp, 0, 0);
-            ft->x2200_ftcmd_var0 = 0;
+            fp->x2200_ftcmd_var0 = 0;
         }
     }
 }
 
 void ftKoopa_SpecialS_StartAction(HSD_GObj *gobj)
 {
-    Fighter *ft = gobj->user_data;
+    Fighter *fp = gobj->user_data;
 
     f64 unk = 0.0;
 
-    ft->x2210_ThrowFlags.flags = 0;
-    ft->x2200_ftcmd_var0 = 0;
-    ft->x2344_stateVar2 = 0;
-    ft->x234C_stateVar4 = 0;
+    fp->x2210_ThrowFlags.flags = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2344_stateVar2 = 0;
+    fp->x234C_stateVar4 = 0;
 
     Fighter_ActionStateChange_800693AC(gobj, 0x15B, 0, 0, lbl_804D9AD8, lbl_804D9ADC, lbl_804D9AD8);
 
     func_8006EBA4(gobj);
 
-    ft = gobj->user_data;
+    fp = gobj->user_data;
 
-    func_8007E2D0(ft, 8, func_8013302C, NULL, func_800BC7E0);
+    func_8007E2D0(fp, 8, func_8013302C, NULL, func_800BC7E0);
 
-    ft->x2340_stateVar1 = 0;
-    ft->x2348_stateVar3 = 0;
+    fp->x2340_stateVar1 = 0;
+    fp->x2348_stateVar3 = 0;
 
     return;
 }
 
 void ftKoopa_SpecialAirS_StartAction(HSD_GObj *gobj)
 {
-    Fighter *ft = gobj->user_data;
+    Fighter *fp = gobj->user_data;
 
     f64 unk = 0.0;
 
-    ft->x2210_ThrowFlags.flags = 0;
-    ft->x2200_ftcmd_var0 = 0;
-    ft->x2344_stateVar2 = 0;
-    ft->x234C_stateVar4 = 0;
+    fp->x2210_ThrowFlags.flags = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2344_stateVar2 = 0;
+    fp->x234C_stateVar4 = 0;
 
     Fighter_ActionStateChange_800693AC(gobj, 0x161, 0, 0, lbl_804D9AD8, lbl_804D9ADC, lbl_804D9AD8);
 
     func_8006EBA4(gobj);
 
-    ft = gobj->user_data;
+    fp = gobj->user_data;
 
-    func_8007E2D0(ft, 8, func_801330E4, NULL, func_800BC8D4);
+    func_8007E2D0(fp, 8, func_801330E4, NULL, func_800BC8D4);
 
-    ft->x2340_stateVar1 = 0;
-    ft->x2348_stateVar3 = 0;
+    fp->x2340_stateVar1 = 0;
+    fp->x2348_stateVar3 = 0;
 
     return;
 }
 
 void func_8013302C(HSD_GObj *gobj)
 {
-    Fighter *ft = gobj->user_data;
+    Fighter *fp = gobj->user_data;
 
-    if((s32)ft->x2344_stateVar2 != 0) {
+    if((s32)fp->x2344_stateVar2 != 0) {
         Fighter_ActionStateChange_800693AC(gobj, 349, 0x80, 0, lbl_804D9AD8, lbl_804D9ADC, lbl_804D9AD8);
     } else {
         Fighter_ActionStateChange_800693AC(gobj, 348, 0x0, 0, lbl_804D9AD8, lbl_804D9ADC, lbl_804D9AD8);
     }
-    ft->x2222_flag.bits.b2 = 1;
-    func_8007E2F4(ft, 0x1FF);
+    fp->x2222_flag.bits.b2 = 1;
+    func_8007E2F4(fp, 0x1FF);
     func_8007E2FC(gobj);
-    ft->x2340_stateVar1 = 0;
-    ft->x2200_ftcmd_var0 = 0;
+    fp->x2340_stateVar1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
     return;
 }
 
 void func_801330E4(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = gobj->user_data;
-    if ((s32) ft->x2344_stateVar2 != 0) {
+    fp = gobj->user_data;
+    if ((s32) fp->x2344_stateVar2 != 0) {
         Fighter_ActionStateChange_800693AC(gobj, 0x163, 0x80, 0, lbl_804D9AD8, lbl_804D9ADC, lbl_804D9AD8);
     } else {
         Fighter_ActionStateChange_800693AC(gobj, 0x162, 0, 0, lbl_804D9AD8, lbl_804D9ADC, lbl_804D9AD8);
     }
-    ft->x2222_flag.bits.b2 = 1;
-    func_8007E2F4(ft, 0x1FF);
+    fp->x2222_flag.bits.b2 = 1;
+    func_8007E2F4(fp, 0x1FF);
     func_8007E2FC(gobj);
-    ft->x2340_stateVar1 = 0;
-    ft->x2200_ftcmd_var0 = 0;
+    fp->x2340_stateVar1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
 }
 
 void func_8013319C(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
     double unk = 0.0;
 
-    ft = gobj->user_data;
-    func_8007D5D4(ft);
-    Fighter_ActionStateChange_800693AC(gobj, 0x161, 0x0C4C5088, 0, ft->x894_currentAnimFrame, lbl_804D9ADC, lbl_804D9AD8);
-    ft = gobj->user_data;
-    func_8007E2D0(ft, 8, func_801330E4, NULL, func_800BC8D4);
-    ft->x2340_stateVar1 = 0;
-    ft->x2348_stateVar3 = 0;
+    fp = gobj->user_data;
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(gobj, 0x161, 0x0C4C5088, 0, fp->x894_currentAnimFrame, lbl_804D9ADC, lbl_804D9AD8);
+    fp = gobj->user_data;
+    func_8007E2D0(fp, 8, func_801330E4, NULL, func_800BC8D4);
+    fp->x2340_stateVar1 = 0;
+    fp->x2348_stateVar3 = 0;
 }
 
 void func_8013322C(HSD_GObj* gobj) {
@@ -262,11 +262,11 @@ void func_8013322C(HSD_GObj* gobj) {
 
 void func_801332C4(HSD_GObj* gobj) {
     HSD_GObj* temp_r31;
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = gobj->user_data;
-    temp_r31 = ft->x1A58_interactedFighter;
-    func_8007D5D4(ft);
+    fp = gobj->user_data;
+    temp_r31 = fp->x1A58_interactedFighter;
+    func_8007D5D4(fp);
     if (temp_r31 != 0) {
         func_800DC920(gobj, temp_r31);
         func_800CC730(temp_r31);
@@ -275,22 +275,22 @@ void func_801332C4(HSD_GObj* gobj) {
 }
 
 void func_80133324(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = gobj->user_data;
-    func_8007D7FC(ft);
-    Fighter_ActionStateChange_800693AC(gobj, 0x15C, 0x0C4C5088, 0, ft->x894_currentAnimFrame, lbl_804D9ADC, lbl_804D9AD8);
-    func_8007E2F4(ft, 0x1FF);
+    fp = gobj->user_data;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(gobj, 0x15C, 0x0C4C5088, 0, fp->x894_currentAnimFrame, lbl_804D9ADC, lbl_804D9AD8);
+    func_8007E2F4(fp, 0x1FF);
     func_8007E2FC(gobj);
 }
 
 void func_80133398(HSD_GObj* gobj) {
     HSD_GObj* unk_gobj;
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = gobj->user_data;
-    unk_gobj = ft->x1A58_interactedFighter;
-    func_8007D5D4(ft);
+    fp = gobj->user_data;
+    unk_gobj = fp->x1A58_interactedFighter;
+    func_8007D5D4(fp);
     if (unk_gobj != 0) {
         func_800DC920(gobj, unk_gobj);
         func_800CC730(unk_gobj);
@@ -299,25 +299,25 @@ void func_80133398(HSD_GObj* gobj) {
 }
 
 void func_801333F8(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = gobj->user_data;
-    func_8007D7FC(ft);
-    Fighter_ActionStateChange_800693AC(gobj, 0x15E, 0x044C1080, 0, ft->x894_currentAnimFrame, lbl_804D9ADC, lbl_804D9AD8);
-    func_8007E2F4(ft, 0x1FF);
+    fp = gobj->user_data;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(gobj, 0x15E, 0x044C1080, 0, fp->x894_currentAnimFrame, lbl_804D9ADC, lbl_804D9AD8);
+    func_8007E2F4(fp, 0x1FF);
     func_8007E2FC(gobj);
     func_8006F0FC(gobj, lbl_804D9AD8);
-    ft->x2340_stateVar1 = 0;
-    ft->x2200_ftcmd_var0 = 0;
+    fp->x2340_stateVar1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
 }
 
 void func_80133484(HSD_GObj* gobj) {
     HSD_GObj* unk_gobj;
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = gobj->user_data;
-    unk_gobj = ft->x1A58_interactedFighter;
-    func_8007D5D4(ft);
+    fp = gobj->user_data;
+    unk_gobj = fp->x1A58_interactedFighter;
+    func_8007D5D4(fp);
     if (unk_gobj != 0) {
         func_800DC920(gobj, unk_gobj);
         func_800CC730(unk_gobj);
@@ -326,46 +326,46 @@ void func_80133484(HSD_GObj* gobj) {
 }
 
 void func_801334E4(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
     u32 x = 0;
     
-    ft = gobj->user_data;
+    fp = gobj->user_data;
     
     
-    func_8007D7FC(ft);
+    func_8007D7FC(fp);
     
-    if ((s32) ft->x234C_stateVar4 != 0) {
-        ft->x2C_facing_direction = -ft->x2C_facing_direction;
+    if ((s32) fp->x234C_stateVar4 != 0) {
+        fp->x2C_facing_direction = -fp->x2C_facing_direction;
     }
-    Fighter_ActionStateChange_800693AC(gobj, 0x15F, 0x0C4C5088, 0, ft->x894_currentAnimFrame, lbl_804D9ADC, lbl_804D9AD8);
+    Fighter_ActionStateChange_800693AC(gobj, 0x15F, 0x0C4C5088, 0, fp->x894_currentAnimFrame, lbl_804D9ADC, lbl_804D9AD8);
     
-    if ((s32) ft->x234C_stateVar4 != 0) {
-        ft->x2C_facing_direction = -ft->x2C_facing_direction;
+    if ((s32) fp->x234C_stateVar4 != 0) {
+        fp->x2C_facing_direction = -fp->x2C_facing_direction;
     }
-    if (ft->x1A58_interactedFighter != 0) {
-        func_800BCE64(ft->x1A58_interactedFighter, 0x119);
+    if (fp->x1A58_interactedFighter != 0) {
+        func_800BCE64(fp->x1A58_interactedFighter, 0x119);
     }
-    func_8007E2F4(ft, 0x1FF);
+    func_8007E2F4(fp, 0x1FF);
     func_8007E2FC(gobj);
 }
 
 void func_8013359C(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = gobj->user_data;
-    func_8007D7FC(ft);
-    if ((s32) ft->x234C_stateVar4 != 0) {
-        ft->x2C_facing_direction = -ft->x2C_facing_direction;
+    fp = gobj->user_data;
+    func_8007D7FC(fp);
+    if ((s32) fp->x234C_stateVar4 != 0) {
+        fp->x2C_facing_direction = -fp->x2C_facing_direction;
     }
-    Fighter_ActionStateChange_800693AC(gobj, 0x160, 0x0C4C5088, 0, ft->x894_currentAnimFrame, lbl_804D9ADC, lbl_804D9AD8);
-    if ((s32) ft->x234C_stateVar4 != 0) {
-        ft->x2C_facing_direction = -ft->x2C_facing_direction;
+    Fighter_ActionStateChange_800693AC(gobj, 0x160, 0x0C4C5088, 0, fp->x894_currentAnimFrame, lbl_804D9ADC, lbl_804D9AD8);
+    if ((s32) fp->x234C_stateVar4 != 0) {
+        fp->x2C_facing_direction = -fp->x2C_facing_direction;
     }
-    if (ft->x1A58_interactedFighter != 0U) {
-        func_800BCE64(ft->x1A58_interactedFighter, 0x11A);
+    if (fp->x1A58_interactedFighter != 0U) {
+        func_800BCE64(fp->x1A58_interactedFighter, 0x11A);
     }
-    func_8007E2F4(ft, 0x1FF);
+    func_8007E2F4(fp, 0x1FF);
     func_8007E2FC(gobj);
 }
 
@@ -383,22 +383,22 @@ void func_80133690(HSD_GObj* gobj) {
 
 void func_801336CC(HSD_GObj* gobj) {
     Fighter* ft_temp;
-    Fighter* ft;
+    Fighter* fp;
 
     ftKoopaAttributes* koopaAttr;
 
     double unk = 0.0;
     double unk1 = 0.0;
 
-    ft = ft_temp = gobj->user_data;
-    koopaAttr = (ftKoopaAttributes *) ft->x2D4_specialAttributes;
-    if (((u32) ft->x2200_ftcmd_var0 != 0) && ((s32) ft->x2344_stateVar2 != 0)) {
-        func_8007ABD0(&ft->x914[0], koopaAttr->x2C, gobj);
-        ft->x2200_ftcmd_var0 = 0;
+    fp = ft_temp = gobj->user_data;
+    koopaAttr = (ftKoopaAttributes *) fp->x2D4_specialAttributes;
+    if (((u32) fp->x2200_ftcmd_var0 != 0) && ((s32) fp->x2344_stateVar2 != 0)) {
+        func_8007ABD0(&fp->x914[0], koopaAttr->x2C, gobj);
+        fp->x2200_ftcmd_var0 = 0;
     }
     if (ftAnim_IsFramesRemaining(gobj) == 0) {
-        if ((s32) ft->x2340_stateVar1 != 0) {
-            ft->x2344_stateVar2 = 1;
+        if ((s32) fp->x2340_stateVar1 != 0) {
+            fp->x2344_stateVar2 = 1;
             ft_temp = gobj->user_data;
             if ((s32) ft_temp->x2344_stateVar2 != 0) {
                 Fighter_ActionStateChange_800693AC(gobj, 0x15D, 0x80, 0, lbl_804D9AD8, lbl_804D9ADC, lbl_804D9AD8);
@@ -410,14 +410,14 @@ void func_801336CC(HSD_GObj* gobj) {
             func_8007E2FC(gobj);
             ft_temp->x2340_stateVar1 = 0;
             ft_temp->x2200_ftcmd_var0 = 0;
-            func_800BC9C8(ft->x1A58_interactedFighter);
+            func_800BC9C8(fp->x1A58_interactedFighter);
             return;
         }
-        ft = gobj->user_data;
-        Fighter_ActionStateChange_800693AC(gobj, 0x15E, 0x80080, 0, ft->x894_currentAnimFrame, lbl_804D9ADC, lbl_804D9AD8);
+        fp = gobj->user_data;
+        Fighter_ActionStateChange_800693AC(gobj, 0x15E, 0x80080, 0, fp->x894_currentAnimFrame, lbl_804D9ADC, lbl_804D9AD8);
         func_8006F0FC(gobj, lbl_804D9AD8);
-        ft->x2340_stateVar1 = 0;
-        ft->x2200_ftcmd_var0 = 0;
-        func_8007E2F4(ft, 0x1FF);
+        fp->x2340_stateVar1 = 0;
+        fp->x2200_ftcmd_var0 = 0;
+        func_8007E2F4(fp, 0x1FF);
     }
 }

--- a/src/melee/ft/chara/ftLink/ftlink.c
+++ b/src/melee/ft/chara/ftLink/ftlink.c
@@ -3,46 +3,46 @@
 // extern float lbl_804D92E0; // 0.0f
 
 s32 func_800EAD64(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    if (fighter->sa.link.x2234) {
+    Fighter* fp = fighterObj->user_data;
+    if (fp->sa.link.x2234) {
         return 1;
     }
     return 0;
 }
 
 void ftLink_OnDeath(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     func_80074A4C(fighterObj, 0, 0);
     func_80074A4C(fighterObj, 1, 0);
     func_80074A4C(fighterObj, 2, 0);
-    fighter->sa.link.x222C = 0;
-    fighter->sa.link.x2234 = 0;
-    fighter->sa.link.x2238 = 0;
-    fighter->sa.link.x223C = 0;
-    fighter->sa.link.x2240 = 0;
-    fighter->sa.link.x2238 = 0;
-    fighter->sa.link.x2244 = 0;
+    fp->sa.link.x222C = 0;
+    fp->sa.link.x2234 = 0;
+    fp->sa.link.x2238 = 0;
+    fp->sa.link.x223C = 0;
+    fp->sa.link.x2240 = 0;
+    fp->sa.link.x2238 = 0;
+    fp->sa.link.x2244 = 0;
 }
 
-void ftLink_OnLoadForCLink(Fighter* fighter) {
-    PUSH_ATTRS(fighter, ftLinkAttributes);
+void ftLink_OnLoadForCLink(Fighter* fp) {
+    PUSH_ATTRS(fp, ftLinkAttributes);
 }
 
 void ftLink_OnLoad(HSD_GObj* fighterObj) {
 
-    Fighter* fighter = fighterObj->user_data;
-    ftLinkAttributes* link_attr = fighter->x10C_ftData->ext_attr;
-    void** item_list = fighter->x10C_ftData->x48_items;
-    link_attr->x54 = func_8001E8F8(func_80085E50(fighter, 0x48U));
-    PUSH_ATTRS(fighter, ftLinkAttributes);
+    Fighter* fp = fighterObj->user_data;
+    ftLinkAttributes* link_attr = fp->x10C_ftData->ext_attr;
+    void** item_list = fp->x10C_ftData->x48_items;
+    link_attr->x54 = func_8001E8F8(func_80085E50(fp, 0x48U));
+    PUSH_ATTRS(fp, ftLinkAttributes);
 
-    link_attr = fighter->x2D4_specialAttributes;
+    link_attr = fp->x2D4_specialAttributes;
     func_8026B3F8(item_list[0], link_attr->x48);
     func_8026B3F8(item_list[1], link_attr->x2C);
     func_8026B3F8(item_list[2], link_attr->xBC);
     func_8026B3F8(item_list[3], link_attr->xC);
     func_8026B3F8(item_list[4], link_attr->x10);
-    func_800753D4(fighter, *lbl_804D6540[fighter->x4_fighterKind], item_list[6]);
+    func_800753D4(fp, *lbl_804D6540[fp->x4_fighterKind], item_list[6]);
 }
 
 void func_800EAF38() {
@@ -58,8 +58,8 @@ void func_800EAF58(HSD_GObj* fighterObj) {
 }
 
 void ftLink_OnItemPickupExt(HSD_GObj* fighterObj, int arg1) {
-    Fighter* link = getFighter(fighterObj);
-    if (func_8026B2B4(link->x1974_heldItem) == 1) {
+    Fighter* fp = getFighter(fighterObj);
+    if (func_8026B2B4(fp->x1974_heldItem) == 1) {
         func_80074A4C(fighterObj, 1, 1);
     }
     func_80074A4C(fighterObj, 2, 1);
@@ -75,8 +75,8 @@ void ftLink_OnItemVisible(HSD_GObj* fighterObj) {
 }
 
 void ftLink_OnItemDropExt(HSD_GObj* fighterObj, BOOL arg1) {
-    Fighter* link = getFighter(fighterObj);
-    if (func_8026B2B4(link->x1974_heldItem) == 1) {
+    Fighter* fp = getFighter(fighterObj);
+    if (func_8026B2B4(fp->x1974_heldItem) == 1) {
         func_80074A4C(fighterObj, 1, 0);
     }
     func_80074A4C(fighterObj, 2, 0);
@@ -90,14 +90,14 @@ void ftLink_OnItemPickup(HSD_GObj* fighterObj, BOOL bool) {
 
 void ftLink_OnItemDrop(HSD_GObj* gobj, BOOL bool1)
 {
-    Fighter* link = getFighter(gobj);
+    Fighter* fp = getFighter(gobj);
     Fighter_OnItemDrop(gobj, bool1, 1, 1);
 }
 
 void ftLink_LoadSpecialAttrs(HSD_GObj* fighterObj) {
     COPY_ATTRS(fighterObj, ftLinkAttributes);
-    if (ft->x34_scale.y != 1.0f) {
-        sA2->x28 *= ft->x34_scale.y;
+    if (fp->x34_scale.y != 1.0f) {
+        sA2->x28 *= fp->x34_scale.y;
     }
 }
 
@@ -112,16 +112,16 @@ void ftLink_OnKnockbackExit(HSD_GObj* fighterObj) {
 void ftLink_800EB334(HSD_GObj* fighterObj) {
     f32 new_ground_vel;
 
-    Fighter* fighter = fighterObj->user_data;
-    ftLinkAttributes* link_attr = fighter->x10C_ftData->ext_attr;
+    Fighter* fp = fighterObj->user_data;
+    ftLinkAttributes* link_attr = fp->x10C_ftData->ext_attr;
 
-    f32 resultf = func_80092ED8(fighter->x19A4, link_attr, link_attr->xD8);
-    fighter->xEC_ground_vel = resultf * p_ftCommonData->x294;
-    if (fighter->x19AC < 0.0f) {
-        new_ground_vel = fighter->xEC_ground_vel;
+    f32 resultf = func_80092ED8(fp->x19A4, link_attr, link_attr->xD8);
+    fp->xEC_ground_vel = resultf * p_ftCommonData->x294;
+    if (fp->x19AC < 0.0f) {
+        new_ground_vel = fp->xEC_ground_vel;
     } else {
-        new_ground_vel = -fighter->xEC_ground_vel;
+        new_ground_vel = -fp->xEC_ground_vel;
     }
-    fighter->xEC_ground_vel = new_ground_vel;
-    func_80088148(fighter, 0x2716AU, 0x7FU, 0x40U);
+    fp->xEC_ground_vel = new_ground_vel;
+    func_80088148(fp, 0x2716AU, 0x7FU, 0x40U);
 }

--- a/src/melee/ft/chara/ftLuigi/ftluigi.c
+++ b/src/melee/ft/chara/ftLuigi/ftluigi.c
@@ -1,16 +1,16 @@
 #include <ftluigi.h>
 
 void ftLuigi_OnDeath(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     func_80074A4C(fighterObj, 0, 0);
-    fighter->sa.luigi.x2234 = 0;
+    fp->sa.luigi.x2234 = 0;
 }
 
 void ftLuigi_OnLoad(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    void** item_list = fighter->x10C_ftData->x48_items;
+    Fighter* fp = fighterObj->user_data;
+    void** item_list = fp->x10C_ftData->x48_items;
 
-    PUSH_ATTRS(fighter, ftLuigiAttributes);
+    PUSH_ATTRS(fp, ftLuigiAttributes);
     
     func_8026B3F8(item_list[0], It_Kind_Luigi_Fire);
 }

--- a/src/melee/ft/chara/ftMario/ftMario_SpecialHi.c
+++ b/src/melee/ft/chara/ftMario/ftMario_SpecialHi.c
@@ -4,27 +4,27 @@
 #include <melee/it/itkind.h>
 
 void ftMario_SpecialHi_StartAction(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = getFighter(gobj);
-    ft->x2200_ftcmd_var0 = 0;
-    ft->x2210_ThrowFlags.flags = 0;
+    fp = getFighter(gobj);
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2210_ThrowFlags.flags = 0;
 	Fighter_ActionStateChange_800693AC(gobj, AS_MARIO_SPECIALHI, 0, NULL, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
 }
 
 void ftMario_SpecialAirHi_StartAction(HSD_GObj* gobj) 
 {
-    Fighter* ft;
+    Fighter* fp;
     ftMarioAttributes *sa;
     u8 unused[4];
 
-    ft = getFighter(gobj);
-    sa = (ftMarioAttributes*)ft->x2D4_specialAttributes;
-    ft->x2200_ftcmd_var0 = 0;
-    ft->x2210_ThrowFlags.flags = 0;
-    ft->x80_self_vel.y = 0.0f;
-    ft->x80_self_vel.x = (f32) (ft->x80_self_vel.x * sa->x2C_MARIO_SUPERJUMP_VEL_X);
+    fp = getFighter(gobj);
+    sa = (ftMarioAttributes*)fp->x2D4_specialAttributes;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2210_ThrowFlags.flags = 0;
+    fp->x80_self_vel.y = 0.0f;
+    fp->x80_self_vel.x = (f32) (fp->x80_self_vel.x * sa->x2C_MARIO_SUPERJUMP_VEL_X);
     Fighter_ActionStateChange_800693AC(gobj, AS_MARIO_SPECIALAIRHI, 0, NULL, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
 }
@@ -32,11 +32,11 @@ void ftMario_SpecialAirHi_StartAction(HSD_GObj* gobj)
 // 0x800E1B24
 void ftMario_SpecialHi_Anim(HSD_GObj* gobj) 
 {
-    Fighter* ft;
+    Fighter* fp;
     ftMarioAttributes *sa;
 
-    ft = getFighter(gobj);
-    sa = (ftMarioAttributes*)ft->x2D4_specialAttributes;
+    fp = getFighter(gobj);
+    sa = (ftMarioAttributes*)fp->x2D4_specialAttributes;
     if (ftAnim_IsFramesRemaining(gobj) == FALSE) 
     {
         func_80096900(gobj, 0, 1, 0, sa->x18_MARIO_SUPERJUMP_FREEFALL_MOBILITY, sa->x1C_MARIO_SUPERJUMP_LANDING_LAG);
@@ -58,7 +58,7 @@ void ftMario_SpecialAirHi_Anim(HSD_GObj* gobj)
 //https://decomp.me/scratch/9AoMu
 inline void ftMario_SpecialHi_CalcAngle(HSD_GObj* gobj) 
 {
-    Fighter* ft;
+    Fighter* fp;
     ftMarioAttributes* sa;
 
     f32  inputStickangle, lstick_x;
@@ -66,36 +66,36 @@ inline void ftMario_SpecialHi_CalcAngle(HSD_GObj* gobj)
     f32 tmp;
 
     s32 throwflag_flag;
-    ft = getFighter(gobj);
+    fp = getFighter(gobj);
 
-    sa = (ftMarioAttributes*)ft->x2D4_specialAttributes;
+    sa = (ftMarioAttributes*)fp->x2D4_specialAttributes;
 
-    lstick_x = abs(ft->input.x620_lstick_x);
+    lstick_x = abs(fp->input.x620_lstick_x);
 
-    if ((s32) ft->x2200_ftcmd_var0 == 0U) {
+    if ((s32) fp->x2200_ftcmd_var0 == 0U) {
         if(lstick_x > sa->x24_MARIO_SUPERJUMP_MOMENTUM_STICK_RANGE) {
             tmp_expr = (f32) ((f64) sa->x28_MARIO_SUPERJUMP_ANGLE_DIFF *
                 ((f64) (lstick_x - sa->x24_MARIO_SUPERJUMP_MOMENTUM_STICK_RANGE) / (1.0 - (f64)sa->x24_MARIO_SUPERJUMP_MOMENTUM_STICK_RANGE)));
 
-            tmp = (ft->input.x620_lstick_x > 0.0f) ? -(DEGREES_TO_RADIANS * tmp_expr) : (DEGREES_TO_RADIANS * tmp_expr);
-            inputStickangle = ft->x6BC_inputStickangle;
+            tmp = (fp->input.x620_lstick_x > 0.0f) ? -(DEGREES_TO_RADIANS * tmp_expr) : (DEGREES_TO_RADIANS * tmp_expr);
+            inputStickangle = fp->x6BC_inputStickangle;
 
             if (abs(tmp) > abs(inputStickangle)) {
-                ft->x6BC_inputStickangle = tmp;
+                fp->x6BC_inputStickangle = tmp;
             }
         }
     }
 
-    if (ft->x2210_ThrowFlags.b3 != 0) {
-        ft->x2210_ThrowFlags.b3 = 0;
+    if (fp->x2210_ThrowFlags.b3 != 0) {
+        fp->x2210_ThrowFlags.b3 = 0;
         throwflag_flag= 1;
     } else {
         throwflag_flag = 0;
     }
     if (throwflag_flag != 0) {
-        if (abs(ft->input.x620_lstick_x) > sa->x20_MARIO_SUPERJUMP_REVERSE_STICK_RANGE) {
-            func_8007D9FC(ft);
-            func_80075AF0(ft, 0, (f32) (HALF_PI * (f64) ft->x2C_facing_direction));
+        if (abs(fp->input.x620_lstick_x) > sa->x20_MARIO_SUPERJUMP_REVERSE_STICK_RANGE) {
+            func_8007D9FC(fp);
+            func_80075AF0(fp, 0, (f32) (HALF_PI * (f64) fp->x2C_facing_direction));
         }
     }
 }
@@ -114,8 +114,8 @@ void ftMario_SpecialAirHi_IASA(HSD_GObj* gobj) {
 // 0x800E1E74
 // https://decomp.me/scratch/8axfI
 void ftMario_SpecialHi_Phys(HSD_GObj* gobj) {
-    Fighter* ft = getFighter(gobj);
-    if (ft->xE0_ground_or_air == GA_Air) {
+    Fighter* fp = getFighter(gobj);
+    if (fp->xE0_ground_or_air == GA_Air) {
         func_80085154(gobj);
     } else {
         func_80084FA8(gobj);
@@ -125,34 +125,34 @@ void ftMario_SpecialHi_Phys(HSD_GObj* gobj) {
 // 0x800E1EAC
 // https://decomp.me/scratch/1jYsR
 void ftMario_SpecialAirHi_Phys(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     ftMarioAttributes* sa;
     struct attr* attr_ptr;
 
-    ft = getFighter(gobj);
-    sa = GetMarioAttr(ft);
-    attr_ptr = &(ft->x110_attr);
+    fp = getFighter(gobj);
+    sa = GetMarioAttr(fp);
+    attr_ptr = &(fp->x110_attr);
 
-    if ((u32) ft->x2200_ftcmd_var0 != 0U) {
+    if ((u32) fp->x2200_ftcmd_var0 != 0U) {
         func_80085154(gobj);
-        ft->x80_self_vel.x = (f32) (ft->x80_self_vel.x * sa->x34_MARIO_SUPERJUMP_VEL_MUL);
-        ft->x80_self_vel.y = (f32) (ft->x80_self_vel.y * sa->x34_MARIO_SUPERJUMP_VEL_MUL);
-        ft->x80_self_vel.z = (f32) (ft->x80_self_vel.z * sa->x34_MARIO_SUPERJUMP_VEL_MUL);
+        fp->x80_self_vel.x = (f32) (fp->x80_self_vel.x * sa->x34_MARIO_SUPERJUMP_VEL_MUL);
+        fp->x80_self_vel.y = (f32) (fp->x80_self_vel.y * sa->x34_MARIO_SUPERJUMP_VEL_MUL);
+        fp->x80_self_vel.z = (f32) (fp->x80_self_vel.z * sa->x34_MARIO_SUPERJUMP_VEL_MUL);
         return;
     }
-    func_8007D494(ft, sa->x30_MARIO_SUPERJUMP_GRAVITY, attr_ptr->x170_TerminalVelocity);
-    func_8007CF58(ft);
+    func_8007D494(fp, sa->x30_MARIO_SUPERJUMP_GRAVITY, attr_ptr->x170_TerminalVelocity);
+    func_8007CF58(fp);
 }
 
 // 0x800E1F40
 // https://decomp.me/scratch/5eIAp
 void ftMario_SpecialHi_CheckLanding(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     ftMarioAttributes* sa;
 
-    ft = getFighter(gobj);
+    fp = getFighter(gobj);
 
-    sa = (ftMarioAttributes*)ft->x2D4_specialAttributes;
+    sa = (ftMarioAttributes*)fp->x2D4_specialAttributes;
     func_800D5CB0(gobj, 0, sa->x1C_MARIO_SUPERJUMP_LANDING_LAG);
 }
 
@@ -160,11 +160,11 @@ void ftMario_SpecialHi_CheckLanding(HSD_GObj* gobj) {
 // https://decomp.me/scratch/k2DCy
 void ftMario_SpecialHi_Coll(HSD_GObj* gobj) 
 {
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = getFighter(gobj);
-    if (ft->xE0_ground_or_air == GA_Air) {
-        if (ft->x2200_ftcmd_var0 == 0 || ft->x80_self_vel.y >= 0.0f) 
+    fp = getFighter(gobj);
+    if (fp->xE0_ground_or_air == GA_Air) {
+        if (fp->x2200_ftcmd_var0 == 0 || fp->x80_self_vel.y >= 0.0f) 
         {
             func_80083B68(gobj);
         } 

--- a/src/melee/ft/chara/ftMario/ftMario_SpecialLw.c
+++ b/src/melee/ft/chara/ftMario/ftMario_SpecialLw.c
@@ -9,117 +9,117 @@ extern const ftMario_SpecialLw_ECB lbl_803C72A0;
 // https://decomp.me/scratch/8zo4V
 void ftMario_SpecialLw_UpdateRot(HSD_GObj* gobj) 
 {
-    Fighter* ft;
-    ft = getFighter(gobj);
+    Fighter* fp;
+    fp = getFighter(gobj);
 
-    func_8007592C(ft, 0, 0.0f);
+    func_8007592C(fp, 0, 0.0f);
 }
 
 void ftMario_SpecialLw_SetGFX(HSD_GObj* gobj)
 {
     void* hsd_obj_ptr;
-    Fighter* ft;
-    ft = getFighter(gobj);
+    Fighter* fp;
+    fp = getFighter(gobj);
     hsd_obj_ptr = gobj->hsd_obj;
 
     ef_Spawn(0x47C, gobj, hsd_obj_ptr);
-    ft->x2219_flag.bits.b0 = 1;
-    ft->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
-    ft->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
+    fp->x2219_flag.bits.b0 = 1;
+    fp->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
 }
 
 void ftMario_SpecialLw_SetCall(HSD_GObj* gobj)
 {
-    Fighter* ft = getFighter(gobj);
-    ft->cb.x21DC_callback_OnTakeDamage = &ftMario_SpecialLw_UpdateRot;
-    ft->cb.x21E4_callback_OnDeath2 = &ftMario_SpecialLw_UpdateRot;
+    Fighter* fp = getFighter(gobj);
+    fp->cb.x21DC_callback_OnTakeDamage = &ftMario_SpecialLw_UpdateRot;
+    fp->cb.x21E4_callback_OnDeath2 = &ftMario_SpecialLw_UpdateRot;
 }
 
 void _ftMario_800E207C_800E2194_helper(HSD_GObj* gobj)
 {
-    Fighter* ft;
+    Fighter* fp;
     ftMarioAttributes* sa;
     void* hsd_obj_ptr;
-    ft = getFighter(gobj);
-    sa = (ftMarioAttributes*)ft->x2D4_specialAttributes;
-    ft->x2200_ftcmd_var0 = 0;
-    ft->x2204_ftcmd_var1 = 0;
-    ft->marioVars[0].specialLw.groundVelX = (f32) 0.0f;
-    ft->marioVars[0].specialLw.unk = (s32) (sa->x50_MARIO_TORNADO_UNK + 1);
-    ft->marioVars[0].specialLw.isUnkColl = 0;
+    fp = getFighter(gobj);
+    sa = (ftMarioAttributes*)fp->x2D4_specialAttributes;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->marioVars[0].specialLw.groundVelX = (f32) 0.0f;
+    fp->marioVars[0].specialLw.unk = (s32) (sa->x50_MARIO_TORNADO_UNK + 1);
+    fp->marioVars[0].specialLw.isUnkColl = 0;
     ftMario_SpecialLw_SetCall(gobj);
     ftMario_SpecialLw_SetGFX(gobj);
 }
 
 void ftMario_SpecialLw_SetVar(HSD_GObj* gobj)
 {
-    Fighter* ft = gobj->user_data;
-    ft->x2208_ftcmd_var2 = 0;
+    Fighter* fp = gobj->user_data;
+    fp->x2208_ftcmd_var2 = 0;
 }
 
 //https://decomp.me/scratch/4saR2
 void ftMario_SpecialLw_StartAction(HSD_GObj* gobj)
 {
 
-    Fighter* ft;
+    Fighter* fp;
 
     ftMarioAttributes* sa;
 
     void* hsd_obj_ptr;
     u8 padding[24];
     
-    ft = gobj->user_data;
+    fp = gobj->user_data;
     
-    sa = (ftMarioAttributes*)ft->x2D4_specialAttributes;
+    sa = (ftMarioAttributes*)fp->x2D4_specialAttributes;
     ftMario_SpecialLw_SetVar(gobj);
     Fighter_ActionStateChange_800693AC(gobj, AS_MARIO_SPECIALAIRLW, 0, NULL, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
-    ft->x80_self_vel.y = (f32) (sa->x38_MARIO_TORNADO_GROUND_VEL_Y - sa->x54_MARIO_TORNADO_TAP_Y_VEL_MAX);
-    func_8007D440(ft, sa->x40_MARIO_TORNADO_MOMENTUM_X_AIR);
+    fp->x80_self_vel.y = (f32) (sa->x38_MARIO_TORNADO_GROUND_VEL_Y - sa->x54_MARIO_TORNADO_TAP_Y_VEL_MAX);
+    func_8007D440(fp, sa->x40_MARIO_TORNADO_MOMENTUM_X_AIR);
     _ftMario_800E207C_800E2194_helper(gobj);
-    ft->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
-    ft->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
+    fp->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
 }
 
 //https://decomp.me/scratch/nQT5V
 void ftMario_SpecialAirLw_StartAction(HSD_GObj* gobj) {
     f32 sub_val;
-    Fighter* ft;
+    Fighter* fp;
 
     ftMarioAttributes* sa;
 
     void* hsd_obj_ptr;
     u8 padding[24];
     
-    ft = gobj->user_data;
+    fp = gobj->user_data;
     
-    sa = (ftMarioAttributes*)ft->x2D4_specialAttributes;
+    sa = (ftMarioAttributes*)fp->x2D4_specialAttributes;
     ftMario_SpecialLw_SetVar(gobj);
     Fighter_ActionStateChange_800693AC(gobj, AS_MARIO_SPECIALAIRLW, 0, NULL, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
-    if ((s32) ft->sa.mario.x2234_tornadoCharge != 0) {
+    if ((s32) fp->sa.mario.x2234_tornadoCharge != 0) {
         sub_val = 0.0f;
     } else {
         sub_val = sa->x54_MARIO_TORNADO_TAP_Y_VEL_MAX;
     }
-    ft->x80_self_vel.y = (f32) (sa->x38_MARIO_TORNADO_GROUND_VEL_Y - sub_val);
-    func_8007D440(ft, sa->x40_MARIO_TORNADO_MOMENTUM_X_AIR);
+    fp->x80_self_vel.y = (f32) (sa->x38_MARIO_TORNADO_GROUND_VEL_Y - sub_val);
+    func_8007D440(fp, sa->x40_MARIO_TORNADO_MOMENTUM_X_AIR);
     _ftMario_800E207C_800E2194_helper(gobj);
-    ft->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
-    ft->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
+    fp->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
 }
 
 void ftMario_SpecialLw_SetNULL(HSD_GObj* gobj) {
-    Fighter *ft = getFighter(gobj);
+    Fighter *fp = getFighter(gobj);
 
-    ft->cb.x21DC_callback_OnTakeDamage = NULL;
-    ft->cb.x21E4_callback_OnDeath2 = NULL;
+    fp->cb.x21DC_callback_OnTakeDamage = NULL;
+    fp->cb.x21E4_callback_OnDeath2 = NULL;
 }
 
 // 0x800E22BC
 // https://decomp.me/scratch/FT3Fl
 void ftMario_SpecialLw_Anim(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
     if (ftAnim_IsFramesRemaining(gobj) == FALSE) {
         ftMario_SpecialLw_SetNULL(gobj);
@@ -130,12 +130,12 @@ void ftMario_SpecialLw_Anim(HSD_GObj* gobj) {
 // 0x800E2308
 // https://decomp.me/scratch/QF5fb
 void ftMario_SpecialAirLw_Anim(HSD_GObj* gobj) {
-    Fighter* ft = getFighter(gobj);
-    ftMarioAttributes* sa = (ftMarioAttributes*)ft->x2D4_specialAttributes;
+    Fighter* fp = getFighter(gobj);
+    ftMarioAttributes* sa = (ftMarioAttributes*)fp->x2D4_specialAttributes;
 
-    if ((u32) ft->x2204_ftcmd_var1 != 0U) {
-        ft->x2204_ftcmd_var1 = 0U;
-        ft->sa.mario.x2234_tornadoCharge = 1;
+    if ((u32) fp->x2204_ftcmd_var1 != 0U) {
+        fp->x2204_ftcmd_var1 = 0U;
+        fp->sa.mario.x2234_tornadoCharge = 1;
     }
     if (ftAnim_IsFramesRemaining(gobj) == FALSE) {
         ftMario_SpecialLw_SetNULL(gobj);
@@ -161,15 +161,15 @@ void ftMario_SpecialAirLw_IASA(HSD_GObj* gobj)
 }
 
 void _ftMario_800E23E4_800E25C4_helper_0(HSD_GObj* gobj) {
-    Fighter* ft = getFighter(gobj);
-    ftMarioAttributes* sa = GetMarioAttr(ft);
-    ft->x2208_ftcmd_var2 = 0;
-    func_8007D5D4(ft);
-    Fighter_ActionStateChange_800693AC(gobj, AS_MARIO_SPECIALAIRLW, FTMARIO_SPECIALLW_COLL_FLAG, NULL, ft->x894_currentAnimFrame, 1.0f, 0.0f);
-    ftComm_ClampFalllSpeed(ft, sa->x58_MARIO_TORNADO_TAP_GRAVITY);
-    func_8007D440(ft, sa->x40_MARIO_TORNADO_MOMENTUM_X_AIR);
-    ft->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
-    ft->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
+    Fighter* fp = getFighter(gobj);
+    ftMarioAttributes* sa = GetMarioAttr(fp);
+    fp->x2208_ftcmd_var2 = 0;
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(gobj, AS_MARIO_SPECIALAIRLW, FTMARIO_SPECIALLW_COLL_FLAG, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
+    ftComm_ClampFalllSpeed(fp, sa->x58_MARIO_TORNADO_TAP_GRAVITY);
+    func_8007D440(fp, sa->x40_MARIO_TORNADO_MOMENTUM_X_AIR);
+    fp->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
 }
 
 // 0x800E23E4
@@ -177,30 +177,30 @@ void _ftMario_800E23E4_800E25C4_helper_0(HSD_GObj* gobj) {
 void ftMario_SpecialLw_Phys(HSD_GObj* gobj) {
     f32 flt_var;
     ftMarioAttributes* sa;
-    Fighter* ft;
+    Fighter* fp;
     Fighter* ft_tmp;
 
     u8 padding[8];
 
-    ft = getFighter(gobj);
-    sa = GetMarioAttr(ft);
+    fp = getFighter(gobj);
+    sa = GetMarioAttr(fp);
 
     flt_var = sa->x3C_MARIO_TORNADO_MOMENTUM_X_GROUND;
-    if ((u32) ft->x2200_ftcmd_var0 != 0U) {
-        ft->marioVars[0].specialLw.groundVelX = (f32) (ft->marioVars[0].specialLw.groundVelX - sa->x4C_MARIO_TORNADO_FRICTION_END);
-        flt_var += ft->marioVars[0].specialLw.groundVelX;
+    if ((u32) fp->x2200_ftcmd_var0 != 0U) {
+        fp->marioVars[0].specialLw.groundVelX = (f32) (fp->marioVars[0].specialLw.groundVelX - sa->x4C_MARIO_TORNADO_FRICTION_END);
+        flt_var += fp->marioVars[0].specialLw.groundVelX;
         if (flt_var < 0.0f) {
             flt_var = 0.0f;
         }
     }
 
-    ft_tmp = ft;
+    ft_tmp = fp;
     func_8007CADC(ft_tmp, 0.0f, sa->x44_MARIO_TORNADO_MOMENTUM_X_MUL_GROUND, flt_var);
     func_8007CB74(gobj);
-    if (((u32) ft->x2208_ftcmd_var2 != 0U) && ((ft->input.x668 & HSD_BUTTON_B) != 0)) 
+    if (((u32) fp->x2208_ftcmd_var2 != 0U) && ((fp->input.x668 & HSD_BUTTON_B) != 0)) 
     {
-        flt_var = ft->x80_self_vel.y;
-        ft->x80_self_vel.y = (f32) (flt_var + sa->x54_MARIO_TORNADO_TAP_Y_VEL_MAX);
+        flt_var = fp->x80_self_vel.y;
+        fp->x80_self_vel.y = (f32) (flt_var + sa->x54_MARIO_TORNADO_TAP_Y_VEL_MAX);
         _ftMario_800E23E4_800E25C4_helper_0(gobj);
     }
 }
@@ -211,58 +211,58 @@ void ftMario_SpecialAirLw_Phys(HSD_GObj* gobj) {
     f32 flt_var;
     ftMarioAttributes* sa;
     ftMarioAttributes* sa_2;
-    Fighter* ft;
+    Fighter* fp;
     u8 padding[8];
 
-    ft = getFighter(gobj);
-    sa = ft->x2D4_specialAttributes;
+    fp = getFighter(gobj);
+    sa = fp->x2D4_specialAttributes;
 
-    if (((s32) ft->sa.mario.x2234_tornadoCharge == FALSE) && ((u32) ft->x2208_ftcmd_var2 != 0U) && ((ft->input.x668 & HSD_BUTTON_B) != 0)) 
+    if (((s32) fp->sa.mario.x2234_tornadoCharge == FALSE) && ((u32) fp->x2208_ftcmd_var2 != 0U) && ((fp->input.x668 & HSD_BUTTON_B) != 0)) 
     {
-        func_8007D508(ft, sa->x54_MARIO_TORNADO_TAP_Y_VEL_MAX, sa->x58_MARIO_TORNADO_TAP_GRAVITY);
+        func_8007D508(fp, sa->x54_MARIO_TORNADO_TAP_Y_VEL_MAX, sa->x58_MARIO_TORNADO_TAP_GRAVITY);
     }
-    func_8007D4B8(ft);
+    func_8007D4B8(fp);
     flt_var = sa->x40_MARIO_TORNADO_MOMENTUM_X_AIR;
-    sa_2 = ft->x2D4_specialAttributes;
-    if ((u32) ft->x2200_ftcmd_var0 != 0U) {
-        ft->marioVars[0].specialLw.groundVelX = (f32) (ft->marioVars[0].specialLw.groundVelX - sa_2->x4C_MARIO_TORNADO_FRICTION_END);
-        flt_var += ft->marioVars[0].specialLw.groundVelX;
+    sa_2 = fp->x2D4_specialAttributes;
+    if ((u32) fp->x2200_ftcmd_var0 != 0U) {
+        fp->marioVars[0].specialLw.groundVelX = (f32) (fp->marioVars[0].specialLw.groundVelX - sa_2->x4C_MARIO_TORNADO_FRICTION_END);
+        flt_var += fp->marioVars[0].specialLw.groundVelX;
         if (flt_var < 0.0f) {
             flt_var = 0.0f;
         }
     }
-    func_8007D3A8(ft, 0.0f, sa->x48_MARIO_TORNADO_MOMENTUM_X_MUL_AIR, flt_var);
+    func_8007D3A8(fp, 0.0f, sa->x48_MARIO_TORNADO_MOMENTUM_X_MUL_AIR, flt_var);
 }
 
 void _ftMario_800E25C4_800E2778_helper(HSD_GObj* gobj) {
-    Fighter* ft = getFighter(gobj);
-    ftMarioAttributes* sa = GetMarioAttr(ft);
+    Fighter* fp = getFighter(gobj);
+    ftMarioAttributes* sa = GetMarioAttr(fp);
 
-    if ((ft->x220C_ftcmd_var3 != 0U) && ((s32)(ft->marioVars[0].specialLw.isUnkColl) != 0)) {
-        func_8007592C(ft, 0, ft->x2C_facing_direction * atan2f(ft->x6F0_collData.x154_groundNormal.x, ft->x6F0_collData.x154_groundNormal.y));
+    if ((fp->x220C_ftcmd_var3 != 0U) && ((s32)(fp->marioVars[0].specialLw.isUnkColl) != 0)) {
+        func_8007592C(fp, 0, fp->x2C_facing_direction * atan2f(fp->x6F0_collData.x154_groundNormal.x, fp->x6F0_collData.x154_groundNormal.y));
     } else {
-        func_8007592C(ft, 0, 0.0f);
+        func_8007592C(fp, 0, 0.0f);
     }
 }
 
 // 0x800E25C4
 // https://decomp.me/scratch/ykJHP
 void ftMario_SpecialLw_Coll(HSD_GObj* gobj) {
-    Fighter* ft = getFighter(gobj);
+    Fighter* fp = getFighter(gobj);
 
-    if (ft->xE0_ground_or_air == GA_Ground) {
+    if (fp->xE0_ground_or_air == GA_Ground) {
         if (func_80082888(gobj, &lbl_803C72A0) == 0) {
             _ftMario_800E23E4_800E25C4_helper_0(gobj);
-            ft->marioVars[0].specialLw.isUnkColl = 0;
+            fp->marioVars[0].specialLw.isUnkColl = 0;
         } else {
-            ft->marioVars[0].specialLw.isUnkColl = 1;
+            fp->marioVars[0].specialLw.isUnkColl = 1;
         }
     } else {
         if (func_800824A0(gobj, &lbl_803C72A0) == 0) {
             _ftMario_800E23E4_800E25C4_helper_0(gobj);
-            ft->marioVars[0].specialLw.isUnkColl = 0;
+            fp->marioVars[0].specialLw.isUnkColl = 0;
         } else {
-            ft->marioVars[0].specialLw.isUnkColl = 1;
+            fp->marioVars[0].specialLw.isUnkColl = 1;
         }
     }
 
@@ -271,29 +271,29 @@ void ftMario_SpecialLw_Coll(HSD_GObj* gobj) {
 
 void _ftMario_800E2778_helper(HSD_GObj* gobj) {
     Fighter* ft_tmp;
-    Fighter* ft;
+    Fighter* fp;
     ftMarioAttributes* sa;
-    ft = getFighter(gobj);
-    sa = GetMarioAttr(ft);
-    ft->x2208_ftcmd_var2 = 0;
-    func_8007D7FC(ft);
-    ft->x80_self_vel.y = 0.0f;
-    ft->sa.mario.x2234_tornadoCharge = 0;
-    Fighter_ActionStateChange_800693AC(gobj, AS_MARIO_SPECIALLW, FTMARIO_SPECIALLW_COLL_FLAG, NULL, ft->x894_currentAnimFrame, 1.0f, 0.0f);
-    func_8007CC78(ft_tmp = ft, sa->x3C_MARIO_TORNADO_MOMENTUM_X_GROUND);
-    ft->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
-    ft->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
+    fp = getFighter(gobj);
+    sa = GetMarioAttr(fp);
+    fp->x2208_ftcmd_var2 = 0;
+    func_8007D7FC(fp);
+    fp->x80_self_vel.y = 0.0f;
+    fp->sa.mario.x2234_tornadoCharge = 0;
+    Fighter_ActionStateChange_800693AC(gobj, AS_MARIO_SPECIALLW, FTMARIO_SPECIALLW_COLL_FLAG, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
+    func_8007CC78(ft_tmp = fp, sa->x3C_MARIO_TORNADO_MOMENTUM_X_GROUND);
+    fp->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
 }
 
 // 0x800E2778
 // https://decomp.me/scratch/v3srn
 void ftMario_SpecialAirLw_Coll(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     if (func_800824A0(gobj, &lbl_803C72A0) != 0) {
         _ftMario_800E2778_helper(gobj);
-        ft->marioVars[0].specialLw.isUnkColl = 1;
+        fp->marioVars[0].specialLw.isUnkColl = 1;
     } else {
-        ft->marioVars[0].specialLw.isUnkColl = 0;
+        fp->marioVars[0].specialLw.isUnkColl = 0;
     }
 
     _ftMario_800E25C4_800E2778_helper(gobj);

--- a/src/melee/ft/chara/ftMario/ftMario_SpecialN.c
+++ b/src/melee/ft/chara/ftMario/ftMario_SpecialN.c
@@ -3,11 +3,11 @@
 
 #include <melee/it/itkind.h>
 
-int ftDrMario_SpecialN_GetRandomInt(Fighter* ft, int* arr, int outpos) {
+int ftDrMario_SpecialN_GetRandomInt(Fighter* fp, int* arr, int outpos) {
     int r3;
     r3 = (int)arr[HSD_Randi(outpos)];
-    ft->sa.mario.x2230_vitaminPrev = ft->sa.mario.x222C_vitaminCurr;
-    ft->sa.mario.x222C_vitaminCurr = r3;
+    fp->sa.mario.x2230_vitaminPrev = fp->sa.mario.x222C_vitaminCurr;
+    fp->sa.mario.x222C_vitaminCurr = r3;
     return r3;
 }
 
@@ -15,33 +15,33 @@ int ftDrMario_SpecialN_GetRandomInt(Fighter* ft, int* arr, int outpos) {
 // https://decomp.me/scratch/od8nq
 int ftMario_SpecialN_VitaminRandom(HSD_GObj* gobj) // Get random Megavitamin color combo for Dr. Mario //
 {
-    Fighter* ft;
+    Fighter* fp;
     int arr[9];
     int r3,i;
 
-    ft = gobj->user_data;
+    fp = gobj->user_data;
 
     for (i = r3 = 0; i < 9; i++) {
-        if (i != (int)ft->sa.mario.x222C_vitaminCurr && i != (int)ft->sa.mario.x2230_vitaminPrev) 
+        if (i != (int)fp->sa.mario.x222C_vitaminCurr && i != (int)fp->sa.mario.x2230_vitaminPrev) 
         {
             arr[r3] = i;
             r3++;
         }
     }
 
-    r3 = ftDrMario_SpecialN_GetRandomInt(ft, arr, r3);
+    r3 = ftDrMario_SpecialN_GetRandomInt(fp, arr, r3);
 
     return r3;
 }
 
 void ftMario_SpecialN_StartAction(HSD_GObj* gobj)
 {
-    Fighter* ft = getFighter(gobj);
-    ft->x2200_ftcmd_var0 = 0;
-    ft->x2210_ThrowFlags.flags = 0;
+    Fighter* fp = getFighter(gobj);
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2210_ThrowFlags.flags = 0;
     Fighter_ActionStateChange_800693AC(gobj,AS_MARIO_SPECIALN,0,NULL,0.0f,1.0f,0.0f);
     func_8006EBA4(gobj);
-    ft->cb.x21BC_callback_Accessory4 = ftMario_SpecialN_ItemFireSpawn;
+    fp->cb.x21BC_callback_Accessory4 = ftMario_SpecialN_ItemFireSpawn;
 }
 
 // 0x800E0E18
@@ -56,9 +56,9 @@ void ftMario_SpecialN_Anim(HSD_GObj* gobj)
 // 0x800E0E54
 void ftMario_SpecialN_IASA(HSD_GObj* gobj)
 {
-    Fighter* ft;
-    ft = getFighter(gobj);
-    if(ft->x2200_ftcmd_var0 != 0)
+    Fighter* fp;
+    fp = getFighter(gobj);
+    if(fp->x2200_ftcmd_var0 != 0)
     {
         func_8008A4D4(gobj);
     }
@@ -84,7 +84,7 @@ void ftMario_SpecialN_Coll(HSD_GObj* gobj)
 void ftMario_SpecialN_ItemFireSpawn(HSD_GObj* gobj) 
 {
     Vec3 coords;
-    Fighter* ft;
+    Fighter* fp;
 
     s32 flag_res;
 
@@ -92,11 +92,11 @@ void ftMario_SpecialN_ItemFireSpawn(HSD_GObj* gobj)
 
     u8 padding[4];
 
-    ft = gobj->user_data;
+    fp = gobj->user_data;
 
-    if (ft->x2210_ThrowFlags.b0 != 0) 
+    if (fp->x2210_ThrowFlags.b0 != 0) 
     {
-        ft->x2210_ThrowFlags.b0 = 0;
+        fp->x2210_ThrowFlags.b0 = 0;
         flag_res = 1;
     } 
     else 
@@ -105,26 +105,26 @@ void ftMario_SpecialN_ItemFireSpawn(HSD_GObj* gobj)
     }
 
     if (flag_res != 0) {
-        func_8000B1CC(ft->x5E8_fighterBones[func_8007500C(ft, 0x17)].x0_jobj,NULL,&coords);
-        if(ft->x4_fighterKind == FTKIND_MARIO) 
+        func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 0x17)].x0_jobj,NULL,&coords);
+        if(fp->x4_fighterKind == FTKIND_MARIO) 
         {
-            func_8029B6F8(ft->x2C_facing_direction, gobj,&coords,0x30);
-            ef_Spawn(0x47a,gobj,ft->x5E8_fighterBones[func_8007500C(ft, 0x17)].x0_jobj,&ft->x2C_facing_direction);
+            func_8029B6F8(fp->x2C_facing_direction, gobj,&coords,0x30);
+            ef_Spawn(0x47a,gobj,fp->x5E8_fighterBones[func_8007500C(fp, 0x17)].x0_jobj,&fp->x2C_facing_direction);
         } else {
             rand_val_800E0D1C = ftMario_SpecialN_VitaminRandom(gobj);
-            func_802C0510(gobj, &coords, rand_val_800E0D1C, 0x31, ft->x2C_facing_direction);
+            func_802C0510(gobj, &coords, rand_val_800E0D1C, 0x31, fp->x2C_facing_direction);
         }
     }
 }
 
 void ftMario_SpecialAirN_StartAction(HSD_GObj* gobj)
 {
-    Fighter* ft = getFighter(gobj);
-    ft->x2200_ftcmd_var0 = 0;
-    ft->x2210_ThrowFlags.flags = 0;
+    Fighter* fp = getFighter(gobj);
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2210_ThrowFlags.flags = 0;
     Fighter_ActionStateChange_800693AC(gobj, AS_MARIO_SPECIALAIRN, 0, NULL, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
-    ft->cb.x21BC_callback_Accessory4 = ftMario_SpecialN_ItemFireSpawn;
+    fp->cb.x21BC_callback_Accessory4 = ftMario_SpecialN_ItemFireSpawn;
 }
 
 // 0x800E10B0
@@ -139,8 +139,8 @@ void ftMario_SpecialAirN_Anim(HSD_GObj* gobj)
 // 0x800E10EC
 void ftMario_SpecialAirN_IASA(HSD_GObj* gobj) 
 {
-    Fighter* ft = getFighter(gobj);
-    if (ft->x2200_ftcmd_var0 != 0) 
+    Fighter* fp = getFighter(gobj);
+    if (fp->x2200_ftcmd_var0 != 0) 
     {
         func_800CCAAC(gobj);
     }
@@ -164,19 +164,19 @@ void ftMario_SpecialAirN_Coll(HSD_GObj* gobj)
 // 0x800E1178
 void ftMario_SpecialN_GroundToAir(HSD_GObj* gobj) 
 {
-    Fighter* ft = getFighter(gobj);
-    func_8007D5D4(ft);
-    Fighter_ActionStateChange_800693AC(gobj, AS_MARIO_SPECIALAIRN, (FIGHTER_CMD_UPDATE | FIGHTER_COLANIM_NOUPDATE), NULL, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = getFighter(gobj);
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(gobj, AS_MARIO_SPECIALAIRN, (FIGHTER_CMD_UPDATE | FIGHTER_COLANIM_NOUPDATE), NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 
-    ft->cb.x21BC_callback_Accessory4 = ftMario_SpecialN_ItemFireSpawn;
+    fp->cb.x21BC_callback_Accessory4 = ftMario_SpecialN_ItemFireSpawn;
 }
 
 // 0x800E11E0
 void ftMario_SpecialAirN_AirToGround(HSD_GObj* gobj)
 {
-    Fighter* ft = getFighter(gobj);
-    func_8007D7FC(ft);
-    Fighter_ActionStateChange_800693AC(gobj, AS_MARIO_SPECIALN, (FIGHTER_CMD_UPDATE | FIGHTER_COLANIM_NOUPDATE), NULL, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = getFighter(gobj);
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(gobj, AS_MARIO_SPECIALN, (FIGHTER_CMD_UPDATE | FIGHTER_COLANIM_NOUPDATE), NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 
-    ft->cb.x21BC_callback_Accessory4 = ftMario_SpecialN_ItemFireSpawn;
+    fp->cb.x21BC_callback_Accessory4 = ftMario_SpecialN_ItemFireSpawn;
 }

--- a/src/melee/ft/chara/ftMario/ftMario_SpecialS.c
+++ b/src/melee/ft/chara/ftMario/ftMario_SpecialS.c
@@ -5,15 +5,15 @@
 
 extern HSD_GObj* func_802B2560(HSD_GObj*,f32,Vec3*,long,u32);
 
-void ftMario_SpecialS_SetCall(Fighter* ft) 
+void ftMario_SpecialS_SetCall(Fighter* fp) 
 {
-    if(ft->sa.mario.x223C_capeGObj != NULL)
+    if(fp->sa.mario.x223C_capeGObj != NULL)
     {
-        ft->cb.x21E4_callback_OnDeath2 = ftMario_OnTakeDamage;
-        ft->cb.x21DC_callback_OnTakeDamage = ftMario_OnTakeDamage;
+        fp->cb.x21E4_callback_OnDeath2 = ftMario_OnTakeDamage;
+        fp->cb.x21DC_callback_OnTakeDamage = ftMario_OnTakeDamage;
     }
-    ft->cb.x21D4_callback_EnterHitlag = ftMario_SpecialS_EnterHitlag;
-    ft->cb.x21D8_callback_ExitHitlag = ftMario_SpecialS_ExitHitlag;
+    fp->cb.x21D4_callback_EnterHitlag = ftMario_SpecialS_EnterHitlag;
+    fp->cb.x21D8_callback_ExitHitlag = ftMario_SpecialS_ExitHitlag;
 }
 
 // 0x800E1248
@@ -22,43 +22,43 @@ void ftMario_SpecialS_CreateCape(HSD_GObj* gobj)
 {
     Vec3 coords;
     HSD_GObj* gobj2;
-    Fighter* ft = getFighter(gobj);
-    ftMarioAttributes* sa = (ftMarioAttributes*)ft->x2D4_specialAttributes;
+    Fighter* fp = getFighter(gobj);
+    ftMarioAttributes* sa = (ftMarioAttributes*)fp->x2D4_specialAttributes;
     u8 padding[8];
 
-    if(ft->x2208_ftcmd_var2 == 0) 
+    if(fp->x2208_ftcmd_var2 == 0) 
     {
-        ft->x2208_ftcmd_var2 = 1;
-        func_8000B1CC(ft->x5E8_fighterBones[func_8007500C(ft, 0x31)].x0_jobj,NULL,&coords);
+        fp->x2208_ftcmd_var2 = 1;
+        func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 0x31)].x0_jobj,NULL,&coords);
 
-        gobj2 = func_802B2560(gobj,ft->x2C_facing_direction,&coords,func_8007500C(ft, 0x31),sa->x14_MARIO_CAPE_IT_KIND);
+        gobj2 = func_802B2560(gobj,fp->x2C_facing_direction,&coords,func_8007500C(fp, 0x31),sa->x14_MARIO_CAPE_IT_KIND);
 
-        ft->sa.mario.x223C_capeGObj = gobj2;
-        ft->x1984_heldItemSpec = ft->sa.mario.x223C_capeGObj;
-        ftMario_SpecialS_SetCall(ft);
-        ft->cb.x21BC_callback_Accessory4 = NULL;
+        fp->sa.mario.x223C_capeGObj = gobj2;
+        fp->x1984_heldItemSpec = fp->sa.mario.x223C_capeGObj;
+        ftMario_SpecialS_SetCall(fp);
+        fp->cb.x21BC_callback_Accessory4 = NULL;
     }
 }
 
 // 0x800E132C
 void ftMario_SpecialS_SetNULL(HSD_GObj* gobj) 
 {
-    Fighter* ft = getFighter(gobj);
+    Fighter* fp = getFighter(gobj);
     ftMario_SpecialS_ExitHitlag(gobj);
-    ft->sa.mario.x223C_capeGObj = NULL;
-    ft->cb.x21E4_callback_OnDeath2 = NULL;
-    ft->cb.x21DC_callback_OnTakeDamage = NULL;
+    fp->sa.mario.x223C_capeGObj = NULL;
+    fp->cb.x21E4_callback_OnDeath2 = NULL;
+    fp->cb.x21DC_callback_OnTakeDamage = NULL;
 }
 
 // 0x800E1368
 void ftMario_SpecialS_RemoveCape(HSD_GObj* gobj)
 {
-    Fighter* ft = getFighter(gobj);
+    Fighter* fp = getFighter(gobj);
     u8 padding[8];
 
-    if(ft->sa.mario.x223C_capeGObj != NULL)
+    if(fp->sa.mario.x223C_capeGObj != NULL)
     {
-        func_802B2674(ft->sa.mario.x223C_capeGObj);
+        func_802B2674(fp->sa.mario.x223C_capeGObj);
         ftMario_SpecialS_SetNULL(gobj);
     }
 }
@@ -66,29 +66,29 @@ void ftMario_SpecialS_RemoveCape(HSD_GObj* gobj)
 // 0x800E13C8
 void ftMario_SpecialS_EnterHitlag(HSD_GObj* gobj)
 {
-    Fighter* ft = getFighter(gobj);
-    if(ft->sa.mario.x223C_capeGObj != NULL) 
+    Fighter* fp = getFighter(gobj);
+    if(fp->sa.mario.x223C_capeGObj != NULL) 
     {
-        func_802B26C0(ft->sa.mario.x223C_capeGObj);
+        func_802B26C0(fp->sa.mario.x223C_capeGObj);
     }
 }
 
 // 0x800E13F8
 void ftMario_SpecialS_ExitHitlag(HSD_GObj* gobj) 
 {
-    Fighter* ft = getFighter(gobj);
-    if(ft->sa.mario.x223C_capeGObj != NULL)
+    Fighter* fp = getFighter(gobj);
+    if(fp->sa.mario.x223C_capeGObj != NULL)
     {
-        func_802B26E0(ft->sa.mario.x223C_capeGObj);
+        func_802B26E0(fp->sa.mario.x223C_capeGObj);
     }
 }
 
 // 0x800E1428
 BOOL ftMario_SpecialS_CheckItemCapeRemove(HSD_GObj* gobj) 
 {
-    Fighter* ft = getFighter(gobj);
+    Fighter* fp = getFighter(gobj);
 
-    s32 var0 = ft->x10_action_state_index;
+    s32 var0 = fp->x10_action_state_index;
 
     if ((var0  >= AS_MARIO_SPECIALS) && (var0  <= AS_MARIO_SPECIALAIRS))
     {
@@ -102,23 +102,23 @@ BOOL ftMario_SpecialS_CheckItemCapeRemove(HSD_GObj* gobj)
 
 void ftMario_SpecialS_ChangeAction(HSD_GObj* gobj, s32 new_action_state_index) 
 {
-    Fighter* ft;
+    Fighter* fp;
     Fighter_ActionStateChange_800693AC(gobj, new_action_state_index,0,NULL,0.0f,1.0f,0.0f);
     func_8006EBA4(gobj);
-    ft = getFighter(gobj);
-    ft->x2208_ftcmd_var2 = 0;
-    ft->x2204_ftcmd_var1 = 0;
-    ft->x2200_ftcmd_var0 = 0;
-    ft->marioVars[0].specialS.isReflect = FALSE;
-    ft->cb.x21BC_callback_Accessory4 = ftMario_SpecialS_CreateCape;
+    fp = getFighter(gobj);
+    fp->x2208_ftcmd_var2 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->marioVars[0].specialS.isReflect = FALSE;
+    fp->cb.x21BC_callback_Accessory4 = ftMario_SpecialS_CreateCape;
 }
 
 void ftMario_SpecialS_StartAction(HSD_GObj* gobj)
 {
-    Fighter* ft;
+    Fighter* fp;
     u8 unused[8];
-    ft = getFighter(gobj);
-    ft->x80_self_vel.y = 0.0f;
+    fp = getFighter(gobj);
+    fp->x80_self_vel.y = 0.0f;
 
     ftMario_SpecialS_ChangeAction(gobj, AS_MARIO_SPECIALS);
 }
@@ -126,11 +126,11 @@ void ftMario_SpecialS_StartAction(HSD_GObj* gobj)
 
 void ftMario_SpecialAirS_StartAction(HSD_GObj* gobj)
 {
-    Fighter* ft = getFighter(gobj);
-    ftMarioAttributes* sa = (ftMarioAttributes*)ft->x2D4_specialAttributes;
+    Fighter* fp = getFighter(gobj);
+    ftMarioAttributes* sa = (ftMarioAttributes*)fp->x2D4_specialAttributes;
     u8 unused[8];
 
-    ft->x80_self_vel.x = (ft->x80_self_vel.x / ((Vec3*)(sa))->x);
+    fp->x80_self_vel.x = (fp->x80_self_vel.x / ((Vec3*)(sa))->x);
 
     ftMario_SpecialS_ChangeAction(gobj, AS_MARIO_SPECIALAIRS);
 }
@@ -169,18 +169,18 @@ extern void ftColl_CreateReflectHit(HSD_GObj*, ReflectDesc*, void(*cb_OnReflect)
 
 void ftMario_SpecialS_ReflectThink(HSD_GObj* gobj) 
 {
-    Fighter* ft = getFighter(gobj);
-    ftMarioAttributes* sa_tmp = ft->x2D4_specialAttributes;
+    Fighter* fp = getFighter(gobj);
+    ftMarioAttributes* sa_tmp = fp->x2D4_specialAttributes;
     
-    if ((ft->x2204_ftcmd_var1 == 1U) && ((s32) ft->marioVars[0].specialS.isReflect == FALSE)) 
+    if ((fp->x2204_ftcmd_var1 == 1U) && ((s32) fp->marioVars[0].specialS.isReflect == FALSE)) 
     {
-        ft->marioVars[0].specialS.isReflect= TRUE;
+        fp->marioVars[0].specialS.isReflect= TRUE;
         ftColl_CreateReflectHit(gobj, &sa_tmp->x60_MARIO_CAPE_REFLECTION, NULL);
     }
-    else if ((ft->x2204_ftcmd_var1 == 0U) && ((s32) ft->marioVars[0].specialS.isReflect == TRUE)) 
+    else if ((fp->x2204_ftcmd_var1 == 0U) && ((s32) fp->marioVars[0].specialS.isReflect == TRUE)) 
     {
-        ft->marioVars[0].specialS.isReflect = FALSE;
-        ft->x2218_flag.bits.b3 = 0;
+        fp->marioVars[0].specialS.isReflect = FALSE;
+        fp->x2218_flag.bits.b3 = 0;
     }
     func_8007AEF8(gobj);
 }
@@ -190,18 +190,18 @@ void ftMario_SpecialS_ReflectThink(HSD_GObj* gobj)
 // 0x800E15D0
 void ftMario_SpecialS_Phys(HSD_GObj* gobj) 
 {
-    Fighter* ft;
+    Fighter* fp;
     u8 unused0[4];
     Vec3 coords;
     u8 unused1[20];
 
-    ft = gobj->user_data;
-    if (ft->x2200_ftcmd_var0 == 1U)
+    fp = gobj->user_data;
+    if (fp->x2200_ftcmd_var0 == 1U)
     {
-        ft->x2200_ftcmd_var0 = 2U;
-        func_8000B1CC(ft->x5E8_fighterBones[func_8007500C(ft, 0x4)].x0_jobj,NULL,&coords);
+        fp->x2200_ftcmd_var0 = 2U;
+        func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 0x4)].x0_jobj,NULL,&coords);
 
-        coords.x += 3.0f * ft->x2C_facing_direction;
+        coords.x += 3.0f * fp->x2C_facing_direction;
 		func_800119DC(&coords, 0x78, 0.9f, 0.02f, PI_3);
     }
 
@@ -214,43 +214,43 @@ void ftMario_SpecialAirS_Phys(HSD_GObj* gobj)
 {
     u32 ftcmd_var0_tmp;
 
-    Fighter *ft;
+    Fighter *fp;
     ftMarioAttributes* sa;
 
     u8 unused0[4];
     Vec3 coords;
     u8 unused1[24];
 
-    ft = gobj->user_data;
+    fp = gobj->user_data;
 
-    ftcmd_var0_tmp = ft->x2200_ftcmd_var0;
-    sa = (ftMarioAttributes*)ft->x2D4_specialAttributes;
+    ftcmd_var0_tmp = fp->x2200_ftcmd_var0;
+    sa = (ftMarioAttributes*)fp->x2D4_specialAttributes;
 
     if (ftcmd_var0_tmp >= 1U) 
     {
         if(ftcmd_var0_tmp == 1U) 
         {
-            ft->x2200_ftcmd_var0 = 2U;
-            if((s32)ft->sa.mario.x2238_isCapeBoost == FALSE) 
+            fp->x2200_ftcmd_var0 = 2U;
+            if((s32)fp->sa.mario.x2238_isCapeBoost == FALSE) 
             {
-                ft->sa.mario.x2238_isCapeBoost = TRUE;
-                ft->x80_self_vel.y = sa->x8_MARIO_CAPE_VEL_Y;
+                fp->sa.mario.x2238_isCapeBoost = TRUE;
+                fp->x80_self_vel.y = sa->x8_MARIO_CAPE_VEL_Y;
             } 
             else 
             {
-                ft->x80_self_vel.y = 0.0f;
+                fp->x80_self_vel.y = 0.0f;
             }
-            func_8000B1CC(ft->x5E8_fighterBones[func_8007500C(ft, 0x4)].x0_jobj,NULL,&coords);
-            coords.x += 3.0f * ft->x2C_facing_direction;
+            func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 0x4)].x0_jobj,NULL,&coords);
+            coords.x += 3.0f * fp->x2C_facing_direction;
             func_800119DC(&coords, 0x78, 3.0f, 0.1f, PI_3);
         }
-        func_8007D494(ft, sa->xC_MARIO_CAPE_GRAVITY, sa->x10_MARIO_CAPE_TERMINAL_VELOCITY);
+        func_8007D494(fp, sa->xC_MARIO_CAPE_GRAVITY, sa->x10_MARIO_CAPE_TERMINAL_VELOCITY);
     } 
     else 
     {
-        func_8007D4B8(ft);
+        func_8007D4B8(fp);
     }
-    func_8007CE94(ft, sa->x4_MARIO_CAPE_VEL_X);
+    func_8007CE94(fp, sa->x4_MARIO_CAPE_VEL_X);
     ftMario_SpecialS_ReflectThink(gobj);
 }
 
@@ -274,27 +274,27 @@ void ftMario_SpecialAirS_Coll(HSD_GObj* gobj)
 
 void ftMario_SpecialS_UpdateVarsColl(HSD_GObj* gobj) 
 {
-    Fighter* ft = getFighter(gobj);
-    if ((s32) ft->marioVars[0].specialS.isReflect != FALSE) 
+    Fighter* fp = getFighter(gobj);
+    if ((s32) fp->marioVars[0].specialS.isReflect != FALSE) 
     {
-        ft->x2218_flag.bits.b3 = 1;
+        fp->x2218_flag.bits.b3 = 1;
     }
-    ftMario_SpecialS_SetCall(ft);
-    ft->cb.x21BC_callback_Accessory4 = ftMario_SpecialS_CreateCape;
+    ftMario_SpecialS_SetCall(fp);
+    fp->cb.x21BC_callback_Accessory4 = ftMario_SpecialS_CreateCape;
 }
 
 // 0x800E18B8
 void ftMario_SpecialS_GroundToAir(HSD_GObj* gobj)
 {
-    Fighter* ft;
+    Fighter* fp;
     u8 unused[4];
 
-    ft = getFighter(gobj);
-    func_8007D5D4(ft);
-    Fighter_ActionStateChange_800693AC(gobj, AS_MARIO_SPECIALAIRS, FTMARIO_SPECIALS_COLL_FLAG, NULL, ft->x894_currentAnimFrame, 1.0f, 0.0f);
-    if ((s32) ft->x2200_ftcmd_var0 == 1U) 
+    fp = getFighter(gobj);
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(gobj, AS_MARIO_SPECIALAIRS, FTMARIO_SPECIALS_COLL_FLAG, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
+    if ((s32) fp->x2200_ftcmd_var0 == 1U) 
     {
-        ft->x2200_ftcmd_var0 = 2U;
+        fp->x2200_ftcmd_var0 = 2U;
     }
 
     ftMario_SpecialS_UpdateVarsColl(gobj);
@@ -303,13 +303,13 @@ void ftMario_SpecialS_GroundToAir(HSD_GObj* gobj)
 // 0x800E198C
 void ftMario_SpecialAirS_AirToGround(HSD_GObj* gobj)
 {
-    Fighter* ft;
+    Fighter* fp;
     u8 unused[4];
 
-    ft = gobj->user_data;
-    ft->sa.mario.x2238_isCapeBoost = FALSE;
-    func_8007D7FC(ft);
-    Fighter_ActionStateChange_800693AC(gobj, AS_MARIO_SPECIALS, FTMARIO_SPECIALS_COLL_FLAG, NULL, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    fp = gobj->user_data;
+    fp->sa.mario.x2238_isCapeBoost = FALSE;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(gobj, AS_MARIO_SPECIALS, FTMARIO_SPECIALS_COLL_FLAG, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 
     ftMario_SpecialS_UpdateVarsColl(gobj);
 }

--- a/src/melee/ft/chara/ftMario/ftmario.c
+++ b/src/melee/ft/chara/ftMario/ftmario.c
@@ -6,33 +6,33 @@
 extern s32 lbl_803C5A20[];
 
 void ftMario_OnDeath(HSD_GObj* gobj) {
-    Fighter* ft = getFighter(gobj);
+    Fighter* fp = getFighter(gobj);
     func_80074A4C(gobj, 0, 0);
-    ft->sa.mario.x222C_vitaminCurr = 9;
-    ft->sa.mario.x2230_vitaminPrev = 9;
-    ft->sa.mario.x2234_tornadoCharge = FALSE;
-    ft->sa.mario.x2238_isCapeBoost = FALSE;
-    ft->sa.mario.x223C_capeGObj = NULL;
-    ft->sa.mario.x2240 = 0;
+    fp->sa.mario.x222C_vitaminCurr = 9;
+    fp->sa.mario.x2230_vitaminPrev = 9;
+    fp->sa.mario.x2234_tornadoCharge = FALSE;
+    fp->sa.mario.x2238_isCapeBoost = FALSE;
+    fp->sa.mario.x223C_capeGObj = NULL;
+    fp->sa.mario.x2240 = 0;
 }
 
-void ftMario_OnLoadForDrMario(Fighter* ft) {
-	PUSH_ATTRS(ft, ftMarioAttributes);
+void ftMario_OnLoadForDrMario(Fighter* fp) {
+	PUSH_ATTRS(fp, ftMarioAttributes);
 }
 
 void ftMario_OnLoad(HSD_GObj* gobj) {
     ftData* ftDataInfo;
     void** items;
     ftMarioAttributes *sa;
-    Fighter* ft = gobj->user_data;
-    ftDataInfo = ft->x10C_ftData;
+    Fighter* fp = gobj->user_data;
+    ftDataInfo = fp->x10C_ftData;
     items = ftDataInfo->x48_items;
 
-    ft->x2224_flag.bits.b7 = 1;
+    fp->x2224_flag.bits.b7 = 1;
 
-    PUSH_ATTRS(ft, ftMarioAttributes);
+    PUSH_ATTRS(fp, ftMarioAttributes);
 
-    sa = (ftMarioAttributes*)ft->x2D4_specialAttributes;
+    sa = (ftMarioAttributes*)fp->x2D4_specialAttributes;
 
     func_8026B3F8(items[0], It_Kind_Mario_Fire);
     func_8026B3F8(items[2], sa->x14_MARIO_CAPE_IT_KIND);

--- a/src/melee/ft/chara/ftMario/ftmario.h
+++ b/src/melee/ft/chara/ftMario/ftmario.h
@@ -92,9 +92,9 @@ typedef struct ftMario_SpecialLw_ECB
     u32 x14;
 } ftMario_SpecialLw_ECB;
 
-inline ftMarioAttributes* GetMarioAttr(Fighter* ft)
+inline ftMarioAttributes* GetMarioAttr(Fighter* fp)
 {
-    ftMarioAttributes* mario_attr = ft->x2D4_specialAttributes;
+    ftMarioAttributes* mario_attr = fp->x2D4_specialAttributes;
     return mario_attr;
 }
 

--- a/src/melee/ft/chara/ftMars/ftMars.c
+++ b/src/melee/ft/chara/ftMars/ftMars.c
@@ -3,10 +3,10 @@
 // 80136258 00132E38
 // https://decomp.me/scratch/6RQ5w
 void ftMars_OnDeath(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     func_80074A4C(gobj, 0, 0);
     func_80074A4C(gobj, 1, 0);
-    ft->sa.mars.x222C = 0;
+    fp->sa.mars.x222C = 0;
 }
 
 // 801362B0 00132E90
@@ -38,15 +38,15 @@ void ftMars_OnItemDrop(HSD_GObj* gobj, BOOL bool1) {
 
 // 80136474 00133054
 // https://decomp.me/scratch/2TlGi
-void ftMars_OnLoadForRoy(Fighter* ft) {
-    PUSH_ATTRS(ft, MarsAttributes);
+void ftMars_OnLoadForRoy(Fighter* fp) {
+    PUSH_ATTRS(fp, MarsAttributes);
 }
 
 // 801364AC 0013308C
 // https://decomp.me/scratch/9UJHY
 void ftMars_OnLoad(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    PUSH_ATTRS(ft, MarsAttributes);
+    Fighter* fp = gobj->user_data;
+    PUSH_ATTRS(fp, MarsAttributes);
 }
 
 // 801364E8 001330C8
@@ -71,55 +71,55 @@ void ftMars_OnKnockbackExit(HSD_GObj* gobj) {
 // 801365A8 00133188
 // https://decomp.me/scratch/Jqd2A
 void lbl_801365A8(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 result;
-    if (!ft->x2219_flag.bits.b0) {
+    if (!fp->x2219_flag.bits.b0) {
         result = func_800872A4(gobj);
         switch (result) {
             case 0x12:
-                ef_Spawn(0x4F2, gobj, ft->x5E8_fighterBones->x0_jobj);
+                ef_Spawn(0x4F2, gobj, fp->x5E8_fighterBones->x0_jobj);
                 break;
             case 0x1A:
-                ef_Spawn(0x511, gobj, ft->x5E8_fighterBones->x0_jobj);
+                ef_Spawn(0x511, gobj, fp->x5E8_fighterBones->x0_jobj);
                 break;
         }
-        ft->x2219_flag.bits.b0 = 1;
+        fp->x2219_flag.bits.b0 = 1;
     }
 
-    ft->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-    ft->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
-    ft->cb.x21BC_callback_Accessory4 = 0;
+    fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    fp->cb.x21BC_callback_Accessory4 = 0;
     return;
 }
 
 // 8013666C 0013324C
 // https://decomp.me/scratch/Jqd2A
 void lbl_8013666C(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 result;
-    if (!ft->x2219_flag.bits.b0) {
+    if (!fp->x2219_flag.bits.b0) {
         result = func_800872A4(gobj);
         switch (result) {
             case 0x12:
-                ef_Spawn(0x4F3, gobj, ft->x5E8_fighterBones->x0_jobj);
+                ef_Spawn(0x4F3, gobj, fp->x5E8_fighterBones->x0_jobj);
                 break;
             case 0x1A:
-                ef_Spawn(0x512, gobj, ft->x5E8_fighterBones->x0_jobj);
+                ef_Spawn(0x512, gobj, fp->x5E8_fighterBones->x0_jobj);
                 break;
         }
-        ft->x2219_flag.bits.b0 = 1;
+        fp->x2219_flag.bits.b0 = 1;
     }
 
-    ft->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-    ft->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
-    ft->cb.x21BC_callback_Accessory4 = 0;
+    fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    fp->cb.x21BC_callback_Accessory4 = 0;
     return;
 }
 
 // 80136730 00133310
 // https://decomp.me/scratch/Jqd2A
 void lbl_80136730(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    ft->x2200_ftcmd_var0 = 0;
-    ft->x2340_stateVar1 = 0;
+    Fighter* fp = gobj->user_data;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2340_stateVar1 = 0;
 }

--- a/src/melee/ft/chara/ftMars/ftMars.h
+++ b/src/melee/ft/chara/ftMars/ftMars.h
@@ -41,7 +41,7 @@ void ftMars_OnItemPickup(HSD_GObj* gobj, BOOL arg1);
 void ftMars_OnItemInvisible(HSD_GObj* gobj);
 void ftMars_OnItemVisible(HSD_GObj* gobj);
 void ftMars_OnItemDrop(HSD_GObj* gobj, BOOL arg1);
-void ftMars_OnLoadForRoy(Fighter* ft);
+void ftMars_OnLoadForRoy(Fighter* fp);
 void ftMars_OnLoad(HSD_GObj* gobj);
 void ftMars_LoadSpecialAttrs(HSD_GObj* gobj);
 void ftMars_OnKnockbackEnter(HSD_GObj* gobj);

--- a/src/melee/ft/chara/ftMars/ftMarsSpecialHi.c
+++ b/src/melee/ft/chara/ftMars/ftMarsSpecialHi.c
@@ -3,12 +3,12 @@
 // 80138208 00134DE8
 // https://decomp.me/scratch/lrV6F
 void ftMars_SpecialHi_StartAction(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
 
-    ft->x2208_ftcmd_var2 = 0;
-    ft->x2204_ftcmd_var1 = 0;
-    ft->x2200_ftcmd_var0 = 0;
-    ft->x2210_ThrowFlags.flags = 0;
+    fp->x2208_ftcmd_var2 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2210_ThrowFlags.flags = 0;
     // ActionStateChange
     Fighter_ActionStateChange_800693AC(gobj, 0x16F, 0, NULL, 0.0f, 1.0f, 0.0f);
     // AS_AnimationFrameUpdate&More
@@ -18,16 +18,16 @@ void ftMars_SpecialHi_StartAction(HSD_GObj* gobj) {
 // 8013826C 00134E4C
 // https://decomp.me/scratch/PuVdx
 void ftMars_SpecialAirHi_StartAction(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    MarsAttributes* attr = ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    MarsAttributes* attr = fp->x2D4_specialAttributes;
     s32 unused[2];
 
-    ft->x2208_ftcmd_var2 = 0;
-    ft->x2204_ftcmd_var1 = 0;
-    ft->x2200_ftcmd_var0 = 0;
-    ft->x2210_ThrowFlags.flags = 0;
-    ft->x80_self_vel.y = 0.0f;
-    ft->x80_self_vel.x *= attr->x3C;
+    fp->x2208_ftcmd_var2 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2210_ThrowFlags.flags = 0;
+    fp->x80_self_vel.y = 0.0f;
+    fp->x80_self_vel.x *= attr->x3C;
     // ActionStateChange
     Fighter_ActionStateChange_800693AC(gobj, 0x170, 0, NULL, 0.0f, 1.0f, 0.0f);
     // AS_AnimationFrameUpdate&More
@@ -37,8 +37,8 @@ void ftMars_SpecialAirHi_StartAction(HSD_GObj* gobj) {
 // 801382E8 00134EC8
 // https://decomp.me/scratch/56Ycw
 void lbl_801382E8(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    MarsAttributes* attr = ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    MarsAttributes* attr = fp->x2D4_specialAttributes;
     s32 unused[2];
 
     // FrameTimerCheck
@@ -51,8 +51,8 @@ void lbl_801382E8(HSD_GObj* gobj) {
 // 80138348 00134F28
 // https://decomp.me/scratch/WdpFi
 void lbl_80138348(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    MarsAttributes* attr = ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    MarsAttributes* attr = fp->x2D4_specialAttributes;
     s32 unused[4];
 
     // FrameTimerCheck
@@ -69,31 +69,31 @@ void lbl_80138348(HSD_GObj* gobj) {
 // 801383A8 00134F88
 // https://decomp.me/scratch/0VOrt
 void lbl_801383A8(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    MarsAttributes* attr = ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    MarsAttributes* attr = fp->x2D4_specialAttributes;
 
-    f32 abs_lstick_x = abs(ft->input.x620_lstick_x);
+    f32 abs_lstick_x = abs(fp->input.x620_lstick_x);
 
     s32 phi_r0;
     s32 unused;
 
-    if (ft->x2200_ftcmd_var0 == 0 && abs_lstick_x > attr->x34) {
+    if (fp->x2200_ftcmd_var0 == 0 && abs_lstick_x > attr->x34) {
         f32 temp_f1 = attr->x38 * ((abs_lstick_x - attr->x34) / (1.0/*d*/ - attr->x34));
-        temp_f1 = (ft->input.x620_lstick_x > 0.0f) ? -(DEGREES_TO_RADIANS * temp_f1) : (DEGREES_TO_RADIANS * temp_f1);
-        if (abs(temp_f1) > abs(ft->x6BC_inputStickangle)) {
-            ft->x6BC_inputStickangle = temp_f1;
+        temp_f1 = (fp->input.x620_lstick_x > 0.0f) ? -(DEGREES_TO_RADIANS * temp_f1) : (DEGREES_TO_RADIANS * temp_f1);
+        if (abs(temp_f1) > abs(fp->x6BC_inputStickangle)) {
+            fp->x6BC_inputStickangle = temp_f1;
         }
     }
-    if (ft->x2210_ThrowFlags.b3) {
-        ft->x2210_ThrowFlags.b3 = 0;
+    if (fp->x2210_ThrowFlags.b3) {
+        fp->x2210_ThrowFlags.b3 = 0;
         phi_r0 = 1;
     } else {
         phi_r0 = 0;
     }
     if (phi_r0 != 0) {
-        if (abs(ft->input.x620_lstick_x) > attr->x30) {
-            func_8007D9FC(ft);
-            func_80075AF0(ft, 0, (f32) (HALF_PI * ft->x2C_facing_direction));
+        if (abs(fp->input.x620_lstick_x) > attr->x30) {
+            func_8007D9FC(fp);
+            func_80075AF0(fp, 0, (f32) (HALF_PI * fp->x2C_facing_direction));
         }
     }
 }
@@ -101,31 +101,31 @@ void lbl_801383A8(HSD_GObj* gobj) {
 // 801384F0 001350D0
 // https://decomp.me/scratch/2yXhH
 void lbl_801384F0(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    MarsAttributes* attr = ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    MarsAttributes* attr = fp->x2D4_specialAttributes;
 
-    f32 abs_lstick_x = abs(ft->input.x620_lstick_x);
+    f32 abs_lstick_x = abs(fp->input.x620_lstick_x);
 
     s32 phi_r0;
     s32 unused[6];
 
-    if (ft->x2200_ftcmd_var0 == 0 && abs_lstick_x > attr->x34) {
+    if (fp->x2200_ftcmd_var0 == 0 && abs_lstick_x > attr->x34) {
         f32 temp_f1 = attr->x38 * ((abs_lstick_x - attr->x34) / (1.0/*d*/ - attr->x34));
-        temp_f1 = (ft->input.x620_lstick_x > 0.0f) ? -(DEGREES_TO_RADIANS * temp_f1) : (DEGREES_TO_RADIANS * temp_f1);
-        if (abs(temp_f1) > abs(ft->x6BC_inputStickangle)) {
-            ft->x6BC_inputStickangle = temp_f1;
+        temp_f1 = (fp->input.x620_lstick_x > 0.0f) ? -(DEGREES_TO_RADIANS * temp_f1) : (DEGREES_TO_RADIANS * temp_f1);
+        if (abs(temp_f1) > abs(fp->x6BC_inputStickangle)) {
+            fp->x6BC_inputStickangle = temp_f1;
         }
     }
-    if (ft->x2210_ThrowFlags.b3) {
-        ft->x2210_ThrowFlags.b3 = 0;
+    if (fp->x2210_ThrowFlags.b3) {
+        fp->x2210_ThrowFlags.b3 = 0;
         phi_r0 = 1;
     } else {
         phi_r0 = 0;
     }
     if (phi_r0 != 0) {
-        if (abs(ft->input.x620_lstick_x) > attr->x30) {
-            func_8007D9FC(ft);
-            func_80075AF0(ft, 0, (f32) (HALF_PI * ft->x2C_facing_direction));
+        if (abs(fp->input.x620_lstick_x) > attr->x30) {
+            func_8007D9FC(fp);
+            func_80075AF0(fp, 0, (f32) (HALF_PI * fp->x2C_facing_direction));
         }
     }
 }
@@ -135,32 +135,32 @@ void lbl_801384F0(HSD_GObj* gobj) {
 void lbl_80138638(HSD_GObj* gobj) {
     struct attr* attr2;
     MarsAttributes* attr;
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 unused[8];
     s32 num;
 
     // this is required, dunno why
-    ft->xE0_ground_or_air;
+    fp->xE0_ground_or_air;
 
-    if (ft->xE0_ground_or_air == GA_Air) {
-        if (ft->x2208_ftcmd_var2 == 0) {
+    if (fp->xE0_ground_or_air == GA_Air) {
+        if (fp->x2208_ftcmd_var2 == 0) {
             func_80085154(gobj);
-            if (ft->x80_self_vel.x < 0.0f) {
+            if (fp->x80_self_vel.x < 0.0f) {
                 num = -1;
             } else {
                 num = 1;
             }
-            if (ft->x2C_facing_direction != num) {
-                ft->x80_self_vel.x *= -1.0f;
+            if (fp->x2C_facing_direction != num) {
+                fp->x80_self_vel.x *= -1.0f;
             }
-            if (ft->x6A4_transNOffset.y < 0.0f) {
-                ft->x2208_ftcmd_var2 = 1;
+            if (fp->x6A4_transNOffset.y < 0.0f) {
+                fp->x2208_ftcmd_var2 = 1;
             }
         } else {
-            attr = ft->x2D4_specialAttributes;
-            attr2 = &ft->x110_attr;
-            func_8007D494(ft, attr->x44, attr->x48);
-            func_8007D344(ft, 0.0f, attr2->x174_AerialDriftStickMult * attr->x28, attr2->x17C_AerialDriftMax * attr->x28);
+            attr = fp->x2D4_specialAttributes;
+            attr2 = &fp->x110_attr;
+            func_8007D494(fp, attr->x44, attr->x48);
+            func_8007D344(fp, 0.0f, attr2->x174_AerialDriftStickMult * attr->x28, attr2->x17C_AerialDriftMax * attr->x28);
         }
     } else {
         func_80084FA8(gobj);
@@ -170,44 +170,44 @@ void lbl_80138638(HSD_GObj* gobj) {
 // 8013873C 0013531C
 // https://decomp.me/scratch/9gz2V
 void lbl_8013873C(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    MarsAttributes* attr = ft->x2D4_specialAttributes;
-    struct attr* attr2 = &ft->x110_attr;
+    Fighter* fp = gobj->user_data;
+    MarsAttributes* attr = fp->x2D4_specialAttributes;
+    struct attr* attr2 = &fp->x110_attr;
     s32 num;
     s32 unused[10];
 
-    if (ft->x2200_ftcmd_var0 != 0) {
-        if (ft->x2208_ftcmd_var2 == 0) {
+    if (fp->x2200_ftcmd_var0 != 0) {
+        if (fp->x2208_ftcmd_var2 == 0) {
             func_80085154(gobj);
-            ft->x80_self_vel.x *= attr->x40;
-            ft->x80_self_vel.y *= attr->x40;
-            ft->x80_self_vel.z *= attr->x40;
-            if (ft->x80_self_vel.x < 0.0f) {
+            fp->x80_self_vel.x *= attr->x40;
+            fp->x80_self_vel.y *= attr->x40;
+            fp->x80_self_vel.z *= attr->x40;
+            if (fp->x80_self_vel.x < 0.0f) {
                 num = -1;
             } else {
                 num = 1;
             }
-            if (ft->x2C_facing_direction != num) {
-                ft->x80_self_vel.x *= -1.0f;
+            if (fp->x2C_facing_direction != num) {
+                fp->x80_self_vel.x *= -1.0f;
             }
-            if (ft->x6A4_transNOffset.y < 0.0f) {
-                ft->x2208_ftcmd_var2 = 1;
+            if (fp->x6A4_transNOffset.y < 0.0f) {
+                fp->x2208_ftcmd_var2 = 1;
             }
         } else {
-            func_8007D494(ft, attr->x44, attr->x48);
-            func_8007D344(ft, 0.0f, attr2->x174_AerialDriftStickMult * attr->x28, attr2->x17C_AerialDriftMax * attr->x28);
+            func_8007D494(fp, attr->x44, attr->x48);
+            func_8007D344(fp, 0.0f, attr2->x174_AerialDriftStickMult * attr->x28, attr2->x17C_AerialDriftMax * attr->x28);
         }
     } else {
-        func_8007D494(ft, attr2->x16C_Gravity, attr2->x170_TerminalVelocity);
-        func_8007CF58(ft);
+        func_8007D494(fp, attr2->x16C_Gravity, attr2->x170_TerminalVelocity);
+        func_8007CF58(fp);
     }
 }
 
 // 80138884 00135464
 // https://decomp.me/scratch/NTb4a
 void lbl_80138884(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    MarsAttributes* attr = ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    MarsAttributes* attr = fp->x2D4_specialAttributes;
     func_800D5CB0(gobj, 0, attr->x2C);
 }
 
@@ -216,12 +216,12 @@ void lbl_80138884(HSD_GObj* gobj) {
 // 801388B4 00135494
 // https://decomp.me/scratch/3MMkJ
 void lbl_801388B4(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    if (ft->xE0_ground_or_air == GA_Air) {
-        if (ft->x2200_ftcmd_var0 == 0 || ft->x80_self_vel.y >= 0.0f) {
+    Fighter* fp = gobj->user_data;
+    if (fp->xE0_ground_or_air == GA_Air) {
+        if (fp->x2200_ftcmd_var0 == 0 || fp->x80_self_vel.y >= 0.0f) {
             func_80083B68(gobj);
-        } else if (ft->x2204_ftcmd_var1 == 0) {
-            ft->x2204_ftcmd_var1 = 1;
+        } else if (fp->x2204_ftcmd_var1 == 0) {
+            fp->x2204_ftcmd_var1 = 1;
             func_80083B68(gobj);
         } else {
             func_800831CC(gobj, &func_80096CC8, &lbl_80138884);
@@ -234,12 +234,12 @@ void lbl_801388B4(HSD_GObj* gobj) {
 // 80138940 00135520
 // https://decomp.me/scratch/QEKrM
 void lbl_80138940(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    if (ft->xE0_ground_or_air == GA_Air) {
-        if (ft->x2200_ftcmd_var0 == 0 || ft->x80_self_vel.y >= 0.0f) {
+    Fighter* fp = gobj->user_data;
+    if (fp->xE0_ground_or_air == GA_Air) {
+        if (fp->x2200_ftcmd_var0 == 0 || fp->x80_self_vel.y >= 0.0f) {
             func_80083B68(gobj);
-        } else if (ft->x2204_ftcmd_var1 == 0) {
-            ft->x2204_ftcmd_var1 = 1;
+        } else if (fp->x2204_ftcmd_var1 == 0) {
+            fp->x2204_ftcmd_var1 = 1;
             func_80083B68(gobj);
         } else {
             func_800831CC(gobj, &func_80096CC8, &lbl_80138884);

--- a/src/melee/ft/chara/ftMars/ftMarsSpecialLw.c
+++ b/src/melee/ft/chara/ftMars/ftMarsSpecialLw.c
@@ -3,29 +3,29 @@
 // 801389CC 001355AC
 // https://decomp.me/scratch/r3Of5
 void ftMars_SpecialLw_StartAction(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     u32 unused[2];
 
     ((Fighter*)gobj->user_data)->x80_self_vel.y = 0.0f;
     Fighter_ActionStateChange_800693AC(gobj, 0x171, 0, NULL, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
-    ft = gobj->user_data;
-    ft->x2204_ftcmd_var1 = 0;
-    ft->x2340_stateVar1 = 0;
+    fp = gobj->user_data;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2340_stateVar1 = 0;
 }
 
 // 80138A30 00135610
 // https://decomp.me/scratch/dhCgH
 void ftMars_SpecialAirLw_StartAction(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     Fighter* ft2;
     MarsAttributes* attr;
     u32 unused[4];
 
-    ft = gobj->user_data;
-    attr = ft->x2D4_specialAttributes;
-    ft->x80_self_vel.x /= attr->x4C;
-    ft->x80_self_vel.y = 0.0f;
+    fp = gobj->user_data;
+    attr = fp->x2D4_specialAttributes;
+    fp->x80_self_vel.x /= attr->x4C;
+    fp->x80_self_vel.y = 0.0f;
     Fighter_ActionStateChange_800693AC(gobj, 0x173, 0, NULL, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
     ft2 = gobj->user_data;
@@ -37,19 +37,19 @@ void ftMars_SpecialAirLw_StartAction(HSD_GObj* gobj) {
 // https://decomp.me/scratch/cZhES
 void lbl_80138AA8(HSD_GObj* gobj) {
     MarsAttributes* attr;
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     u32 unused[4];
 
-    attr = ft->x2D4_specialAttributes;
+    attr = fp->x2D4_specialAttributes;
 
-    if (ft->x2204_ftcmd_var1 == 1) {
-        ft->x2204_ftcmd_var1 = 2;
+    if (fp->x2204_ftcmd_var1 == 1) {
+        fp->x2204_ftcmd_var1 = 2;
         func_8007B1B8(gobj, &attr->x64, &lbl_80139140);
-        ft->x221B_flag.bits.b1 = 1;
-        ft->x19B4_shieldUnk = attr->x60;
-        ft->x19B8_shieldUnk = attr->x60;
-    } else if (ft->x2204_ftcmd_var1 == 0) {
-        ft->x221B_flag.bits.b0 = 0;
+        fp->x221B_flag.bits.b1 = 1;
+        fp->x19B4_shieldUnk = attr->x60;
+        fp->x19B8_shieldUnk = attr->x60;
+    } else if (fp->x2204_ftcmd_var1 == 0) {
+        fp->x221B_flag.bits.b0 = 0;
     }
     if (ftAnim_IsFramesRemaining(gobj) == 0) {
         func_8008A2BC(gobj);
@@ -60,19 +60,19 @@ void lbl_80138AA8(HSD_GObj* gobj) {
 // https://decomp.me/scratch/cXGg1
 void lbl_80138B64(HSD_GObj* gobj) {
     MarsAttributes* attr;
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     u32 unused[4];
 
-    attr = ft->x2D4_specialAttributes;
+    attr = fp->x2D4_specialAttributes;
 
-    if (ft->x2204_ftcmd_var1 == 1) {
-        ft->x2204_ftcmd_var1 = 2;
+    if (fp->x2204_ftcmd_var1 == 1) {
+        fp->x2204_ftcmd_var1 = 2;
         func_8007B1B8(gobj, &attr->x64, &lbl_80139140);
-        ft->x221B_flag.bits.b1 = 1;
-        ft->x19B4_shieldUnk = attr->x60;
-        ft->x19B8_shieldUnk = attr->x60;
-    } else if (ft->x2204_ftcmd_var1 == 0) {
-        ft->x221B_flag.bits.b0 = 0;
+        fp->x221B_flag.bits.b1 = 1;
+        fp->x19B4_shieldUnk = attr->x60;
+        fp->x19B8_shieldUnk = attr->x60;
+    } else if (fp->x2204_ftcmd_var1 == 0) {
+        fp->x221B_flag.bits.b0 = 0;
     }
     if (ftAnim_IsFramesRemaining(gobj) == 0) {
         func_800CC730(gobj);
@@ -98,14 +98,14 @@ void lbl_80138C28(HSD_GObj* gobj) {
 // 80138C5C 0013583C
 // https://decomp.me/scratch/mO6jh
 void lbl_80138C5C(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     MarsAttributes* attr;
     u32 unused[4];
 
-    ft = gobj->user_data;
-    attr = ft->x2D4_specialAttributes;
-    func_8007D494(ft, attr->x54, attr->x58);
-    func_8007CE94(ft, attr->x50);
+    fp = gobj->user_data;
+    attr = fp->x2D4_specialAttributes;
+    func_8007D494(fp, attr->x54, attr->x58);
+    func_8007CE94(fp, attr->x50);
     func_8007AEE0(gobj);
 }
 
@@ -128,14 +128,14 @@ void lbl_80138CFC(HSD_GObj* gobj) {
 // 80138D38 00135918
 // https://decomp.me/scratch/Oy4iP
 void func_80138D38(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     Fighter* ft_2;
     MarsAttributes* attr;
     u32 unused[4];
 
-    ft = gobj->user_data;
-    func_8007D5D4(ft);
-    Fighter_ActionStateChange_800693AC(gobj, 0x173, 0x0C4C508C, NULL, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    fp = gobj->user_data;
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(gobj, 0x173, 0x0C4C508C, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
     ft_2 = gobj->user_data;
     attr = ft_2->x2D4_specialAttributes;
     if (ft_2->x2204_ftcmd_var1 == 2) {
@@ -147,14 +147,14 @@ void func_80138D38(HSD_GObj* gobj) {
 // 80138DD0 001359B0
 // https://decomp.me/scratch/1GmaW
 void func_80138DD0(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     Fighter* ft_2;
     MarsAttributes* attr;
     s32 unused[4];
 
-    ft = gobj->user_data;
-    func_8007D7FC(ft);
-    Fighter_ActionStateChange_800693AC(gobj, 0x171, 0x0C4C508C, NULL, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    fp = gobj->user_data;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(gobj, 0x171, 0x0C4C508C, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
     ft_2 = gobj->user_data;
     attr = ft_2->x2D4_specialAttributes;
     if (ft_2->x2204_ftcmd_var1 == 2) {
@@ -167,29 +167,29 @@ void func_80138DD0(HSD_GObj* gobj) {
 // https://decomp.me/scratch/OGvxj
 void lbl_80138E68(HSD_GObj* gobj) {
     s32 ndx, hb;
-    Fighter* ft;
+    Fighter* fp;
     s32 sv1;
     s32 unused[2];
 
-    ft = gobj->user_data;
-    sv1 = ft->x2340_stateVar1;
+    fp = gobj->user_data;
+    sv1 = fp->x2340_stateVar1;
 
-    ft->x2340_stateVar1; // required for some reason
+    fp->x2340_stateVar1; // required for some reason
 
     if (sv1 > 0 && func_800872A4(gobj) == FTKIND_EMBLEM) {
         // register swap:
         // for (ndx = 0; ndx < 4; ndx++) {
-        //     if (ft->x914[ndx].x0 == 1) {
-        //         func_8007ABD0(&ft->x914[ndx], ft->x2340_stateVar1, gobj);
+        //     if (fp->x914[ndx].x0 == 1) {
+        //         func_8007ABD0(&fp->x914[ndx], fp->x2340_stateVar1, gobj);
         //     }
         // }
 
         // matches but gross:
         ndx = 0;
-        hb = (s32)ft;
+        hb = (s32)fp;
         while (ndx < 4) {
             if (*(s32*)(hb+0x914) == 1) {
-                func_8007ABD0((Hitbox*)(hb+0x914), ft->x2340_stateVar1, gobj);
+                func_8007ABD0((Hitbox*)(hb+0x914), fp->x2340_stateVar1, gobj);
             }
             ndx++;
             hb += 0x138;
@@ -204,29 +204,29 @@ void lbl_80138E68(HSD_GObj* gobj) {
 // https://decomp.me/scratch/Jx7Ov
 void lbl_80138F14(HSD_GObj* gobj) {
     s32 ndx, hb;
-    Fighter* ft;
+    Fighter* fp;
     s32 sv1;
     s32 unused[2];
 
-    ft = gobj->user_data;
-    sv1 = ft->x2340_stateVar1;
+    fp = gobj->user_data;
+    sv1 = fp->x2340_stateVar1;
 
-    ft->x2340_stateVar1; // required for some reason
+    fp->x2340_stateVar1; // required for some reason
 
     if (sv1 > 0 && func_800872A4(gobj) == FTKIND_EMBLEM) {
         // register swap:
         // for (ndx = 0; ndx < 4; ndx++) {
-        //     if (ft->x914[ndx].x0 == 1) {
-        //         func_8007ABD0(&ft->x914[ndx], ft->x2340_stateVar1, gobj);
+        //     if (fp->x914[ndx].x0 == 1) {
+        //         func_8007ABD0(&fp->x914[ndx], fp->x2340_stateVar1, gobj);
         //     }
         // }
 
         // matches but gross:
         ndx = 0;
-        hb = (s32)ft;
+        hb = (s32)fp;
         while (ndx < 4) {
             if (*(s32*)(hb+0x914) == 1) {
-                func_8007ABD0((Hitbox*)(hb+0x914), ft->x2340_stateVar1, gobj);
+                func_8007ABD0((Hitbox*)(hb+0x914), fp->x2340_stateVar1, gobj);
             }
             ndx++;
             hb += 0x138;
@@ -276,23 +276,23 @@ void lbl_80139044(HSD_GObj* gobj) {
 // 80139080 00135C60
 // https://decomp.me/scratch/w0qtf
 void func_80139080(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    func_8007D5D4(ft);
-    Fighter_ActionStateChange_800693AC(gobj, 0x174, 0x0C4C508E, NULL, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = gobj->user_data;
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(gobj, 0x174, 0x0C4C508E, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 // 801390E0 00135CC0
 // https://decomp.me/scratch/qAmn3
 void func_801390E0(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    func_8007D7FC(ft);
-    Fighter_ActionStateChange_800693AC(gobj, 0x172, 0x0C4C508E, NULL, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = gobj->user_data;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(gobj, 0x172, 0x0C4C508E, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 // 80139140 00135D20
 // https://decomp.me/scratch/8uP2v
 void lbl_80139140(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     Fighter* ft_2;
     MarsAttributes* attr;
     s32 temp_r0;
@@ -301,16 +301,16 @@ void lbl_80139140(HSD_GObj* gobj) {
     Vec3 sp18;
     s32 unused2[3];
 
-    ft = gobj->user_data;
-    attr = ft->x2D4_specialAttributes;
-    ft->x2C_facing_direction = ft->x19AC;
-    temp_r0 = (s32) ft->x19A4;
+    fp = gobj->user_data;
+    attr = fp->x2D4_specialAttributes;
+    fp->x2C_facing_direction = fp->x19AC;
+    temp_r0 = (s32) fp->x19A4;
     if (temp_r0 > 0) {
-        ft->x2340_stateVar1 = (s32) (temp_r0 * attr->x5C);
+        fp->x2340_stateVar1 = (s32) (temp_r0 * attr->x5C);
     }
-    func_8000B1CC(ft->x5E8_fighterBones[func_8007500C(ft, 4)].x0_jobj, 0, &sp18);
+    func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 4)].x0_jobj, 0, &sp18);
     func_800119DC(&sp18, 0x78, 0.9f, 0.02f, 1.0471975803375244f);
-    if (ft->xE0_ground_or_air == GA_Ground) {
+    if (fp->xE0_ground_or_air == GA_Ground) {
         thing = 0x172;
     } else {
         thing = 0x174;

--- a/src/melee/ft/chara/ftMars/ftMarsSpecialN.c
+++ b/src/melee/ft/chara/ftMars/ftMarsSpecialN.c
@@ -4,13 +4,13 @@
 // ftMars_SpecialN
 // https://decomp.me/scratch/i9Tn0
 void ftMars_SpecialN_StartAction(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    MarsAttributes* attrs = ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    MarsAttributes* attrs = fp->x2D4_specialAttributes;
     u32 unused, unused2; // need to eat more stack
 
-    ft->cb.x21EC_callback = &lbl_80136730;
+    fp->cb.x21EC_callback = &lbl_80136730;
 
-    ft->xEC_ground_vel /= attrs->xC;
+    fp->xEC_ground_vel /= attrs->xC;
     Fighter_ActionStateChange_800693AC(gobj, 0x155, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
 }
@@ -19,16 +19,16 @@ void ftMars_SpecialN_StartAction(HSD_GObj* gobj) {
 // ftMars_SpecialNAir
 // https://decomp.me/scratch/4vPWj
 void ftMars_SpecialAirN_StartAction(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    MarsAttributes* attrs = ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    MarsAttributes* attrs = fp->x2D4_specialAttributes;
     u32 unused, unused2; // need to eat more stack
 
-    ft->cb.x21EC_callback = &lbl_80136730;
+    fp->cb.x21EC_callback = &lbl_80136730;
 
-    ft->x80_self_vel.x /= attrs->xC;
+    fp->x80_self_vel.x /= attrs->xC;
 
-    if (ft->x80_self_vel.y <= 0.0f) {
-        ft->x80_self_vel.y = 0.0f;
+    if (fp->x80_self_vel.y <= 0.0f) {
+        fp->x80_self_vel.y = 0.0f;
     }
 
     Fighter_ActionStateChange_800693AC(gobj, 0x159, 0, 0, 0.0f, 1.0f, 0.0f);
@@ -72,23 +72,23 @@ void lbl_80136918(HSD_GObj* gobj) {
 // 8013691C 001334FC
 // https://decomp.me/scratch/rfZA7
 void lbl_8013691C(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    MarsAttributes* attr = ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    MarsAttributes* attr = fp->x2D4_specialAttributes;
     u32 unused, unused2; // gobble stack space
 
-    func_8007C930(ft, attr->x10);
+    func_8007C930(fp, attr->x10);
     func_8007CB74(gobj);
 }
 
 // 8013695C 0013353C
 // https://decomp.me/scratch/dKnHk
 void lbl_8013695C(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    MarsAttributes* attr = ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    MarsAttributes* attr = fp->x2D4_specialAttributes;
     u32 unused, unused2;
 
-    func_8007D4B8(ft);
-    func_8007CE94(ft, attr->x10);
+    func_8007D4B8(fp);
+    func_8007CE94(fp, attr->x10);
 }
 
 // 801369A4 00133584
@@ -110,37 +110,37 @@ void lbl_801369E0(HSD_GObj* gobj) {
 // 80136A1C 001335FC
 // https://decomp.me/scratch/9GhD1
 void func_80136A1C(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
 
-    func_8007D5D4(ft);
-    Fighter_ActionStateChange_800693AC(gobj, 0x159, 0x0C4C5084, 0, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(gobj, 0x159, 0x0C4C5084, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 // 80136A7C 0013365C
 // https://decomp.me/scratch/GU6fn
 void func_80136A7C(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
 
-    func_8007D7FC(ft);
-    Fighter_ActionStateChange_800693AC(gobj, 0x155, 0x0C4C5084, 0, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(gobj, 0x155, 0x0C4C5084, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 // 80136ADC 001336BC
 // Animation_MarthNeutralBCharge
 // https://decomp.me/scratch/jR5uM
 void lbl_80136ADC(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    s32* specialAttrs = ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    s32* specialAttrs = fp->x2D4_specialAttributes;
     Vec3 sp28;
     s32 unused[7];
 
-    if ((s32)ft->x2340_stateVar1 % 30 == 0) {
-        func_8000B1CC(ft->x5E8_fighterBones[func_8007500C(ft, 4)].x0_jobj, 0, &sp28);
+    if ((s32)fp->x2340_stateVar1 % 30 == 0) {
+        func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 4)].x0_jobj, 0, &sp28);
         func_800119DC(&sp28, 10, 0.5f, 0.05f, 1.0471975803375244f);
     }
-    ft->x2340_stateVar1++;
-    if ((s32)ft->x2340_stateVar1 > *specialAttrs * 30) {
-        ft->x2200_ftcmd_var0 = 1;
+    fp->x2340_stateVar1++;
+    if ((s32)fp->x2340_stateVar1 > *specialAttrs * 30) {
+        fp->x2200_ftcmd_var0 = 1;
         func_80137354(gobj);
     }
 }
@@ -149,18 +149,18 @@ void lbl_80136ADC(HSD_GObj* gobj) {
 // 80136BB4 00133794
 // https://decomp.me/scratch/3bMh4
 void lbl_80136BB4(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    MarsAttributes* attrs = ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    MarsAttributes* attrs = fp->x2D4_specialAttributes;
     Vec3 sp28;
     s32 unused[7];
 
-    if ((s32)ft->x2340_stateVar1 % 30 == 0) {
-        func_8000B1CC(ft->x5E8_fighterBones[func_8007500C(ft, 4)].x0_jobj, 0, &sp28);
+    if ((s32)fp->x2340_stateVar1 % 30 == 0) {
+        func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 4)].x0_jobj, 0, &sp28);
         func_800119DC(&sp28, 10, 0.5f, 0.05f, 1.0471975803375244f);
     }
-    ft->x2340_stateVar1++;
-    if ((s32)ft->x2340_stateVar1 > attrs->x0 * 30) {
-        ft->x2200_ftcmd_var0 = 1;
+    fp->x2340_stateVar1++;
+    if ((s32)fp->x2340_stateVar1 > attrs->x0 * 30) {
+        fp->x2200_ftcmd_var0 = 1;
         func_801373B8(gobj);
     }
 }
@@ -169,9 +169,9 @@ void lbl_80136BB4(HSD_GObj* gobj) {
 // Interrupt_MarthNeutralBCharge
 // https://decomp.me/scratch/zR8Hv
 void lbl_80136C8C(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    if ((ft->input.x65C_heldInputs & 0x200) == 0) {
-        ft->x2200_ftcmd_var0 = 0;
+    Fighter* fp = gobj->user_data;
+    if ((fp->input.x65C_heldInputs & 0x200) == 0) {
+        fp->x2200_ftcmd_var0 = 0;
         func_80137354(gobj);
     }
 }
@@ -179,9 +179,9 @@ void lbl_80136C8C(HSD_GObj* gobj) {
 // 80136CC4 001338A4
 // https://decomp.me/scratch/ykJFN
 void lbl_80136CC4(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    if ((ft->input.x65C_heldInputs & 0x200) == 0) {
-        ft->x2200_ftcmd_var0 = 0;
+    Fighter* fp = gobj->user_data;
+    if ((fp->input.x65C_heldInputs & 0x200) == 0) {
+        fp->x2200_ftcmd_var0 = 0;
         func_801373B8(gobj);
     }
 }
@@ -217,19 +217,19 @@ void lbl_80136D78(HSD_GObj* gobj) {
 // 80136DB4 00133994
 // https://decomp.me/scratch/eJxjC
 void func_80136DB4(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
 
     func_8007D5D4(gobj->user_data);
-    Fighter_ActionStateChange_800693AC(gobj, 0x15A, 0x0C4C5A86, 0, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter_ActionStateChange_800693AC(gobj, 0x15A, 0x0C4C5A86, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 // 80136E14 001339F4
 // https://decomp.me/scratch/mzQdp
 void func_80136E14(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
 
-    func_8007D7FC(ft);
-    Fighter_ActionStateChange_800693AC(gobj, 0x156, 0x0C4C5A86, 0, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(gobj, 0x156, 0x0C4C5A86, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 // 80136E74 00133A54
@@ -249,27 +249,27 @@ void func_80136EAC(HSD_GObj* gobj) {
 void lbl_80136EE4(HSD_GObj *gobj) {
     s32 ndx;
     MarsAttributes *attr;
-    Fighter *ft;
+    Fighter *fp;
 
-    ft = gobj->user_data;
-    attr = ft->x2D4_specialAttributes;
-    if (ft->x2200_ftcmd_var0 == 0) {
-        s32 hb = (s32)ft;
+    fp = gobj->user_data;
+    attr = fp->x2D4_specialAttributes;
+    if (fp->x2200_ftcmd_var0 == 0) {
+        s32 hb = (s32)fp;
         ndx = 0;
         while (ndx < 4) {
             if (*(s32*)(hb+0x914) == 1) {
-                func_8007ABD0((Hitbox*)(hb+0x914), (f32) (attr->x4 + (s32)ft->x2340_stateVar1 / 30 * attr->x8), gobj);
+                func_8007ABD0((Hitbox*)(hb+0x914), (f32) (attr->x4 + (s32)fp->x2340_stateVar1 / 30 * attr->x8), gobj);
             }
             ndx++;
             hb += 0x138;
         }
     }
-    if (ft->x894_currentAnimFrame == 9.0f) {
+    if (fp->x894_currentAnimFrame == 9.0f) {
         Vec3 position;
         s32 unused1, unused2, unused3, unused4, unused5;
         // JObj_GetWorldPos(r3=JObj,r4=UnkPointer,r5=StoreResult)
         //         Fighter_BonePersonalToCommon
-        func_8000B1CC(ft->x5E8_fighterBones[func_8007500C(ft, 4)].x0_jobj, 0, &position);
+        func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 4)].x0_jobj, 0, &position);
         // AestheticWindEffect(r3=sourcelocation,r4=duration,f1=radiusSize,f2=effectdegradation,f3=unk)
         func_800119DC(&position, 120, 0.9f, 0.02f, 1.0471975803375244f);
     }
@@ -286,37 +286,37 @@ void lbl_80136EE4(HSD_GObj *gobj) {
 void lbl_80137010(HSD_GObj *gobj) {
     s32 ndx;
     MarsAttributes *attr;
-    Fighter *ft;
+    Fighter *fp;
 
-    ft = gobj->user_data;
-    attr = ft->x2D4_specialAttributes;
-    if (ft->x2200_ftcmd_var0 == 0) {
+    fp = gobj->user_data;
+    attr = fp->x2D4_specialAttributes;
+    if (fp->x2200_ftcmd_var0 == 0) {
         // register swap:
         // s32 ndx;
         // for (ndx = 0; ndx < 4; ndx++) {
-        //     if (ft->x914[ndx].x0 == 1) {
+        //     if (fp->x914[ndx].x0 == 1) {
         //         // Hitbox_ApplyDamageStalingAndMore
-        //         func_8007ABD0(&ft->x914[ndx], (f32) (attr->x4 + (s32)ft->x2340_stateVar1 / 30 * attr->x8), gobj);
+        //         func_8007ABD0(&fp->x914[ndx], (f32) (attr->x4 + (s32)fp->x2340_stateVar1 / 30 * attr->x8), gobj);
         //     }
         // }
 
         // matches but gross:
-        s32 hb = (s32)ft;
+        s32 hb = (s32)fp;
         ndx = 0;
         while (ndx < 4) {
             if (*(s32*)(hb+0x914) == 1) {
-                func_8007ABD0((Hitbox*)(hb+0x914), (f32) (attr->x4 + (s32)ft->x2340_stateVar1 / 30 * attr->x8), gobj);
+                func_8007ABD0((Hitbox*)(hb+0x914), (f32) (attr->x4 + (s32)fp->x2340_stateVar1 / 30 * attr->x8), gobj);
             }
             ndx++;
             hb += 0x138;
         }
     }
-    if (ft->x894_currentAnimFrame == 9.0f) {
+    if (fp->x894_currentAnimFrame == 9.0f) {
         Vec3 position;
         s32 unused1, unused2, unused3, unused4, unused5;
         // JObj_GetWorldPos(r3=JObj,r4=UnkPointer,r5=StoreResult)
         //         Fighter_BonePersonalToCommon
-        func_8000B1CC(ft->x5E8_fighterBones[func_8007500C(ft, 4)].x0_jobj, 0, &position);
+        func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 4)].x0_jobj, 0, &position);
         // AestheticWindEffect(r3=sourcelocation,r4=duration,f1=radiusSize,f2=effectdegradation,f3=unk)
         func_800119DC(&position, 120, 0.9f, 0.02f, 1.0471975803375244f);
     }
@@ -368,23 +368,23 @@ void lbl_801371C0(HSD_GObj* arg0) {
 // 801371FC 00133DDC
 // https://decomp.me/scratch/5lf3a
 void func_801371FC(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 thing;
 
-    if (ft->x2200_ftcmd_var0 == 0) {
+    if (fp->x2200_ftcmd_var0 == 0) {
         thing = 0x15B;
     } else {
         thing = 0x15C;
     }
 
     // Air_StoreBool_LoseGroundJump_NoECBfor10Frames
-    func_8007D5D4(ft);
+    func_8007D5D4(fp);
     // ActionStateChange
-    Fighter_ActionStateChange_800693AC(gobj, thing, 0x0C4C508E, 0, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter_ActionStateChange_800693AC(gobj, thing, 0x0C4C508E, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 
-    if (ft->x2219_flag.bits.b0 == 1) {
-        ft->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
-        ft->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
+    if (fp->x2219_flag.bits.b0 == 1) {
+        fp->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
+        fp->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
     }
 }
 
@@ -392,23 +392,23 @@ void func_801371FC(HSD_GObj* gobj) {
 // AS_MarthNeutralBHitAir->Ground
 // https://decomp.me/scratch/IV8RT
 void func_801372A8(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 thing;
 
-    if (ft->x2200_ftcmd_var0 == 0) {
+    if (fp->x2200_ftcmd_var0 == 0) {
         thing = 0x157;
     } else {
         thing = 0x158;
     }
 
     // Air_SetAsGrounded2
-    func_8007D7FC(ft);
+    func_8007D7FC(fp);
     // ActionStateChange
-    Fighter_ActionStateChange_800693AC(gobj, thing, 0x0C4C508E, 0, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter_ActionStateChange_800693AC(gobj, thing, 0x0C4C508E, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 
-    if (ft->x2219_flag.bits.b0 == 1) {
-        ft->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
-        ft->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
+    if (fp->x2219_flag.bits.b0 == 1) {
+        fp->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
+        fp->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
     }
 }
 
@@ -416,31 +416,31 @@ void func_801372A8(HSD_GObj* gobj) {
 // AS_RoyNeutralBSwing
 // https://decomp.me/scratch/4CbiS
 void func_80137354(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 thing;
 
-    if (ft->x2200_ftcmd_var0 == 0) {
+    if (fp->x2200_ftcmd_var0 == 0) {
         thing = 0x157;
     } else {
         thing = 0x158;
     }
 
     Fighter_ActionStateChange_800693AC(gobj, thing, 0, 0, 1.0f, 1.0f, 0.0f);
-    ft->cb.x21BC_callback_Accessory4 = &lbl_801365A8;
+    fp->cb.x21BC_callback_Accessory4 = &lbl_801365A8;
 }
 
 // 801373B8 00133F98
 // https://decomp.me/scratch/mXbi4
 void func_801373B8(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 thing;
 
-    if (ft->x2200_ftcmd_var0 == 0) {
+    if (fp->x2200_ftcmd_var0 == 0) {
         thing = 0x15B;
     } else {
         thing = 0x15C;
     }
 
     Fighter_ActionStateChange_800693AC(gobj, thing, 0, 0, 1.0f, 1.0f, 0.0f);
-    ft->cb.x21BC_callback_Accessory4 = &lbl_8013666C;
+    fp->cb.x21BC_callback_Accessory4 = &lbl_8013666C;
 }

--- a/src/melee/ft/chara/ftMars/ftMarsSpecialS.c
+++ b/src/melee/ft/chara/ftMars/ftMarsSpecialS.c
@@ -3,17 +3,17 @@
 // 8013741C 00133FFC
 // https://decomp.me/scratch/DLE90
 void ftMars_SpecialS_StartAction(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     s32 thing;
     s32 unused1, unused2, unused3, unused4;
 
     ((Fighter*)gobj->user_data)->x80_self_vel.y = 0.0f;
-    ft = gobj->user_data;
-    ft->x2204_ftcmd_var1 = 0;
-    ft->x2200_ftcmd_var0 = 0;
-    ft->x2340_stateVar1 = 0;
+    fp = gobj->user_data;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2340_stateVar1 = 0;
 
-    if (ft->xE0_ground_or_air == GA_Ground) {
+    if (fp->xE0_ground_or_air == GA_Ground) {
         thing = 0x15D;
     } else {
         thing = 0x166;
@@ -26,18 +26,18 @@ void ftMars_SpecialS_StartAction(HSD_GObj* gobj) {
 // 801374A0 00134080
 // https://decomp.me/scratch/vI96P
 void ftMars_SpecialAirS_StartAction(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     Fighter* ft2;
-    MarsAttributes* attr = ft->x2D4_specialAttributes;
+    MarsAttributes* attr = fp->x2D4_specialAttributes;
     s32 thing;
     s32 unused1, unused2;
 
-    ft->x80_self_vel.x = ft->x80_self_vel.x / attr->x14;
-    if ((s32)ft->sa.mars.x222C == 0) {
-        ft->sa.mars.x222C = 1;
-        ft->x80_self_vel.y = attr->x1C;
+    fp->x80_self_vel.x = fp->x80_self_vel.x / attr->x14;
+    if ((s32)fp->sa.mars.x222C == 0) {
+        fp->sa.mars.x222C = 1;
+        fp->x80_self_vel.y = attr->x1C;
     } else {
-        ft->x80_self_vel.y = 0.0f;
+        fp->x80_self_vel.y = 0.0f;
     }
 
     ft2 = gobj->user_data;
@@ -58,10 +58,10 @@ void ftMars_SpecialAirS_StartAction(HSD_GObj* gobj) {
 // 80137558 00134138
 // https://decomp.me/scratch/jDGXt
 void lbl_80137558(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 thing = ftAnim_IsFramesRemaining(gobj);
     if (thing == 0) {
-        if (ft->xE0_ground_or_air == GA_Ground) {
+        if (fp->xE0_ground_or_air == GA_Ground) {
             func_8008A2BC(gobj);
         } else {
             func_800CC730(gobj);
@@ -72,14 +72,14 @@ void lbl_80137558(HSD_GObj* gobj) {
 // 801375B8 00134198
 // https://decomp.me/scratch/tqS1E
 void lbl_801375B8(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    if (ft->x2200_ftcmd_var0 != 0) {
-        if (ft->x2204_ftcmd_var1 == 0 && (ft->input.x668 & 0x300) != 0) {
+    Fighter* fp = gobj->user_data;
+    if (fp->x2200_ftcmd_var0 != 0) {
+        if (fp->x2204_ftcmd_var1 == 0 && (fp->input.x668 & 0x300) != 0) {
             func_80137A9C(gobj);
         }
     } else {
-        if ((ft->input.x668 & 0x300) != 0) {
-            ft->x2204_ftcmd_var1 = 1;
+        if ((fp->input.x668 & 0x300) != 0) {
+            fp->x2204_ftcmd_var1 = 1;
         }
     }
 }
@@ -87,17 +87,17 @@ void lbl_801375B8(HSD_GObj* gobj) {
 // 80137618 001341F8
 // https://decomp.me/scratch/BqYoF
 void lbl_80137618(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    MarsAttributes* attr = ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    MarsAttributes* attr = fp->x2D4_specialAttributes;
     s32 unused1, unused2, unused3, unused4;
 
-    if (ft->xE0_ground_or_air == GA_Ground) {
+    if (fp->xE0_ground_or_air == GA_Ground) {
         // Physics_Friction
         func_80084F3C(gobj);
     } else {
         // subtractF1FromVerticalVelocityAndCheckForTerminalVelocity
-        func_8007D494(ft, attr->x20, attr->x24);
-        func_8007CE94(ft, attr->x18);
+        func_8007D494(fp, attr->x20, attr->x24);
+        func_8007CE94(fp, attr->x18);
     }
 }
 
@@ -105,10 +105,10 @@ void lbl_80137618(HSD_GObj* gobj) {
 // Collision_MarthSideBAir
 // https://decomp.me/scratch/GBmCn
 void lbl_8013767C(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 unused1, unused2;
 
-    if (ft->xE0_ground_or_air == GA_Ground) {
+    if (fp->xE0_ground_or_air == GA_Ground) {
         // EnvironmentCollision_StopAtLedge
         if (func_800827A0(gobj) == 0) {
             func_801376E8(gobj);
@@ -125,32 +125,32 @@ void lbl_8013767C(HSD_GObj* gobj) {
 // 801376E8 001342C8
 // https://decomp.me/scratch/wulEU
 void func_801376E8(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     // Air_StoreBool_LoseGroundJump_NoECBfor10Frames
-    func_8007D5D4(ft);
+    func_8007D5D4(fp);
     // ActionStateChange
-    Fighter_ActionStateChange_800693AC(gobj, 0x166, 0x0C4E508C, 0, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter_ActionStateChange_800693AC(gobj, 0x166, 0x0C4E508C, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 // 80137748 00134328
 // MarthSideBAirToGround
 // https://decomp.me/scratch/fpZ5r
 void func_80137748(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    ft->sa.mars.x222C = 0;
+    Fighter* fp = gobj->user_data;
+    fp->sa.mars.x222C = 0;
     // Air_SetAsGrounded2
-    func_8007D7FC(ft);
+    func_8007D7FC(fp);
     // ActionStateChange
-    Fighter_ActionStateChange_800693AC(gobj, 0x15D, 0x0C4E508C, 0, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter_ActionStateChange_800693AC(gobj, 0x15D, 0x0C4E508C, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 // 801377B0 00134390
 // https://decomp.me/scratch/baBIS
 void lbl_801377B0(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     // FrameTimerCheck
     if (ftAnim_IsFramesRemaining(gobj) == 0) {
-        if (ft->xE0_ground_or_air == GA_Ground) {
+        if (fp->xE0_ground_or_air == GA_Ground) {
             // AS_014_Wait_PlayerCheck
             func_8008A2BC(gobj);
         } else {
@@ -163,14 +163,14 @@ void lbl_801377B0(HSD_GObj* gobj) {
 // 80137810 001343F0
 // https://decomp.me/scratch/wl5uM
 void lbl_80137810(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    if (ft->x2200_ftcmd_var0 != 0) {
-        if (ft->x2204_ftcmd_var1 == 0 && (ft->input.x668 & 0x300) != 0) {
+    Fighter* fp = gobj->user_data;
+    if (fp->x2200_ftcmd_var0 != 0) {
+        if (fp->x2204_ftcmd_var1 == 0 && (fp->input.x668 & 0x300) != 0) {
             func_80137E0C(gobj);
         }
     } else {
-        if ((ft->input.x668 & 0x300) != 0) {
-            ft->x2204_ftcmd_var1 = 1;
+        if ((fp->input.x668 & 0x300) != 0) {
+            fp->x2204_ftcmd_var1 = 1;
         }
     }
 }
@@ -178,17 +178,17 @@ void lbl_80137810(HSD_GObj* gobj) {
 // 80137870 00134450
 // https://decomp.me/scratch/iRZdQ
 void lbl_80137870(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    MarsAttributes* attr = ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    MarsAttributes* attr = fp->x2D4_specialAttributes;
     s32 unused1, unused2, unused3, unused4;
 
-    if (ft->xE0_ground_or_air == GA_Ground) {
+    if (fp->xE0_ground_or_air == GA_Ground) {
         // Physics_Friction
         func_80084F3C(gobj);
     } else {
         // subtractF1FromVerticalVelocityAndCheckForTerminalVelocity
-        func_8007D494(ft, attr->x20, attr->x24);
-        func_8007CE94(ft, attr->x18);
+        func_8007D494(fp, attr->x20, attr->x24);
+        func_8007CE94(fp, attr->x18);
     }
 }
 
@@ -196,10 +196,10 @@ void lbl_80137870(HSD_GObj* gobj) {
 // Collision_MarthSideB2Air
 // https://decomp.me/scratch/MqEA1
 void lbl_801378D4(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 unused1, unused2;
 
-    if (ft->xE0_ground_or_air == GA_Ground) {
+    if (fp->xE0_ground_or_air == GA_Ground) {
         // EnvironmentCollision_StopAtLedge
         if (func_800827A0(gobj) == 0) {
             func_80137940(gobj);
@@ -214,11 +214,11 @@ void lbl_801378D4(HSD_GObj* gobj) {
 // 80137940 00134520
 // https://decomp.me/scratch/HjsYm
 void func_80137940(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 thing;
 
-    func_8007D5D4(ft);
-    switch (ft->x10_action_state_index) {
+    func_8007D5D4(fp);
+    switch (fp->x10_action_state_index) {
         case 0x15E:
             thing = 0x167;
             break;
@@ -228,19 +228,19 @@ void func_80137940(HSD_GObj* gobj) {
         // default:
         // thing uninitialized
     }
-    Fighter_ActionStateChange_800693AC(gobj, thing, 0x0C4E508C, 0, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter_ActionStateChange_800693AC(gobj, thing, 0x0C4E508C, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 // 801379D0 001345B0
 // MarthSideB2AirToGround
 // https://decomp.me/scratch/711pp
 void func_801379D0(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 thing;
 
-    ft->sa.mars.x222C = 0;
-    func_8007D7FC(ft);
-    switch (ft->x10_action_state_index) {
+    fp->sa.mars.x222C = 0;
+    func_8007D7FC(fp);
+    switch (fp->x10_action_state_index) {
         case 0x167:
             thing = 0x15E;
             break;
@@ -250,7 +250,7 @@ void func_801379D0(HSD_GObj* gobj) {
         // default:
         // thing uninitialized
     }
-    Fighter_ActionStateChange_800693AC(gobj, thing, 0x0C4E508C, 0, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter_ActionStateChange_800693AC(gobj, thing, 0x0C4E508C, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 // 80137A68 00134648
@@ -263,21 +263,21 @@ void lbl_80137A68(HSD_GObj* gobj) {
 // 80137A9C 0013467C
 // https://decomp.me/scratch/CVXJ2
 void func_80137A9C(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 thing;
 
-    ft->x2204_ftcmd_var1 = 0;
-    ft->x2200_ftcmd_var0 = 0;
-    ft->cb.x21EC_callback = &lbl_80137A68;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->cb.x21EC_callback = &lbl_80137A68;
 
-    if (ft->input.x624_lstick_y > p_ftCommonData->x21C) {
-        if (ft->xE0_ground_or_air == GA_Ground) {
+    if (fp->input.x624_lstick_y > p_ftCommonData->x21C) {
+        if (fp->xE0_ground_or_air == GA_Ground) {
             thing = 0x15E;
         } else {
             thing = 0x167;
         }
     } else {
-        if (ft->xE0_ground_or_air == GA_Ground) {
+        if (fp->xE0_ground_or_air == GA_Ground) {
             thing = 0x15F;
         } else {
             thing = 0x168;
@@ -289,10 +289,10 @@ void func_80137A9C(HSD_GObj* gobj) {
 // 80137B34 00134714
 // https://decomp.me/scratch/nDoR1
 void lbl_80137B34(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     // FrameTimerCheck
     if (ftAnim_IsFramesRemaining(gobj) == 0) {
-        if (ft->xE0_ground_or_air == GA_Ground) {
+        if (fp->xE0_ground_or_air == GA_Ground) {
             // AS_014_Wait_PlayerCheck
             func_8008A2BC(gobj);
         } else {
@@ -305,15 +305,15 @@ void lbl_80137B34(HSD_GObj* gobj) {
 // 80137B94 00134774
 // https://decomp.me/scratch/5TRaz
 void lbl_80137B94(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
 
-    if (ft->x2200_ftcmd_var0 != 0) {
-        if (ft->x2204_ftcmd_var1 == 0 && (ft->input.x668 & 0x300) != 0) {
+    if (fp->x2200_ftcmd_var0 != 0) {
+        if (fp->x2204_ftcmd_var1 == 0 && (fp->input.x668 & 0x300) != 0) {
             func_80138148(gobj);
         }
     } else {
-        if ((ft->input.x668 & 0x300) != 0) {
-            ft->x2204_ftcmd_var1 = 1;
+        if ((fp->input.x668 & 0x300) != 0) {
+            fp->x2204_ftcmd_var1 = 1;
         }
     }
 }
@@ -321,16 +321,16 @@ void lbl_80137B94(HSD_GObj* gobj) {
 // 80137BF4 001347D4
 // https://decomp.me/scratch/vI7hc
 void lbl_80137BF4(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    MarsAttributes* attr = ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    MarsAttributes* attr = fp->x2D4_specialAttributes;
     s32 unused1, unused2, unused3, unused4;
 
-    if (ft->xE0_ground_or_air == GA_Ground) {
+    if (fp->xE0_ground_or_air == GA_Ground) {
         // somethingFriction
         func_80084FA8(gobj);
     } else {
         // subtractF1FromVerticalVelocityAndCheckForTerminalVelocity
-        func_8007D494(ft, attr->x20, attr->x24);
+        func_8007D494(fp, attr->x20, attr->x24);
         func_80085204(gobj);
     }
 }
@@ -338,9 +338,9 @@ void lbl_80137BF4(HSD_GObj* gobj) {
 // 80137C50 00134830
 // https://decomp.me/scratch/uvl0U
 void lbl_80137C50(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 unused1, unused2;
-    if (ft->xE0_ground_or_air == GA_Ground) {
+    if (fp->xE0_ground_or_air == GA_Ground) {
         // EnvironmentCollision_StopAtLedge
         if (func_800827A0(gobj) == 0) {
             func_80137CBC(gobj);
@@ -356,12 +356,12 @@ void lbl_80137C50(HSD_GObj* gobj) {
 // 80137CBC 0013489C
 // https://decomp.me/scratch/vJNoz
 void func_80137CBC(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 thing;
 
     // Air_StoreBool_LoseGroundJump_NoECBfor10Frames
-    func_8007D5D4(ft);
-    switch (ft->x10_action_state_index) {
+    func_8007D5D4(fp);
+    switch (fp->x10_action_state_index) {
         case 0x160:
             thing = 0x169;
             break;
@@ -375,18 +375,18 @@ void func_80137CBC(HSD_GObj* gobj) {
         // thing uninitialized
     }
     // ActionStateChange
-    Fighter_ActionStateChange_800693AC(gobj, thing, 0x0C4E508C, 0, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter_ActionStateChange_800693AC(gobj, thing, 0x0C4E508C, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 // 80137D60 00134940
 // https://decomp.me/scratch/yYIRO
 void func_80137D60(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 thing;
-    ft->sa.mars.x222C = 0;
+    fp->sa.mars.x222C = 0;
     // // Air_SetAsGrounded2
-    func_8007D7FC(ft);
-    switch (ft->x10_action_state_index) {
+    func_8007D7FC(fp);
+    switch (fp->x10_action_state_index) {
         case 0x169:
             thing = 0x160;
             break;
@@ -398,34 +398,34 @@ void func_80137D60(HSD_GObj* gobj) {
             break;
     }
     // ActionStateChange
-    Fighter_ActionStateChange_800693AC(gobj, thing, 0x0C4E508C, 0, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter_ActionStateChange_800693AC(gobj, thing, 0x0C4E508C, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 // 80137E0C 001349EC
 // https://decomp.me/scratch/zlWGu
 void func_80137E0C(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 thing;
 
-    ft->x2204_ftcmd_var1 = 0;
-    ft->x2200_ftcmd_var0 = 0;
-    ft->cb.x21EC_callback = &lbl_80137A68;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->cb.x21EC_callback = &lbl_80137A68;
 
-    if (ft->input.x624_lstick_y > p_ftCommonData->x21C) {
-        if (ft->xE0_ground_or_air == GA_Ground) {
+    if (fp->input.x624_lstick_y > p_ftCommonData->x21C) {
+        if (fp->xE0_ground_or_air == GA_Ground) {
             thing = 0x160;
         } else {
             thing = 0x169;
         }
     } else {
-        if (ft->input.x624_lstick_y < -p_ftCommonData->x21C) {
-            if (ft->xE0_ground_or_air == GA_Ground) {
+        if (fp->input.x624_lstick_y < -p_ftCommonData->x21C) {
+            if (fp->xE0_ground_or_air == GA_Ground) {
                 thing = 0x162;
             } else {
                 thing = 0x16B;
             }
         } else {
-            if (ft->xE0_ground_or_air == GA_Ground) {
+            if (fp->xE0_ground_or_air == GA_Ground) {
                 thing = 0x161;
             } else {
                 thing = 0x16A;
@@ -438,10 +438,10 @@ void func_80137E0C(HSD_GObj* gobj) {
 // 80137ECC 00134AAC
 // https://decomp.me/scratch/5uXTE
 void lbl_80137ECC(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     // FrameTimerCheck
     if (ftAnim_IsFramesRemaining(gobj) == 0) {
-        if (ft->xE0_ground_or_air == GA_Ground) {
+        if (fp->xE0_ground_or_air == GA_Ground) {
             // AS_014_Wait_PlayerCheck
             func_8008A2BC(gobj);
         } else {
@@ -458,16 +458,16 @@ void lbl_80137F2C(HSD_GObj* gobj) {
 // 80137F30 00134B10
 // https://decomp.me/scratch/zDuRP
 void lbl_80137F30(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    MarsAttributes* attr = ft->x2D4_specialAttributes;
+    Fighter* fp = gobj->user_data;
+    MarsAttributes* attr = fp->x2D4_specialAttributes;
     s32 unused[4];
 
-    if (ft->xE0_ground_or_air == GA_Ground) {
+    if (fp->xE0_ground_or_air == GA_Ground) {
         // somethingFriction
         func_80084FA8(gobj);
     } else {
         // subtractF1FromVerticalVelocityAndCheckForTerminalVelocity
-        func_8007D494(ft, attr->x20, attr->x24);
+        func_8007D494(fp, attr->x20, attr->x24);
         func_80085204(gobj);
     }
 }
@@ -475,10 +475,10 @@ void lbl_80137F30(HSD_GObj* gobj) {
 // 80137F8C 00134B6C
 // https://decomp.me/scratch/qwYn8
 void lbl_80137F8C(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 unused[2];
 
-    if (ft->xE0_ground_or_air == GA_Ground) {
+    if (fp->xE0_ground_or_air == GA_Ground) {
         // EnvironmentCollision_StopAtLedge
         if (func_800827A0(gobj) == 0) {
             func_80137FF8(gobj);
@@ -494,11 +494,11 @@ void lbl_80137F8C(HSD_GObj* gobj) {
 // 80137FF8 00134BD8
 // https://decomp.me/scratch/9o4hn
 void func_80137FF8(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 thing;
     // Air_StoreBool_LoseGroundJump_NoECBfor10Frames
-    func_8007D5D4(ft);
-    switch (ft->x10_action_state_index) {
+    func_8007D5D4(fp);
+    switch (fp->x10_action_state_index) {
         case 0x163:
             thing = 0x16C;
             break;
@@ -512,19 +512,19 @@ void func_80137FF8(HSD_GObj* gobj) {
         // thing uninitialized
     }
     // ActionStateChange
-    Fighter_ActionStateChange_800693AC(gobj, thing, 0x0C4E508C, 0, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter_ActionStateChange_800693AC(gobj, thing, 0x0C4E508C, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 // 8013809C 00134C7C
 // https://decomp.me/scratch/qwafK
 void func_8013809C(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 thing;
 
-    ft->sa.mars.x222C = 0;
+    fp->sa.mars.x222C = 0;
     // Air_SetAsGrounded2
-    func_8007D7FC(ft);
-    switch (ft->x10_action_state_index) {
+    func_8007D7FC(fp);
+    switch (fp->x10_action_state_index) {
         case 0x16C:
             thing = 0x163;
             break;
@@ -538,34 +538,34 @@ void func_8013809C(HSD_GObj* gobj) {
         // thing uninitialized
     }
     // ActionStateChange
-    Fighter_ActionStateChange_800693AC(gobj, thing, 0x0C4E508C, 0, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter_ActionStateChange_800693AC(gobj, thing, 0x0C4E508C, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 // 80138148 00134D28
 // https://decomp.me/scratch/V6aHf
 void func_80138148(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 thing;
 
-    ft->x2204_ftcmd_var1 = 0;
-    ft->x2200_ftcmd_var0 = 0;
-    ft->cb.x21EC_callback = &lbl_80137A68;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->cb.x21EC_callback = &lbl_80137A68;
 
-    if (ft->input.x624_lstick_y > p_ftCommonData->x21C) {
-        if (ft->xE0_ground_or_air == GA_Ground) {
+    if (fp->input.x624_lstick_y > p_ftCommonData->x21C) {
+        if (fp->xE0_ground_or_air == GA_Ground) {
             thing = 0x163;
         } else {
             thing = 0x16C;
         }
     } else {
-        if (ft->input.x624_lstick_y < -p_ftCommonData->x21C) {
-            if (ft->xE0_ground_or_air == GA_Ground) {
+        if (fp->input.x624_lstick_y < -p_ftCommonData->x21C) {
+            if (fp->xE0_ground_or_air == GA_Ground) {
                 thing = 0x165;
             } else {
                 thing = 0x16E;
             }
         } else {
-            if (ft->xE0_ground_or_air == GA_Ground) {
+            if (fp->xE0_ground_or_air == GA_Ground) {
                 thing = 0x164;
             } else {
                 thing = 0x16D;

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_1.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_1.c
@@ -12,43 +12,43 @@ void ftMasterhand_OnLoad(HSD_GObj* gobj) {
     ftData* ftdata;
     MasterHandAttributes* ftData_attr;
     void** items;
-    Fighter* ft;
+    Fighter* fp;
 
     
-    ft = gobj->user_data;
-    ftdata = ft->x10C_ftData;
+    fp = gobj->user_data;
+    ftdata = fp->x10C_ftData;
     ftData_attr = ftdata->ext_attr;
     items = ftdata->x48_items;
 
-    PUSH_ATTRS(ft, MasterHandAttributes);
+    PUSH_ATTRS(fp, MasterHandAttributes);
     
     func_8015BDB4(gobj);
     func_8026B3F8(items[0], 0x7D);
     func_8026B3F8(items[1], 0x7E);
-    ft->x2229_b5_no_normal_motion = 1;
-    ft->x2229_b6 = 1;
-    ft->x2229_b7 = 1;
-    ft->x222A_flag.bits.b0 = 1;
-    ft->x222A_flag.bits.b1 = 1;
-    ft->x2229_b3 = 1;
-    ft->xB0_pos.x = ftData_attr->x30_pos2.x;
-    ft->xB0_pos.y = ftData_attr->x30_pos2.y;
-    ft->xB0_pos.z = 0.0f;
-    ft->x2374 = 0;
-    ft->x2378 = 0;
-    ft->x237C = 0;
-    ft->x2380 = 0;
-    ft->x2368 = -1;
-    ft->x236C = -1;
-    ft->x2370 = -1;
-    ft->x235C = 0.0f;
-    ft->x2360 = 0;
-    ft->sa.masterhand.x222C = func_8015C244(gobj, &ft->xB0_pos);
-    ft->sa.masterhand.x2238 = 1.0f;
-    ft->sa.masterhand.x224C = 0;
-    ft->sa.masterhand.x2250 = 0x15B;
-    ft->sa.masterhand.x2254 = 0;
-    ft->x1A98 = 1;
-    func_8015BD24(ft->x1A98, &ft->sa.masterhand.x223C, ft->sa.masterhand.x2238, ftData_attr->x18, ftData_attr->x20, ftData_attr->x1C);
+    fp->x2229_b5_no_normal_motion = 1;
+    fp->x2229_b6 = 1;
+    fp->x2229_b7 = 1;
+    fp->x222A_flag.bits.b0 = 1;
+    fp->x222A_flag.bits.b1 = 1;
+    fp->x2229_b3 = 1;
+    fp->xB0_pos.x = ftData_attr->x30_pos2.x;
+    fp->xB0_pos.y = ftData_attr->x30_pos2.y;
+    fp->xB0_pos.z = 0.0f;
+    fp->x2374 = 0;
+    fp->x2378 = 0;
+    fp->x237C = 0;
+    fp->x2380 = 0;
+    fp->x2368 = -1;
+    fp->x236C = -1;
+    fp->x2370 = -1;
+    fp->x235C = 0.0f;
+    fp->x2360 = 0;
+    fp->sa.masterhand.x222C = func_8015C244(gobj, &fp->xB0_pos);
+    fp->sa.masterhand.x2238 = 1.0f;
+    fp->sa.masterhand.x224C = 0;
+    fp->sa.masterhand.x2250 = 0x15B;
+    fp->sa.masterhand.x2254 = 0;
+    fp->x1A98 = 1;
+    func_8015BD24(fp->x1A98, &fp->sa.masterhand.x223C, fp->sa.masterhand.x2238, ftData_attr->x18, ftData_attr->x20, ftData_attr->x1C);
 }
 

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_10.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_10.c
@@ -13,8 +13,8 @@ void lbl_80152138(HSD_GObj* arg0) {
 // 80152174 14ED54
 // https://decomp.me/scratch/6NWxd
 void lbl_80152174(HSD_GObj* gobj) {
-    Fighter* fighter = gobj->user_data;
-    if (Player_GetPlayerSlotType(fighter->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }
@@ -64,8 +64,8 @@ void lbl_8015223C(HSD_GObj* arg0) {
 // 80152278 14EE58
 // https://decomp.me/scratch/KNhTn
 void lbl_80152278(HSD_GObj* gobj) {
-    Fighter* fighter = gobj->user_data;
-    if (Player_GetPlayerSlotType(fighter->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }
@@ -75,17 +75,17 @@ void lbl_80152278(HSD_GObj* gobj) {
 // 801522BC 14EE9C
 // https://decomp.me/scratch/hAUig
 void lbl_801522BC(HSD_GObj* gobj) {
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
     ftData* r4_ftData;
     MasterHandAttributes* r30_attributes;
 
-    r31_ft_userdata = gobj->user_data;
-    r4_ftData = r31_ft_userdata->x10C_ftData;
+    r31_fp = gobj->user_data;
+    r4_ftData = r31_fp->x10C_ftData;
     r30_attributes = r4_ftData->ext_attr;
     func_80085134(gobj);
 
-    if ((--r31_ft_userdata->x2340_f32 > r30_attributes->x84) || (r31_ft_userdata->x2340_f32 < 0.0f)) {
-        r31_ft_userdata->x80_self_vel.x = 0.0f;
+    if ((--r31_fp->x2340_f32 > r30_attributes->x84) || (r31_fp->x2340_f32 < 0.0f)) {
+        r31_fp->x80_self_vel.x = 0.0f;
     } else {
         func_8015C010(gobj, r30_attributes->x80);
     }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_11.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_11.c
@@ -19,16 +19,16 @@ void lbl_80152370(HSD_GObj* arg0) {
 // 801523BC 14EF9C
 // https://decomp.me/scratch/4nWVy
 void lbl_801523BC(HSD_GObj* gobj) {
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
     MasterHandAttributes* r30_attributes;
 
     if (ftAnim_IsFramesRemaining(gobj)) {
         return;
     }
-    r31_ft_userdata = gobj->user_data;
-    r30_attributes = r31_ft_userdata->x10C_ftData->ext_attr;
+    r31_fp = gobj->user_data;
+    r30_attributes = r31_fp->x10C_ftData->ext_attr;
     func_8015247C(gobj);
-    r31_ft_userdata->x2348_stateVar3 = r30_attributes->xA0;
+    r31_fp->x2348_stateVar3 = r30_attributes->xA0;
 }
 
 
@@ -36,8 +36,8 @@ void lbl_801523BC(HSD_GObj* gobj) {
 // 80152414 14EFF4
 // https://decomp.me/scratch/u6Ii5
 void lbl_80152414(HSD_GObj* gobj) {
-    Fighter* fighter = gobj->user_data;
-    if (Player_GetPlayerSlotType(fighter->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }
@@ -88,8 +88,8 @@ void lbl_801524C8(HSD_GObj* gobj) {
 // 80152544 14F124
 // https://decomp.me/scratch/nlkfy
 void lbl_80152544(HSD_GObj* gobj) {
-    Fighter* fighter = gobj->user_data;
-    if (Player_GetPlayerSlotType(fighter->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_12.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_12.c
@@ -13,8 +13,8 @@ void lbl_80152634(HSD_GObj* arg0) {
 // 80152670 14F250
 // https://decomp.me/scratch/8k9M0
 void lbl_80152670(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -62,8 +62,8 @@ void lbl_80152738(HSD_GObj* arg0) {
 // 80152774 14F354
 // https://decomp.me/scratch/FCaLx
 void lbl_80152774(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -73,22 +73,22 @@ void lbl_80152774(HSD_GObj* arg0) {
 // 801527B8 14F398
 // https://decomp.me/scratch/lzl13
 void lbl_801527B8(HSD_GObj* gobj) {
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
     MasterHandAttributes* r30_attributes;
     f32 tmp;
 
-    r31_ft_userdata = gobj->user_data;
-    r30_attributes = r31_ft_userdata->x10C_ftData->ext_attr;
+    r31_fp = gobj->user_data;
+    r30_attributes = r31_fp->x10C_ftData->ext_attr;
 
     func_80085134(gobj);
 
-    tmp = ++r31_ft_userdata->x2340_f32;
+    tmp = ++r31_fp->x2340_f32;
     if (tmp                        > r30_attributes->xB0 && 
-        r31_ft_userdata->x2340_f32 < r30_attributes->xB4
+        r31_fp->x2340_f32 < r30_attributes->xB4
     ) {
         func_8015C010(gobj, r30_attributes->xB8);
     } else {
-        r31_ft_userdata->x80_self_vel.x = 0.0f;
+        r31_fp->x80_self_vel.x = 0.0f;
     }
     func_8015C190(gobj);
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_13.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_13.c
@@ -9,16 +9,16 @@ void lbl_8015287C(HSD_GObj* gobj) {
 // 80152880 14F460
 // https://decomp.me/scratch/is1xu
 void func_80152880(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     MasterHandAttributes* attr;
     s32 unk[2];
 
-    ft = gobj->user_data;
-    attr = ft->x10C_ftData->ext_attr;
+    fp = gobj->user_data;
+    attr = fp->x10C_ftData->ext_attr;
     Fighter_ActionStateChange_800693AC(gobj, 0x167, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
-    ft->x2340_f32 = attr->x94 + HSD_Randi(attr->x90 - attr->x94);
-    ft->x2344_f32 = 0.0f;
+    fp->x2340_f32 = attr->x94 + HSD_Randi(attr->x90 - attr->x94);
+    fp->x2344_f32 = 0.0f;
 }
 
 
@@ -61,8 +61,8 @@ void lbl_801529D0(HSD_GObj* arg0) {
 // 80152A0C 14F5EC
 // https://decomp.me/scratch/7UfC7
 void lbl_80152A0C(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -97,7 +97,7 @@ static inline float my_lbvector_Len(Vec3 *vec)
 }
 
 void lbl_80152A50(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     MasterHandAttributes* attr;
     f32 speed;
     ftData* ftData;
@@ -105,28 +105,28 @@ void lbl_80152A50(HSD_GObj* gobj) {
     Vec3 sp1C_vel;
     f32 len;
 
-    ft = gobj->user_data;
+    fp = gobj->user_data;
     func_80085134(gobj);
-    if (ft->x2344_f32) {
-        ftData = ft->x10C_ftData;
+    if (fp->x2344_f32) {
+        ftData = fp->x10C_ftData;
         attr = ftData->ext_attr;
         func_8015C208(gobj, &sp28_pos);
         sp28_pos.x += attr->x98;
         sp28_pos.y += attr->x9C;
         sp28_pos.z = 0.0f;
-        lbvector_Diff(&sp28_pos, &ft->xB0_pos, &sp1C_vel);
+        lbvector_Diff(&sp28_pos, &fp->xB0_pos, &sp1C_vel);
         len = my_lbvector_Len(&sp1C_vel);
         if (len < attr->x2C) {
-            ft->x80_self_vel.x = sp1C_vel.x;
-            ft->x80_self_vel.y = sp1C_vel.y;
+            fp->x80_self_vel.x = sp1C_vel.x;
+            fp->x80_self_vel.y = sp1C_vel.y;
         } else {
             lbvector_Normalize(&sp1C_vel);
             speed = len * attr->x28;
             sp1C_vel.x *= speed;
             sp1C_vel.y *= speed;
             sp1C_vel.z *= speed;
-            ft->x80_self_vel.x = sp1C_vel.x;
-            ft->x80_self_vel.y = sp1C_vel.y;
+            fp->x80_self_vel.x = sp1C_vel.x;
+            fp->x80_self_vel.y = sp1C_vel.y;
         }
     }
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_14.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_14.c
@@ -34,8 +34,8 @@ void lbl_80152C34(HSD_GObj* arg0) {
 // 80152C70 14F850
 // https://decomp.me/scratch/5SqNT
 void lbl_80152C70(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -59,11 +59,11 @@ void lbl_80152CD4(HSD_GObj *arg0) {
 // 80152CD8 14F8B8
 // https://decomp.me/scratch/C5hzY
 void func_80152CD8(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
+    Fighter* fp = arg0->user_data;
     Fighter_ActionStateChange_800693AC(arg0, 0x16A, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(arg0);
-    ft->cb.x21BC_callback_Accessory4 = &lbl_80152E28;
-    ft->x2200_ftcmd_var0 = 1;
+    fp->cb.x21BC_callback_Accessory4 = &lbl_80152E28;
+    fp->x2200_ftcmd_var0 = 1;
 }
 
 
@@ -92,8 +92,8 @@ void lbl_80152D44(HSD_GObj* arg0) {
 // 80152DC0 14F9A0
 // https://decomp.me/scratch/X13ZG
 void lbl_80152DC0(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -117,24 +117,24 @@ void lbl_80152E24(HSD_GObj* gobj) {
 // 80152E28 14FA08
 // https://decomp.me/scratch/Uqf2Q
 void lbl_80152E28(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 unk1;
     Vec3 sp10;
     s32 unk2;
 
-    if (ft->x2200_ftcmd_var0 != 0) {
-        func_8000B1CC(ft->x5E8_fighterBones[11].x0_jobj, 0, &sp10);
-        ft->x2374 = func_802F0340(gobj, &sp10, &sp10, 0xB, 0x7D, ft->x2C_facing_direction);
-        func_8000B1CC(ft->x5E8_fighterBones[16].x0_jobj, 0, &sp10);
-        ft->x2378 = func_802F0340(gobj, &sp10, &sp10, 0x10, 0x7D, ft->x2C_facing_direction);
-        func_8000B1CC(ft->x5E8_fighterBones[21].x0_jobj, 0, &sp10);
-        ft->x237C = func_802F0340(gobj, &sp10, &sp10, 0x15, 0x7D, ft->x2C_facing_direction);
-        func_8000B1CC(ft->x5E8_fighterBones[26].x0_jobj, 0, &sp10);
-        ft->x2380 = func_802F0340(gobj, &sp10, &sp10, 0x1A, 0x7D, ft->x2C_facing_direction);
-        ft->x2368 = func_800237A8(0x4E204, 0x7F, 0x40);
-        ft->x236C = func_800237A8(0x4E205, 0x7F, 0x40);
-        ft->x2370 = func_800237A8(0x4E206, 0x7F, 0x40);
-        ft->x2200_ftcmd_var0 = 0;
+    if (fp->x2200_ftcmd_var0 != 0) {
+        func_8000B1CC(fp->x5E8_fighterBones[11].x0_jobj, 0, &sp10);
+        fp->x2374 = func_802F0340(gobj, &sp10, &sp10, 0xB, 0x7D, fp->x2C_facing_direction);
+        func_8000B1CC(fp->x5E8_fighterBones[16].x0_jobj, 0, &sp10);
+        fp->x2378 = func_802F0340(gobj, &sp10, &sp10, 0x10, 0x7D, fp->x2C_facing_direction);
+        func_8000B1CC(fp->x5E8_fighterBones[21].x0_jobj, 0, &sp10);
+        fp->x237C = func_802F0340(gobj, &sp10, &sp10, 0x15, 0x7D, fp->x2C_facing_direction);
+        func_8000B1CC(fp->x5E8_fighterBones[26].x0_jobj, 0, &sp10);
+        fp->x2380 = func_802F0340(gobj, &sp10, &sp10, 0x1A, 0x7D, fp->x2C_facing_direction);
+        fp->x2368 = func_800237A8(0x4E204, 0x7F, 0x40);
+        fp->x236C = func_800237A8(0x4E205, 0x7F, 0x40);
+        fp->x2370 = func_800237A8(0x4E206, 0x7F, 0x40);
+        fp->x2200_ftcmd_var0 = 0;
     }
 }
 

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_15.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_15.c
@@ -12,8 +12,8 @@ void lbl_80153000(HSD_GObj* arg0) {
 
 // 8015303C 14FC1C
 void lbl_8015303C(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -37,20 +37,20 @@ void lbl_801530A0(HSD_GObj* arg0) {
 // 801530A4 14FC84
 // https://decomp.me/scratch/ZtWrg
 void func_801530A4(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     MasterHandAttributes* attr;
     s32 rand;
     s32 unk[2];
 
-    ft = gobj->user_data;
-    attr = ft->x10C_ftData->ext_attr;
+    fp = gobj->user_data;
+    attr = fp->x10C_ftData->ext_attr;
     Fighter_ActionStateChange_800693AC(gobj, 0x16C, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
     rand = HSD_Randi(attr->xE8 - attr->xE4);
-    ft->x2390 = attr->xE4 + rand;
-    ft->x2200_ftcmd_var0 = 0;
-    ft->x2204_ftcmd_var1 = 0;
-    ft->x2208_ftcmd_var2 = 0;
+    fp->x2390 = attr->xE4 + rand;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2208_ftcmd_var2 = 0;
 }
 
 
@@ -58,27 +58,27 @@ void func_801530A4(HSD_GObj* gobj) {
 // 80153160 14FD40
 // https://decomp.me/scratch/7Kmdd
 void lbl_80153160(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     MasterHandAttributes* temp_r29;
     ftData* ftData;
     f32 temp_f1;
     s32 unk[2];
 
-    ft = gobj->user_data;
+    fp = gobj->user_data;
     if (ftAnim_IsFramesRemaining(gobj) == 0) {
-        ft->x2208_ftcmd_var2 = 1;
-        temp_f1 = ft->x2390 - 1.0f;
-        ft->x2390 = temp_f1;
+        fp->x2208_ftcmd_var2 = 1;
+        temp_f1 = fp->x2390 - 1.0f;
+        fp->x2390 = temp_f1;
         if (temp_f1 < 0.0f) {
-            ftData = ft->x10C_ftData;
+            ftData = fp->x10C_ftData;
             temp_r29 = ftData->ext_attr;
             func_801533CC(gobj);
             if (func_80087120(gobj) > temp_r29->xEC) {
-                ft->x2394 = (s32) temp_r29->xF0;
+                fp->x2394 = (s32) temp_r29->xF0;
             } else {
-                ft->x2394 = 1;
+                fp->x2394 = 1;
             }
-            ft->x2208_ftcmd_var2 = 0;
+            fp->x2208_ftcmd_var2 = 0;
         }
     }
 }
@@ -88,8 +88,8 @@ void lbl_80153160(HSD_GObj* gobj) {
 // 80153210 14FDF0
 // https://decomp.me/scratch/Ssmxs
 void lbl_80153210(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -121,7 +121,7 @@ static inline float my_lbvector_Len(Vec3 *vec)
 }
 
 void lbl_80153254(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     MasterHandAttributes* attr;
     f32 len;
     f32 speed;
@@ -129,27 +129,27 @@ void lbl_80153254(HSD_GObj* gobj) {
     Vec3 sp1C_vel;
     s32 unk;
 
-    ft = gobj->user_data;
+    fp = gobj->user_data;
     func_80085134(gobj);
-    if (ft->x2208_ftcmd_var2 != 0) {
-        attr = ft->x10C_ftData->ext_attr;
+    if (fp->x2208_ftcmd_var2 != 0) {
+        attr = fp->x10C_ftData->ext_attr;
         func_8015C208(gobj, &sp28_pos);
         sp28_pos.x += attr->xDC;
         sp28_pos.y += attr->xE0;
         sp28_pos.z = 0.0f;
-        lbvector_Diff(&sp28_pos, &ft->xB0_pos, &sp1C_vel);
+        lbvector_Diff(&sp28_pos, &fp->xB0_pos, &sp1C_vel);
         len = my_lbvector_Len(&sp1C_vel);
         if (len < attr->x2C) {
-            ft->x80_self_vel.x = sp1C_vel.x;
-            ft->x80_self_vel.y = sp1C_vel.y;
+            fp->x80_self_vel.x = sp1C_vel.x;
+            fp->x80_self_vel.y = sp1C_vel.y;
         } else {
             lbvector_Normalize(&sp1C_vel);
             speed = len * attr->x28;
             sp1C_vel.x *= speed;
             sp1C_vel.y *= speed;
             sp1C_vel.z *= speed;
-            ft->x80_self_vel.x = sp1C_vel.x;
-            ft->x80_self_vel.y = sp1C_vel.y;
+            fp->x80_self_vel.x = sp1C_vel.x;
+            fp->x80_self_vel.y = sp1C_vel.y;
         }
     }
 }
@@ -165,19 +165,19 @@ void lbl_801533C8(HSD_GObj* gobj) {
 // 801533CC 14FFAC
 // https://decomp.me/scratch/uSNs4
 void func_801533CC(HSD_GObj* arg0) {
-    Fighter* ft;
+    Fighter* fp;
     MasterHandAttributes* attr;
 
-    ft = arg0->user_data;
-    attr = ft->x10C_ftData->ext_attr;
+    fp = arg0->user_data;
+    attr = fp->x10C_ftData->ext_attr;
     Fighter_ActionStateChange_800693AC(arg0, 0x16D, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(arg0);
     if (func_80087120(arg0) > attr->xEC) {
         ftAnim_SetAnimRate(arg0, attr->xF4);
     }
-    ft->x80_self_vel.x = 0.0f;
-    ft->x80_self_vel.y = 0.0f;
-    ft->cb.x21BC_callback_Accessory4 = &lbl_801535B0;
+    fp->x80_self_vel.x = 0.0f;
+    fp->x80_self_vel.y = 0.0f;
+    fp->cb.x21BC_callback_Accessory4 = &lbl_801535B0;
 }
 
 
@@ -217,8 +217,8 @@ void lbl_8015346C(HSD_GObj* gobj) {
 // 80153548 150128
 // https://decomp.me/scratch/VcNLJ
 void lbl_80153548(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -242,18 +242,18 @@ void lbl_801535AC(HSD_GObj* gobj) {
 // 801535B0 150190
 // https://decomp.me/scratch/zL8mX
 void lbl_801535B0(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     MasterHandAttributes* attr;
 
-    ft = gobj->user_data;
-    attr = ft->x10C_ftData->ext_attr;
-    if (ft->x2200_ftcmd_var0 != 0) {
-        func_8015364C(gobj, ft->x5E8_fighterBones[8].x0_jobj, attr->xF8, attr->xFC);
-        ft->x2200_ftcmd_var0 = 0;
+    fp = gobj->user_data;
+    attr = fp->x10C_ftData->ext_attr;
+    if (fp->x2200_ftcmd_var0 != 0) {
+        func_8015364C(gobj, fp->x5E8_fighterBones[8].x0_jobj, attr->xF8, attr->xFC);
+        fp->x2200_ftcmd_var0 = 0;
     }
-    if (ft->x2204_ftcmd_var1 != 0) {
-        func_8015364C(gobj, ft->x5E8_fighterBones[13].x0_jobj, attr->x100, attr->x104);
-        ft->x2204_ftcmd_var1 = 0;
+    if (fp->x2204_ftcmd_var1 != 0) {
+        func_8015364C(gobj, fp->x5E8_fighterBones[13].x0_jobj, attr->x100, attr->x104);
+        fp->x2204_ftcmd_var1 = 0;
     }
 }
 
@@ -262,15 +262,15 @@ void lbl_801535B0(HSD_GObj* gobj) {
 // 8015364C 15022C
 // https://decomp.me/scratch/YITWN
 void func_8015364C(HSD_GObj* arg0, HSD_JObj* arg1, f32 arg2, f32 arg3) {
-    Fighter* ft;
+    Fighter* fp;
     MasterHandAttributes* attr;
     s32 phi_r29;
     Vec3 sp28_leek;
     Vec3 sp1C_carrot;
     s32 unk;
 
-    ft = arg0->user_data;
-    attr = ft->x10C_ftData->ext_attr;
+    fp = arg0->user_data;
+    attr = fp->x10C_ftData->ext_attr;
     phi_r29 = 0;
     func_8000B1CC(arg1, 0, &sp28_leek);
     sp1C_carrot = sp28_leek;
@@ -279,7 +279,7 @@ void func_8015364C(HSD_GObj* arg0, HSD_JObj* arg1, f32 arg2, f32 arg3) {
     if (func_80087120(arg0) > attr->xEC) {
         phi_r29 = 1;
     }
-    func_802F0AE0(arg0, &sp28_leek, &sp1C_carrot, 0x7E, phi_r29, ft->x2C_facing_direction, attr->xD4, attr->xD8);
+    func_802F0AE0(arg0, &sp28_leek, &sp1C_carrot, 0x7E, phi_r29, fp->x2C_facing_direction, attr->xD4, attr->xD8);
 }
 
 

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_16.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_16.c
@@ -12,8 +12,8 @@ void lbl_8015377C(HSD_GObj* arg0) {
 
 // 801537B8 150398
 void lbl_801537B8(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_17.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_17.c
@@ -12,8 +12,8 @@ void lbl_8015386C(HSD_GObj* arg0) {
 
 // 801538A8 150488
 void lbl_801538A8(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -37,21 +37,21 @@ void lbl_8015390C(HSD_GObj* gobj) {
 // 80153910 1504F0
 // https://decomp.me/scratch/AYDbj
 void func_80153910(HSD_GObj* arg0) {
-    Fighter* ft;
+    Fighter* fp;
     MasterHandAttributes* attr;
     Vec3 sp10;
     s32 unk;
 
-    ft = arg0->user_data;
-    attr = ft->x10C_ftData->ext_attr;
+    fp = arg0->user_data;
+    attr = fp->x10C_ftData->ext_attr;
     Fighter_ActionStateChange_800693AC(arg0, 0x170, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(arg0);
     func_8015C208(arg0, &sp10);
-    ft->xB0_pos.x = sp10.x;
-    ft->xB0_pos.y = attr->x5C;
-    ft->x80_self_vel.z = 0.0f;
-    ft->x80_self_vel.y = 0.0f;
-    ft->x80_self_vel.x = 0.0f;
+    fp->xB0_pos.x = sp10.x;
+    fp->xB0_pos.y = attr->x5C;
+    fp->x80_self_vel.z = 0.0f;
+    fp->x80_self_vel.y = 0.0f;
+    fp->x80_self_vel.x = 0.0f;
 }
 
 

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_18.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_18.c
@@ -2,8 +2,8 @@
 
 // 801539EC 1505CC
 void lbl_801539EC(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -13,8 +13,8 @@ void lbl_801539EC(HSD_GObj* arg0) {
 // 80153A30 150610
 // https://decomp.me/scratch/oph8G
 void lbl_80153A30(HSD_GObj* gobj) {
-    Fighter* fighter = gobj->user_data;
-    MasterHandAttributes* r4_attributes = fighter->x10C_ftData->ext_attr;
+    Fighter* fp = gobj->user_data;
+    MasterHandAttributes* r4_attributes = fp->x10C_ftData->ext_attr;
 
     func_8015BF74(gobj, r4_attributes->x58);
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_19.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_19.c
@@ -11,8 +11,8 @@ void lbl_80153AEC(HSD_GObj* gobj) {
 
 // 80153B28 150708
 void lbl_80153B28(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }
@@ -71,8 +71,8 @@ void lbl_80153C48(HSD_GObj* arg0) {
 // 80153C90 150870
 // https://decomp.me/scratch/ijnCv
 void lbl_80153C90(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -82,12 +82,12 @@ void lbl_80153C90(HSD_GObj* arg0) {
 // 80153CD4 1508B4
 // https://decomp.me/scratch/qCZ0G
 void lbl_80153CD4(HSD_GObj* gobj) {
-    Fighter* r4_fighter;
+    Fighter* r4_fp;
 
-    r4_fighter = gobj->user_data;
-    if (--r4_fighter->x2340_f32 > 0.0f) {
-        func_8015BF74(gobj, ((MasterHandAttributes*)r4_fighter->x10C_ftData->ext_attr)->x58);
+    r4_fp = gobj->user_data;
+    if (--r4_fp->x2340_f32 > 0.0f) {
+        func_8015BF74(gobj, ((MasterHandAttributes*)r4_fp->x10C_ftData->ext_attr)->x58);
     } else {
-        r4_fighter->x80_self_vel.x = 0.0f;
+        r4_fp->x80_self_vel.x = 0.0f;
     }
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_2.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_2.c
@@ -27,101 +27,101 @@ void func_8014FE58(HSD_GObj* gobj) {
 // 8014FE5C 0014CA3C
 // https://decomp.me/scratch/7T8fr
 void func_8014FE5C(HSD_GObj* gobj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = gobj->user_data;
-    if ((fighter->x10_action_state_index == 341) || (fighter->x10_action_state_index == 342)) {
-        fighter->xB0_pos = fighter->sa.masterhand.x2240_pos;
+    fp = gobj->user_data;
+    if ((fp->x10_action_state_index == 341) || (fp->x10_action_state_index == 342)) {
+        fp->xB0_pos = fp->sa.masterhand.x2240_pos;
     } else {
-        fighter->sa.masterhand.x2240_pos = fighter->xB0_pos;
+        fp->sa.masterhand.x2240_pos = fp->xB0_pos;
     }
-    if (fighter->sa.masterhand.x2258 == 389) {
-        Fighter_ActionStateChange_800693AC(gobj, 341, 0, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+    if (fp->sa.masterhand.x2258 == 389) {
+        Fighter_ActionStateChange_800693AC(gobj, 341, 0, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
     } else {
         Fighter_ActionStateChange_800693AC(gobj, 341, 0, 0, 0.0f, 1.0f, 0.0f);
     }
-    fighter->sa.masterhand.x2258 = 341;
+    fp->sa.masterhand.x2258 = 341;
 }
 
 // 8014FF1C 0014CAFC
 // https://decomp.me/scratch/cG41T
 void func_8014FF1C(HSD_GObj* gobj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = gobj->user_data;
-    if ((fighter->x10_action_state_index == 341) || (fighter->x10_action_state_index == 342)) {
-        fighter->xB0_pos = fighter->sa.masterhand.x2240_pos;
+    fp = gobj->user_data;
+    if ((fp->x10_action_state_index == 341) || (fp->x10_action_state_index == 342)) {
+        fp->xB0_pos = fp->sa.masterhand.x2240_pos;
     } else {
-        fighter->sa.masterhand.x2240_pos = fighter->xB0_pos;
+        fp->sa.masterhand.x2240_pos = fp->xB0_pos;
     }
-    if (fighter->sa.masterhand.x2258 == 390) {
-        Fighter_ActionStateChange_800693AC(gobj, 342, 0, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+    if (fp->sa.masterhand.x2258 == 390) {
+        Fighter_ActionStateChange_800693AC(gobj, 342, 0, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
     } else {
         Fighter_ActionStateChange_800693AC(gobj, 342, 0, 0, 0.0f, 1.0f, 0.0f);
     }
-    fighter->sa.masterhand.x2258 = 342;
+    fp->sa.masterhand.x2258 = 342;
 }
 
 // 8014FFDC 0014CBBC
 // https://decomp.me/scratch/0Gtar
 void lbl_8014FFDC(HSD_GObj* gobj) {
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
     u32 unk[4];
 
-    r31_ft_userdata = gobj->user_data;
-    if (r31_ft_userdata->sa.masterhand.x2258 == 0x186) {
-        if ((r31_ft_userdata->x10_action_state_index == 0x155) || (r31_ft_userdata->x10_action_state_index == 0x156)) {
-            r31_ft_userdata->xB0_pos = r31_ft_userdata->sa.masterhand.x2240_pos;
+    r31_fp = gobj->user_data;
+    if (r31_fp->sa.masterhand.x2258 == 0x186) {
+        if ((r31_fp->x10_action_state_index == 0x155) || (r31_fp->x10_action_state_index == 0x156)) {
+            r31_fp->xB0_pos = r31_fp->sa.masterhand.x2240_pos;
         } else {
-            r31_ft_userdata->sa.masterhand.x2240_pos = r31_ft_userdata->xB0_pos;
+            r31_fp->sa.masterhand.x2240_pos = r31_fp->xB0_pos;
         }
-        if (r31_ft_userdata->sa.masterhand.x2258 == 0x186) {
-            Fighter_ActionStateChange_800693AC(gobj, 0x156, 0, 0, r31_ft_userdata->x894_currentAnimFrame, 1.0f, 0.0f);
+        if (r31_fp->sa.masterhand.x2258 == 0x186) {
+            Fighter_ActionStateChange_800693AC(gobj, 0x156, 0, 0, r31_fp->x894_currentAnimFrame, 1.0f, 0.0f);
         } else {
             Fighter_ActionStateChange_800693AC(gobj, 0x156, 0, 0, 0.0f, 1.0f, 0.0f);
         }
-        r31_ft_userdata->sa.masterhand.x2258 = 0x156;
+        r31_fp->sa.masterhand.x2258 = 0x156;
         return;
     }
-    if ((r31_ft_userdata->x10_action_state_index == 0x155) || (r31_ft_userdata->x10_action_state_index == 0x156)) {
-        r31_ft_userdata->xB0_pos = r31_ft_userdata->sa.masterhand.x2240_pos;
+    if ((r31_fp->x10_action_state_index == 0x155) || (r31_fp->x10_action_state_index == 0x156)) {
+        r31_fp->xB0_pos = r31_fp->sa.masterhand.x2240_pos;
     } else {
-        r31_ft_userdata->sa.masterhand.x2240_pos = r31_ft_userdata->xB0_pos;
+        r31_fp->sa.masterhand.x2240_pos = r31_fp->xB0_pos;
     }
-    if (r31_ft_userdata->sa.masterhand.x2258 == 0x185) {
-        Fighter_ActionStateChange_800693AC(gobj, 0x155, 0, 0, r31_ft_userdata->x894_currentAnimFrame, 1.0f, 0.0f);
+    if (r31_fp->sa.masterhand.x2258 == 0x185) {
+        Fighter_ActionStateChange_800693AC(gobj, 0x155, 0, 0, r31_fp->x894_currentAnimFrame, 1.0f, 0.0f);
     } else {
         Fighter_ActionStateChange_800693AC(gobj, 0x155, 0, 0, 0.0f, 1.0f, 0.0f);
     }
-    r31_ft_userdata->sa.masterhand.x2258 = 0x155;
+    r31_fp->sa.masterhand.x2258 = 0x155;
 }
 
 // 80150144 0014CD24
 // https://decomp.me/scratch/S2AJH
 void func_80150144(HSD_GObj* gobj) {
     MasterHandAttributes* r5_attributes;
-    Fighter* fighter;
-    Fighter* userdata; // todo: dup?
+    Fighter* fp;
+    Fighter* fp_1; // todo: dup?
     Vec2 unusedPos;
 
-    fighter = gobj->user_data;
-    r5_attributes = fighter->x10C_ftData->ext_attr;
-    fighter->sa.masterhand.x2258 = 341;
-    fighter->x10_action_state_index = 343;
-    fighter->xB0_pos.x = r5_attributes->x30_pos2.x;
-    fighter->xB0_pos.y = r5_attributes->x30_pos2.y;
-    userdata = gobj->user_data;
-    if ((userdata->x10_action_state_index == 341) || (userdata->x10_action_state_index == 342)) {
-        userdata->xB0_pos = userdata->sa.masterhand.x2240_pos;
+    fp = gobj->user_data;
+    r5_attributes = fp->x10C_ftData->ext_attr;
+    fp->sa.masterhand.x2258 = 341;
+    fp->x10_action_state_index = 343;
+    fp->xB0_pos.x = r5_attributes->x30_pos2.x;
+    fp->xB0_pos.y = r5_attributes->x30_pos2.y;
+    fp_1 = gobj->user_data;
+    if ((fp_1->x10_action_state_index == 341) || (fp_1->x10_action_state_index == 342)) {
+        fp_1->xB0_pos = fp_1->sa.masterhand.x2240_pos;
     } else {
-        userdata->sa.masterhand.x2240_pos = userdata->xB0_pos;
+        fp_1->sa.masterhand.x2240_pos = fp_1->xB0_pos;
     }
-    if (userdata->sa.masterhand.x2258 == 389) {
-        Fighter_ActionStateChange_800693AC(gobj, 341, 0, 0, userdata->x894_currentAnimFrame, 1.0f, 0.0f);
+    if (fp_1->sa.masterhand.x2258 == 389) {
+        Fighter_ActionStateChange_800693AC(gobj, 341, 0, 0, fp_1->x894_currentAnimFrame, 1.0f, 0.0f);
     } else {
         Fighter_ActionStateChange_800693AC(gobj, 341, 0, 0, 0.0f, 1.0f, 0.0f);
     }
-    userdata->sa.masterhand.x2258 = 341;
+    fp_1->sa.masterhand.x2258 = 341;
 }
 
 #pragma dont_inline off
@@ -180,23 +180,23 @@ struct MasterHandDataStuff lbl_803D40D0 = {
 };
 
 inline void lbl_80150230_inline_1(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    if (ft->x10_action_state_index == 0x155 || ft->x10_action_state_index == 0x156) {
-        ft->xB0_pos = ft->sa.masterhand.x2240_pos;
+    Fighter* fp = gobj->user_data;
+    if (fp->x10_action_state_index == 0x155 || fp->x10_action_state_index == 0x156) {
+        fp->xB0_pos = fp->sa.masterhand.x2240_pos;
     } else {
-        ft->sa.masterhand.x2240_pos = ft->xB0_pos;
+        fp->sa.masterhand.x2240_pos = fp->xB0_pos;
     }
-    if (ft->sa.masterhand.x2258 == 0x186) {
-        Fighter_ActionStateChange_800693AC(gobj, 0x156, 0, 0, ft->x894_currentAnimFrame, 1.0f, 0.0f);
+    if (fp->sa.masterhand.x2258 == 0x186) {
+        Fighter_ActionStateChange_800693AC(gobj, 0x156, 0, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
     } else {
         Fighter_ActionStateChange_800693AC(gobj, 0x156, 0, 0, 0.0f, 1.0f, 0.0f);
     }
-    ft->sa.masterhand.x2258 = 0x156;
+    fp->sa.masterhand.x2258 = 0x156;
 }
 
 inline void lbl_80150230_inline_2(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    if (ft->sa.masterhand.x2258 == 0x186) {
+    Fighter* fp = gobj->user_data;
+    if (fp->sa.masterhand.x2258 == 0x186) {
         func_8014FF1C(gobj);
     } else {
         func_8014FE5C(gobj);
@@ -207,28 +207,28 @@ inline void lbl_80150230_inline_2(HSD_GObj* gobj) {
 // https://decomp.me/scratch/NJIf7
 void lbl_80150230(HSD_GObj* gobj) {
     // r31 = &lbl_803D40D0
-    // r30 = ft
+    // r30 = fp
     // r29 = ft_inline / attr
     // r28 = gobj
     // r27 = tmp
     // r26 = tmp2?
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     s32 unused[2];
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_80150894(gobj);
         if (ftAnim_IsFramesRemaining(gobj) == 0) {
-            if (ft->x10_action_state_index == 0x155) {
+            if (fp->x10_action_state_index == 0x155) {
                 lbl_80150230_inline_1(gobj);
-            } else if (ft->x10_action_state_index == 0x156) {
+            } else if (fp->x10_action_state_index == 0x156) {
                 lbl_80150230_inline_2(gobj);
             }
         }
     } else {
-        if (--ft->sa.masterhand.x223C < 0.0f) {
-            MasterHandAttributes* attr = ft->x10C_ftData->ext_attr;
+        if (--fp->sa.masterhand.x223C < 0.0f) {
+            MasterHandAttributes* attr = fp->x10C_ftData->ext_attr;
             Vec3 vec;
             s32 unused[6];
-            func_8015BD24(ft->x1A98, &ft->sa.masterhand.x223C, ft->sa.masterhand.x2238, attr->x18, attr->x20, attr->x1C);
+            func_8015BD24(fp->x1A98, &fp->sa.masterhand.x223C, fp->sa.masterhand.x2238, attr->x18, attr->x20, attr->x1C);
             if (func_8015C44C(0x1C) == 0x180) {
                 // Crazy Hand Combo Attack
                 switch (func_8015C4C4()) {
@@ -261,25 +261,25 @@ void lbl_80150230(HSD_GObj* gobj) {
                 s32 tmp2;
                 u8_pair *qwe;
                 f32 rand;
-                if (ft->sa.masterhand.x2254 == attr->x24) {
-                    ft->sa.masterhand.x2254 = 0;
+                if (fp->sa.masterhand.x2254 == attr->x24) {
+                    fp->sa.masterhand.x2254 = 0;
                     tmp = 2;
                 } else {
-                    s32 qwe4 = lbl_803D40D0.x54[ft->sa.masterhand.x224C * 5 + HSD_Randi(5)];
+                    s32 qwe4 = lbl_803D40D0.x54[fp->sa.masterhand.x224C * 5 + HSD_Randi(5)];
                     tmp = qwe4;
                     if (qwe4 == 2) {
-                        ft->sa.masterhand.x2254 = 0;
+                        fp->sa.masterhand.x2254 = 0;
                     } else {
-                        ft->sa.masterhand.x2254++;
+                        fp->sa.masterhand.x2254++;
                     }
                 }
                 // cast required, don't know why
                 qwe = &((u8_pair*) lbl_803D40D0.x48)[tmp];
                 tmp2 = lbl_803D40D0.x0[lbl_803D40D0.x38[qwe->a + HSD_Randi(qwe->b)]];
 
-                ft->sa.masterhand.x224C = tmp;
-                ft->sa.masterhand.x2250 = tmp2;
-                if (ft->x221D_flag.bits.b4) {
+                fp->sa.masterhand.x224C = tmp;
+                fp->sa.masterhand.x2250 = tmp2;
+                if (fp->x221D_flag.bits.b4) {
                     tmp2 = 0x155;
                 }
                 switch(tmp2) {
@@ -349,9 +349,9 @@ void lbl_80150230(HSD_GObj* gobj) {
                 }
             }
         } else if (ftAnim_IsFramesRemaining(gobj) == 0) {
-            if (ft->x10_action_state_index == 0x155) {
+            if (fp->x10_action_state_index == 0x155) {
                 lbl_80150230_inline_1(gobj);
-            } else if (ft->x10_action_state_index == 0x156) {
+            } else if (fp->x10_action_state_index == 0x156) {
                 lbl_80150230_inline_2(gobj);
             }
         }
@@ -361,8 +361,8 @@ void lbl_80150230(HSD_GObj* gobj) {
 // 8015082C 0014D40C
 // https://decomp.me/scratch/rgMOD
 void lbl_8015082C(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }
@@ -396,8 +396,8 @@ void lbl_80150890(HSD_GObj* gobj) {
 #include <sysdolphin/baselib/controller.h>
 extern HSD_PadStatus HSD_PadMasterStatus[4];
 void func_80150894(HSD_GObj* gobj) {
-    Fighter* r4_fighter = gobj->user_data;
-    MasterHandAttributes* r31_attributes = r4_fighter->x10C_ftData->ext_attr;
+    Fighter* r4_fp = gobj->user_data;
+    MasterHandAttributes* r31_attributes = r4_fp->x10C_ftData->ext_attr;
     Vec3 sp10_pos;
     s32 unused;
     u32 l_pressed = r6_button & BUTTON_L;
@@ -463,11 +463,11 @@ void func_80150894(HSD_GObj* gobj) {
         func_801530A4(gobj);
     } else if ((r6_button & BUTTON_Z) && ((r6_button & DPAD_UP))) {
         // Grab
-        r4_fighter->sa.masterhand.x2250 = 0x17B;
+        r4_fp->sa.masterhand.x2250 = 0x17B;
         func_801542E0(gobj);
     } else if ((r6_button & BUTTON_Z) && ((r6_button & DPAD_RIGHT))) {
         // Grab
-        r4_fighter->sa.masterhand.x2250 = 0x17C;
+        r4_fp->sa.masterhand.x2250 = 0x17C;
         func_801542E0(gobj);
     } else if (((r6_button & BUTTON_Y)) && ((r6_button & DPAD_UP))) {
         // Crazy Hand Combo Attack

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_20.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_20.c
@@ -15,47 +15,47 @@ inline HSD_JObj* get_jobj(HSD_GObj* gobj) {
 
 void lbl_80153D2C(HSD_GObj* gobj) {
     HSD_JObj* jobj;
-    Fighter* ft;
+    Fighter* fp;
     MasterHandAttributes* attr;
     Vec3 sp1C;
     Vec3 scale;
     s32 unk;
 
-    ft = gobj->user_data;
+    fp = gobj->user_data;
     jobj = get_jobj(gobj);
-    attr = ft->x10C_ftData->ext_attr;
+    attr = fp->x10C_ftData->ext_attr;
     Fighter_ActionStateChange_800693AC(gobj, 0x173, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
     func_8015C208(gobj, &sp1C);
-    ft->xB0_pos.x = sp1C.x;
-    ft->xB0_pos.y = attr->x70;
+    fp->xB0_pos.x = sp1C.x;
+    fp->xB0_pos.y = attr->x70;
 
-    ft->x80_self_vel.z = 0.0f;
-    ft->x80_self_vel.y = 0.0f;
-    ft->x80_self_vel.x = 0.0f;
+    fp->x80_self_vel.z = 0.0f;
+    fp->x80_self_vel.y = 0.0f;
+    fp->x80_self_vel.x = 0.0f;
 
-    ft->x2340_f32 = attr->x74;
-    ft->x23B0 = attr->x7C;
+    fp->x2340_f32 = attr->x74;
+    fp->x23B0 = attr->x7C;
 
     HSD_JObjGetScale(jobj, &scale);
-    ft->x23A4.x = scale.x;
-    ft->x23A4.y = scale.y;
-    ft->x23A4.z = scale.z;
+    fp->x23A4.x = scale.x;
+    fp->x23A4.y = scale.y;
+    fp->x23A4.z = scale.z;
 
-    ft->x2398.x = scale.x - attr->x78;
-    ft->x2398.y = scale.y - attr->x78;
-    ft->x2398.z = scale.z - attr->x78;
+    fp->x2398.x = scale.x - attr->x78;
+    fp->x2398.y = scale.y - attr->x78;
+    fp->x2398.z = scale.z - attr->x78;
 
-    ft->x2398.x /= attr->x7C;
-    ft->x2398.y /= attr->x7C;
-    ft->x2398.z /= attr->x7C;
+    fp->x2398.x /= attr->x7C;
+    fp->x2398.y /= attr->x7C;
+    fp->x2398.z /= attr->x7C;
 
     scale.x = attr->x78;
     scale.y = attr->x78;
     scale.z = attr->x78;
     HSD_JObjSetScale(jobj, &scale);
 
-    ft->x2200_ftcmd_var0 = 1;
+    fp->x2200_ftcmd_var0 = 1;
 }
 
 
@@ -64,24 +64,24 @@ void lbl_80153D2C(HSD_GObj* gobj) {
 // https://decomp.me/scratch/w6kte
 void lbl_80153F8C(HSD_GObj* gobj_arg) {
     HSD_GObj* gobj = gobj_arg;
-    Fighter* ft;
+    Fighter* fp;
     s32 unk;
     Vec3 scale;
     s32 unk2[3];
 
-    ft = gobj->user_data;
-    if (ft->x2200_ftcmd_var0 != 0) {
+    fp = gobj->user_data;
+    if (fp->x2200_ftcmd_var0 != 0) {
         HSD_JObj* jobj = get_jobj(gobj);
-        if (--ft->x23B0 < 0) {
-            ft->x2200_ftcmd_var0 = 0;
-            scale.x = ft->x23A4.x;
-            scale.y = ft->x23A4.y;
-            scale.z = ft->x23A4.z;
+        if (--fp->x23B0 < 0) {
+            fp->x2200_ftcmd_var0 = 0;
+            scale.x = fp->x23A4.x;
+            scale.y = fp->x23A4.y;
+            scale.z = fp->x23A4.z;
         } else {
             HSD_JObjGetScale(jobj, &scale);
-            scale.x += ft->x2398.x;
-            scale.y += ft->x2398.y;
-            scale.z += ft->x2398.z;
+            scale.x += fp->x2398.x;
+            scale.y += fp->x2398.y;
+            scale.z += fp->x2398.z;
         }
         HSD_JObjSetScale(jobj, &scale);
     }
@@ -95,8 +95,8 @@ void lbl_80153F8C(HSD_GObj* gobj_arg) {
 
 // 80154114 150CF4
 void lbl_80154114(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -106,16 +106,16 @@ void lbl_80154114(HSD_GObj* arg0) {
 // 80154158 150D38
 // https://decomp.me/scratch/rgPDD
 void lbl_80154158(HSD_GObj* gobj) {
-    Fighter* r3_ft_userdata;
+    Fighter* r3_fp;
     MasterHandAttributes* r4_attributes;
     u32 unk[2];
 
-    r3_ft_userdata = gobj->user_data;
-    if (--r3_ft_userdata->x2340_f32 > 0.0f) {
-        r4_attributes = r3_ft_userdata->x10C_ftData->ext_attr;
+    r3_fp = gobj->user_data;
+    if (--r3_fp->x2340_f32 > 0.0f) {
+        r4_attributes = r3_fp->x10C_ftData->ext_attr;
         func_8015BF74(gobj, r4_attributes->x58);
     } else {
-        r3_ft_userdata->x80_self_vel.x = 0.0f;
+        r3_fp->x80_self_vel.x = 0.0f;
     }
     func_8015C190(gobj);
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_21.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_21.c
@@ -9,11 +9,11 @@ void lbl_801541C4(HSD_GObj* gobj) {
 // 801541C8 150DA8
 // https://decomp.me/scratch/WhlXG
 void func_801541C8(HSD_GObj* gobj, void* arg1) {
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
     u32 unk[2];
 
-    r31_ft_userdata = gobj->user_data;
+    r31_fp = gobj->user_data;
     Fighter_ActionStateChange_800693AC(gobj, 0x174, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
-    r31_ft_userdata->x2344_callback = arg1;
+    r31_fp->x2344_callback = arg1;
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_22.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_22.c
@@ -3,12 +3,12 @@
 // 80154230 150E10
 // https://decomp.me/scratch/dpg50
 void lbl_80154230(HSD_GObj* gobj) {
-    Fighter* r4_userdata;
+    Fighter* r4_fp;
     u32 unk[2];
 
     if (ftAnim_IsFramesRemaining(gobj) == 0) {
-        r4_userdata = gobj->user_data;
-        (r4_userdata->x2344_callback)(gobj);
+        r4_fp = gobj->user_data;
+        (r4_fp->x2344_callback)(gobj);
     }
 }
 
@@ -17,8 +17,8 @@ void lbl_80154230(HSD_GObj* gobj) {
 
 // 80154278 150E58
 void lbl_80154278(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -42,14 +42,14 @@ void lbl_801542DC(HSD_GObj* gobj) {
 // 801542E0 150EC0
 // https://decomp.me/scratch/pmJHD
 void func_801542E0(HSD_GObj* gobj) {
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
     MasterHandAttributes* r30_attributes;
 
-    r31_ft_userdata = gobj->user_data;
-    r30_attributes = r31_ft_userdata->x10C_ftData->ext_attr;
-    Fighter_ActionStateChange_800693AC(gobj, 0x175, 0, 0, r31_ft_userdata->x894_currentAnimFrame, 1.0f, 0.0f);
+    r31_fp = gobj->user_data;
+    r30_attributes = r31_fp->x10C_ftData->ext_attr;
+    Fighter_ActionStateChange_800693AC(gobj, 0x175, 0, 0, r31_fp->x894_currentAnimFrame, 1.0f, 0.0f);
     ftAnim_SetAnimRate(gobj, r30_attributes->x110_pos.y);
-    r31_ft_userdata->x2348_stateVar3 = (s32) r30_attributes->x110_pos.x;
+    r31_fp->x2348_stateVar3 = (s32) r30_attributes->x110_pos.x;
 }
 
 
@@ -80,8 +80,8 @@ void lbl_80154360(HSD_GObj* gobj) {
 
 // 801543E8 150FC8
 void lbl_801543E8(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -113,7 +113,7 @@ static inline float my_lbvector_Len(Vec3 *vec)
 }
 
 void lbl_8015442C(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     MasterHandAttributes* attr;
     f32 len;
     f32 speed;
@@ -121,27 +121,27 @@ void lbl_8015442C(HSD_GObj* gobj) {
     Vec3 sp1C_vel;
     s32 unk[1];
 
-    ft = gobj->user_data;
+    fp = gobj->user_data;
 
-    attr = ft->x10C_ftData->ext_attr;
+    attr = fp->x10C_ftData->ext_attr;
     func_80085134(gobj);
     func_8015C208(gobj, &sp28_pos);
     sp28_pos.x += attr->x108;
     sp28_pos.y += attr->x10C;
     sp28_pos.z = 0.0f;
-    lbvector_Diff(&sp28_pos, &ft->xB0_pos, &sp1C_vel);
+    lbvector_Diff(&sp28_pos, &fp->xB0_pos, &sp1C_vel);
     len = my_lbvector_Len(&sp1C_vel);
     if (len < attr->x2C) {
-        ft->x80_self_vel.x = sp1C_vel.x;
-        ft->x80_self_vel.y = sp1C_vel.y;
+        fp->x80_self_vel.x = sp1C_vel.x;
+        fp->x80_self_vel.y = sp1C_vel.y;
     } else {
         lbvector_Normalize(&sp1C_vel);
         speed = len * attr->x28;
         sp1C_vel.x *= speed;
         sp1C_vel.y *= speed;
         sp1C_vel.z *= speed;
-        ft->x80_self_vel.x = sp1C_vel.x;
-        ft->x80_self_vel.y = sp1C_vel.y;
+        fp->x80_self_vel.x = sp1C_vel.x;
+        fp->x80_self_vel.y = sp1C_vel.y;
     }
 }
 
@@ -189,8 +189,8 @@ void lbl_80154620(HSD_GObj* gobj) {
 
 // 80154670 151250
 void lbl_80154670(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -214,17 +214,17 @@ void lbl_801546D4(HSD_GObj* gobj) {
 // 801546D8 1512B8
 // https://decomp.me/scratch/UYsam
 void func_801546D8(HSD_GObj* gobj) {
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
     MasterHandAttributes* temp_r30;
 
-    r31_ft_userdata = gobj->user_data;
+    r31_fp = gobj->user_data;
     // temp_f1 = ;
-    temp_r30 = r31_ft_userdata->x10C_ftData->ext_attr;
+    temp_r30 = r31_fp->x10C_ftData->ext_attr;
     Fighter_ActionStateChange_800693AC(gobj, 0x17D, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
-    r31_ft_userdata->x234C_pos.x = temp_r30->x30_pos2.x;
-    r31_ft_userdata->x234C_pos.y = temp_r30->x30_pos2.y;
-    r31_ft_userdata->x234C_pos.z = 0.0f;
+    r31_fp->x234C_pos.x = temp_r30->x30_pos2.x;
+    r31_fp->x234C_pos.y = temp_r30->x30_pos2.y;
+    r31_fp->x234C_pos.z = 0.0f;
 }
 
 
@@ -242,8 +242,8 @@ void lbl_80154758(HSD_GObj* arg0) {
 
 // 80154794 151374
 void lbl_80154794(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -253,16 +253,16 @@ void lbl_80154794(HSD_GObj* arg0) {
 // 801547D8 1513B8
 // https://decomp.me/scratch/e8kBC
 void lbl_801547D8(HSD_GObj* gobj) {
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
     MasterHandAttributes* r30_attributes;
 
-    r31_ft_userdata = gobj->user_data;
-    r30_attributes = r31_ft_userdata->x10C_ftData->ext_attr;
+    r31_fp = gobj->user_data;
+    r30_attributes = r31_fp->x10C_ftData->ext_attr;
     func_80085134(gobj);
     func_8015BE40(
         gobj,
-        &r31_ft_userdata->x234C_pos,
-        &r31_ft_userdata->x2358_stateVar7,
+        &r31_fp->x234C_pos,
+        &r31_fp->x2358_stateVar7,
         r30_attributes->x2C,
         r30_attributes->x28
     );
@@ -281,21 +281,21 @@ void lbl_80154838(HSD_GObj* gobj) {
 // 8015483C 15141C
 // https://decomp.me/scratch/rkMCg
 void func_8015483C(HSD_GObj* gobj) {
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
     MasterHandAttributes* r30_attributes;
 
-    r31_ft_userdata = gobj->user_data;
-    r30_attributes = r31_ft_userdata->x10C_ftData->ext_attr;
+    r31_fp = gobj->user_data;
+    r30_attributes = r31_fp->x10C_ftData->ext_attr;
     Fighter_ActionStateChange_800693AC(gobj, 0x177, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
-    r31_ft_userdata->x2364 = r30_attributes->x120;
-    r31_ft_userdata->x2200_ftcmd_var0 = 1;
-    r31_ft_userdata->x80_self_vel.x = 0.0f;
-    r31_ft_userdata->x80_self_vel.y = 0.0f;
-    r31_ft_userdata->x80_self_vel.z = 0.0f;
-    r31_ft_userdata->x234C_pos.x = r30_attributes->x30_pos2.x;
-    r31_ft_userdata->x234C_pos.y = r30_attributes->x30_pos2.y;
-    r31_ft_userdata->x234C_pos.z = 0.0f;
+    r31_fp->x2364 = r30_attributes->x120;
+    r31_fp->x2200_ftcmd_var0 = 1;
+    r31_fp->x80_self_vel.x = 0.0f;
+    r31_fp->x80_self_vel.y = 0.0f;
+    r31_fp->x80_self_vel.z = 0.0f;
+    r31_fp->x234C_pos.x = r30_attributes->x30_pos2.x;
+    r31_fp->x234C_pos.y = r30_attributes->x30_pos2.y;
+    r31_fp->x234C_pos.z = 0.0f;
 }
 
 
@@ -304,12 +304,12 @@ void func_8015483C(HSD_GObj* gobj) {
 // 801548D8 1514B8
 // https://decomp.me/scratch/rGeOV
 void lbl_801548D8(HSD_GObj* gobj) {
-    Fighter* r31_ft_userdata = gobj->user_data;
+    Fighter* r31_fp = gobj->user_data;
 
-    if (--r31_ft_userdata->x2364 <= 0.0f && r31_ft_userdata->x2200_ftcmd_var0) {
-        func_80155D1C(r31_ft_userdata->x1A58_interactedFighter);
-        r31_ft_userdata->x2360 = 0;
-        r31_ft_userdata->x2200_ftcmd_var0 = 0;
+    if (--r31_fp->x2364 <= 0.0f && r31_fp->x2200_ftcmd_var0) {
+        func_80155D1C(r31_fp->x1A58_interactedFighter);
+        r31_fp->x2360 = 0;
+        r31_fp->x2200_ftcmd_var0 = 0;
     }
     if (!ftAnim_IsFramesRemaining(gobj)) {
         func_80151018(gobj);
@@ -321,8 +321,8 @@ void lbl_801548D8(HSD_GObj* gobj) {
 
 // 80154964 151544
 void lbl_80154964(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_23.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_23.c
@@ -3,21 +3,21 @@
 // 80154A78 151658
 // https://decomp.me/scratch/ci0xf
 void func_80154A78(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     MasterHandAttributes* attr;
 
-    ft = gobj->user_data;
-    attr = ft->x10C_ftData->ext_attr;
-    ft->x2204_ftcmd_var1 = 0;
+    fp = gobj->user_data;
+    attr = fp->x10C_ftData->ext_attr;
+    fp->x2204_ftcmd_var1 = 0;
     Fighter_ActionStateChange_800693AC(gobj, 0x17A, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
-    ft->x2222_flag.bits.b2 = 1;
-    func_8007E2F4(ft, 0x1FFU);
+    fp->x2222_flag.bits.b2 = 1;
+    func_8007E2F4(fp, 0x1FFU);
     func_8007E2FC(gobj);
-    func_80155B80(ft->x1A58_interactedFighter);
-    ft->x234C_pos.x = attr->x118_pos.x;
-    ft->x234C_pos.y = attr->x118_pos.y;
-    ft->x234C_pos.z = 0.0f;
+    func_80155B80(fp->x1A58_interactedFighter);
+    fp->x234C_pos.x = attr->x118_pos.x;
+    fp->x234C_pos.y = attr->x118_pos.y;
+    fp->x234C_pos.z = 0.0f;
 }
 
 
@@ -25,13 +25,13 @@ void func_80154A78(HSD_GObj* gobj) {
 // 80154B2C 15170C
 // https://decomp.me/scratch/6WD6p
 void lbl_80154B2C(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     s32 unused[2];
 
-    ft = gobj->user_data;
-    if (ft->x2204_ftcmd_var1 != 0) {
+    fp = gobj->user_data;
+    if (fp->x2204_ftcmd_var1 != 0) {
         func_8015C5F8(gobj);
-        ft->x2204_ftcmd_var1 = 0;
+        fp->x2204_ftcmd_var1 = 0;
     }
     if (ftAnim_IsFramesRemaining(gobj) == 0) {
         if (((Fighter*)gobj->user_data)->sa.masterhand.x2250 == 0x17B) {
@@ -46,8 +46,8 @@ void lbl_80154B2C(HSD_GObj* gobj) {
 
 // 80154BB0 151790
 void lbl_80154BB0(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -57,13 +57,13 @@ void lbl_80154BB0(HSD_GObj* arg0) {
 // 80154BF4 1517D4
 // https://decomp.me/scratch/D7Kd4
 void lbl_80154BF4(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     MasterHandAttributes* attr;
 
-    ft = gobj->user_data;
-    attr = ft->x10C_ftData->ext_attr;
+    fp = gobj->user_data;
+    attr = fp->x10C_ftData->ext_attr;
     func_80085134(gobj);
-    func_8015BE40(gobj, &ft->x234C_pos, &ft->x2358_stateVar7, attr->x2C, attr->x28);
+    func_8015BE40(gobj, &fp->x234C_pos, &fp->x2358_stateVar7, attr->x2C, attr->x28);
 }
 
 
@@ -72,12 +72,12 @@ void lbl_80154BF4(HSD_GObj* gobj) {
 // https://decomp.me/scratch/Pp9nI
 void lbl_80154C54(HSD_GObj* gobj) {
     f32 temp_f1;
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = gobj->user_data;
-    if (ft->x2358_stateVar7 == 0.0f) {
-        ft->x80_self_vel.z = 0.0f;
-        ft->x80_self_vel.y = 0.0f;
-        ft->x80_self_vel.x = 0.0f;
+    fp = gobj->user_data;
+    if (fp->x2358_stateVar7 == 0.0f) {
+        fp->x80_self_vel.z = 0.0f;
+        fp->x80_self_vel.y = 0.0f;
+        fp->x80_self_vel.x = 0.0f;
     }
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_24.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_24.c
@@ -19,14 +19,14 @@ void func_80154C78(HSD_GObj* arg0) {
 
 // 80154CF8 1518D8
 // https://decomp.me/scratch/XwAlv
-void func_80154CF8(HSD_GObj* arg0, Fighter* arg1) {
+void func_80154CF8(HSD_GObj* gobj, Fighter* fp) {
     Fighter* temp_r31;
     MasterHandAttributes* temp_r30;
 
-    temp_r31 = arg0->user_data;
+    temp_r31 = gobj->user_data;
     temp_r30 = temp_r31->x10C_ftData->ext_attr;
-    Fighter_ActionStateChange_800693AC(arg0, 0x179, 0, 0, 0.0f, 1.0f, 0.0f);
-    func_8006EBA4(arg0);
+    Fighter_ActionStateChange_800693AC(gobj, 0x179, 0, 0, 0.0f, 1.0f, 0.0f);
+    func_8006EBA4(gobj);
     temp_r31->x234C_pos.x = temp_r30->x30_pos2.x;
     temp_r31->x234C_pos.y = temp_r30->x30_pos2.y;
     temp_r31->x234C_pos.z = 0.0f;

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_25.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_25.c
@@ -3,11 +3,11 @@
 // 80154D78 151958
 // https://decomp.me/scratch/DzZiN
 void lbl_80154D78(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     s32 unused[2];
     if (ftAnim_IsFramesRemaining(gobj) == 0) {
-        ft = gobj->user_data;
-        if (ft->x2360 == 1) {
+        fp = gobj->user_data;
+        if (fp->x2360 == 1) {
             func_80154A78(gobj);
         } else {
             func_801546D8(gobj);
@@ -21,8 +21,8 @@ void lbl_80154D78(HSD_GObj* gobj) {
 // 80154DD0 1519B0
 // https://decomp.me/scratch/5olg2
 void lbl_80154DD0(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -33,11 +33,11 @@ void lbl_80154DD0(HSD_GObj* arg0) {
 // 80154E14 1519F4
 // https://decomp.me/scratch/2yMnG
 void lbl_80154E14(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    MasterHandAttributes* attr = ft->x10C_ftData->ext_attr;
+    Fighter* fp = gobj->user_data;
+    MasterHandAttributes* attr = fp->x10C_ftData->ext_attr;
 
     func_80085134(gobj);
-    func_8015BE40(gobj, &ft->x234C_pos, &ft->x2358_stateVar7, attr->x2C, attr->x28);
+    func_8015BE40(gobj, &fp->x234C_pos, &fp->x2358_stateVar7, attr->x2C, attr->x28);
 }
 
 
@@ -55,12 +55,12 @@ void lbl_80154E74(HSD_GObj* gobj) {
 // 80154E78 151A58
 // https://decomp.me/scratch/lmtfb
 void func_80154E78(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = gobj->user_data;
+    fp = gobj->user_data;
     Fighter_ActionStateChange_800693AC(gobj, 0x17B, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
-    ft->x2200_ftcmd_var0 = 0;
+    fp->x2200_ftcmd_var0 = 0;
 }
 
 
@@ -69,24 +69,24 @@ void func_80154E78(HSD_GObj* gobj) {
 // 80154ED8 151AB8
 // https://decomp.me/scratch/6H8xW
 void lbl_80154ED8(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     HSD_GObj* gobj_2;
     Fighter* ft_2;
     s32 unused[2];
 
-    ft = gobj->user_data;
-    if (ft->x2200_ftcmd_var0 != 0) {
-        ft->x2200_ftcmd_var0 = 0;
-        func_80155D6C(ft->x1A58_interactedFighter, 0x14A);
-        if (ft->x1A58_interactedFighter != 0) {
-            gobj_2 = ft->x1A58_interactedFighter;
+    fp = gobj->user_data;
+    if (fp->x2200_ftcmd_var0 != 0) {
+        fp->x2200_ftcmd_var0 = 0;
+        func_80155D6C(fp->x1A58_interactedFighter, 0x14A);
+        if (fp->x1A58_interactedFighter != 0) {
+            gobj_2 = fp->x1A58_interactedFighter;
             ft_2 = gobj_2->user_data;
-            func_8007E2F4(ft, 0);
+            func_8007E2F4(fp, 0);
             func_800DE2A8(gobj, gobj_2);
             ft_2->dmg.x1844_direction *= -1.0f;
             func_800DE7C0(gobj_2, 0, 0);
         }
-        ft->x2360 = 0;
+        fp->x2360 = 0;
     }
     if (ftAnim_IsFramesRemaining(gobj) == 0) {
         func_80151018(gobj);

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_26.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_26.c
@@ -2,8 +2,8 @@
 
 // 80154FAC 151B8C
 void lbl_80154FAC(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -27,8 +27,8 @@ void lbl_80155010(HSD_GObj* gobj) {
 // 80155014 151BF4
 // https://decomp.me/scratch/ZAwzc
 void func_80155014(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     Fighter_ActionStateChange_800693AC(gobj, 0x17C, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
-    ft->x2200_ftcmd_var0 = 0;
+    fp->x2200_ftcmd_var0 = 0;
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_27.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_27.c
@@ -4,20 +4,20 @@
 // https://decomp.me/scratch/GL82m
 void lbl_80155074(HSD_GObj* gobj) {
     s32 unused[2];
-    Fighter* ft;
+    Fighter* fp;
     HSD_GObj* gobj_2;
 
-    ft = gobj->user_data;
-    if (ft->x2200_ftcmd_var0 != 0) {
-        ft->x2200_ftcmd_var0 = 0;
-        func_80155D6C(ft->x1A58_interactedFighter, 0x14A);
-        if (ft->x1A58_interactedFighter != 0) {
-            gobj_2 = ft->x1A58_interactedFighter;
-            func_8007E2F4(ft, 0);
+    fp = gobj->user_data;
+    if (fp->x2200_ftcmd_var0 != 0) {
+        fp->x2200_ftcmd_var0 = 0;
+        func_80155D6C(fp->x1A58_interactedFighter, 0x14A);
+        if (fp->x1A58_interactedFighter != 0) {
+            gobj_2 = fp->x1A58_interactedFighter;
+            func_8007E2F4(fp, 0);
             func_800DE2A8(gobj, gobj_2);
             func_800DE7C0(gobj_2, 0, 0);
         }
-        ft->x2360 = 0;
+        fp->x2360 = 0;
     }
     if (ftAnim_IsFramesRemaining(gobj) == 0) {
         func_80151018(gobj);
@@ -29,8 +29,8 @@ void lbl_80155074(HSD_GObj* gobj) {
 
 // 8015512C 151D0C
 void lbl_8015512C(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -54,15 +54,15 @@ void lbl_80155190(HSD_GObj* gobj) {
 // 80155194 151D74
 // https://decomp.me/scratch/3ppDy
 void lbl_80155194(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     HSD_GObj* gobj_2;
 
-    ft = gobj->user_data;
+    fp = gobj->user_data;
     gobj_2 = func_8015C3E8(0x1C);
     if (func_8015C31C() == 0) {
         func_8015A2B0(gobj_2);
     }
-    ft->x1A5C = gobj_2;
+    fp->x1A5C = gobj_2;
     Fighter_ActionStateChange_800693AC(gobj, 0x17E, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_28.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_28.c
@@ -3,12 +3,12 @@
 // 8015521C 151DFC
 // https://decomp.me/scratch/veN50
 void lbl_8015521C(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
     if ((func_8015C31C() != 0) || (func_8015C3A0() != 0) || (ftAnim_IsFramesRemaining(gobj) == 0)) {
-        ft = gobj->user_data;
+        fp = gobj->user_data;
         Fighter_UnkSetFlag_8006CFBC(gobj);
-        ft->x1A5C = 0;
+        fp->x1A5C = 0;
         func_80151018(gobj);
     }
 }
@@ -18,8 +18,8 @@ void lbl_8015521C(HSD_GObj* gobj) {
 
 // 80155290 151E70
 void lbl_80155290(HSD_GObj* arg0) {
-    Fighter* ft = arg0->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = arg0->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(arg0);
     }
 }
@@ -43,16 +43,16 @@ void lbl_801552F4(HSD_GObj* gobj) {
 // 801552F8 151ED8
 // https://decomp.me/scratch/x0WJ4
 void lbl_801552F8(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     HSD_GObj* gobj_2;
 
-    ft = gobj->user_data;
-    ft->x2204_ftcmd_var1 = 0;
+    fp = gobj->user_data;
+    fp->x2204_ftcmd_var1 = 0;
     gobj_2 = func_8015C3E8(0x1CU);
     if (func_8015C31C() == 0) {
         func_8015A3F4(gobj_2);
     }
-    ft->x1A5C = gobj_2;
+    fp->x1A5C = gobj_2;
     Fighter_ActionStateChange_800693AC(gobj, 0x17F, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_29.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_29.c
@@ -3,14 +3,14 @@
 // 80155388 151F68
 // https://decomp.me/scratch/6nLDB
 void lbl_80155388(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     Fighter* ft_2;
     s32 unused[2];
 
-    ft = gobj->user_data;
-    if (ft->x2204_ftcmd_var1 != 0) {
+    fp = gobj->user_data;
+    if (fp->x2204_ftcmd_var1 != 0) {
         func_8015C5F8(gobj);
-        ft->x2204_ftcmd_var1 = 0;
+        fp->x2204_ftcmd_var1 = 0;
     }
     // inlined? possibly shared with lbl_8015521C
     if ((func_8015C31C() != 0) || (func_8015C3A0() != 0) || (ftAnim_IsFramesRemaining(gobj) == 0)) {
@@ -25,8 +25,8 @@ void lbl_80155388(HSD_GObj* gobj) {
 
 // 8015541C 151FFC
 void lbl_8015541C(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }
@@ -50,15 +50,15 @@ void lbl_80155480(HSD_GObj* gobj) {
 // 80155484 152064
 // https://decomp.me/scratch/jsnxb
 void lbl_80155484(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     HSD_GObj* gobj_2;
 
-    ft = gobj->user_data;
+    fp = gobj->user_data;
     gobj_2 = func_8015C3E8(0x1CU);
     if (func_8015C31C() == 0) {
         func_8015A560(gobj_2);
     }
-    ft->x1A5C = gobj_2;
+    fp->x1A5C = gobj_2;
     Fighter_ActionStateChange_800693AC(gobj, 0x180, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_3.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_3.c
@@ -5,16 +5,16 @@
 // 80150C8C 0014D86C
 // https://decomp.me/scratch/Nhsvo
 void func_80150C8C(HSD_GObj* gobj) {
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
 
-    r31_ft_userdata = gobj->user_data;
-    if ((r31_ft_userdata->sa.masterhand.x2258 == 0x155) || (r31_ft_userdata->sa.masterhand.x2258 == 0x185)) {
-        Fighter_ActionStateChange_800693AC(gobj, 0x185, 0, 0, r31_ft_userdata->x894_currentAnimFrame, 1.0f, 0.0f);
+    r31_fp = gobj->user_data;
+    if ((r31_fp->sa.masterhand.x2258 == 0x155) || (r31_fp->sa.masterhand.x2258 == 0x185)) {
+        Fighter_ActionStateChange_800693AC(gobj, 0x185, 0, 0, r31_fp->x894_currentAnimFrame, 1.0f, 0.0f);
     } else {
         Fighter_ActionStateChange_800693AC(gobj, 0x185, 0, 0, 0.0f, 1.0f, 0.0f);
         func_8006EBA4(gobj);
     }
-    r31_ft_userdata->sa.masterhand.x2258 = 0x185;
+    r31_fp->sa.masterhand.x2258 = 0x185;
 }
 
 
@@ -22,16 +22,16 @@ void func_80150C8C(HSD_GObj* gobj) {
 // 80150D28 0014D908
 // https://decomp.me/scratch/ntaE2
 void func_80150D28(HSD_GObj* gobj) {
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
 
-    r31_ft_userdata = gobj->user_data;
-    if ((r31_ft_userdata->sa.masterhand.x2258 == 0x156) || (r31_ft_userdata->sa.masterhand.x2258 == 0x186)) {
-        Fighter_ActionStateChange_800693AC(gobj, 0x186, 0, 0, r31_ft_userdata->x894_currentAnimFrame, 1.0f, 0.0f);
+    r31_fp = gobj->user_data;
+    if ((r31_fp->sa.masterhand.x2258 == 0x156) || (r31_fp->sa.masterhand.x2258 == 0x186)) {
+        Fighter_ActionStateChange_800693AC(gobj, 0x186, 0, 0, r31_fp->x894_currentAnimFrame, 1.0f, 0.0f);
     } else {
         Fighter_ActionStateChange_800693AC(gobj, 0x186, 0, 0, 0.0f, 1.0f, 0.0f);
         func_8006EBA4(gobj);
     }
-    r31_ft_userdata->sa.masterhand.x2258 = 0x186;
+    r31_fp->sa.masterhand.x2258 = 0x186;
 }
 
 
@@ -40,30 +40,30 @@ void func_80150D28(HSD_GObj* gobj) {
 // https://decomp.me/scratch/vZOBB
 void func_80150DC4(HSD_GObj* gobj, void* arg1_stateVar2, Vec3* arg2_pos) {
     f32 temp_f1;
-    Fighter* r32_ft_userdata;
+    Fighter* r32_fp;
     s32 unk_filler[4];
 
-    r32_ft_userdata = gobj->user_data;
-    if (r32_ft_userdata->sa.masterhand.x2258 == 0x156) {
-        if ((r32_ft_userdata->sa.masterhand.x2258 == 0x156) || (r32_ft_userdata->sa.masterhand.x2258 == 0x186)) {
-            Fighter_ActionStateChange_800693AC(gobj, 0x186, 0, 0, r32_ft_userdata->x894_currentAnimFrame, 1.0f, 0.0f);
+    r32_fp = gobj->user_data;
+    if (r32_fp->sa.masterhand.x2258 == 0x156) {
+        if ((r32_fp->sa.masterhand.x2258 == 0x156) || (r32_fp->sa.masterhand.x2258 == 0x186)) {
+            Fighter_ActionStateChange_800693AC(gobj, 0x186, 0, 0, r32_fp->x894_currentAnimFrame, 1.0f, 0.0f);
         } else {
             temp_f1 = 0.0f;
             Fighter_ActionStateChange_800693AC(gobj, 0x186, 0, 0, temp_f1, 1.0f, temp_f1);
             func_8006EBA4(gobj);
         }
-        r32_ft_userdata->sa.masterhand.x2258 = 0x186;
+        r32_fp->sa.masterhand.x2258 = 0x186;
     } else {
-        if ((r32_ft_userdata->sa.masterhand.x2258 == 0x155) || (r32_ft_userdata->sa.masterhand.x2258 == 0x185)) {
-            Fighter_ActionStateChange_800693AC(gobj, 0x185, 0, 0, r32_ft_userdata->x894_currentAnimFrame, 1.0f, 0.0f);
+        if ((r32_fp->sa.masterhand.x2258 == 0x155) || (r32_fp->sa.masterhand.x2258 == 0x185)) {
+            Fighter_ActionStateChange_800693AC(gobj, 0x185, 0, 0, r32_fp->x894_currentAnimFrame, 1.0f, 0.0f);
         } else {
             Fighter_ActionStateChange_800693AC(gobj, 0x185, 0, 0, 0.0f, 1.0f, 0.0f);
             func_8006EBA4(gobj);
         }
-        r32_ft_userdata->sa.masterhand.x2258 = 0x185;
+        r32_fp->sa.masterhand.x2258 = 0x185;
     }
-    r32_ft_userdata->x2344_callback = arg1_stateVar2;
-    r32_ft_userdata->x234C_pos = *arg2_pos;
+    r32_fp->x2344_callback = arg1_stateVar2;
+    r32_fp->x234C_pos = *arg2_pos;
 }
 
 
@@ -74,8 +74,8 @@ void lbl_80150F00(HSD_GObj* gobj) {
     u32 unk[1];
 
     if (!ftAnim_IsFramesRemaining(gobj)) {
-        Fighter* fighter = gobj->user_data;
-        fighter->sa.masterhand.x2258 = 0x185;
+        Fighter* fp = gobj->user_data;
+        fp->sa.masterhand.x2258 = 0x185;
         Fighter_ActionStateChange_800693AC(gobj, 0x185, 0, 0, 0.0f, 1.0f, 0.0f);
         func_8006EBA4(gobj);
     }
@@ -86,16 +86,16 @@ void lbl_80150F00(HSD_GObj* gobj) {
 // 80150F68 0014DB48
 // https://decomp.me/scratch/kHlJR
 void lbl_80150F68(HSD_GObj* gobj) {
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
     MasterHandAttributes* r30_ft_attributes;
     ftData* r4_ftdata;
 
-    r31_ft_userdata = gobj->user_data;
-    r4_ftdata = r31_ft_userdata->x10C_ftData;
+    r31_fp = gobj->user_data;
+    r4_ftdata = r31_fp->x10C_ftData;
     r30_ft_attributes = r4_ftdata->ext_attr;
 
     func_80085134(gobj);
-    func_8015BE40(gobj, &r31_ft_userdata->x234C_pos, &r31_ft_userdata->x2358_stateVar7, r30_ft_attributes->x2C, r30_ft_attributes->x28);
+    func_8015BE40(gobj, &r31_fp->x234C_pos, &r31_fp->x2358_stateVar7, r30_ft_attributes->x2C, r30_ft_attributes->x28);
 }
 
 
@@ -103,16 +103,16 @@ void lbl_80150F68(HSD_GObj* gobj) {
 // 80150FC8 0014DBA8
 // https://decomp.me/scratch/8qlZ7
 void lbl_80150FC8(HSD_GObj* gobj) {
-    Fighter* r4_ft_userdata;
+    Fighter* r4_fp;
 
-    r4_ft_userdata = gobj->user_data;
-    if (0.0f == r4_ft_userdata->x2358_stateVar7) {
-        r4_ft_userdata->x80_self_vel.z = 0.0f;
-        r4_ft_userdata->x80_self_vel.y = 0.0f;
-        r4_ft_userdata->x80_self_vel.x = 0.0f;
+    r4_fp = gobj->user_data;
+    if (0.0f == r4_fp->x2358_stateVar7) {
+        r4_fp->x80_self_vel.z = 0.0f;
+        r4_fp->x80_self_vel.y = 0.0f;
+        r4_fp->x80_self_vel.x = 0.0f;
 
-        if (r4_ft_userdata->x2344_stateVar2) {
-            ((void(*)(HSD_GObj*))r4_ft_userdata->x2344_stateVar2)(gobj);
+        if (r4_fp->x2344_stateVar2) {
+            ((void(*)(HSD_GObj*))r4_fp->x2344_stateVar2)(gobj);
         }
     }
 }
@@ -124,23 +124,23 @@ void lbl_80150FC8(HSD_GObj* gobj) {
 void func_80151018(HSD_GObj* gobj) {
     Vec3 sp1C_pos;
     MasterHandAttributes* r5_attributes;
-    Fighter* r6_ft_userdata;
-    Fighter* r31_ft_userdata;
+    Fighter* r6_fp;
+    Fighter* r31_fp;
     u32 unk[4];
 
-    r6_ft_userdata = gobj->user_data;
-    r5_attributes = r6_ft_userdata->x10C_ftData->ext_attr;
-    r6_ft_userdata->x2360 = 0;
+    r6_fp = gobj->user_data;
+    r5_attributes = r6_fp->x10C_ftData->ext_attr;
+    r6_fp->x2360 = 0;
     sp1C_pos.x = r5_attributes->x30_pos2.x;
     sp1C_pos.y = r5_attributes->x30_pos2.y;
     sp1C_pos.z = 0.0f;
-    r6_ft_userdata->sa.masterhand.x2258 = 0x186;
-    r31_ft_userdata = gobj->user_data;
-    if (r31_ft_userdata->sa.masterhand.x2258 == 0x156) {
+    r6_fp->sa.masterhand.x2258 = 0x186;
+    r31_fp = gobj->user_data;
+    if (r31_fp->sa.masterhand.x2258 == 0x156) {
         func_80150D28(gobj);
     } else {
         func_80150C8C(gobj);
     }
-    r31_ft_userdata->x2344_callback = lbl_8014FFDC;
-    r31_ft_userdata->x234C_pos = sp1C_pos;
+    r31_fp->x2344_callback = lbl_8014FFDC;
+    r31_fp->x234C_pos = sp1C_pos;
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_30.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_30.c
@@ -5,12 +5,12 @@ extern const f32 neg1;
 // 8015550C 1520EC
 // https://decomp.me/scratch/wrO5N
 void lbl_8015550C(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
     if ((func_8015C31C() != 0) || (func_8015C3A0() != 0) || (ftAnim_IsFramesRemaining(gobj) == 0)) {
-        ft = gobj->user_data;
+        fp = gobj->user_data;
         Fighter_UnkSetFlag_8006CFBC(gobj);
-        ft->x1A5C = 0;
+        fp->x1A5C = 0;
         func_80151018(gobj);
     }
 }
@@ -19,8 +19,8 @@ void lbl_8015550C(HSD_GObj* gobj) {
 
 // 80155580 152160
 void lbl_80155580(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }
@@ -44,12 +44,12 @@ void lbl_801555E4(HSD_GObj* gobj) {
 // 801555E8 1521C8
 // https://decomp.me/scratch/mvCUe
 void lbl_801555E8(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
     if ((func_8015C31C() != 0) || (func_8015C3A0() != 0) || (ftAnim_IsFramesRemaining(gobj) == 0)) {
-        ft = gobj->user_data;
+        fp = gobj->user_data;
         Fighter_UnkSetFlag_8006CFBC(gobj);
-        ft->x1A5C = 0;
+        fp->x1A5C = 0;
         func_80155818(gobj);
     }
 }
@@ -58,8 +58,8 @@ void lbl_801555E8(HSD_GObj* gobj) {
 
 // 8015565C 15223C
 void lbl_8015565C(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }
@@ -83,20 +83,20 @@ void lbl_801556C0(HSD_GObj* gobj) {
 // 801556C4 1522A4
 // https://decomp.me/scratch/Uuy48
 void lbl_801556C4(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     HSD_GObj* gobj_2;
     Fighter* ft_2;
     Fighter* ft_3;
     s32 unused[4];
 
-    ft = gobj->user_data;
-    if (ft->x2200_ftcmd_var0 != 0) {
-        ft->x2200_ftcmd_var0 = 0;
-        func_80155D6C(ft->x1A58_interactedFighter, 0x14A);
-        if (ft->x1A58_interactedFighter != 0) {
-            gobj_2 = ft->x1A58_interactedFighter;
+    fp = gobj->user_data;
+    if (fp->x2200_ftcmd_var0 != 0) {
+        fp->x2200_ftcmd_var0 = 0;
+        func_80155D6C(fp->x1A58_interactedFighter, 0x14A);
+        if (fp->x1A58_interactedFighter != 0) {
+            gobj_2 = fp->x1A58_interactedFighter;
             ft_2 = gobj_2->user_data;
-            func_8007E2F4(ft, 0);
+            func_8007E2F4(fp, 0);
             func_800DE2A8(gobj, gobj_2);
             ft_2->dmg.x1844_direction *= neg1;
             func_800DE7C0(gobj_2, 0, 0);
@@ -114,8 +114,8 @@ void lbl_801556C4(HSD_GObj* gobj) {
 
 // 801557B0 152390
 void lbl_801557B0(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }
@@ -157,8 +157,8 @@ void lbl_80155864(HSD_GObj* gobj) {
 
 // 801558A0 152480
 void lbl_801558A0(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }
@@ -182,12 +182,12 @@ void lbl_80155904(HSD_GObj* gobj) {
 // 80155908 1524E8
 // https://decomp.me/scratch/jo0OK
 void lbl_80155908(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = gobj->user_data;
-    if ((--ft->x2364 <= 0.0f) && (ft->x2200_ftcmd_var0 != 0)) {
-        func_80155D1C(ft->x1A58_interactedFighter);
-        ft->x2200_ftcmd_var0 = 0;
+    fp = gobj->user_data;
+    if ((--fp->x2364 <= 0.0f) && (fp->x2200_ftcmd_var0 != 0)) {
+        func_80155D1C(fp->x1A58_interactedFighter);
+        fp->x2200_ftcmd_var0 = 0;
     }
     if (ftAnim_IsFramesRemaining(gobj) == 0) {
         func_80151018(gobj);
@@ -198,8 +198,8 @@ void lbl_80155908(HSD_GObj* gobj) {
 
 // 80155990 152570
 void lbl_80155990(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    if (Player_GetPlayerSlotType(ft->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }
@@ -209,13 +209,13 @@ void lbl_80155990(HSD_GObj* gobj) {
 // 801559D4 1525B4
 // https://decomp.me/scratch/cRlBe
 void lbl_801559D4(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     MasterHandAttributes* attr;
 
-    ft = gobj->user_data;
-    attr = ft->x10C_ftData->ext_attr;
+    fp = gobj->user_data;
+    attr = fp->x10C_ftData->ext_attr;
     func_80085134(gobj);
-    func_8015BE40(gobj, &ft->x234C_pos, &ft->x2358_stateVar7, attr->x2C, attr->x28);
+    func_8015BE40(gobj, &fp->x234C_pos, &fp->x2358_stateVar7, attr->x2C, attr->x28);
 }
 
 
@@ -223,13 +223,13 @@ void lbl_801559D4(HSD_GObj* gobj) {
 // 80155A34 152614
 // https://decomp.me/scratch/OedGK
 void lbl_80155A34(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = gobj->user_data;
-    if (ft->x2358_stateVar7 == 0.0f) {
-        ft->x80_self_vel.z = 0.0f;
-        ft->x80_self_vel.y = 0.0f;
-        ft->x80_self_vel.x = 0.0f;
+    fp = gobj->user_data;
+    if (fp->x2358_stateVar7 == 0.0f) {
+        fp->x80_self_vel.z = 0.0f;
+        fp->x80_self_vel.y = 0.0f;
+        fp->x80_self_vel.x = 0.0f;
     }
 }
 

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_32.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_32.c
@@ -31,15 +31,15 @@ void func_80155B7C(HSD_GObj* gobj) {
 // 80155B80 152760
 // https://decomp.me/scratch/BFD9X
 void func_80155B80(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = gobj->user_data;
+    fp = gobj->user_data;
     Fighter_ActionStateChange_800693AC(gobj, 0x148, 0, 0, 0.0f, 1.0f, 0.0f);
-    ft->x221E_flag.bits.b0 = 1;
-    ft->x2220_flag.bits.b3 = 1;
-    ft->cb.x21B0_callback_Accessory1 = &func_800DB464;
-    func_8007E2F4(ft, 0x1FF);
-    ft->x2220_flag.bits.b3 = 1;
+    fp->x221E_flag.bits.b0 = 1;
+    fp->x2220_flag.bits.b3 = 1;
+    fp->cb.x21B0_callback_Accessory1 = &func_800DB464;
+    func_8007E2F4(fp, 0x1FF);
+    fp->x2220_flag.bits.b3 = 1;
     func_8006EBA4(gobj);
 }
 
@@ -52,12 +52,12 @@ void func_8015483C(HSD_GObj*);
 void func_80155C94(HSD_GObj*);
 
 void func_80155C20(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = gobj->user_data;
-    func_8007DC08(ft, p_ftCommonData->x3A8);
-    if (ft->x1A4C <= 0.0f) {
+    fp = gobj->user_data;
+    func_8007DC08(fp, p_ftCommonData->x3A8);
+    if (fp->x1A4C <= 0.0f) {
         func_80155C94(gobj);
-        func_8015483C(ft->x1A58_interactedFighter);
+        func_8015483C(fp->x1A58_interactedFighter);
     }
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_33.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_33.c
@@ -24,13 +24,13 @@ void func_80155C90(HSD_GObj* gobj) {
 // 80155C94 152874
 // https://decomp.me/scratch/8Kpd7
 void func_80155C94(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = gobj->user_data;
+    fp = gobj->user_data;
     Fighter_ActionStateChange_800693AC(gobj, 0x149, 0, 0, 0.0f, 1.0f, 0.0f);
-    ft->x221E_flag.bits.b0 = 1;
-    func_8007E2F4(ft, 0x1FF);
-    ft->x2220_flag.bits.b3 = 1;
+    fp->x221E_flag.bits.b0 = 1;
+    func_8007E2F4(fp, 0x1FF);
+    fp->x2220_flag.bits.b3 = 1;
     func_8006EBA4(gobj);
 }
 

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_34.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_34.c
@@ -3,11 +3,11 @@
 // 80155D1C 1528FC
 // https://decomp.me/scratch/YDeLe
 void func_80155D1C(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = gobj->user_data;
-    ft->x221E_flag.bits.b0 = 0;
-    ft->x2C_facing_direction = -ft->x2C_facing_direction;
+    fp = gobj->user_data;
+    fp->x221E_flag.bits.b0 = 0;
+    fp->x2C_facing_direction = -fp->x2C_facing_direction;
     func_800DC750(gobj);
 }
 
@@ -45,16 +45,16 @@ void func_80155D68(HSD_GObj* gobj) {
 // 80155D6C 15294C
 // https://decomp.me/scratch/y3wmm
 void func_80155D6C(HSD_GObj* gobj, s32 arg1) {
-    Fighter* ft;
+    Fighter* fp;
     s32 unused[6];
 
-    ft = gobj->user_data;
-    ft->x2C_facing_direction = ((Fighter*)ft->x1A58_interactedFighter->user_data)->x2C_facing_direction;
-    ft->x2340_stateVar1 = 0;
+    fp = gobj->user_data;
+    fp->x2C_facing_direction = ((Fighter*)fp->x1A58_interactedFighter->user_data)->x2C_facing_direction;
+    fp->x2340_stateVar1 = 0;
     Fighter_ActionStateChange_800693AC(gobj, 0x14A, 0, 0, 0.0f, 1.0f, 0.0f);
-    ft->x221E_flag.bits.b0 = 0;
-    ft->cb.x21B0_callback_Accessory1 = &func_800DE508;
-    func_8007E2F4(ft, 0x1FFU);
+    fp->x221E_flag.bits.b0 = 0;
+    fp->cb.x21B0_callback_Accessory1 = &func_800DE508;
+    func_8007E2F4(fp, 0x1FFU);
     func_8006EBA4(gobj);
 }
 

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_4.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_4.c
@@ -3,20 +3,20 @@
 // 801510B0 14DC90
 // https://decomp.me/scratch/sIqel
 void func_801510B0(HSD_GObj* gobj) {
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
     MasterHandAttributes* r30_attributes;
 
-    r31_ft_userdata = gobj->user_data;
-    r30_attributes = r31_ft_userdata->x10C_ftData->ext_attr;
+    r31_fp = gobj->user_data;
+    r30_attributes = r31_fp->x10C_ftData->ext_attr;
     Fighter_ActionStateChange_800693AC(gobj, 0x157, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
-    r31_ft_userdata->xB0_pos.x = r30_attributes->x30_pos2.x;
-    r31_ft_userdata->xB0_pos.y = r30_attributes->x30_pos2.y;
-    r31_ft_userdata->xB0_pos.z = 0.0f;
-    r31_ft_userdata->cb.x21BC_callback_Accessory4 = &lbl_801511FC;
-    r31_ft_userdata->x2340_stateVar1 = 0;
-    func_800881D8(r31_ft_userdata, 0x4E201, 0x7F, 0x40 /*, lbl_801511FC */); // probs same file if lbl_801511FC is getting implicitly passed.
-    // func_800881D8(r31_ft_userdata, 0x4E201, 0x7F, 0x40, lbl_801511FC);
+    r31_fp->xB0_pos.x = r30_attributes->x30_pos2.x;
+    r31_fp->xB0_pos.y = r30_attributes->x30_pos2.y;
+    r31_fp->xB0_pos.z = 0.0f;
+    r31_fp->cb.x21BC_callback_Accessory4 = &lbl_801511FC;
+    r31_fp->x2340_stateVar1 = 0;
+    func_800881D8(r31_fp, 0x4E201, 0x7F, 0x40 /*, lbl_801511FC */); // probs same file if lbl_801511FC is getting implicitly passed.
+    // func_800881D8(r31_fp, 0x4E201, 0x7F, 0x40, lbl_801511FC);
     func_8015C09C(gobj, -1.0f);
 }
 
@@ -25,12 +25,12 @@ void func_801510B0(HSD_GObj* gobj) {
 // 80151168 14DD48
 // https://decomp.me/scratch/896fc
 void lbl_80151168(HSD_GObj* gobj) {
-    Fighter* r4_ft_userdata;
+    Fighter* r4_fp;
     u32 unk[2];
 
     if (!ftAnim_IsFramesRemaining(gobj)) {
-        r4_ft_userdata = gobj->user_data;
-        r4_ft_userdata->sa.masterhand.x2258 = 0x155;
+        r4_fp = gobj->user_data;
+        r4_fp->sa.masterhand.x2258 = 0x155;
         func_80151018(gobj);
     }
 }
@@ -40,9 +40,9 @@ void lbl_80151168(HSD_GObj* gobj) {
 // 801511B0 14DD90
 // https://decomp.me/scratch/lkMK2
 void lbl_801511B0(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
 
-    if (!Player_GetPlayerSlotType(ft->xC_playerID)) {
+    if (!Player_GetPlayerSlotType(fp->xC_playerID)) {
         func_8015BD20(gobj);
     }
 }
@@ -67,12 +67,12 @@ void lbl_801511F8(HSD_GObj* gobj) {
 
 // 801511FC 14DDDC
 void lbl_801511FC(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     HSD_GObj* tmp_gobj;
     s32 unused[4];
-    switch(ft->x2340_stateVar1) {
+    switch(fp->x2340_stateVar1) {
         case 0:
-            tmp_gobj = func_8008627C(&ft->xB0_pos, gobj);
+            tmp_gobj = func_8008627C(&fp->xB0_pos, gobj);
             if (tmp_gobj != 0) {
                 func_8002E6FC(func_80086BE0(tmp_gobj));
             } else {
@@ -84,21 +84,21 @@ void lbl_801511FC(HSD_GObj* gobj) {
             func_8002EF14();
             func_8002EC7C(0.0f);
             func_8002F0E4(0x78);
-            ft->x2340_stateVar1 = 1;
+            fp->x2340_stateVar1 = 1;
             break;
         case 1:
             if (func_8002F260() != 0) {
                 func_8002E948(&lbl_80151428);
                 func_8002ED9C(120.0f);
                 func_8002F0E4(0x14);
-                ft->x2340_stateVar1 = 2;
+                fp->x2340_stateVar1 = 2;
             }
             break;
         case 2:
             if (func_8002F260() != 0) {
                 func_8002EC7C(1.5707963705062866f);
                 func_8002F0E4(0x3C);
-                ft->x2340_stateVar1 = 3;
+                fp->x2340_stateVar1 = 3;
             }
             break;
         case 3:
@@ -107,49 +107,49 @@ void lbl_801511FC(HSD_GObj* gobj) {
                 func_8002EC7C(-0.3490658402442932f);
                 func_8002EB5C(-0.2617993950843811f);
                 func_8002EF14();
-                ft->x2340_stateVar1 = 4;
+                fp->x2340_stateVar1 = 4;
             }
             break;
         case 4:
             func_8002F274();
-            ft->x2348_stateVar3 = 0x78;
-            ft->x2340_stateVar1 = 5;
+            fp->x2348_stateVar3 = 0x78;
+            fp->x2340_stateVar1 = 5;
             break;
         case 5:
-            if (--ft->x2348_stateVar3 == 0) {
+            if (--fp->x2348_stateVar3 == 0) {
                 func_8002EC7C(-0.3490658402442932f);
                 func_8002EF14();
                 func_8002ED9C(120.0f);
-                ft->x2348_stateVar3 = 0x1E;
-                ft->x2340_stateVar1 = 6;
+                fp->x2348_stateVar3 = 0x1E;
+                fp->x2340_stateVar1 = 6;
             }
             break;
         case 6:
-            if (--ft->x2348_stateVar3 == 0) {
+            if (--fp->x2348_stateVar3 == 0) {
                 func_8002EC7C(0.3490658402442932f);
                 func_8002EF14();
-                ft->x2348_stateVar3 = 0x1E;
-                ft->x2340_stateVar1 = 7;
+                fp->x2348_stateVar3 = 0x1E;
+                fp->x2340_stateVar1 = 7;
             }
             break;
         case 7:
-            if (--ft->x2348_stateVar3 == 0) {
+            if (--fp->x2348_stateVar3 == 0) {
                 func_8002ED9C(180.0f);
                 func_8002EC7C(-1.5707963705062866f);
                 func_8002EB5C(-0.3490658402442932f);
                 func_8002EF14();
-                ft->x2348_stateVar3 = 0x32;
-                ft->x2340_stateVar1 = 8;
+                fp->x2348_stateVar3 = 0x32;
+                fp->x2340_stateVar1 = 8;
             }
             break;
         case 8:
             func_8002F274();
-            ft->x2340_stateVar1 = 9;
+            fp->x2340_stateVar1 = 9;
             break;
         case 9:
-            if (--ft->x2348_stateVar3 == 0) {
+            if (--fp->x2348_stateVar3 == 0) {
                 func_8002F474();
-                ft->x2340_stateVar1 = 10;
+                fp->x2340_stateVar1 = 10;
             }
             break;
         // no default

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_5.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_5.c
@@ -21,47 +21,47 @@ u32 lbl_80151428(Vec* vec) {
 // 80151484 14E064
 // https://decomp.me/scratch/0vIXi
 inline void func_80151484_inline1(HSD_GObj* gobj) {
-    Fighter* r29_ft_userdata = gobj->user_data;
-    MasterHandAttributes* temp_r30 = r29_ft_userdata->x10C_ftData->ext_attr;
-    r29_ft_userdata->x80_self_vel.z = 0.0f;
-    r29_ft_userdata->x80_self_vel.y = 0.0f;
-    r29_ft_userdata->x80_self_vel.x = 0.0f;
-    func_802F046C(r29_ft_userdata->x2374);
-    func_802F046C(r29_ft_userdata->x2378);
-    func_802F046C(r29_ft_userdata->x237C);
-    func_802F046C(r29_ft_userdata->x2380);
-    r29_ft_userdata->x2374 = 0;
-    r29_ft_userdata->x2378 = 0;
-    r29_ft_userdata->x237C = 0;
-    r29_ft_userdata->x2380 = 0;
-    func_800236B8(r29_ft_userdata->x2368);
-    func_800236B8(r29_ft_userdata->x236C);
-    func_800236B8(r29_ft_userdata->x2370);
-    if (r29_ft_userdata->x2360) {
-        func_80155D1C(r29_ft_userdata->x1A58_interactedFighter);
+    Fighter* r29_fp = gobj->user_data;
+    MasterHandAttributes* temp_r30 = r29_fp->x10C_ftData->ext_attr;
+    r29_fp->x80_self_vel.z = 0.0f;
+    r29_fp->x80_self_vel.y = 0.0f;
+    r29_fp->x80_self_vel.x = 0.0f;
+    func_802F046C(r29_fp->x2374);
+    func_802F046C(r29_fp->x2378);
+    func_802F046C(r29_fp->x237C);
+    func_802F046C(r29_fp->x2380);
+    r29_fp->x2374 = 0;
+    r29_fp->x2378 = 0;
+    r29_fp->x237C = 0;
+    r29_fp->x2380 = 0;
+    func_800236B8(r29_fp->x2368);
+    func_800236B8(r29_fp->x236C);
+    func_800236B8(r29_fp->x2370);
+    if (r29_fp->x2360) {
+        func_80155D1C(r29_fp->x1A58_interactedFighter);
     }
-    r29_ft_userdata->x80_self_vel.y = temp_r30->x14C;
-    r29_ft_userdata->x80_self_vel.z = temp_r30->x154;
-    r29_ft_userdata->x2348_stateVar3 = (s32) temp_r30->x15C;
+    r29_fp->x80_self_vel.y = temp_r30->x14C;
+    r29_fp->x80_self_vel.z = temp_r30->x154;
+    r29_fp->x2348_stateVar3 = (s32) temp_r30->x15C;
 }
 
 void func_80151484(HSD_GObj* gobj) {
     s32 unused[2];
-    Fighter* r3_ft_userdata;
+    Fighter* r3_fp;
 
-    r3_ft_userdata = gobj->user_data;
-    r3_ft_userdata->x2200_ftcmd_var0 = 0;
+    r3_fp = gobj->user_data;
+    r3_fp->x2200_ftcmd_var0 = 0;
 
     func_80151484_inline1(gobj);
 
     Fighter_ActionStateChange_800693AC(gobj, 0x158, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
 
-    // r3_ft_userdata now stored in r28
-    func_800881D8(r3_ft_userdata, 0x4E217, 0x7F, 0x40);
-    func_80088148(r3_ft_userdata, 0x4E218, 0x7F, 0x40);
-    r3_ft_userdata->x23B4 = 0;
-    r3_ft_userdata->x23B8 = 0;
+    // r3_fp now stored in r28
+    func_800881D8(r3_fp, 0x4E217, 0x7F, 0x40);
+    func_80088148(r3_fp, 0x4E218, 0x7F, 0x40);
+    r3_fp->x23B4 = 0;
+    r3_fp->x23B8 = 0;
 }
 
 
@@ -72,34 +72,34 @@ void lbl_801515B8(HSD_GObj* gobj) {
     s32 temp_r0;
     s32 temp_r3;
     s32 temp_r3_2;
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
     MasterHandAttributes* r4_attributes;
 
-    r31_ft_userdata = gobj->user_data;
-    if (r31_ft_userdata->x2200_ftcmd_var0) {
-        r4_attributes = r31_ft_userdata->x10C_ftData->ext_attr;
-        temp_r3 = r31_ft_userdata->x23B4 + 1;
-        r31_ft_userdata->x23B4 = temp_r3;
+    r31_fp = gobj->user_data;
+    if (r31_fp->x2200_ftcmd_var0) {
+        r4_attributes = r31_fp->x10C_ftData->ext_attr;
+        temp_r3 = r31_fp->x23B4 + 1;
+        r31_fp->x23B4 = temp_r3;
         if (temp_r3 <= r4_attributes->x144) {
             func_8002438C(0x81652);
         } else {
-            temp_r3_2 = r31_ft_userdata->x23B8 + 1;
-            r31_ft_userdata->x23B8 = temp_r3_2;
+            temp_r3_2 = r31_fp->x23B8 + 1;
+            r31_fp->x23B8 = temp_r3_2;
             if (temp_r3_2 <= r4_attributes->x148) {
                 func_8002438C(0x81653);
             }
         }
-        r31_ft_userdata->x2200_ftcmd_var0 = 0U;
+        r31_fp->x2200_ftcmd_var0 = 0U;
     }
 
     // x2348_stateVar3 does that make sense if its u32?
-    if ((s32)r31_ft_userdata->x2348_stateVar3 > 0 && !ftAnim_IsFramesRemaining(gobj)) {
+    if ((s32)r31_fp->x2348_stateVar3 > 0 && !ftAnim_IsFramesRemaining(gobj)) {
         Fighter_ActionStateChange_800693AC(gobj, 0x159, 0, 0, 0.0f, 1.0f, 0.0f);
         func_8006EBA4(gobj);
     }
-    temp_r0 = r31_ft_userdata->x2348_stateVar3 - 1;
+    temp_r0 = r31_fp->x2348_stateVar3 - 1;
 
-    r31_ft_userdata->x2348_stateVar3 = temp_r0;
+    r31_fp->x2348_stateVar3 = temp_r0;
     if (temp_r0) {
         return;
     }
@@ -116,33 +116,33 @@ void lbl_801516B4(HSD_GObj* gobj) {
     s32 temp_r0;
     s32 temp_r3;
     s32 temp_r3_2;
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
     MasterHandAttributes* r4_attributes;
 
-    r31_ft_userdata = gobj->user_data;
-    if ((u32) r31_ft_userdata->x2200_ftcmd_var0 != 0U) {
-        r4_attributes = r31_ft_userdata->x10C_ftData->ext_attr;
-        temp_r3 = r31_ft_userdata->x23B4 + 1;
-        r31_ft_userdata->x23B4 = temp_r3;
+    r31_fp = gobj->user_data;
+    if ((u32) r31_fp->x2200_ftcmd_var0 != 0U) {
+        r4_attributes = r31_fp->x10C_ftData->ext_attr;
+        temp_r3 = r31_fp->x23B4 + 1;
+        r31_fp->x23B4 = temp_r3;
         if (temp_r3 <= (s32) r4_attributes->x144) {
             func_8002438C(0x81652);
         } else {
-            temp_r3_2 = r31_ft_userdata->x23B8 + 1;
-            r31_ft_userdata->x23B8 = temp_r3_2;
+            temp_r3_2 = r31_fp->x23B8 + 1;
+            r31_fp->x23B8 = temp_r3_2;
             if (temp_r3_2 <= (s32) r4_attributes->x148) {
                 func_8002438C(0x81653);
             }
         }
-        r31_ft_userdata->x2200_ftcmd_var0 = 0U;
+        r31_fp->x2200_ftcmd_var0 = 0U;
     }
-    if (((s32) r31_ft_userdata->x2348_stateVar3 > 0) && !ftAnim_IsFramesRemaining(gobj)) {
+    if (((s32) r31_fp->x2348_stateVar3 > 0) && !ftAnim_IsFramesRemaining(gobj)) {
         temp_f1 = 0.0f;
         Fighter_ActionStateChange_800693AC(gobj, 0x159, 0, 0, temp_f1, 1.0f, temp_f1);
         func_8006EBA4(gobj);
     }
-    temp_r0 = r31_ft_userdata->x2348_stateVar3 - 1;
+    temp_r0 = r31_fp->x2348_stateVar3 - 1;
     // temp_cr0_eq = ;
-    r31_ft_userdata->x2348_stateVar3 = temp_r0;
+    r31_fp->x2348_stateVar3 = temp_r0;
     if (temp_r0 == 0) {
         func_800D4F24(gobj, 0);
     }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_6.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_6.c
@@ -3,8 +3,8 @@
 // 801517B0 14E390
 // https://decomp.me/scratch/ayfDz
 void lbl_801517B0(HSD_GObj* gobj) {
-    Fighter* fighter = gobj->user_data;
-    if (!Player_GetPlayerSlotType(fighter->xC_playerID)) {
+    Fighter* fp = gobj->user_data;
+    if (!Player_GetPlayerSlotType(fp->xC_playerID)) {
         func_8015BD20(gobj);
     }
 }
@@ -15,12 +15,12 @@ void lbl_801517B0(HSD_GObj* gobj) {
 // https://decomp.me/scratch/TjBLH
 void lbl_801517F4(HSD_GObj* gobj) {
     MasterHandAttributes* r3_attributes;
-    Fighter* r4_ft_userdata;
+    Fighter* r4_fp;
 
-    r4_ft_userdata = gobj->user_data;
-    r3_attributes = r4_ft_userdata->x10C_ftData->ext_attr;
-    r4_ft_userdata->x80_self_vel.y += r3_attributes->x150;
-    r4_ft_userdata->x80_self_vel.z += r3_attributes->x158;
+    r4_fp = gobj->user_data;
+    r3_attributes = r4_fp->x10C_ftData->ext_attr;
+    r4_fp->x80_self_vel.y += r3_attributes->x150;
+    r4_fp->x80_self_vel.z += r3_attributes->x158;
 }
 
 
@@ -53,8 +53,8 @@ void lbl_80151874(HSD_GObj* arg0) {
 // 801518B0 14E490
 // https://decomp.me/scratch/x8MEh
 void lbl_801518B0(HSD_GObj* gobj) {
-    Fighter* fighter = gobj->user_data;
-    if (!Player_GetPlayerSlotType(fighter->xC_playerID)) {
+    Fighter* fp = gobj->user_data;
+    if (!Player_GetPlayerSlotType(fp->xC_playerID)) {
         func_8015BD20(gobj);
     }
 }
@@ -80,14 +80,14 @@ void lbl_80151914(void) {
 // 80151918 14E4F8
 // https://decomp.me/scratch/uyxzl
 void func_80151918(HSD_GObj* gobj) {
-    Fighter* r8_ft_userdata;
+    Fighter* r8_fp;
     MasterHandAttributes* r7_attributes;
 
-    r8_ft_userdata = gobj->user_data;
-    r7_attributes = r8_ft_userdata->x10C_ftData->ext_attr;
-    r8_ft_userdata->x234C_pos.x = (r8_ft_userdata->xB0_pos.x - r7_attributes->x3C);
-    r8_ft_userdata->x234C_pos.y = r7_attributes->x38;
-    r8_ft_userdata->x234C_pos.z = 0.0f;
+    r8_fp = gobj->user_data;
+    r7_attributes = r8_fp->x10C_ftData->ext_attr;
+    r8_fp->x234C_pos.x = (r8_fp->xB0_pos.x - r7_attributes->x3C);
+    r8_fp->x234C_pos.y = r7_attributes->x38;
+    r8_fp->x234C_pos.z = 0.0f;
 
     Fighter_ActionStateChange_800693AC(gobj, 0x15B, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
@@ -126,8 +126,8 @@ void lbl_8015198C(HSD_GObj* gobj) {
 // 80151A44 14E624
 // https://decomp.me/scratch/RccD3
 void lbl_80151A44(HSD_GObj* gobj) {
-    Fighter* fighter = gobj->user_data;
-    if (Player_GetPlayerSlotType(fighter->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }
@@ -137,12 +137,12 @@ void lbl_80151A44(HSD_GObj* gobj) {
 // 80151A88 14E668
 // https://decomp.me/scratch/3ONNP
 void lbl_80151A88(HSD_GObj* gobj) {
-    Fighter* r5_ft_userdata;
+    Fighter* r5_fp;
     MasterHandAttributes* r6_attributes;
 
-    r5_ft_userdata = gobj->user_data;
-    r6_attributes = r5_ft_userdata->x10C_ftData->ext_attr;
-    func_8015BE40(gobj, &r5_ft_userdata->x234C_pos, &r5_ft_userdata->x2358_stateVar7, r6_attributes->x2C, r6_attributes->x28);
+    r5_fp = gobj->user_data;
+    r6_attributes = r5_fp->x10C_ftData->ext_attr;
+    func_8015BE40(gobj, &r5_fp->x234C_pos, &r5_fp->x2358_stateVar7, r6_attributes->x2C, r6_attributes->x28);
 }
 
 

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_7.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_7.c
@@ -21,8 +21,8 @@ void lbl_80151B50(HSD_GObj* arg0) {
 // 80151B70 14E750
 // https://decomp.me/scratch/50coe
 void lbl_80151B70(HSD_GObj* gobj) {
-    Fighter* fighter = gobj->user_data;
-    if (Player_GetPlayerSlotType(fighter->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_8.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_8.c
@@ -14,8 +14,8 @@ void lbl_80151C04(HSD_GObj* arg0) {
 // 80151C40 14E820
 // https://decomp.me/scratch/QJiom
 void lbl_80151C40(HSD_GObj* gobj) {
-    Fighter* fighter = gobj->user_data;
-    if (Player_GetPlayerSlotType(fighter->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMasterHand_9.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMasterHand_9.c
@@ -13,8 +13,8 @@ void lbl_80151D20(HSD_GObj* arg0) {
 // 80151D5C 14E93C
 // https://decomp.me/scratch/8YW2K
 void lbl_80151D5C(HSD_GObj* gobj) {
-    Fighter* fighter = gobj->user_data;
-    if (Player_GetPlayerSlotType(fighter->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }
@@ -59,8 +59,8 @@ void lbl_80151E10(HSD_GObj* arg0) {
 // 80151E4C 14EA2C
 // https://decomp.me/scratch/FpXjP
 void lbl_80151E4C(HSD_GObj* gobj) {
-    Fighter* fighter = gobj->user_data;
-    if (Player_GetPlayerSlotType(fighter->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }
@@ -122,19 +122,19 @@ static inline float my_lbvector_Len(Vec3 *vec)
 void lbl_80151F00(HSD_GObj* gobj) {
     Vec3 sp28;
     Vec3 sp1C_resultVector;
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
     MasterHandAttributes* r30_attributes;
     s32 unk2[1];
 
-    r31_ft_userdata = gobj->user_data;
-    r30_attributes = r31_ft_userdata->x10C_ftData->ext_attr;
-    func_800866DC(func_8015C244(gobj, &r31_ft_userdata->xB0_pos), &sp28);
-    lbvector_Diff(&sp28, &r31_ft_userdata->xB0_pos, &sp1C_resultVector);
+    r31_fp = gobj->user_data;
+    r30_attributes = r31_fp->x10C_ftData->ext_attr;
+    func_800866DC(func_8015C244(gobj, &r31_fp->xB0_pos), &sp28);
+    lbvector_Diff(&sp28, &r31_fp->xB0_pos, &sp1C_resultVector);
     if (my_lbvector_Len(&sp1C_resultVector) < r30_attributes->x4C) {
         func_80151CA8(gobj);
     }
     func_80054158(0, &sp28);
-    if (r31_ft_userdata->xB0_pos.x < sp28.x) {
+    if (r31_fp->xB0_pos.x < sp28.x) {
         func_801520D8(gobj);
     }
     if (!ftAnim_IsFramesRemaining(gobj)) {
@@ -148,8 +148,8 @@ void lbl_80151F00(HSD_GObj* gobj) {
 // 8015204C 14EC2C
 // https://decomp.me/scratch/6N3wk
 void lbl_8015204C(HSD_GObj* gobj) {
-    Fighter* fighter = gobj->user_data;
-    if (Player_GetPlayerSlotType(fighter->xC_playerID) == 0) {
+    Fighter* fp = gobj->user_data;
+    if (Player_GetPlayerSlotType(fp->xC_playerID) == 0) {
         func_8015BD20(gobj);
     }
 }
@@ -162,14 +162,14 @@ void func_80085134(HSD_GObj*);                             /* extern */
 
 void lbl_80152090(HSD_GObj* gobj) {
     ftData* r4_ftData;
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
     MasterHandAttributes* r30_attributes;
 
-    r31_ft_userdata = gobj->user_data;
-    r4_ftData = r31_ft_userdata->x10C_ftData;
+    r31_fp = gobj->user_data;
+    r4_ftData = r31_fp->x10C_ftData;
     r30_attributes = r4_ftData->ext_attr;
     func_80085134(gobj);
-    r31_ft_userdata->x80_self_vel.x = r30_attributes->x40_pos.z;
+    r31_fp->x80_self_vel.x = r30_attributes->x40_pos.z;
 }
 
 
@@ -185,11 +185,11 @@ void lbl_801520D4(void) {
 // 801520D8 14ECB8
 // https://decomp.me/scratch/HUhGv
 void func_801520D8(HSD_GObj* gobj) {
-    Fighter* r31_ft_userdata;
+    Fighter* r31_fp;
     f32 temp_f1;
 
-    r31_ft_userdata = gobj->user_data;
+    r31_fp = gobj->user_data;
     Fighter_ActionStateChange_800693AC(gobj, 0x160, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
-    r31_ft_userdata->x80_self_vel.x = 0.0f;
+    r31_fp->x80_self_vel.x = 0.0f;
 }

--- a/src/melee/ft/chara/ftMewtwo/ftmewtwo.c
+++ b/src/melee/ft/chara/ftMewtwo/ftmewtwo.c
@@ -2,24 +2,24 @@
 #include <melee/it/itkind.h>
 
 void ftMewtwo_OnDeath(HSD_GObj* gobj) {
-    Fighter* ft = (Fighter*)gobj->user_data;
+    Fighter* fp = (Fighter*)gobj->user_data;
     func_80074A4C(gobj, 0, 0);
-    ft->sa.mewtwo.x222C_disableGObj = NULL;
-    ft->sa.mewtwo.x2230 = 0;
-    ft->sa.mewtwo.x2234_shadowBallCharge = 0;
-    ft->sa.mewtwo.x2238_shadowBallGObj = NULL;
-    ft->sa.mewtwo.x223C_isConfusionBoost = FALSE;
+    fp->sa.mewtwo.x222C_disableGObj = NULL;
+    fp->sa.mewtwo.x2230 = 0;
+    fp->sa.mewtwo.x2234_shadowBallCharge = 0;
+    fp->sa.mewtwo.x2238_shadowBallGObj = NULL;
+    fp->sa.mewtwo.x223C_isConfusionBoost = FALSE;
 }
 
 void ftMewtwo_OnLoad(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    ftMewtwoAttributes* attr = fighter->x10C_ftData->ext_attr;
-    void** item_list = fighter->x10C_ftData->x48_items;
-    PUSH_ATTRS(fighter, ftMewtwoAttributes);
+    Fighter* fp = fighterObj->user_data;
+    ftMewtwoAttributes* attr = fp->x10C_ftData->ext_attr;
+    void** item_list = fp->x10C_ftData->x48_items;
+    PUSH_ATTRS(fp, ftMewtwoAttributes);
 
     {
-        fighter->x5E8_fighterBones[1].flags.bits.b4 = 1;
-        fighter->x2221_flag.bits.b2 = 1;
+        fp->x5E8_fighterBones[1].flags.bits.b4 = 1;
+        fp->x2221_flag.bits.b2 = 1;
     }
     func_8026B3F8(item_list[0], It_Kind_Mewtwo_Disable);
     func_8026B3F8(item_list[1], It_Kind_Mewtwo_ShadowBall);
@@ -45,19 +45,19 @@ void ftMewTwo_OnItemVisible(HSD_GObj* fighterObj) {}
 
 void ftMewTwo_80144F58(HSD_GObj* fighterObj) {
 
-    Fighter* fighter = getFighter(fighterObj);
-    ftMewtwoAttributes* attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = getFighter(fighterObj);
+    ftMewtwoAttributes* attr = fp->x2D4_specialAttributes;
     f32 attr_value = attr->x0_MEWTWO_SHADOWBALL_CHARGE_CYCLES;
-    if (fighter->sa.mewtwo.x2234_shadowBallCharge == attr_value) {
-        func_800BFFD0(fighter, 0x5C, 0);
+    if (fp->sa.mewtwo.x2234_shadowBallCharge == attr_value) {
+        func_800BFFD0(fp, 0x5C, 0);
     }
 }
 
 void ftMewTwo_LoadSpecialAttrs(HSD_GObj* fighterObj) {
     COPY_ATTRS(fighterObj, ftMewtwoAttributes);
-    if (ft->x34_scale.y != 1.0f) {
-        sA2->x80_MEWTWO_DISABLE_OFFSET_X *= ft->x34_scale.y;
-        sA2->x84_MEWTWO_DISABLE_OFFSET_Y *= ft->x34_scale.y;
+    if (fp->x34_scale.y != 1.0f) {
+        sA2->x80_MEWTWO_DISABLE_OFFSET_X *= fp->x34_scale.y;
+        sA2->x84_MEWTWO_DISABLE_OFFSET_Y *= fp->x34_scale.y;
     }
 }
 

--- a/src/melee/ft/chara/ftNess/ftNess.c
+++ b/src/melee/ft/chara/ftNess/ftNess.c
@@ -2,21 +2,21 @@
 
 void ftNess_OnDeath(HSD_GObj* gobj)
 {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     func_80074A4C(gobj, 0, 0);
-    ft->sa.ness.x2240_flashGObj = NULL;
-    ft->sa.ness.x2244_pkThunderGObj = NULL;
-    ft->sa.ness.x2248_baseballBatGObj = NULL;
-    ft->sa.ness.x222C_yoyoGObj = NULL;
-    ft->sa.ness.x224C_thunderGFX = FALSE;
+    fp->sa.ness.x2240_flashGObj = NULL;
+    fp->sa.ness.x2244_pkThunderGObj = NULL;
+    fp->sa.ness.x2248_baseballBatGObj = NULL;
+    fp->sa.ness.x222C_yoyoGObj = NULL;
+    fp->sa.ness.x224C_thunderGFX = FALSE;
 }
 
 void ftNess_OnLoad(HSD_GObj* gobj) 
 {
-    Fighter* ft = gobj->user_data;
-    void** item_list = ft->x10C_ftData->x48_items;
+    Fighter* fp = gobj->user_data;
+    void** item_list = fp->x10C_ftData->x48_items;
 
-    PUSH_ATTRS(ft, ftNessAttributes);
+    PUSH_ATTRS(fp, ftNessAttributes);
 
     func_8026B3F8(item_list[0], It_Kind_Ness_PKFire);
     func_8026B3F8(item_list[1], It_Kind_Ness_PKFire_Flame);
@@ -44,9 +44,9 @@ void ftNess_OnAbsorb(HSD_GObj* gobj)
     ftNess_AbsorbThink_DecideAction(gobj);
 }
 
-f32 ftNess_GetAbsorbHeal(Fighter* ft)
+f32 ftNess_GetAbsorbHeal(Fighter* fp)
 {
-    return ((ftNessAttributes*)ft->x2D4_specialAttributes)->x94_PSI_MAGNET_HEAL_MUL;
+    return ((ftNessAttributes*)fp->x2D4_specialAttributes)->x94_PSI_MAGNET_HEAL_MUL;
 }
 
 void ftNess_OnItemPickup(HSD_GObj* fighterObj, BOOL catchItemFlag) {

--- a/src/melee/ft/chara/ftNess/ftNess.h
+++ b/src/melee/ft/chara/ftNess/ftNess.h
@@ -136,7 +136,7 @@ void ftNess_OnDeath(HSD_GObj* gobj);
 void ftNess_OnLoad(HSD_GObj* gobj);
 void ftNess_OnDamage(HSD_GObj* gobj);
 void ftNess_OnAbsorb(HSD_GObj* gobj);
-f32 ftNess_GetAbsorbHeal(Fighter* ft);
+f32 ftNess_GetAbsorbHeal(Fighter* fp);
 void ftNess_OnItemPickup(HSD_GObj* gobj, BOOL catchItemFlag);
 void ftNess_OnItemInvisible(HSD_GObj* gobj);
 void ftNess_OnItemVisible(HSD_GObj* gobj);

--- a/src/melee/ft/chara/ftNess/ftNess_AttackHi4.c
+++ b/src/melee/ft/chara/ftNess/ftNess_AttackHi4.c
@@ -277,7 +277,7 @@ BOOL ftNess_YoyoCheckNoObstruct(HSD_GObj* fighter_gobj) // Check if Yo-Yo is col
 
 // 0x80115534 //
 // https://decomp.me/scratch/SAmhe //
-void ftNess_YoyoSetVarAll(HSD_GObj* fighter_gobj) // Set ftcmd-, fighter- and stateVars //
+void ftNess_YoyoSetVarAll(HSD_GObj* fighter_gobj) // Set ftcmd-, fp- and stateVars //
 {
     Fighter* fighter_data = getFighter(fighter_gobj);
     fighter_data->x2204_ftcmd_var1 = 0;
@@ -616,23 +616,23 @@ void ftNess_YoyoItemSetUnk2(HSD_GObj* fighter_gobj)
 void ftNess_AttackHi4_Action(HSD_GObj* fighter_gobj) // Ness's Up Smash Action State handler //
 {
     Fighter* fighter_data;
-    Fighter* temp_ft;
+    Fighter* temp_fp;
 
     fighter_data = getFighter(fighter_gobj);
     fighter_data->x2218_flag.bits.b0 = 0;
     fighter_data->nessVars[0].attackHi4.isChargeDisable = FALSE;
 
-    temp_ft = getFighter(fighter_gobj);
-    temp_ft->x2204_ftcmd_var1 = 0;
-    temp_ft->x2200_ftcmd_var0 = 0;
-    temp_ft->nessVars[0].attackHi4.yoyoCurrentFrame = 1;
-    temp_ft->nessVars[0].attackHi4.yoyoRehitTimer = 0;
+    temp_fp = getFighter(fighter_gobj);
+    temp_fp->x2204_ftcmd_var1 = 0;
+    temp_fp->x2200_ftcmd_var0 = 0;
+    temp_fp->nessVars[0].attackHi4.yoyoCurrentFrame = 1;
+    temp_fp->nessVars[0].attackHi4.yoyoRehitTimer = 0;
 
-    temp_ft->nessVars[0].attackHi4.isPosUpdateMod = 1;
-    temp_ft->sa.ness.x2230_yoyoHitboxPos.z = 0.0f;
-    temp_ft->sa.ness.x2230_yoyoHitboxPos.y = 0.0f;
-    temp_ft->sa.ness.x2230_yoyoHitboxPos.x = 0.0f;
-    temp_ft->sa.ness.x223C = 0.0f;
+    temp_fp->nessVars[0].attackHi4.isPosUpdateMod = 1;
+    temp_fp->sa.ness.x2230_yoyoHitboxPos.z = 0.0f;
+    temp_fp->sa.ness.x2230_yoyoHitboxPos.y = 0.0f;
+    temp_fp->sa.ness.x2230_yoyoHitboxPos.x = 0.0f;
+    temp_fp->sa.ness.x223C = 0.0f;
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_NESS_ATTACKHI4, 0, NULL, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(fighter_gobj);
     fighter_data->x2222_flag.bits.b2 = 1;
@@ -654,8 +654,8 @@ void ftNess_YoyoStartTimedRehit(HSD_GObj* fighter_gobj) // Initiates rehit timer
 
 Fighter* GetFighterData(HSD_GObj* fighter_gobj)    // 0x80115C9C literally won't match under any circumstances unless this inline is used to get Fighter*. //
 {
-    Fighter* fighter = fighter_gobj->user_data;
-    return fighter;
+    Fighter* fp = fighter_gobj->user_data;
+    return fp;
 }
 
 // 0x80115C9C //
@@ -801,21 +801,21 @@ void ftNess_AttackHi4_Charge_Anim(HSD_GObj* fighter_gobj)   // Ness's Up Smash C
     HSD_GObj* yoyo_GObj;
     Fighter* fighter_data;
     Fighter* fighter_data2;
-    Fighter* temp_fighter;
+    Fighter* temp_fp;
     ftNessAttributes* ness_attr;
     ftNessAttributes* temp_ness_attr;
 
     fighter_data = fighter_gobj->user_data;
     ness_attr = fighter_data->x2D4_specialAttributes;
     fighter_data->nessVars[0].attackHi4.yoyoCurrentFrame++;
-    temp_ness_attr = getFtSpecialAttrs(temp_fighter = getFighterPlus(fighter_gobj));
-    if ((yoyo_GObj = GetYoyoGObj(temp_fighter = getFighterPlus(fighter_gobj))) != NULL)
+    temp_ness_attr = getFtSpecialAttrs(temp_fp = getFighterPlus(fighter_gobj));
+    if ((yoyo_GObj = GetYoyoGObj(temp_fp = getFighterPlus(fighter_gobj))) != NULL)
     {
         item_data = yoyo_GObj->user_data;
         yoyo_attr = item_data->xC4_article_data->x4_specialAttributes;
         unk_float = (yoyo_attr->x20_UNK_TEXANIM_MOD - yoyo_attr->x1C_UNK_TEXANIM_SPEED);
-        unk_float = unk_float * ((f32)temp_fighter->nessVars[0].attackHi4.yoyoCurrentFrame / temp_ness_attr->xAC_YOYO_CHARGE_DURATION);
-        temp_fighter->sa.ness.x223C = yoyo_attr->x20_UNK_TEXANIM_MOD - unk_float;
+        unk_float = unk_float * ((f32)temp_fp->nessVars[0].attackHi4.yoyoCurrentFrame / temp_ness_attr->xAC_YOYO_CHARGE_DURATION);
+        temp_fp->sa.ness.x223C = yoyo_attr->x20_UNK_TEXANIM_MOD - unk_float;
     }
 
     fighter_data2 = fighter_gobj->user_data;
@@ -900,11 +900,11 @@ void ftNess_AttackHi4_Release_Anim(HSD_GObj* fighter_gobj)   // Ness's Up Smash 
     s32 yoyoRehitTimer;
     s32 yoyoSmashFrameCurr;
     Fighter* fighter_data;
-    Fighter* temp_fighter;
+    Fighter* temp_fp;
 
-    temp_fighter = getFighter(fighter_gobj);
-    yoyoSmashFrameCurr = temp_fighter->nessVars[0].attackHi4.yoyoCurrentFrame;
-    temp_fighter->nessVars[0].attackHi4.yoyoCurrentFrame = (s32)(yoyoSmashFrameCurr + 1);
+    temp_fp = getFighter(fighter_gobj);
+    yoyoSmashFrameCurr = temp_fp->nessVars[0].attackHi4.yoyoCurrentFrame;
+    temp_fp->nessVars[0].attackHi4.yoyoCurrentFrame = (s32)(yoyoSmashFrameCurr + 1);
     if (ftNess_YoyoThink_IsRemove(fighter_gobj) == FALSE) 
     {
         fighter_data = getFighter(fighter_gobj);

--- a/src/melee/ft/chara/ftNess/ftNess_AttackS4.c
+++ b/src/melee/ft/chara/ftNess/ftNess_AttackS4.c
@@ -99,7 +99,7 @@ void ftNess_AttackS4_Anim(HSD_GObj* fighter_gobj) // Ness's F-Smash Animation ca
 
     if (fighter_data1->x2218_flag.bits.b3 == 0)
     {
-        if (fighter_data1->x2200_ftcmd_var0 != FALSE) // Check if reflect bubble flag is enabled in fighter script //
+        if (fighter_data1->x2200_ftcmd_var0 != FALSE) // Check if reflect bubble flag is enabled in fp script //
         {
             ness_attr = fighter_data1->x2D4_specialAttributes;
             ftColl_CreateReflectHit(fighter_gobj, &ness_attr->xB8_BASEBALL_BAT, ftNess_AttackS4_OnReflect); // Create reflect bubble //

--- a/src/melee/ft/chara/ftNess/ftNess_SpecialHi.c
+++ b/src/melee/ft/chara/ftNess/ftNess_SpecialHi.c
@@ -208,12 +208,12 @@ BOOL ftNess_ItemPKThunder_CheckNessCollide(HSD_GObj* fighter_gobj)
 BOOL ftNess_CheckSpecialHiHold(HSD_GObj* fighter_gobj) // Checks if Ness is in SpecialHiHold/SpecialAirHiHold (PK Thunder control loop) //
 {
     s32 ASID;
-    Fighter* fighter_data;
+    Fighter* fp;
     s32 phi_r3;
-    Fighter* new_var;
+    Fighter* fp_1;
 
-    fighter_data = (new_var = getFighter(fighter_gobj));
-    ASID = fighter_data->x10_action_state_index;
+    fp = (fp_1 = getFighter(fighter_gobj));
+    ASID = fp->x10_action_state_index;
 
     phi_r3 = TRUE;
 
@@ -235,13 +235,13 @@ BOOL ftNess_CheckSpecialHiHold(HSD_GObj* fighter_gobj) // Checks if Ness is in S
 void ftNess_ItemPKThunderRemove(HSD_GObj* fighter_gobj)  // OnTakeDamage? //
 {
     Fighter* fighter_data;
-    Fighter* temp_fighter;
+    Fighter* temp_fp;
     s32 ASID;
 
-    temp_fighter = fighter_gobj->user_data;
-    if (temp_fighter->sa.ness.x2244_pkThunderGObj != NULL)
+    temp_fp = fighter_gobj->user_data;
+    if (temp_fp->sa.ness.x2244_pkThunderGObj != NULL)
     {
-        temp_fighter->sa.ness.x2244_pkThunderGObj = NULL;
+        temp_fp->sa.ness.x2244_pkThunderGObj = NULL;
     }
     fighter_data = getFighter(fighter_gobj);
     ASID = fighter_data->x10_action_state_index;
@@ -260,9 +260,9 @@ void ftNess_ItemPKThunderRemove(HSD_GObj* fighter_gobj)  // OnTakeDamage? //
         fighter_data->sa.ness.x224C_thunderGFX = FALSE;
 
     default:
-        temp_fighter->cb.x21E4_callback_OnDeath2 = NULL;
-        temp_fighter->cb.x21DC_callback_OnTakeDamage = NULL;
-        func_8007592C(temp_fighter, 0, 0.0f);
+        temp_fp->cb.x21E4_callback_OnDeath2 = NULL;
+        temp_fp->cb.x21DC_callback_OnTakeDamage = NULL;
+        func_8007592C(temp_fp, 0, 0.0f);
     }
 }
 
@@ -275,13 +275,13 @@ void ftNess_SpecialHiTakeDamage(HSD_GObj* fighter_gobj)  // OnTakeDamage again? 
     s32 ASID;
     Fighter* fighter_data;
     Fighter* fighter_data2;
-    Fighter* temp_fighter;
+    Fighter* temp_fp;
 
-    temp_fighter = fighter_gobj->user_data;
-    fighter_data = temp_fighter;
-    if (temp_fighter->sa.ness.x2244_pkThunderGObj != NULL)
+    temp_fp = fighter_gobj->user_data;
+    fighter_data = temp_fp;
+    if (temp_fp->sa.ness.x2244_pkThunderGObj != NULL)
     {
-        func_802AB9C0(temp_fighter->sa.ness.x2244_pkThunderGObj);
+        func_802AB9C0(temp_fp->sa.ness.x2244_pkThunderGObj);
         fighter_data->sa.ness.x2244_pkThunderGObj = NULL;
     }
     fighter_data2 = getFighter(fighter_gobj);
@@ -300,9 +300,9 @@ void ftNess_SpecialHiTakeDamage(HSD_GObj* fighter_gobj)  // OnTakeDamage again? 
         efLib_DestroyAll(fighter_gobj);
         fighter_data2->sa.ness.x224C_thunderGFX = FALSE;
     default:
-        temp_fighter->cb.x21E4_callback_OnDeath2 = NULL;
-        temp_fighter->cb.x21DC_callback_OnTakeDamage = NULL;
-        func_8007592C(temp_fighter, 0, 0.0f);
+        temp_fp->cb.x21E4_callback_OnDeath2 = NULL;
+        temp_fp->cb.x21DC_callback_OnTakeDamage = NULL;
+        func_8007592C(temp_fp, 0, 0.0f);
     }
 }
 
@@ -311,12 +311,12 @@ void ftNess_SpecialHiTakeDamage(HSD_GObj* fighter_gobj)  // OnTakeDamage again? 
 void ftNess_ItemPKThunderCheckOwn(HSD_GObj* fighter_gobj, HSD_GObj* thunder_gobj) // Run from PK Thunder's OnReflect callback. Sets Ness's reference to PK Thunder to NULL if he is reflecting his own PK Thunder. //
 {
     HSD_GObj* temp_thunder;
-    Fighter* temp_fighter = getFighter(fighter_gobj);
+    Fighter* temp_fp = getFighter(fighter_gobj);
 
-    temp_thunder = temp_fighter->sa.ness.x2244_pkThunderGObj;
+    temp_thunder = temp_fp->sa.ness.x2244_pkThunderGObj;
     if ((temp_thunder != NULL) && (temp_thunder == thunder_gobj))
     {
-        temp_fighter->sa.ness.x2244_pkThunderGObj = NULL;
+        temp_fp->sa.ness.x2244_pkThunderGObj = NULL;
     }
 }
 
@@ -410,7 +410,7 @@ void ftNess_SpecialHi_StartAction(HSD_GObj* fighter_gobj)  // Ness's grounded PK
     f32 temp_f1_2;
     Fighter* fighter_data;
     ftNessAttributes* ness_attr;
-    Fighter* temp_fighter;
+    Fighter* temp_fp;
     ftNessAttributes* temp_attr;
     f64 phi_f0;
 
@@ -422,21 +422,21 @@ void ftNess_SpecialHi_StartAction(HSD_GObj* fighter_gobj)  // Ness's grounded PK
     fighter_data->x2208_ftcmd_var2 = 0;
     fighter_data->x2204_ftcmd_var1 = 0;
     fighter_data->x2200_ftcmd_var0 = 0;
-    temp_fighter = fighter_gobj->user_data;
-    temp_attr = getFtSpecialAttrs(temp_fighter);
-    temp_fighter->nessVars[0].specialHi.thunderTimerLoop1 = (s32)temp_attr->x40_PK_THUNDER_LOOP1;
-    temp_fighter->nessVars[0].specialHi.thunderTimerLoop2 = (s32)temp_attr->x44_PK_THUNDER_LOOP2;
-    temp_fighter->nessVars[0].specialHi.gravityDelay = (s32)temp_attr->x48_PK_THUNDER_GRAVITY_DELAY;
+    temp_fp = fighter_gobj->user_data;
+    temp_attr = getFtSpecialAttrs(temp_fp);
+    temp_fp->nessVars[0].specialHi.thunderTimerLoop1 = (s32)temp_attr->x40_PK_THUNDER_LOOP1;
+    temp_fp->nessVars[0].specialHi.thunderTimerLoop2 = (s32)temp_attr->x44_PK_THUNDER_LOOP2;
+    temp_fp->nessVars[0].specialHi.gravityDelay = (s32)temp_attr->x48_PK_THUNDER_GRAVITY_DELAY;
     temp_f1_2 = 0.0f;
-    temp_fighter->nessVars[0].specialHi.fallAccel = 0.0f;
-    temp_fighter->nessVars[0].specialHi.unkVector1.z = 0.0f;
-    temp_fighter->nessVars[0].specialHi.unkVector1.y = 0.0f;
-    temp_fighter->nessVars[0].specialHi.unkVector1.x = 0.0f;
-    temp_fighter->nessVars[0].specialHi.unkVar4 = 0.0f;
-    temp_fighter->nessVars[0].specialHi.unkVar3 = 0.0f;
-    temp_fighter->cb.x21E4_callback_OnDeath2 = NULL;
-    temp_fighter->cb.x21DC_callback_OnTakeDamage = NULL;
-    func_8007592C(temp_fighter, 0, 0.0f);
+    temp_fp->nessVars[0].specialHi.fallAccel = 0.0f;
+    temp_fp->nessVars[0].specialHi.unkVector1.z = 0.0f;
+    temp_fp->nessVars[0].specialHi.unkVector1.y = 0.0f;
+    temp_fp->nessVars[0].specialHi.unkVector1.x = 0.0f;
+    temp_fp->nessVars[0].specialHi.unkVar4 = 0.0f;
+    temp_fp->nessVars[0].specialHi.unkVar3 = 0.0f;
+    temp_fp->cb.x21E4_callback_OnDeath2 = NULL;
+    temp_fp->cb.x21DC_callback_OnTakeDamage = NULL;
+    func_8007592C(temp_fp, 0, 0.0f);
     fighter_data->nessVars[0].specialHi.thunderColl = 1;
     fighter_data->nessVars[0].specialHi.gravityDelay = (s32)ness_attr->x48_PK_THUNDER_GRAVITY_DELAY;
     fighter_data->nessVars[0].specialHi.jibakuGFX = 0;
@@ -469,7 +469,7 @@ void ftNess_SpecialAirHiStart_Action(HSD_GObj* fighter_gobj)  // Ness's aerial P
     f32 temp_f1_2;
     Fighter* fighter_data;
     ftNessAttributes* ness_attr;
-    Fighter* temp_fighter;
+    Fighter* temp_fp;
     ftNessAttributes* temp_attr;
     f64 phi_f0;
 
@@ -481,21 +481,21 @@ void ftNess_SpecialAirHiStart_Action(HSD_GObj* fighter_gobj)  // Ness's aerial P
     fighter_data->x2208_ftcmd_var2 = 0;
     fighter_data->x2204_ftcmd_var1 = 0;
     fighter_data->x2200_ftcmd_var0 = 0;
-    temp_fighter = fighter_gobj->user_data;
-    temp_attr = temp_fighter->x2D4_specialAttributes;
-    temp_fighter->nessVars[0].specialHi.thunderTimerLoop1 = (s32)temp_attr->x40_PK_THUNDER_LOOP1;
-    temp_fighter->nessVars[0].specialHi.thunderTimerLoop2 = (s32)temp_attr->x44_PK_THUNDER_LOOP2;
-    temp_fighter->nessVars[0].specialHi.gravityDelay = (s32)temp_attr->x48_PK_THUNDER_GRAVITY_DELAY;
+    temp_fp = fighter_gobj->user_data;
+    temp_attr = temp_fp->x2D4_specialAttributes;
+    temp_fp->nessVars[0].specialHi.thunderTimerLoop1 = (s32)temp_attr->x40_PK_THUNDER_LOOP1;
+    temp_fp->nessVars[0].specialHi.thunderTimerLoop2 = (s32)temp_attr->x44_PK_THUNDER_LOOP2;
+    temp_fp->nessVars[0].specialHi.gravityDelay = (s32)temp_attr->x48_PK_THUNDER_GRAVITY_DELAY;
     temp_f1_2 = 0.0f;
-    temp_fighter->nessVars[0].specialHi.fallAccel = 0.0f;
-    temp_fighter->nessVars[0].specialHi.unkVector1.z = 0.0f;
-    temp_fighter->nessVars[0].specialHi.unkVector1.y = 0.0f;
-    temp_fighter->nessVars[0].specialHi.unkVector1.x = 0.0f;
-    temp_fighter->nessVars[0].specialHi.unkVar4 = 0.0f;
-    temp_fighter->nessVars[0].specialHi.unkVar3 = 0.0f;
-    temp_fighter->cb.x21E4_callback_OnDeath2 = NULL;
-    temp_fighter->cb.x21DC_callback_OnTakeDamage = NULL;
-    func_8007592C(temp_fighter, 0, 0.0f);
+    temp_fp->nessVars[0].specialHi.fallAccel = 0.0f;
+    temp_fp->nessVars[0].specialHi.unkVector1.z = 0.0f;
+    temp_fp->nessVars[0].specialHi.unkVector1.y = 0.0f;
+    temp_fp->nessVars[0].specialHi.unkVector1.x = 0.0f;
+    temp_fp->nessVars[0].specialHi.unkVar4 = 0.0f;
+    temp_fp->nessVars[0].specialHi.unkVar3 = 0.0f;
+    temp_fp->cb.x21E4_callback_OnDeath2 = NULL;
+    temp_fp->cb.x21DC_callback_OnTakeDamage = NULL;
+    func_8007592C(temp_fp, 0, 0.0f);
     fighter_data->nessVars[0].specialHi.thunderColl = 1;
     fighter_data->nessVars[0].specialHi.gravityDelay = (s32)ness_attr->x48_PK_THUNDER_GRAVITY_DELAY;
     fighter_data->nessVars[0].specialHi.jibakuGFX = FALSE;
@@ -831,11 +831,11 @@ void ftNess_SpecialHi_Anim(HSD_GObj* fighter_gobj) // Ness's grounded PK Thunder
     s32 ASID;
     Fighter* fighter_data;
     Fighter* fighter_data2;
-    Fighter* temp_fighter;
+    Fighter* temp_fp;
 
-    temp_fighter = fighter_gobj->user_data;
-    temp_fighter->nessVars[0].specialHi.jibakuGFX = (s32)(temp_fighter->nessVars[0].specialHi.jibakuGFX + 1);
-    if ((s32)temp_fighter->nessVars[0].specialHi.jibakuGFX == 1)
+    temp_fp = fighter_gobj->user_data;
+    temp_fp->nessVars[0].specialHi.jibakuGFX = (s32)(temp_fp->nessVars[0].specialHi.jibakuGFX + 1);
+    if ((s32)temp_fp->nessVars[0].specialHi.jibakuGFX == 1)
     {
         fighter_data = fighter_gobj->user_data;
         ftNess_SpecialHiStopGFX(fighter_gobj);
@@ -1012,11 +1012,11 @@ void ftNess_SpecialAirHiEnd_Anim(HSD_GObj* fighter_gobj) // Ness's aerial PK Thu
 {
     s32 filler[2];
     Fighter* fighter_data;
-    Fighter* temp_fighter;
+    Fighter* temp_fp;
     ftNessAttributes* ness_attr;
 
-    fighter_data = temp_fighter = fighter_gobj->user_data;
-    ness_attr = temp_fighter->x2D4_specialAttributes;
+    fighter_data = temp_fp = fighter_gobj->user_data;
+    ness_attr = temp_fp->x2D4_specialAttributes;
     if (ftAnim_IsFramesRemaining(fighter_gobj) == FALSE)
     {
         fighter_data->x1968_jumpsUsed = fighter_data->x110_attr.x168_MaxJumps;
@@ -1076,11 +1076,11 @@ void ftNess_SpecialAirHiRebound_Anim(HSD_GObj* fighter_gobj) // Ness's PK Thunde
 {
     s32 filler[2];
     Fighter* fighter_data;
-    Fighter* temp_fighter;
+    Fighter* temp_fp;
     ftNessAttributes* ness_attr;
 
-    fighter_data = temp_fighter = fighter_gobj->user_data;
-    ness_attr = temp_fighter->x2D4_specialAttributes;
+    fighter_data = temp_fp = fighter_gobj->user_data;
+    ness_attr = temp_fp->x2D4_specialAttributes;
     if (ftAnim_IsFramesRemaining(fighter_gobj) == FALSE)
     {
         func_8007D60C(fighter_data);
@@ -1149,14 +1149,14 @@ void ftNess_SpecialAirHiRebound_IASA(HSD_GObj* fighter_gobj)
 
 inline void ThunderPhysTimer(HSD_GObj* fighter_gobj)
 {
-    Fighter* temp_fighter;
+    Fighter* temp_fp;
     s32 thunderPhysTimer;
 
-    temp_fighter = fighter_gobj->user_data;
-    thunderPhysTimer = temp_fighter->nessVars[0].specialHi.gravityDelay;
+    temp_fp = fighter_gobj->user_data;
+    thunderPhysTimer = temp_fp->nessVars[0].specialHi.gravityDelay;
     if (thunderPhysTimer != 0)
     {
-        temp_fighter->nessVars[0].specialHi.gravityDelay = (s32)(thunderPhysTimer - 1);
+        temp_fp->nessVars[0].specialHi.gravityDelay = (s32)(thunderPhysTimer - 1);
     }
 }
 
@@ -1190,37 +1190,37 @@ void ftNess_SpecialHi_Phys(HSD_GObj* fighter_gobj) // Ness's grounded PK Thunder
     f32 temp_f2;
     f32 temp_f3;
     Fighter* fighter_data;
-    Fighter* temp_fighter;
+    Fighter* temp_fp;
     ftNessAttributes* ness_attr;
 
-    temp_fighter = fighter_gobj->user_data;
-    temp_f2 = temp_fighter->xEC_ground_vel;
-    temp_f3 = temp_fighter->x80_self_vel.y;
-    ness_attr = temp_fighter->x2D4_specialAttributes;
-    temp_fighter->xEC_ground_vel = (f32)-((ness_attr->x5C_PK_THUNDER_2_DECELERATION_RATE * temp_fighter->x2C_facing_direction) - temp_f2);
-    if (1.0f == temp_fighter->x2C_facing_direction)
+    temp_fp = fighter_gobj->user_data;
+    temp_f2 = temp_fp->xEC_ground_vel;
+    temp_f3 = temp_fp->x80_self_vel.y;
+    ness_attr = temp_fp->x2D4_specialAttributes;
+    temp_fp->xEC_ground_vel = (f32)-((ness_attr->x5C_PK_THUNDER_2_DECELERATION_RATE * temp_fp->x2C_facing_direction) - temp_f2);
+    if (1.0f == temp_fp->x2C_facing_direction)
     {
-        if (temp_fighter->xEC_ground_vel <= 9.999999747378752e-05f)
+        if (temp_fp->xEC_ground_vel <= 9.999999747378752e-05f)
         {
-            temp_fighter->xEC_ground_vel = temp_f2;
+            temp_fp->xEC_ground_vel = temp_f2;
         }
     }
-    else if (temp_fighter->xEC_ground_vel >= -9.999999747378752e-05f)
+    else if (temp_fp->xEC_ground_vel >= -9.999999747378752e-05f)
     {
-        temp_fighter->xEC_ground_vel = temp_f2;
+        temp_fp->xEC_ground_vel = temp_f2;
     }
-    if (1.0f == temp_fighter->nessVars[0].specialHi.facingDir)
+    if (1.0f == temp_fp->nessVars[0].specialHi.facingDir)
     {
-        if (temp_fighter->x80_self_vel.y <= 9.999999747378752e-05f)
+        if (temp_fp->x80_self_vel.y <= 9.999999747378752e-05f)
         {
-            temp_fighter->x80_self_vel.y = temp_f3;
+            temp_fp->x80_self_vel.y = temp_f3;
         }
     }
-    else if (temp_fighter->x80_self_vel.y >= -9.999999747378752e-05f)
+    else if (temp_fp->x80_self_vel.y >= -9.999999747378752e-05f)
     {
-        temp_fighter->x80_self_vel.y = temp_f3;
+        temp_fp->x80_self_vel.y = temp_f3;
     }
-    temp_fighter->x2374_Vec3 = temp_fighter->x80_self_vel;
+    temp_fp->x2374_Vec3 = temp_fp->x80_self_vel;
     func_8007CB74(fighter_gobj);
     fighter_data = fighter_gobj->user_data;
     func_8007592C(fighter_data, 0, (fighter_data->x2C_facing_direction * atan2f(fighter_data->x80_self_vel.x, fighter_data->x80_self_vel.y)) - 1.5707963705062866f);
@@ -1451,7 +1451,7 @@ void ftNess_SpecialHi_Coll(HSD_GObj* fighter_gobj) // Ness's grounded PK Thunder
     s32 ecbFlag2;
     Fighter* fighter_data2;
     Fighter* fighter_data;
-    Fighter* temp_fighter;
+    Fighter* temp_fp;
     ftNessAttributes* temp_attr;
     f64 phi_f31;
     f64 phi_f31_2;
@@ -1463,20 +1463,20 @@ void ftNess_SpecialHi_Coll(HSD_GObj* fighter_gobj) // Ness's grounded PK Thunder
         if (((ecbFlag & 0x3F) != 0) || ((ecbFlag & 0xFC0) != 0))
         {
             func_8007D60C(fighter_data);
-            temp_fighter = fighter_gobj->user_data;
-            temp_attr = temp_fighter->x2D4_specialAttributes;
-            temp_fighter->nessVars[0].specialHi.thunderTimerLoop1 = (s32)temp_attr->x40_PK_THUNDER_LOOP1;
-            temp_fighter->nessVars[0].specialHi.thunderTimerLoop2 = (s32)temp_attr->x44_PK_THUNDER_LOOP2;
-            temp_fighter->nessVars[0].specialHi.gravityDelay = (s32)temp_attr->x48_PK_THUNDER_GRAVITY_DELAY;
-            temp_fighter->nessVars[0].specialHi.fallAccel = 0.0f;
-            temp_fighter->nessVars[0].specialHi.unkVector1.z = 0.0f;
-            temp_fighter->nessVars[0].specialHi.unkVector1.y = 0.0f;
-            temp_fighter->nessVars[0].specialHi.unkVector1.x = 0.0f;
-            temp_fighter->nessVars[0].specialHi.unkVar4 = 0.0f;
-            temp_fighter->nessVars[0].specialHi.unkVar3 = 0.0f;
-            temp_fighter->cb.x21E4_callback_OnDeath2 = NULL;
-            temp_fighter->cb.x21DC_callback_OnTakeDamage = NULL;
-            func_8007592C(temp_fighter, 0, 0.0f);
+            temp_fp = fighter_gobj->user_data;
+            temp_attr = temp_fp->x2D4_specialAttributes;
+            temp_fp->nessVars[0].specialHi.thunderTimerLoop1 = (s32)temp_attr->x40_PK_THUNDER_LOOP1;
+            temp_fp->nessVars[0].specialHi.thunderTimerLoop2 = (s32)temp_attr->x44_PK_THUNDER_LOOP2;
+            temp_fp->nessVars[0].specialHi.gravityDelay = (s32)temp_attr->x48_PK_THUNDER_GRAVITY_DELAY;
+            temp_fp->nessVars[0].specialHi.fallAccel = 0.0f;
+            temp_fp->nessVars[0].specialHi.unkVector1.z = 0.0f;
+            temp_fp->nessVars[0].specialHi.unkVector1.y = 0.0f;
+            temp_fp->nessVars[0].specialHi.unkVector1.x = 0.0f;
+            temp_fp->nessVars[0].specialHi.unkVar4 = 0.0f;
+            temp_fp->nessVars[0].specialHi.unkVar3 = 0.0f;
+            temp_fp->cb.x21E4_callback_OnDeath2 = NULL;
+            temp_fp->cb.x21DC_callback_OnTakeDamage = NULL;
+            func_8007592C(temp_fp, 0, 0.0f);
             Fighter_ActionStateChange_800693AC(fighter_gobj, AS_NESS_SPECIALAIRHI_END, FTNESS_SPECIALHI_COLL_FLAG, NULL, fighter_data->x894_currentAnimFrame, 1.0f, 0.0f);
             return;
         }

--- a/src/melee/ft/chara/ftNess/ftNess_SpecialLw.c
+++ b/src/melee/ft/chara/ftNess/ftNess_SpecialLw.c
@@ -6,14 +6,14 @@ void ftNess_SpecialLwStart_Action(HSD_GObj* fighter_gobj) // Ness's grounded PSI
 {
     s32 filler[7];
     ftNessAttributes* ness_attr;
-    Fighter* temp_fighter;
+    Fighter* temp_fp;
 
-    temp_fighter = fighter_gobj->user_data;
-    ness_attr = temp_fighter->x2D4_specialAttributes;
-    temp_fighter->nessVars[0].specialLw.releaseLag = (s32)ness_attr->x74_PSI_MAGNET_RELEASE_LAG;
-    temp_fighter->nessVars[0].specialLw.isRelease = 0;
-    temp_fighter->nessVars[0].specialLw.gravityDelay = (s32)ness_attr->x84_PSI_MAGNET_FRAMES_BEFORE_GRAVITY;
-    temp_fighter->x2350_stateVar5 = 0;
+    temp_fp = fighter_gobj->user_data;
+    ness_attr = temp_fp->x2D4_specialAttributes;
+    temp_fp->nessVars[0].specialLw.releaseLag = (s32)ness_attr->x74_PSI_MAGNET_RELEASE_LAG;
+    temp_fp->nessVars[0].specialLw.isRelease = 0;
+    temp_fp->nessVars[0].specialLw.gravityDelay = (s32)ness_attr->x84_PSI_MAGNET_FRAMES_BEFORE_GRAVITY;
+    temp_fp->x2350_stateVar5 = 0;
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_NESS_SPECIALLW_START, 0, NULL, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(fighter_gobj);
 }
@@ -23,17 +23,17 @@ void ftNess_SpecialLwStart_Action(HSD_GObj* fighter_gobj) // Ness's grounded PSI
 void ftNess_SpecialAirLwStart_Action(HSD_GObj* fighter_gobj) // Ness's aerial PSI Magnet Start Action State handler //
 {
     s32 filler[7];
-    Fighter* temp_fighter;
+    Fighter* temp_fp;
     ftNessAttributes* ness_attr;
 
-    temp_fighter = fighter_gobj->user_data;
-    ness_attr = temp_fighter->x2D4_specialAttributes;
-    temp_fighter->nessVars[0].specialLw.releaseLag = (s32)ness_attr->x74_PSI_MAGNET_RELEASE_LAG;
-    temp_fighter->nessVars[0].specialLw.isRelease = 0;
-    temp_fighter->nessVars[0].specialLw.gravityDelay = (s32)ness_attr->x84_PSI_MAGNET_FRAMES_BEFORE_GRAVITY;
-    temp_fighter->x2350_stateVar5 = 0;
-    temp_fighter->x80_self_vel.y = 0.0f;
-    temp_fighter->x80_self_vel.x /= ness_attr->x88_PSI_MAGNET_MOMENTUM_PRESERVATION;
+    temp_fp = fighter_gobj->user_data;
+    ness_attr = temp_fp->x2D4_specialAttributes;
+    temp_fp->nessVars[0].specialLw.releaseLag = (s32)ness_attr->x74_PSI_MAGNET_RELEASE_LAG;
+    temp_fp->nessVars[0].specialLw.isRelease = 0;
+    temp_fp->nessVars[0].specialLw.gravityDelay = (s32)ness_attr->x84_PSI_MAGNET_FRAMES_BEFORE_GRAVITY;
+    temp_fp->x2350_stateVar5 = 0;
+    temp_fp->x80_self_vel.y = 0.0f;
+    temp_fp->x80_self_vel.x /= ness_attr->x88_PSI_MAGNET_MOMENTUM_PRESERVATION;
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_NESS_SPECIALAIRLW_START, 0, NULL, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(fighter_gobj);
 }

--- a/src/melee/ft/chara/ftNess/ftNess_SpecialN.c
+++ b/src/melee/ft/chara/ftNess/ftNess_SpecialN.c
@@ -91,7 +91,7 @@ void ftNess_SpecialNStart_Action(HSD_GObj* fighter_gobj)  // Ness's grounded PK 
 {
     Fighter* fighter_data;
     ftNessAttributes* ness_attr;
-    Fighter* temp_fighter;
+    Fighter* temp_fp;
 
     fighter_data = getFighterPlus(fighter_gobj);
 
@@ -102,17 +102,17 @@ void ftNess_SpecialNStart_Action(HSD_GObj* fighter_gobj)  // Ness's grounded PK 
     fighter_data->x2204_ftcmd_var1 = 0;
     fighter_data->x2200_ftcmd_var0 = 0;
 
-    temp_fighter = fighter_gobj->user_data;
-    ness_attr = getFtSpecialAttrs(temp_fighter);
+    temp_fp = fighter_gobj->user_data;
+    ness_attr = getFtSpecialAttrs(temp_fp);
 
-    temp_fighter->nessVars[0].specialN.flashTimerLoop1 = (s32)ness_attr->x0_PKFLASH_TIMER1_LOOPFRAMES;
-    temp_fighter->nessVars[0].specialN.flashTimerLoop2 = (s32)ness_attr->x4_PKFLASH_TIMER2_LOOPFRAMES;
-    temp_fighter->nessVars[0].specialN.gravityDelay = (s32)ness_attr->x8_PKFLASH_GRAVITY_DELAY;
+    temp_fp->nessVars[0].specialN.flashTimerLoop1 = (s32)ness_attr->x0_PKFLASH_TIMER1_LOOPFRAMES;
+    temp_fp->nessVars[0].specialN.flashTimerLoop2 = (s32)ness_attr->x4_PKFLASH_TIMER2_LOOPFRAMES;
+    temp_fp->nessVars[0].specialN.gravityDelay = (s32)ness_attr->x8_PKFLASH_GRAVITY_DELAY;
 
-    temp_fighter->sa.ness.x2240_flashGObj = NULL;
-    temp_fighter->nessVars[0].specialN.flashTimerMin = (s32)ness_attr->xC_PKFLASH_MINCHARGEFRAMES;
-    temp_fighter->cb.x21E4_callback_OnDeath2 = NULL;
-    temp_fighter->cb.x21DC_callback_OnTakeDamage = NULL;
+    temp_fp->sa.ness.x2240_flashGObj = NULL;
+    temp_fp->nessVars[0].specialN.flashTimerMin = (s32)ness_attr->xC_PKFLASH_MINCHARGEFRAMES;
+    temp_fp->cb.x21E4_callback_OnDeath2 = NULL;
+    temp_fp->cb.x21DC_callback_OnTakeDamage = NULL;
     func_8006EBA4(fighter_gobj);
 }
 
@@ -122,7 +122,7 @@ void ftNess_SpecialAirNStart_Action(HSD_GObj* fighter_gobj)  // Ness's aerial PK
 {
     Fighter* fighter_data;
     ftNessAttributes* ness_attr;
-    Fighter* temp_fighter;
+    Fighter* temp_fp;
 
     fighter_data = getFighterPlus(fighter_gobj);
 
@@ -134,19 +134,19 @@ void ftNess_SpecialAirNStart_Action(HSD_GObj* fighter_gobj)  // Ness's aerial PK
     fighter_data->x2200_ftcmd_var0 = 0;
     fighter_data->x80_self_vel.y = 0.0f;
 
-    temp_fighter = fighter_gobj->user_data;
-    ness_attr = getFtSpecialAttrs(temp_fighter);
+    temp_fp = fighter_gobj->user_data;
+    ness_attr = getFtSpecialAttrs(temp_fp);
 
-    temp_fighter->nessVars[0].specialN.flashTimerLoop1 = (s32)ness_attr->x0_PKFLASH_TIMER1_LOOPFRAMES;
-    temp_fighter->nessVars[0].specialN.flashTimerLoop2 = (s32)ness_attr->x4_PKFLASH_TIMER2_LOOPFRAMES;
-    temp_fighter->nessVars[0].specialN.gravityDelay = (s32)ness_attr->x8_PKFLASH_GRAVITY_DELAY;
+    temp_fp->nessVars[0].specialN.flashTimerLoop1 = (s32)ness_attr->x0_PKFLASH_TIMER1_LOOPFRAMES;
+    temp_fp->nessVars[0].specialN.flashTimerLoop2 = (s32)ness_attr->x4_PKFLASH_TIMER2_LOOPFRAMES;
+    temp_fp->nessVars[0].specialN.gravityDelay = (s32)ness_attr->x8_PKFLASH_GRAVITY_DELAY;
 
-    temp_fighter->sa.ness.x2240_flashGObj = NULL;
+    temp_fp->sa.ness.x2240_flashGObj = NULL;
 
-    temp_fighter->nessVars[0].specialN.flashTimerMin = (s32)ness_attr->xC_PKFLASH_MINCHARGEFRAMES;
+    temp_fp->nessVars[0].specialN.flashTimerMin = (s32)ness_attr->xC_PKFLASH_MINCHARGEFRAMES;
 
-    temp_fighter->cb.x21E4_callback_OnDeath2 = NULL;
-    temp_fighter->cb.x21DC_callback_OnTakeDamage = NULL;
+    temp_fp->cb.x21E4_callback_OnDeath2 = NULL;
+    temp_fp->cb.x21DC_callback_OnTakeDamage = NULL;
 
     func_8006EBA4(fighter_gobj);
 }

--- a/src/melee/ft/chara/ftPeach/ftpeach.c
+++ b/src/melee/ft/chara/ftPeach/ftpeach.c
@@ -4,22 +4,22 @@
 
 void ftPeach_OnDeath(HSD_GObj* gobj)
 {
-    Fighter* ft;
+    Fighter* fp;
 
-    ft = gobj->user_data;
-    ft->sa.peach.x222C = 1;
-    ft->sa.peach.x2234 = -1;
-    ft->sa.peach.x2240 = 0;
-    ft->sa.peach.x223C = 0;
-    ft->sa.peach.x2238 = 0;
-    ft->sa.peach.x2244 = 0;
-    ft->sa.peach.x2248 = 0;
+    fp = gobj->user_data;
+    fp->sa.peach.x222C = 1;
+    fp->sa.peach.x2234 = -1;
+    fp->sa.peach.x2240 = 0;
+    fp->sa.peach.x223C = 0;
+    fp->sa.peach.x2238 = 0;
+    fp->sa.peach.x2244 = 0;
+    fp->sa.peach.x2248 = 0;
     func_80074A4C(gobj, 0, 0);
     func_80074A4C(gobj, 2, 0);
     func_80074A4C(gobj, 3, -1);
     func_80074A4C(gobj, 4, 0);
 
-    switch (ft->x619_costume_id)
+    switch (fp->x619_costume_id)
     {
         case 1:
             func_80074A4C(gobj, 1, -1);
@@ -37,14 +37,14 @@ void ftPeach_OnDeath(HSD_GObj* gobj)
 
 void ftPeach_OnLoad(HSD_GObj* gobj)
 {
-    Fighter* ft = gobj->user_data;
-    ftPeachAttributes* extAtrrs = ft->x10C_ftData->ext_attr;
-    void** items = ft->x10C_ftData->x48_items;
+    Fighter* fp = gobj->user_data;
+    ftPeachAttributes* extAtrrs = fp->x10C_ftData->ext_attr;
+    void** items = fp->x10C_ftData->x48_items;
 
-    extAtrrs->unk0 = func_8001E8F8(func_80085E50(ft, 18));
-    extAtrrs->unk4 = func_8001E8F8(func_80085E50(ft, 19));
+    extAtrrs->unk0 = func_8001E8F8(func_80085E50(fp, 18));
+    extAtrrs->unk4 = func_8001E8F8(func_80085E50(fp, 19));
 
-    PUSH_ATTRS(ft, ftPeachAttributes);
+    PUSH_ATTRS(fp, ftPeachAttributes);
     
     func_8026B3F8(items[0], It_Kind_Peach_Explode);
     func_8026B3F8(items[1], It_Kind_Peach_Turnip);

--- a/src/melee/ft/chara/ftPichu/ftpichu.c
+++ b/src/melee/ft/chara/ftPichu/ftpichu.c
@@ -5,12 +5,12 @@ void ftPichu_OnLoad(HSD_GObj* gobj)
     ftPichuAttributes* attrs;
     u32 unused[2];
 
-    Fighter* ft = gobj->user_data;
-    ftData* ftdata = ft->x10C_ftData;
+    Fighter* fp = gobj->user_data;
+    ftData* ftdata = fp->x10C_ftData;
     void** items = ftdata->x48_items;
-    ft->x2224_flag.bits.b7 = 1;
-    ftPikachu_OnLoadForPichu(ft);
-    attrs = ft->x2D4_specialAttributes;
+    fp->x2224_flag.bits.b7 = 1;
+    ftPikachu_OnLoadForPichu(fp);
+    attrs = fp->x2D4_specialAttributes;
     func_8026B3F8(items[0], attrs->xDC);
     func_8026B3F8(items[1], attrs->x14);
     func_8026B3F8(items[2], attrs->x18);
@@ -19,10 +19,10 @@ void ftPichu_OnLoad(HSD_GObj* gobj)
 void ftPichu_OnDeath(HSD_GObj* gobj)
 {
     u8 temp_r0;
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
 
     func_80074A4C(gobj, 0, 0);
-    temp_r0 = ft->x619_costume_id;
+    temp_r0 = fp->x619_costume_id;
 
     switch (temp_r0) {
         case 0:

--- a/src/melee/ft/chara/ftPikachu/ftpikachu.h
+++ b/src/melee/ft/chara/ftPikachu/ftpikachu.h
@@ -67,7 +67,7 @@ typedef struct _ftPikachuAttributes {
 
 
 ///pika1
-void ftPikachu_OnLoadForPichu(Fighter* fighter);
+void ftPikachu_OnLoadForPichu(Fighter* fp);
 void ftPikachu_OnLoad(HSD_GObj* fighterObj);
 void ftPikachu_OnDeath(HSD_GObj* fighterObj);
 void ftPikachu_OnItemPickup(HSD_GObj* fighterObj, BOOL arg1);

--- a/src/melee/ft/chara/ftPikachu/ftpikachu1.c
+++ b/src/melee/ft/chara/ftPikachu/ftpikachu1.c
@@ -1,18 +1,18 @@
 #include <ftpikachu.h>
 
-void ftPikachu_OnLoadForPichu(Fighter* fighter) {
-    PUSH_ATTRS(fighter, ftPikachuAttributes);
+void ftPikachu_OnLoadForPichu(Fighter* fp) {
+    PUSH_ATTRS(fp, ftPikachuAttributes);
 }
 
 
 void ftPikachu_OnLoad(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    void** item_list = fighter->x10C_ftData->x48_items;
+    Fighter* fp = fighterObj->user_data;
+    void** item_list = fp->x10C_ftData->x48_items;
 
-    PUSH_ATTRS(fighter, ftPikachuAttributes);
+    PUSH_ATTRS(fp, ftPikachuAttributes);
 
     {
-        ftPikachuAttributes *pika_attr = fighter->x2D4_specialAttributes;
+        ftPikachuAttributes *pika_attr = fp->x2D4_specialAttributes;
         func_8026B3F8(item_list[0], pika_attr->xDC);
         func_8026B3F8(item_list[1], pika_attr->x14);
         func_8026B3F8(item_list[2], pika_attr->x18);
@@ -57,7 +57,7 @@ void ftPikachu_801246C0(HSD_GObj* fighterObj) {
 
 void ftPikachu_LoadSpecialAttrs(HSD_GObj* fighterObj) {
     COPY_ATTRS(fighterObj, ftPikachuAttributes);
-    if (ft->x34_scale.y != 1.0f) {
+    if (fp->x34_scale.y != 1.0f) {
         SCALE_HEIGHT_ATTRS(6); 
     }
 }

--- a/src/melee/ft/chara/ftPikachu/ftpikachu2.c
+++ b/src/melee/ft/chara/ftPikachu/ftpikachu2.c
@@ -1,22 +1,22 @@
 #include <ftpikachu.h>
 
 void ftPikachu_SpecialN_StartAction(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x155, 0, 0, 0.0f, 1.0f, 0.0f);
-    fighter->x220C_ftcmd_var3 = 0;
-    fighter->x2208_ftcmd_var2 = 0;
-    fighter->x2204_ftcmd_var1 = 0;
-    fighter->x2200_ftcmd_var0 = 0;
+    fp->x220C_ftcmd_var3 = 0;
+    fp->x2208_ftcmd_var2 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
     func_8006EBA4(fighterObj);
 }
 
 void ftPikachu_SpecialAirN_StartAction(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x156, 0, 0, 0.0f, 1.0f, 0.0f);
-    fighter->x220C_ftcmd_var3 = 0;
-    fighter->x2208_ftcmd_var2 = 0;
-    fighter->x2204_ftcmd_var1 = 0;
-    fighter->x2200_ftcmd_var0 = 0;
+    fp->x220C_ftcmd_var3 = 0;
+    fp->x2208_ftcmd_var2 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
     func_8006EBA4(fighterObj);
 }
 
@@ -24,24 +24,24 @@ void ftPikachu_80124908(HSD_GObj* fighterObj) {
 
     Vec sp14;
     s32 stack_buffer[2];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
-    if (fighter->x2200_ftcmd_var0 == 1) {
-        fighter->x2200_ftcmd_var0 = 0;
+    if (fp->x2200_ftcmd_var0 == 1) {
+        fp->x2200_ftcmd_var0 = 0;
 
-        if (!fighter->x2204_ftcmd_var1) {
-            fighter->x2204_ftcmd_var1 = 1;
-            sp14.x = (fighter->x34_scale.y * (pika_attr->x0 * fighter->x2C_facing_direction)) + fighter->xB0_pos.x;
-            sp14.y = (pika_attr->x4 * fighter->x34_scale.y) + fighter->xB0_pos.y;
+        if (!fp->x2204_ftcmd_var1) {
+            fp->x2204_ftcmd_var1 = 1;
+            sp14.x = (fp->x34_scale.y * (pika_attr->x0 * fp->x2C_facing_direction)) + fp->xB0_pos.x;
+            sp14.y = (pika_attr->x4 * fp->x34_scale.y) + fp->xB0_pos.y;
             sp14.z = 0.0f;
-            func_802B338C(fighterObj, &sp14, fighter->x2C_facing_direction, pika_attr->x14);
+            func_802B338C(fighterObj, &sp14, fp->x2C_facing_direction, pika_attr->x14);
             switch (func_800872A4(fighterObj)) {
                 case 12:
-                    func_80088148(fighter, 0x3a9cc, 0x7F, 0x40);
+                    func_80088148(fp, 0x3a9cc, 0x7F, 0x40);
                     break;
                 case 23:
-                    func_80088148(fighter, 0x382b3, 0x7F, 0x40);
+                    func_80088148(fp, 0x382b3, 0x7F, 0x40);
                     break;
             }
         }
@@ -55,24 +55,24 @@ void ftPikachu_80124908(HSD_GObj* fighterObj) {
 void ftPikachu_80124A20(HSD_GObj* fighterObj) {
     Vec sp14;
     s32 stack_buffer[2];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
-    if (fighter->x2200_ftcmd_var0 == 1) {
-        fighter->x2200_ftcmd_var0 = 0;
+    if (fp->x2200_ftcmd_var0 == 1) {
+        fp->x2200_ftcmd_var0 = 0;
 
-        if (!fighter->x2204_ftcmd_var1) {
-            fighter->x2204_ftcmd_var1 = 1;
-            sp14.x = (fighter->x34_scale.y * (pika_attr->x8 * fighter->x2C_facing_direction)) + fighter->xB0_pos.x;
-            sp14.y = (pika_attr->xC * fighter->x34_scale.y) + fighter->xB0_pos.y;
+        if (!fp->x2204_ftcmd_var1) {
+            fp->x2204_ftcmd_var1 = 1;
+            sp14.x = (fp->x34_scale.y * (pika_attr->x8 * fp->x2C_facing_direction)) + fp->xB0_pos.x;
+            sp14.y = (pika_attr->xC * fp->x34_scale.y) + fp->xB0_pos.y;
             sp14.z = 0.0f;
-            func_802B338C(fighterObj, &sp14, fighter->x2C_facing_direction, pika_attr->x14);
+            func_802B338C(fighterObj, &sp14, fp->x2C_facing_direction, pika_attr->x14);
             switch (func_800872A4(fighterObj)) {
                 case 12:
-                    func_80088148(fighter, 0x3a9cc, 0x7F, 0x40);
+                    func_80088148(fp, 0x3a9cc, 0x7F, 0x40);
                     break;
                 case 23:
-                    func_80088148(fighter, 0x382b3, 0x7F, 0x40);
+                    func_80088148(fp, 0x382b3, 0x7F, 0x40);
                     break;
             }
         }
@@ -100,75 +100,75 @@ void ftPikachu_80124B94(HSD_GObj* fighterObj) {
 }
 
 void ftPikachu_ActionChange_80124BB4(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
     if (!func_80082708(fighterObj)) {
-        fighter = fighterObj->user_data;
-        func_8007D5D4(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x156, 0xc4c5082, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        fp = fighterObj->user_data;
+        func_8007D5D4(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x156, 0xc4c5082, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
     }
 }
 
 
 void ftPikachu_ActionChange_80124C20(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
     if (func_80081D0C(fighterObj) == 1) {
-        fighter = fighterObj->user_data;
-        func_8007D7FC(fighter);
-        fighter->x80_self_vel.y = 0.0f;
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x155, 0xc4c5082, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        fp = fighterObj->user_data;
+        func_8007D7FC(fp);
+        fp->x80_self_vel.y = 0.0f;
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x155, 0xc4c5082, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
     }
 }
 
 void ftPikachu_EfSpawn_80124C90(HSD_GObj* fighterObj) {
-    Fighter *fighter = fighterObj->user_data;
+    Fighter *fp = fighterObj->user_data;
     
     HSD_GObj *tempObj;
     HSD_GObj *tempObj2;
     
-    if (!fighter->x2219_flag.bits.b0)
+    if (!fp->x2219_flag.bits.b0)
     {
-        s32 index = func_8007500C(fighter, 4);
+        s32 index = func_8007500C(fp, 4);
         tempObj = fighterObj;
-        ef_Spawn(0x4BE, tempObj2 = tempObj, fighter->x5E8_fighterBones[index].x0_jobj);
-        fighter->x2219_flag.bits.b0 = 1;
+        ef_Spawn(0x4BE, tempObj2 = tempObj, fp->x5E8_fighterBones[index].x0_jobj);
+        fp->x2219_flag.bits.b0 = 1;
     }
-    fighter->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
-    fighter->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
-    fighter->cb.x21BC_callback_Accessory4 = 0;
+    fp->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
+    fp->cb.x21BC_callback_Accessory4 = 0;
 }
 
 void ftPikachu_EfSpawn_80124D2C(HSD_GObj* fighterObj) {
-    Fighter *fighter = fighterObj->user_data;
+    Fighter *fp = fighterObj->user_data;
     
     HSD_GObj *tempObj;
     HSD_GObj *tempObj2;
     
-    if (!fighter->x2219_flag.bits.b0)
+    if (!fp->x2219_flag.bits.b0)
     {
-        s32 index = func_8007500C(fighter, 4);
+        s32 index = func_8007500C(fp, 4);
         tempObj = fighterObj;
-        ef_Spawn(0x4BF, tempObj2 = tempObj, fighter->x5E8_fighterBones[index].x0_jobj);
-        fighter->x2219_flag.bits.b0 = 1;
+        ef_Spawn(0x4BF, tempObj2 = tempObj, fp->x5E8_fighterBones[index].x0_jobj);
+        fp->x2219_flag.bits.b0 = 1;
     }
-    fighter->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
-    fighter->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
-    fighter->cb.x21BC_callback_Accessory4 = 0;
+    fp->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
+    fp->cb.x21BC_callback_Accessory4 = 0;
 }
 
 void ftPikachu_80124DC8(HSD_GObj* fighterObj) {
     u8 fighter_x673_byte;
-    Fighter *fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    Fighter *fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
     f32 pika_attr_1C;
     
-    fighter->x2200_ftcmd_var0 = 0;
-    fighter_x673_byte = fighter->x673;
+    fp->x2200_ftcmd_var0 = 0;
+    fighter_x673_byte = fp->x673;
 
     pika_attr_1C = pika_attr->x1C;
     if (fighter_x673_byte < pika_attr_1C) {
-        fighter->x2340_stateVar1 = pika_attr->x20;
-        fighter->x2072_b4 = 1;
+        fp->x2340_stateVar1 = pika_attr->x20;
+        fp->x2072_b4 = 1;
     } else {
-        fighter->x2340_stateVar1 = 0;
+        fp->x2340_stateVar1 = 0;
     }    
 }

--- a/src/melee/ft/chara/ftPikachu/ftpikachu3.c
+++ b/src/melee/ft/chara/ftPikachu/ftpikachu3.c
@@ -2,34 +2,34 @@
 
 void ftPikachu_SpecialS_StartAction(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
-    fighter->cb.x21EC_callback = ftPikachu_80124DC8;
+    fp->cb.x21EC_callback = ftPikachu_80124DC8;
 
-    fighter->xEC_ground_vel /= pika_attr->x30;
+    fp->xEC_ground_vel /= pika_attr->x30;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x157, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(fighterObj);
 }
 
 void ftPikachu_SpecialAirS_StartAction(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
-    fighter->cb.x21EC_callback = ftPikachu_80124DC8;
+    fp->cb.x21EC_callback = ftPikachu_80124DC8;
 
-    fighter->x80_self_vel.x /= pika_attr->x30;
-    fighter->x80_self_vel.y = 0.0f;
+    fp->x80_self_vel.x /= pika_attr->x30;
+    fp->x80_self_vel.y = 0.0f;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x15C, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(fighterObj);
 }
 
 void ftPikachu_ZeroVelocity_80124F24(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    fighter->x80_self_vel.x = 0.0f;
-    if (fighter->x80_self_vel.y >= 0.0f) {
-        fighter->x80_self_vel.y = 0.0f;
+    Fighter* fp = fighterObj->user_data;
+    fp->x80_self_vel.x = 0.0f;
+    if (fp->x80_self_vel.y >= 0.0f) {
+        fp->x80_self_vel.y = 0.0f;
     }
     ftPikachu_ActionChange_80125D28(fighterObj);
 }
@@ -52,23 +52,23 @@ void ftPikachu_Stub_80124FE0() {}
 
 void ftPikachu_80124FE4(HSD_GObj* fighterObj) {
     s32 unused;
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
     f32 pika_attr_x34 = pika_attr->x34;
-    func_8007C930(fighter, pika_attr_x34);
+    func_8007C930(fp, pika_attr_x34);
     func_8007CB74(fighterObj);
 }
 
 void ftPikachu_80125024(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
-    struct attr* attr = &fighter->x110_attr;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
+    struct attr* attr = &fp->x110_attr;
     
-    if (fighter->x2200_ftcmd_var0) {
-        func_8007D494(fighter, pika_attr->x38, attr->x170_TerminalVelocity);
+    if (fp->x2200_ftcmd_var0) {
+        func_8007D494(fp, pika_attr->x38, attr->x170_TerminalVelocity);
     }
-    func_8007CE94(fighter, pika_attr->x34);
+    func_8007CE94(fp, pika_attr->x34);
 }
 
 void ftPikachu_80125084(HSD_GObj* fighterObj) {
@@ -84,27 +84,27 @@ void ftPikachu_801250C0(HSD_GObj* fighterObj) {
 }
 
 void ftPikachu_ActionChange_801250FC(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D5D4(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x15C, 0xc4c5284, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = fighterObj->user_data;
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x15C, 0xc4c5284, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 void ftPikachu_ActionChange_8012515C(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D7FC(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x157, 0xc4c5284, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = fighterObj->user_data;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x157, 0xc4c5284, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 void ftPikachu_801251BC(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
         func_8007DB24(fighterObj);
-        fighter->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_80124C90;
+        fp->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_80124C90;
     }
-    fighter->x2340_stateVar1++;
-    if (fighter->x2340_stateVar1 > pika_attr->x24) {
+    fp->x2340_stateVar1++;
+    if (fp->x2340_stateVar1 > pika_attr->x24) {
         ftPikachu_ActionChange_80125834(fighterObj);
     }
 }
@@ -112,32 +112,32 @@ void ftPikachu_801251BC(HSD_GObj* fighterObj) {
 void ftPikachu_8012525C(HSD_GObj* fighterObj) {
 
     s32 unused[2];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
         func_8007DB24(fighterObj);
-        fighter->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_80124C90;
+        fp->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_80124C90;
     }
 
-    fighter->x2340_stateVar1++;
+    fp->x2340_stateVar1++;
 
-    if (fighter->x2340_stateVar1 > pika_attr->x24) {
+    if (fp->x2340_stateVar1 > pika_attr->x24) {
         ftPikachu_ActionChange_801258A0(fighterObj);
     }
     
 }
 
 void ftPikachu_801252FC(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    if (!(fighter->input.x65C_heldInputs & 0x200)) {
+    Fighter* fp = fighterObj->user_data;
+    if (!(fp->input.x65C_heldInputs & 0x200)) {
         ftPikachu_ActionChange_80125834(fighterObj);
     }
 }
 
 void ftPikachu_8012532C(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    if (!(fighter->input.x65C_heldInputs & 0x200)) {
+    Fighter* fp = fighterObj->user_data;
+    if (!(fp->input.x65C_heldInputs & 0x200)) {
         ftPikachu_ActionChange_801258A0(fighterObj);
     }
 }
@@ -163,60 +163,60 @@ void ftPikachu_801253D8(HSD_GObj* fighterObj) {
 }
 
 void ftPikachu_ActionChange_80125414(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D5D4(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x15D, 0xC4C5286, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = fighterObj->user_data;
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x15D, 0xC4C5286, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 void ftPikachu_ActionChange_80125474(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D7FC(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x158, 0xC4C5286, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = fighterObj->user_data;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x158, 0xC4C5286, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 void ftPikachu_ActionChange_801254D4(HSD_GObj* fighterObj) {
     s32 unused[3];
-    Fighter* fighter;
+    Fighter* fp;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x158, 0x200, 0, 0.0f, 1.0f, 0.0f);
-    fighter = fighterObj->user_data;
-    fighter->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_80124C90;
+    fp = fighterObj->user_data;
+    fp->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_80124C90;
 }
 
 void ftPikachu_ActionChange_80125528(HSD_GObj* fighterObj) {
     s32 unused[3];
-    Fighter* fighter;
+    Fighter* fp;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x15D, 0x200, 0, 0.0f, 1.0f, 0.0f);
-    fighter = fighterObj->user_data;
-    fighter->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_80124C90;
+    fp = fighterObj->user_data;
+    fp->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_80124C90;
 }
 
 void ftPikachu_8012557C(HSD_GObj* fighterObj) {
     s32 unused[4];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
-    if (fighter->x914[0].x0 == 1) {
-        f32 float_result = (fighter->x2340_stateVar1 * pika_attr->x2C) + pika_attr->x28;
-        func_8007ABD0(&fighter->x914[0], float_result, fighterObj);
+    if (fp->x914[0].x0 == 1) {
+        f32 float_result = (fp->x2340_stateVar1 * pika_attr->x2C) + pika_attr->x28;
+        func_8007ABD0(&fp->x914[0], float_result, fighterObj);
     }
 
-    if (fighter->x2200_ftcmd_var0) {
-        func_8007D5D4(fighter);
+    if (fp->x2200_ftcmd_var0) {
+        func_8007D5D4(fp);
         ftPikachu_ActionChange_80125A54(fighterObj);
     }
 }
 
 void ftPikachu_8012561C(HSD_GObj* fighterObj) {
     s32 unused[4];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
-    if (fighter->x914[0].x0 == 1) {
-        f32 float_result = (fighter->x2340_stateVar1 * pika_attr->x2C) + pika_attr->x28;
-        func_8007ABD0(&fighter->x914[0], float_result, fighterObj);
+    if (fp->x914[0].x0 == 1) {
+        f32 float_result = (fp->x2340_stateVar1 * pika_attr->x2C) + pika_attr->x28;
+        func_8007ABD0(&fp->x914[0], float_result, fighterObj);
     }
 
-    if (fighter->x2200_ftcmd_var0) {
+    if (fp->x2200_ftcmd_var0) {
         ftPikachu_ActionChange_80125A54(fighterObj);
     }
 }
@@ -246,35 +246,35 @@ void ftPikachu_80125738(HSD_GObj* fighterObj) {
 }
 
 void ftPikachu_ActionChange_80125774(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D5D4(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x160, 0xC4C5086, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = fighterObj->user_data;
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x160, 0xC4C5086, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 void ftPikachu_ActionChange_801257D4(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D7FC(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x15B, 0xC4C5086, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = fighterObj->user_data;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x15B, 0xC4C5086, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 void ftPikachu_ActionChange_80125834(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* fighter;
+    Fighter* fp;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x15B, 0, 0, 0.0f, 1.0f, 0.0f);
-    fighter = fighterObj->user_data;
-    fighter->x2200_ftcmd_var0 = 0;
+    fp = fighterObj->user_data;
+    fp->x2200_ftcmd_var0 = 0;
     func_8007DB24(fighterObj);
-    fighter->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_80124D2C;
+    fp->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_80124D2C;
 }
 
 void ftPikachu_ActionChange_801258A0(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* fighter;
+    Fighter* fp;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x160, 0, 0, 0.0f, 1.0f, 0.0f);
-    fighter = fighterObj->user_data;
-    fighter->x2200_ftcmd_var0 = 0;
+    fp = fighterObj->user_data;
+    fp->x2200_ftcmd_var0 = 0;
     func_8007DB24(fighterObj);
-    fighter->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_80124D2C;
+    fp->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_80124D2C;
 }
 
 void ftPikachu_Stub_8012590C() {}
@@ -294,28 +294,28 @@ void ftPikachu_Stub_80125954() {}
 
 void ftPikachu_80125958(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
-    if (fighter->x2200_ftcmd_var0) {
-        func_8007D494(fighter, pika_attr->x58, pika_attr->x4C);
+    if (fp->x2200_ftcmd_var0) {
+        func_8007D494(fp, pika_attr->x58, pika_attr->x4C);
     } else {
-        func_8007D494(fighter, pika_attr->x48, pika_attr->x4C);
+        func_8007D494(fp, pika_attr->x48, pika_attr->x4C);
     }
 
-    if (fighter->x2200_ftcmd_var0) {
-        func_8007CE94(fighter, pika_attr->x54);
+    if (fp->x2200_ftcmd_var0) {
+        func_8007CE94(fp, pika_attr->x54);
     }
 }
 
 void ftPikachu_Stub_801259D4() {}
 
 void ftPikachu_801259D8(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    CollData* collData = &fighter->x6F0_collData;
+    Fighter* fp = fighterObj->user_data;
+    CollData* collData = &fp->x6F0_collData;
 
     if (func_80081D0C(fighterObj)) {
-        func_8007D7FC(fighter);
+        func_8007D7FC(fp);
         ftPikachu_ActionChange_80125CD0(fighterObj);
     }
 
@@ -326,18 +326,18 @@ void ftPikachu_801259D8(HSD_GObj* fighterObj) {
 
 void ftPikachu_ActionChange_80125A54(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
-    fighter->x2200_ftcmd_var0 = 0;
+    fp->x2200_ftcmd_var0 = 0;
 
-    fighter->x80_self_vel.x = (pika_attr->x40 * fighter->x2340_stateVar1) + pika_attr->x3C;
-    fighter->x80_self_vel.x *= fighter->x2C_facing_direction;
+    fp->x80_self_vel.x = (pika_attr->x40 * fp->x2340_stateVar1) + pika_attr->x3C;
+    fp->x80_self_vel.x *= fp->x2C_facing_direction;
 
-    fighter->x80_self_vel.y = (0.5f * pika_attr->x44) + (pika_attr->x44 * (0.5f * fighter->x2340_stateVar1 / pika_attr->x24));
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x15E, 0xA, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
-    fighter->cb.x21F8_callback = &func_8007F76C;
-    fighter->cb.x21C0_callback_OnGiveDamage = &ftPikachu_ZeroVelocity_80124F24;
+    fp->x80_self_vel.y = (0.5f * pika_attr->x44) + (pika_attr->x44 * (0.5f * fp->x2340_stateVar1 / pika_attr->x24));
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x15E, 0xA, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
+    fp->cb.x21F8_callback = &func_8007F76C;
+    fp->cb.x21C0_callback_OnGiveDamage = &ftPikachu_ZeroVelocity_80124F24;
     
 }
 
@@ -359,18 +359,18 @@ void ftPikachu_Stub_80125BB0() {}
 
 void ftPikachu_80125BB4(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
-    func_8007C930(fighter, pika_attr->x54);
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
+    func_8007C930(fp, pika_attr->x54);
     func_8007CB74(fighterObj);
 }
 
 void ftPikachu_80125BF4(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
-    func_8007D494(fighter, pika_attr->x58, fighter->x110_attr.x170_TerminalVelocity);
-    func_8007CE94(fighter, pika_attr->x54);
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
+    func_8007D494(fp, pika_attr->x58, fp->x110_attr.x170_TerminalVelocity);
+    func_8007CE94(fp, pika_attr->x54);
 }
 
 void ftPikachu_80125C44(HSD_GObj* fighterObj) {
@@ -380,31 +380,31 @@ void ftPikachu_80125C44(HSD_GObj* fighterObj) {
 }
 
 void ftPikachu_80125C80(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     if (func_80081D0C(fighterObj)) {
-        func_8007D7FC(fighter);
+        func_8007D7FC(fp);
         ftPikachu_ActionChange_80125CD0(fighterObj);
     }
 }
 
 void ftPikachu_ActionChange_80125CD0(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
-    fighter->x2200_ftcmd_var0 = 0;
-    fighter->xEC_ground_vel /= pika_attr->x50;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->xEC_ground_vel /= pika_attr->x50;
 
     Fighter_ActionStateChange_800693AC(fighterObj, 0x15A, 0, 0, 0.0f, 1.0f, 0.0f);
 }
 
 void ftPikachu_ActionChange_80125D28(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
-    fighter->x2200_ftcmd_var0 = 0;
-    fighter->x80_self_vel.x /= pika_attr->x50;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x80_self_vel.x /= pika_attr->x50;
 
     Fighter_ActionStateChange_800693AC(fighterObj, 0x15F, 0, 0, 0.0f, 1.0f, 0.0f);
 }

--- a/src/melee/ft/chara/ftPikachu/ftpikachu4.c
+++ b/src/melee/ft/chara/ftPikachu/ftpikachu4.c
@@ -6,24 +6,24 @@
 
 // points velocity toward facing direction
 void ftPikachu_UpdateVel_80125D80(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    fighter->xEC_ground_vel = fighter->x2C_facing_direction * fabs_inline(fighter->xEC_ground_vel);
-    fighter->x80_self_vel.x = fighter->x2C_facing_direction * fabs_inline(fighter->x80_self_vel.x);
-    fighter->x234C_pos.y = fighter->x2C_facing_direction * fabs_inline(fighter->x234C_pos.y);
+    Fighter* fp = fighterObj->user_data;
+    fp->xEC_ground_vel = fp->x2C_facing_direction * fabs_inline(fp->xEC_ground_vel);
+    fp->x80_self_vel.x = fp->x2C_facing_direction * fabs_inline(fp->x80_self_vel.x);
+    fp->x234C_pos.y = fp->x2C_facing_direction * fabs_inline(fp->x234C_pos.y);
 }
 
 void ftPikachu_SpecialHi_StartAction(HSD_GObj* fighterObj) {
     s32 unused[2]; 
     ftPikachuAttributes* pika_attr;
-    Fighter* fighter = fighterObj->user_data;
-    pika_attr = fighter->x2D4_specialAttributes;
-    fighter->x2200_ftcmd_var0 = 0;
-    fighter->x2340_stateVar1 = pika_attr->x5C;
-    fighter->x2348_stateVar3 = 0;
-    fighter->x2358_stateVar7_s32 = 0;
-    fighter->xEC_ground_vel = 0.0f;
-    fighter->x80_self_vel.y = 0.0f;
-    fighter->x80_self_vel.x = 0.0f;
+    Fighter* fp = fighterObj->user_data;
+    pika_attr = fp->x2D4_specialAttributes;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2340_stateVar1 = pika_attr->x5C;
+    fp->x2348_stateVar3 = 0;
+    fp->x2358_stateVar7_s32 = 0;
+    fp->xEC_ground_vel = 0.0f;
+    fp->x80_self_vel.y = 0.0f;
+    fp->x80_self_vel.x = 0.0f;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x161, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(fighterObj);
 }
@@ -31,15 +31,15 @@ void ftPikachu_SpecialHi_StartAction(HSD_GObj* fighterObj) {
 void ftPikachu_SpecialAirHi_StartAction(HSD_GObj* fighterObj) {
     s32 unused[2]; 
     ftPikachuAttributes* pika_attr;
-    Fighter* fighter = fighterObj->user_data;
-    pika_attr = fighter->x2D4_specialAttributes;
-    fighter->x2200_ftcmd_var0 = 0;
-    fighter->x2340_stateVar1 = pika_attr->x5C;
-    fighter->x2348_stateVar3 = 0;
-    fighter->x2358_stateVar7_s32 = 0;
-    fighter->xEC_ground_vel = 0.0f;
-    fighter->x80_self_vel.y = 0.0f;
-    fighter->x80_self_vel.x = 0.0f;
+    Fighter* fp = fighterObj->user_data;
+    pika_attr = fp->x2D4_specialAttributes;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2340_stateVar1 = pika_attr->x5C;
+    fp->x2348_stateVar3 = 0;
+    fp->x2358_stateVar7_s32 = 0;
+    fp->xEC_ground_vel = 0.0f;
+    fp->x80_self_vel.y = 0.0f;
+    fp->x80_self_vel.x = 0.0f;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x164, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(fighterObj);
 }
@@ -66,15 +66,15 @@ void ftPikachu_80125F58(HSD_GObj* fighterObj) {
 
 void ftPikachu_80125F78(HSD_GObj* fighterObj) {
     s32 unused[2]; 
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
-    struct attr* attr = &fighter->x110_attr;
-    if (fighter->x2340_stateVar1) {
-        fighter->x2340_stateVar1--;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
+    struct attr* attr = &fp->x110_attr;
+    if (fp->x2340_stateVar1) {
+        fp->x2340_stateVar1--;
     } else {
-        func_8007D494(fighter, pika_attr->x64, attr->x170_TerminalVelocity);
+        func_8007D494(fp, pika_attr->x64, attr->x170_TerminalVelocity);
     }
-    func_8007CF58(fighter);
+    func_8007CF58(fp);
 }
 
 void ftPikachu_80125FD8(HSD_GObj* fighterObj) {
@@ -85,9 +85,9 @@ void ftPikachu_80125FD8(HSD_GObj* fighterObj) {
 
 void ftPikachu_80126014(HSD_GObj* fighterObj) {
     s32 unused;
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    if (EnvColl_CheckGroundAndLedge(fighterObj, fighter->x2C_facing_direction < 0.0f ? -1 : 1)) {
+    if (EnvColl_CheckGroundAndLedge(fighterObj, fp->x2C_facing_direction < 0.0f ? -1 : 1)) {
         ftPikachu_ActionChange_801260E4(fighterObj);
     } else  {
         if (func_80081298(fighterObj) == 0) { return; };
@@ -95,15 +95,15 @@ void ftPikachu_80126014(HSD_GObj* fighterObj) {
 }
 
 void ftPikachu_ActionChange_80126084(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D60C(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x164, 0xC4C5084, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = fighterObj->user_data;
+    func_8007D60C(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x164, 0xC4C5084, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 void ftPikachu_ActionChange_801260E4(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D7FC(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x161, 0xC4C5084, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = fighterObj->user_data;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x161, 0xC4C5084, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 void ftPikachu_80126144(HSD_GObj* fighterObj) {
@@ -111,32 +111,32 @@ void ftPikachu_80126144(HSD_GObj* fighterObj) {
     Vec vec2;
     s32 unused[5];
 
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     
-    fighter->x2344_stateVar2_s32--;
-    if (fighter->x2344_stateVar2_s32 <= 0) { 
+    fp->x2344_stateVar2_s32--;
+    if (fp->x2344_stateVar2_s32 <= 0) { 
         ftPikachu_ActionChangeUpdateVel_801274AC(fighterObj);
-        fighter = fighterObj->user_data;
-        if (fighter->x4_fighterKind != FTKIND_PICHU) {
-            func_8000B1CC(fighter->x5E8_fighterBones[func_8007500C(fighter, 2)].x0_jobj, 0, &vec);
+        fp = fighterObj->user_data;
+        if (fp->x4_fighterKind != FTKIND_PICHU) {
+            func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 2)].x0_jobj, 0, &vec);
             ef_Spawn(0x3F4, fighterObj, &vec);
-            fighter->x2219_flag.bits.b0 = 1;
-            fighter->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
-            fighter->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
+            fp->x2219_flag.bits.b0 = 1;
+            fp->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
+            fp->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
         }
     } else {
-        fighter = fighterObj->user_data;
-        if (fighter->x4_fighterKind != FTKIND_PICHU) { 
+        fp = fighterObj->user_data;
+        if (fp->x4_fighterKind != FTKIND_PICHU) { 
             f32 tempf;
-            func_8000B1CC(fighter->x5E8_fighterBones[func_8007500C(fighter, 2)].x0_jobj, 0, &vec2);
+            func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 2)].x0_jobj, 0, &vec2);
             tempf = HSD_Randf();
             vec2.x += (6.0f * tempf) - 3.0f; 
             tempf = HSD_Randf();
             vec2.y += (6.0f * tempf) - 3.0f;
             ef_Spawn(0x3F4, fighterObj, &vec2);  
-            fighter->x2219_flag.bits.b0 = 1;
-            fighter->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
-            fighter->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
+            fp->x2219_flag.bits.b0 = 1;
+            fp->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
+            fp->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
         }
     }
 }
@@ -146,32 +146,32 @@ void ftPikachu_801262B4(HSD_GObj* fighterObj) {
     Vec vec2;
     s32 unused[5];
 
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     
-    fighter->x2344_stateVar2_s32--;
-    if (fighter->x2344_stateVar2_s32 <= 0) { 
+    fp->x2344_stateVar2_s32--;
+    if (fp->x2344_stateVar2_s32 <= 0) { 
         ftPikachu_ActionChangeUpdateVel_80127534(fighterObj);
-        fighter = fighterObj->user_data;
-        if (fighter->x4_fighterKind != FTKIND_PICHU) {
-            func_8000B1CC(fighter->x5E8_fighterBones[func_8007500C(fighter, 2)].x0_jobj, 0, &vec);
+        fp = fighterObj->user_data;
+        if (fp->x4_fighterKind != FTKIND_PICHU) {
+            func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 2)].x0_jobj, 0, &vec);
             ef_Spawn(0x3F4, fighterObj, &vec);
-            fighter->x2219_flag.bits.b0 = 1;
-            fighter->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
-            fighter->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
+            fp->x2219_flag.bits.b0 = 1;
+            fp->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
+            fp->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
         }
     } else {
-        fighter = fighterObj->user_data;
-        if (fighter->x4_fighterKind != FTKIND_PICHU) { 
+        fp = fighterObj->user_data;
+        if (fp->x4_fighterKind != FTKIND_PICHU) { 
             f32 tempf;
-            func_8000B1CC(fighter->x5E8_fighterBones[func_8007500C(fighter, 2)].x0_jobj, 0, &vec2);
+            func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 2)].x0_jobj, 0, &vec2);
             tempf = HSD_Randf();
             vec2.x += (10.0f * tempf) - 5.0f; 
             tempf = HSD_Randf();
             vec2.y += (10.0f * tempf) - 5.0f;
             ef_Spawn(0x3F4, fighterObj, &vec2);  
-            fighter->x2219_flag.bits.b0 = 1;
-            fighter->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
-            fighter->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
+            fp->x2219_flag.bits.b0 = 1;
+            fp->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
+            fp->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
         }
     }
 }
@@ -186,38 +186,38 @@ void ftPikachu_8012642C(HSD_GObj* fighterObj) {
     s32 unused;
 
     HSD_JObj* jobj;
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
     
     f32 half_pi = HALF_PI;
-    f32 tempf = (fighter->x2C_facing_direction * atan2f(fighter->x80_self_vel.x, fighter->x80_self_vel.y)) 
+    f32 tempf = (fp->x2C_facing_direction * atan2f(fp->x80_self_vel.x, fp->x80_self_vel.y)) 
         + (pika_attr->x78 - half_pi);
     
-    func_8007592C(fighter, func_8007500C(fighter, 2), tempf);
+    func_8007592C(fp, func_8007500C(fp, 2), tempf);
     scale.x = pika_attr->x7C_scale.x;
     scale.y = pika_attr->x7C_scale.y;
     scale.z = pika_attr->x7C_scale.z;
-    jobj = fighter->x5E8_fighterBones[func_8007500C(fighter, 2)].x0_jobj;
+    jobj = fp->x5E8_fighterBones[func_8007500C(fp, 2)].x0_jobj;
     HSD_JObjSetScale(jobj, &scale); 
     
-    velocity_vec = fighter->x80_self_vel;
+    velocity_vec = fp->x80_self_vel;
     func_8007E2FC(fighterObj);
-    fighter->x80_self_vel = velocity_vec;
+    fp->x80_self_vel = velocity_vec;
  
     
-    fighter->x6D8.x = 
-    fighter->x6D8.y = 
-    fighter->x6D8.z = 
-    fighter->x6C0.x = 
-    fighter->x6C0.y = 
-    fighter->x6C0.z = 
-    fighter->x6BC_inputStickangle = 
-    fighter->x6A4_transNOffset.x = 
-    fighter->x6A4_transNOffset.y = 
-    fighter->x6A4_transNOffset.z =  
-    fighter->x68C_transNPos.x = 
-    fighter->x68C_transNPos.y = 
-    fighter->x68C_transNPos.z = 0.0f;
+    fp->x6D8.x = 
+    fp->x6D8.y = 
+    fp->x6D8.z = 
+    fp->x6C0.x = 
+    fp->x6C0.y = 
+    fp->x6C0.z = 
+    fp->x6BC_inputStickangle = 
+    fp->x6A4_transNOffset.x = 
+    fp->x6A4_transNOffset.y = 
+    fp->x6A4_transNOffset.z =  
+    fp->x68C_transNPos.x = 
+    fp->x68C_transNPos.y = 
+    fp->x68C_transNPos.z = 0.0f;
 }
 
 void ftPikachu_801265D4(HSD_GObj* fighterObj) {
@@ -238,14 +238,14 @@ void ftPikachu_80126614(HSD_GObj* fighterObj) {
 
     HSD_JObj *jobj;
 
-    Fighter* fighter = fighterObj->user_data;
-    CollData* collData = &fighter->x6F0_collData;
+    Fighter* fp = fighterObj->user_data;
+    CollData* collData = &fp->x6F0_collData;
 
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
     if (!func_80082888(fighterObj, &pika_attr->height_attributes)) {
         if ((collData->x134_envFlags & 0x3F) || (collData->x134_envFlags & 0xFC0)) {
-            func_8007D60C(fighter);
+            func_8007D60C(fp);
             ftPikachu_ActionChangeUpdateVel_80127534(fighterObj);
             return;
         }
@@ -292,19 +292,19 @@ BOOL ftPikachu_GetBool(HSD_GObj* fighterObj) {
 void ftPikachu_801267C8(HSD_GObj* fighterObj) {
     s32 unused[5];
     BOOL bool0;
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
-    CollData* collData = &fighter->x6F0_collData;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
+    CollData* collData = &fp->x6F0_collData;
 
-    fighter->x2358_stateVar7_s32++;
-    if (EnvColl_CheckGroundAndLedge(fighterObj, fighter->x2C_facing_direction < 0.0f ? -1 : 1)) {
+    fp->x2358_stateVar7_s32++;
+    if (EnvColl_CheckGroundAndLedge(fighterObj, fp->x2C_facing_direction < 0.0f ? -1 : 1)) {
         bool0 = ftPikachu_GetBool(fighterObj);
 
 
         if (bool0) {
-            f32 tempf = lbvector_AngleXY(&collData->x154_groundNormal, &fighter->x80_self_vel);
+            f32 tempf = lbvector_AngleXY(&collData->x154_groundNormal, &fp->x80_self_vel);
             if (tempf > (DEG_TO_RAD * (90.0f + pika_attr->xA0))) {
-                func_8007D7FC(fighter);
+                func_8007D7FC(fp);
                 ftPikachu_ActionChangeUpdateVel_801274AC(fighterObj);
                 return; 
             }
@@ -316,21 +316,21 @@ void ftPikachu_801267C8(HSD_GObj* fighterObj) {
     if (!func_80081298(fighterObj)) {
 
         if (collData->x134_envFlags & 0x6000) {
-            f32 angle = lbvector_AngleXY(&collData->x190_vec, &fighter->x80_self_vel);
+            f32 angle = lbvector_AngleXY(&collData->x190_vec, &fp->x80_self_vel);
             if (angle > (DEG_TO_RAD * (90.0f + pika_attr->xA0))) {
                 ftPikachu_ActionChangeUpdateVel_80127534(fighterObj);
             }
         }
 
         if (collData->x134_envFlags & 0x3F) {
-            f32 angle = lbvector_AngleXY(&collData->x168_vec, &fighter->x80_self_vel);
+            f32 angle = lbvector_AngleXY(&collData->x168_vec, &fp->x80_self_vel);
             if (angle > (DEG_TO_RAD * (90.0f + pika_attr->xA0))) {
                 ftPikachu_ActionChangeUpdateVel_80127534(fighterObj);
             }
         }
 
         if (collData->x134_envFlags & 0xFC0) {
-            f32 angle = lbvector_AngleXY(&collData->x17C_vec, &fighter->x80_self_vel);
+            f32 angle = lbvector_AngleXY(&collData->x17C_vec, &fp->x80_self_vel);
             if (angle > (DEG_TO_RAD * (90.0f + pika_attr->xA0))) {
                 ftPikachu_ActionChangeUpdateVel_80127534(fighterObj);
             }
@@ -342,10 +342,10 @@ void ftPikachu_801267C8(HSD_GObj* fighterObj) {
 #pragma dont_inline on
 void ftPikachu_ActionChange_80126A2C(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D60C(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x165, 0xC4C508A, 0, fighter->x894_currentAnimFrame, 0.0f, 0.0f);
-    fighter->x2223_flag.bits.b4 = 1;
+    Fighter* fp = fighterObj->user_data;
+    func_8007D60C(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x165, 0xC4C508A, 0, fp->x894_currentAnimFrame, 0.0f, 0.0f);
+    fp->x2223_flag.bits.b4 = 1;
     ftPikachu_8012642C(fighterObj);
 }
 #pragma dont_inline off
@@ -357,7 +357,7 @@ void ftPikachu_ActionChange_80126AA4(HSD_GObj* fighterObj) {
     CollData* collData;
     ftPikachuAttributes* pika_attr;
     
-    Fighter* fighter;
+    Fighter* fp;
     Fighter* fighter2;
     
     HSD_JObj *jobj;
@@ -366,18 +366,18 @@ void ftPikachu_ActionChange_80126AA4(HSD_GObj* fighterObj) {
     func_8007D7FC(fighter2);
     Fighter_ActionStateChange_800693AC(fighterObj, 0x162, 0xC4C508A, 0, fighter2->x894_currentAnimFrame, 0.0f, 0.0f);
     
-    fighter = fighterObj->user_data;
-    collData = &fighter->x6F0_collData;
-    pika_attr = fighter->x2D4_specialAttributes;
-    if (fighter->x6F0_collData.x134_envFlags & 0x18000) {
-        f32 angle = (fighter->x2C_facing_direction * atan2f(collData->x154_groundNormal.x, collData->x154_groundNormal.y)) + pika_attr->x68;
-        func_8007592C(fighter, func_8007500C(fighter, 2), angle);
+    fp = fighterObj->user_data;
+    collData = &fp->x6F0_collData;
+    pika_attr = fp->x2D4_specialAttributes;
+    if (fp->x6F0_collData.x134_envFlags & 0x18000) {
+        f32 angle = (fp->x2C_facing_direction * atan2f(collData->x154_groundNormal.x, collData->x154_groundNormal.y)) + pika_attr->x68;
+        func_8007592C(fp, func_8007500C(fp, 2), angle);
     }
     
     scale.x = pika_attr->x6C_scale.x;
     scale.y = pika_attr->x6C_scale.y;
     scale.z = pika_attr->x6C_scale.z;
-    jobj = fighter->x5E8_fighterBones[func_8007500C(fighter, 2)].x0_jobj;
+    jobj = fp->x5E8_fighterBones[func_8007500C(fp, 2)].x0_jobj;
     HSD_JObjSetScale(jobj, &scale);
 }
 
@@ -389,13 +389,13 @@ inline float get_max_and_fill_stack() {
 
 // grounded up b zip
 void ftPikachu_80126C0C(HSD_GObj* fighterObj) { 
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    CollData* collData = &fighter->x6F0_collData;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    CollData* collData = &fp->x6F0_collData;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
     // distance formula
-    f32 stick_mag = sqrtf((fighter->input.x620_lstick_x * fighter->input.x620_lstick_x) + (fighter->input.x624_lstick_y * fighter->input.x624_lstick_y));
+    f32 stick_mag = sqrtf((fp->input.x620_lstick_x * fp->input.x620_lstick_x) + (fp->input.x624_lstick_y * fp->input.x624_lstick_y));
 
     // cap stick magnitude to MAX_STICK_MAG
     if (stick_mag > MAX_STICK_MAG) {
@@ -405,18 +405,18 @@ void ftPikachu_80126C0C(HSD_GObj* fighterObj) {
     if (!(stick_mag < pika_attr->x8C)) {
         Vec lstick_direction;
     
-        lstick_direction.x = fighter->input.x620_lstick_x;
-        lstick_direction.y = fighter->input.x624_lstick_y;
+        lstick_direction.x = fp->input.x620_lstick_x;
+        lstick_direction.y = fp->input.x624_lstick_y;
         lstick_direction.z = 0.0f;
 
-        // if the angular difference between the ground normal and the stick < 90° and (some check on the fighter)
+        // if the angular difference between the ground normal and the stick < 90° and (some check on the fp)
         if (!(lbvector_AngleXY(&collData->x154_groundNormal, &lstick_direction) < HALF_PI) && (!func_8009A134(fighterObj))) {
             Fighter* fighter2;
-            func_8007D9FC(fighter);
+            func_8007D9FC(fp);
             
             // store stick angle to compare during zip2 check
-            fighter->x234C_pos.y = lstick_direction.x;
-            fighter->x234C_pos.z = lstick_direction.y;
+            fp->x234C_pos.y = lstick_direction.x;
+            fp->x234C_pos.z = lstick_direction.y;
 
             fighter2 = fighterObj->user_data;
 
@@ -428,13 +428,13 @@ void ftPikachu_80126C0C(HSD_GObj* fighterObj) {
 
             // set ground velocity to (zip_slope * stick_mag) + zip_intercept
             // and then flip based on facing direction
-            fighter->xEC_ground_vel = (pika_attr->x90 * stick_mag) + pika_attr->x94;
-            fighter->xEC_ground_vel *= fighter->x2C_facing_direction;
+            fp->xEC_ground_vel = (pika_attr->x90 * stick_mag) + pika_attr->x94;
+            fp->xEC_ground_vel *= fp->x2C_facing_direction;
 
             // if second zip
-            if (fighter->x2348_stateVar3_s32) {
+            if (fp->x2348_stateVar3_s32) {
                 // multiply ground velocity by second_zip_decay
-                fighter->xEC_ground_vel *= pika_attr->x98;
+                fp->xEC_ground_vel *= pika_attr->x98;
                 
                 Fighter_ActionStateChange_800693AC(fighterObj, 0x162, 2, 0, 12.0f, 1.0f, 0.0f);
                 func_8006EBA4(fighterObj);
@@ -442,12 +442,12 @@ void ftPikachu_80126C0C(HSD_GObj* fighterObj) {
             Fighter_ActionStateChange_800693AC(fighterObj, 0x162, 0xA, 0, 13.0f, 1.0f, 0.0f);
             func_8006EBA4(fighterObj);
             ftAnim_SetAnimRate(fighterObj, 0.0f); 
-            fighter->x2223_flag.bits.b4 = 1;
-            fighter->cb.x21F8_callback = &ftPikachu_UpdateVel_80125D80;
+            fp->x2223_flag.bits.b4 = 1;
+            fp->cb.x21F8_callback = &ftPikachu_UpdateVel_80125D80;
             return;
         }
     }
-    func_8007D60C(fighter);
+    func_8007D60C(fp);
     ftPikachu_80126E1C(fighterObj);
 }
 
@@ -458,12 +458,12 @@ void ftPikachu_80126E1C(HSD_GObj* fighterObj) {
     f32 final_stick_mag;
 
     Fighter* fighter2;
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
     // distance formula
-    f32 temp_stick_mag = sqrtf((fighter->input.x620_lstick_x * fighter->input.x620_lstick_x) + (fighter->input.x624_lstick_y * fighter->input.x624_lstick_y));
+    f32 temp_stick_mag = sqrtf((fp->input.x620_lstick_x * fp->input.x620_lstick_x) + (fp->input.x624_lstick_y * fp->input.x624_lstick_y));
 
     final_stick_mag = temp_stick_mag;
 
@@ -474,27 +474,27 @@ void ftPikachu_80126E1C(HSD_GObj* fighterObj) {
 
     if ((final_stick_mag > pika_attr->x8C)) {
 
-        if (fabs_inline(fighter->input.x620_lstick_x) > 0.001f) {
-            func_8007D9FC(fighter);
+        if (fabs_inline(fp->input.x620_lstick_x) > 0.001f) {
+            func_8007D9FC(fp);
         }
 
         // zip angle = atan2(stick_y, stick_x * facing_direction)
-        some_angle = atan2f(fighter->input.x624_lstick_y, fighter->input.x620_lstick_x * fighter->x2C_facing_direction);
+        some_angle = atan2f(fp->input.x624_lstick_y, fp->input.x620_lstick_x * fp->x2C_facing_direction);
         
         // store stick angle to compare during zip2 check
-        fighter->x234C_pos.y = fighter->input.x620_lstick_x;
-        fighter->x234C_pos.z = fighter->input.x624_lstick_y;
+        fp->x234C_pos.y = fp->input.x620_lstick_x;
+        fp->x234C_pos.z = fp->input.x624_lstick_y;
     } else {
         // set facing direction if stick x meets a threshold
-        func_8007DA24(fighter);
+        func_8007DA24(fp);
 
         // use max stick_mag and 90°
         final_stick_mag = MAX_STICK_MAG;
         some_angle = HALF_PI;
 
         // store inputs as if x=0 and y=max
-        fighter->x234C_pos.y = 0.0f;
-        fighter->x234C_pos.z = MAX_STICK_MAG;
+        fp->x234C_pos.y = 0.0f;
+        fp->x234C_pos.z = MAX_STICK_MAG;
     }
 
     fighter2 = fighterObj->user_data;
@@ -508,15 +508,15 @@ void ftPikachu_80126E1C(HSD_GObj* fighterObj) {
     // compute velocity as (zip slope * stick_mag) + zip intercept
     // x velocity is the same but flips based on facing direction
     temp_f2_2 = ((pika_attr->x90 * final_stick_mag) + pika_attr->x94) * cosf(some_angle);
-    fighter->x80_self_vel.x = fighter->x2C_facing_direction * temp_f2_2;
-    fighter->x80_self_vel.y = ((pika_attr->x90 * final_stick_mag) + pika_attr->x94) * sinf(some_angle);
+    fp->x80_self_vel.x = fp->x2C_facing_direction * temp_f2_2;
+    fp->x80_self_vel.y = ((pika_attr->x90 * final_stick_mag) + pika_attr->x94) * sinf(some_angle);
 
 
     // if second zip
-    if (fighter->x2348_stateVar3_s32) {
+    if (fp->x2348_stateVar3_s32) {
         // multiply velocity by second-zip decay
-        fighter->x80_self_vel.x *= pika_attr->x98;
-        fighter->x80_self_vel.y *= pika_attr->x98;
+        fp->x80_self_vel.x *= pika_attr->x98;
+        fp->x80_self_vel.y *= pika_attr->x98;
 
         Fighter_ActionStateChange_800693AC(fighterObj, 0x165, 2, 0, 12.0f, 1.0f, 0.0f);
         func_8006EBA4(fighterObj);
@@ -524,10 +524,10 @@ void ftPikachu_80126E1C(HSD_GObj* fighterObj) {
     Fighter_ActionStateChange_800693AC(fighterObj, 0x165, 0xA, 0, 13.0f, 1.0f, 0.0f);
     func_8006EBA4(fighterObj);
     ftAnim_SetAnimRate(fighterObj, 0.0f); 
-    fighter->x2223_flag.bits.b4 = 1;
+    fp->x2223_flag.bits.b4 = 1;
 
     // set velocity to move toward facing direction
-    fighter->cb.x21F8_callback = &ftPikachu_UpdateVel_80125D80;
+    fp->cb.x21F8_callback = &ftPikachu_UpdateVel_80125D80;
     
 }
 
@@ -543,29 +543,29 @@ s32 ftPikachu_80127064(HSD_GObj* fighterObj) {
     Vec vec1;
     Vec vec2;
 
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;    
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;    
 
     // distance formula
-    f32 stick_mag = sqrtf((fighter->input.x620_lstick_x * fighter->input.x620_lstick_x) + (fighter->input.x624_lstick_y * fighter->input.x624_lstick_y));
+    f32 stick_mag = sqrtf((fp->input.x620_lstick_x * fp->input.x620_lstick_x) + (fp->input.x624_lstick_y * fp->input.x624_lstick_y));
 
     // if stick_mag is less than the threshold, push the max stick magnitude onto the stack and return 0
     if (stick_mag < pika_attr->x8C) {
         return return_and_fill_stack();
     }
 
-    if (!fighter->x2348_stateVar3_s32) {
+    if (!fp->x2348_stateVar3_s32) {
         f32 tempf;
 
         // push current stick to temporary vector
-        vec1.x = fighter->input.x620_lstick_x;
-        vec1.y = fighter->input.x624_lstick_y;
+        vec1.x = fp->input.x620_lstick_x;
+        vec1.y = fp->input.x624_lstick_y;
         vec1.z = 0.0f;
 
         // push stick from zip1 to temporary vector
-        vec2.x = fighter->x234C_pos.y;
-        vec2.y = fighter->x234C_pos.z;
+        vec2.x = fp->x234C_pos.y;
+        vec2.y = fp->x234C_pos.z;
         vec2.z = 0.0f;
         
         // get the angular difference between them
@@ -581,15 +581,15 @@ s32 ftPikachu_80127064(HSD_GObj* fighterObj) {
 }
 
 void ftPikachu_80127198(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    if ((u32) fighter->x2200_ftcmd_var0 == 1U) {
+    Fighter* fp = fighterObj->user_data;
+    if ((u32) fp->x2200_ftcmd_var0 == 1U) {
         if (ftPikachu_80127064(fighterObj)) {
-            fighter->x2200_ftcmd_var0 = 0;
-            fighter->x2348_stateVar3 = 1;
+            fp->x2200_ftcmd_var0 = 0;
+            fp->x2348_stateVar3 = 1;
             ftPikachu_80126C0C(fighterObj);
             return;
         }
-        fighter->x2200_ftcmd_var0 = 2;
+        fp->x2200_ftcmd_var0 = 2;
         return;
     }
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
@@ -599,16 +599,16 @@ void ftPikachu_80127198(HSD_GObj* fighterObj) {
 
 void ftPikachu_80127228(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
-    if (fighter->x2200_ftcmd_var0 == 1) {
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
+    if (fp->x2200_ftcmd_var0 == 1) {
         if (ftPikachu_80127064(fighterObj)) {
-            fighter->x2200_ftcmd_var0 = 0;
-            fighter->x2348_stateVar3 = 1;
+            fp->x2200_ftcmd_var0 = 0;
+            fp->x2348_stateVar3 = 1;
             ftPikachu_80126E1C(fighterObj);
             return;
         }
-        fighter->x2200_ftcmd_var0 = 2;
+        fp->x2200_ftcmd_var0 = 2;
         return;
     }
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
@@ -621,29 +621,29 @@ void ftPikachu_Stub_801272D8() {}
 void ftPikachu_Stub_801272DC() {}
 
 void ftPikachu_801272E0(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    if (fighter->x2200_ftcmd_var0) {
+    Fighter* fp = fighterObj->user_data;
+    if (fp->x2200_ftcmd_var0) {
         func_80084F3C(fighterObj);
     }
 }
 
 void ftPikachu_80127310(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
-    if (fighter->x2200_ftcmd_var0) {
-        func_8007D4B8(fighter);
-        func_8007D440(fighter, pika_attr->x9C * fighter->x110_attr.x17C_AerialDriftMax);
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
+    if (fp->x2200_ftcmd_var0) {
+        func_8007D4B8(fp);
+        func_8007D440(fp, pika_attr->x9C * fp->x110_attr.x17C_AerialDriftMax);
         return;
     }
-    fighter->x80_self_vel.y -= (fighter->x80_self_vel.y / 9.0f);
-    func_8007CEF4(fighter);
+    fp->x80_self_vel.y -= (fp->x80_self_vel.y / 9.0f);
+    func_8007CEF4(fp);
 }
 
 void ftPikachu_8012738C(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
     if (!func_80082888(fighterObj, &pika_attr->height_attributes)) {
         ftPikachu_ActionChange_8012744C(fighterObj);
     }
@@ -651,9 +651,9 @@ void ftPikachu_8012738C(HSD_GObj* fighterObj) {
 
 void ftPikachu_801273D4(HSD_GObj* fighterObj) {
     s32 unused[2];
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
-    if (func_8008239C(fighterObj, fighter->x2C_facing_direction, pika_attr->height_attributes)) {
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
+    if (func_8008239C(fighterObj, fp->x2C_facing_direction, pika_attr->height_attributes)) {
         func_800D5CB0(fighterObj, 0, pika_attr->xB0);
         return;
     }
@@ -661,42 +661,42 @@ void ftPikachu_801273D4(HSD_GObj* fighterObj) {
 }
 
 void ftPikachu_ActionChange_8012744C(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D60C(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x166, 0xC4C508A, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = fighterObj->user_data;
+    func_8007D60C(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x166, 0xC4C508A, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 void ftPikachu_ActionChangeUpdateVel_801274AC(HSD_GObj* fighterObj) {
     s32 unused[2]; 
     ftPikachuAttributes* pika_attr;
-    Fighter* fighter = fighterObj->user_data;
-    pika_attr = fighter->x2D4_specialAttributes;
-    fighter->x235C = fighter->x80_self_vel.x;
-    fighter->x2360_f32 = fighter->x80_self_vel.y;
-    fighter->x2364 = fighter->xEC_ground_vel;
+    Fighter* fp = fighterObj->user_data;
+    pika_attr = fp->x2D4_specialAttributes;
+    fp->x235C = fp->x80_self_vel.x;
+    fp->x2360_f32 = fp->x80_self_vel.y;
+    fp->x2364 = fp->xEC_ground_vel;
     
-    fighter->x80_self_vel.y = 0.0f;
-    fighter->x80_self_vel.x = 0.0f;
-    fighter->xEC_ground_vel = 0.0f;
-    fighter->xEC_ground_vel = fighter->x2364 * pika_attr->xA4;
+    fp->x80_self_vel.y = 0.0f;
+    fp->x80_self_vel.x = 0.0f;
+    fp->xEC_ground_vel = 0.0f;
+    fp->xEC_ground_vel = fp->x2364 * pika_attr->xA4;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x163, 2, 0, 0.0f, 1.0f, 0.0f);
-    fighter->cb.x21F8_callback = &ftPikachu_UpdateVel_80125D80;
+    fp->cb.x21F8_callback = &ftPikachu_UpdateVel_80125D80;
 }
 
 void ftPikachu_ActionChangeUpdateVel_80127534(HSD_GObj* fighterObj) {
     s32 unused[2]; 
     ftPikachuAttributes* pika_attr;
-    Fighter* fighter = fighterObj->user_data;
-    pika_attr = fighter->x2D4_specialAttributes;
-    fighter->x235C = fighter->x80_self_vel.x;
-    fighter->x2360_f32 = fighter->x80_self_vel.y;
-    fighter->x2364 = fighter->xEC_ground_vel;
+    Fighter* fp = fighterObj->user_data;
+    pika_attr = fp->x2D4_specialAttributes;
+    fp->x235C = fp->x80_self_vel.x;
+    fp->x2360_f32 = fp->x80_self_vel.y;
+    fp->x2364 = fp->xEC_ground_vel;
     
-    fighter->x80_self_vel.y = 0.0f;
-    fighter->x80_self_vel.x = 0.0f;
-    fighter->xEC_ground_vel = 0.0f;
-    fighter->x80_self_vel.x = fighter->x235C * pika_attr->xA4;
-    fighter->x80_self_vel.y = fighter->x2360_f32 * pika_attr->xA4;
+    fp->x80_self_vel.y = 0.0f;
+    fp->x80_self_vel.x = 0.0f;
+    fp->xEC_ground_vel = 0.0f;
+    fp->x80_self_vel.x = fp->x235C * pika_attr->xA4;
+    fp->x80_self_vel.y = fp->x2360_f32 * pika_attr->xA4;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x166, 2, 0, 0.0f, 1.0f, 0.0f);
-    fighter->cb.x21F8_callback = &ftPikachu_UpdateVel_80125D80;
+    fp->cb.x21F8_callback = &ftPikachu_UpdateVel_80125D80;
 }

--- a/src/melee/ft/chara/ftPikachu/ftpikachu5.c
+++ b/src/melee/ft/chara/ftPikachu/ftpikachu5.c
@@ -1,9 +1,9 @@
 #include <ftpikachu.h>
 
 s32 ftPikachu_CheckProperty_801275CC(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    s32 value = fighter->x2071_b0_3;
+    s32 value = fp->x2071_b0_3;
 
     switch (value) {
         case 1: 
@@ -27,14 +27,14 @@ s32 ftPikachu_CheckProperty_801275CC(HSD_GObj* fighterObj) {
 }
 
 void ftPikachu_80127608(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_80030E44(2, &fighter->xB0_pos);
-    func_8007EBAC(fighter, 0xB, 0);
+    Fighter* fp = fighterObj->user_data;
+    func_80030E44(2, &fp->xB0_pos);
+    func_8007EBAC(fp, 0xB, 0);
 }
 
 void ftPikachu_SetState_8012764C(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    fighter->x2344_stateVar2 = 3;
+    Fighter* fp = fighterObj->user_data;
+    fp->x2344_stateVar2 = 3;
 }
 
 
@@ -48,11 +48,11 @@ inline f32 nested_sum_fabs(f32 fighter_pos_y, f32 pika_attr_xBC, f32 pika_attr_x
 
 s32 ftPikachu_8012765C(HSD_GObj* fighterObj) {
     Vec vec;
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
-    u32 state_var = fighter->x2340_stateVar1_u32;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
+    u32 state_var = fp->x2340_stateVar1_u32;
 
-    if (!fighter->x2344_stateVar2_s32) {
+    if (!fp->x2344_stateVar2_s32) {
         return 0;
     }
 
@@ -63,19 +63,19 @@ s32 ftPikachu_8012765C(HSD_GObj* fighterObj) {
     }
     
 
-    if (fabs_inline(fighter->xB0_pos.x - vec.x) < fabs_inline(pika_attr->xC4)) {
+    if (fabs_inline(fp->xB0_pos.x - vec.x) < fabs_inline(pika_attr->xC4)) {
 
-        f32 final_y_pos = nested_sum_fabs(fighter->xB0_pos.y, pika_attr->xBC, fabs_inline(pika_attr->xBC), vec.y);
+        f32 final_y_pos = nested_sum_fabs(fp->xB0_pos.y, pika_attr->xBC, fabs_inline(pika_attr->xBC), vec.y);
 
         if (
             (final_y_pos < pika_attr->xC8) 
             && 
-            fighter->x2340_stateVar1_u32 
+            fp->x2340_stateVar1_u32 
             && 
-            !func_802B1DEC(fighter->x2340_stateVar1_u32)
+            !func_802B1DEC(fp->x2340_stateVar1_u32)
         )
         {
-            func_802B1FC8(fighter->x2340_stateVar1_u32);
+            func_802B1FC8(fp->x2340_stateVar1_u32);
             return 1;
         }
     }
@@ -85,8 +85,8 @@ s32 ftPikachu_8012765C(HSD_GObj* fighterObj) {
 }
 
 void ftPikachu_SetState_8012779C(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    fighter->x2344_stateVar2 = 0;
+    Fighter* fp = fighterObj->user_data;
+    fp->x2344_stateVar2 = 0;
 }
 
 void ftPikachu_EfSpawn_801277AC(HSD_GObj* fighterObj) {
@@ -96,21 +96,21 @@ void ftPikachu_EfSpawn_801277AC(HSD_GObj* fighterObj) {
     Vec vec3;
     s32 unused2[2];
     
-    Fighter* fighter;
+    Fighter* fp;
     ftPikachuAttributes* pika_attr;
     BOOL flag_check;
 
-    fighter = fighterObj->user_data;
-    pika_attr = fighter->x2D4_specialAttributes;
+    fp = fighterObj->user_data;
+    pika_attr = fp->x2D4_specialAttributes;
     
-    if (fighter->x2210_ThrowFlags.b0) {
-        fighter->x2210_ThrowFlags.b0 = 0;
+    if (fp->x2210_ThrowFlags.b0) {
+        fp->x2210_ThrowFlags.b0 = 0;
         flag_check = 1;
     } else {
         flag_check = 0;
     }
-    if (flag_check && !fighter->x2340_stateVar1_u32) {
-        vec1 = fighter->xB0_pos;
+    if (flag_check && !fp->x2340_stateVar1_u32) {
+        vec1 = fp->xB0_pos;
 
         vec1.y += pika_attr->xD0;
         vec2 = vec1;
@@ -120,86 +120,86 @@ void ftPikachu_EfSpawn_801277AC(HSD_GObj* fighterObj) {
             vec3.z = 0.0f;
             vec3.x = 0.0f;
             vec3.y = pika_attr->xC0;
-            fighter->x2340_stateVar1 = func_802B1DF8(fighterObj, &vec1, &vec3, pika_attr->xD4, pika_attr->xD8, pika_attr->xDC);
+            fp->x2340_stateVar1 = func_802B1DF8(fighterObj, &vec1, &vec3, pika_attr->xD4, pika_attr->xD8, pika_attr->xDC);
         }
     }
 }
 
 void ftPikachu_SpecialLw_StartAction(HSD_GObj* fighterObj) {
 
-    Fighter* fighter = fighterObj->user_data;
-    fighter->x2200_ftcmd_var0 = 0;
-    *((u32*)(&fighter->x2210_ThrowFlags)) = 0;
-    fighter->x2344_stateVar2 = 1;
-    fighter->x2340_stateVar1 = 0;
+    Fighter* fp = fighterObj->user_data;
+    fp->x2200_ftcmd_var0 = 0;
+    *((u32*)(&fp->x2210_ThrowFlags)) = 0;
+    fp->x2344_stateVar2 = 1;
+    fp->x2340_stateVar1 = 0;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x167, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(fighterObj);
 }
 
 void ftPikachu_SpecialAirLw_StartAction(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    fighter->x2200_ftcmd_var0 = 0;
-    *((u32*)(&fighter->x2210_ThrowFlags)) = 0;
-    fighter->x2344_stateVar2 = 1;
-    fighter->x2340_stateVar1 = 0;
+    Fighter* fp = fighterObj->user_data;
+    fp->x2200_ftcmd_var0 = 0;
+    *((u32*)(&fp->x2210_ThrowFlags)) = 0;
+    fp->x2344_stateVar2 = 1;
+    fp->x2340_stateVar1 = 0;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x16B, 0, 0, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(fighterObj);
 }
 
 void ftPikachu_ActionChange_8012798C(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D7FC(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x167, 0xC4C5086, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = fighterObj->user_data;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x167, 0xC4C5086, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 void ftPikachu_ActionChange_801279EC(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D5D4(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x16B, 0xC4C5086, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
-    func_8007D468(fighter);
+    Fighter* fp = fighterObj->user_data;
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x16B, 0xC4C5086, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
+    func_8007D468(fp);
 }
 
 void ftPikachu_ActionChange_80127A54(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D7FC(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x168, 0xC4C588E, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
-    fighter->cb.x21DC_callback_OnTakeDamage = &ftPikachu_SetState_8012779C;
-    fighter->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_801277AC;
+    Fighter* fp = fighterObj->user_data;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x168, 0xC4C588E, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
+    fp->cb.x21DC_callback_OnTakeDamage = &ftPikachu_SetState_8012779C;
+    fp->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_801277AC;
 }
 
 void ftPikachu_ActionChange_80127ACC(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D5D4(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x16C, 0xC4C588E, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
-    fighter->cb.x21DC_callback_OnTakeDamage = &ftPikachu_SetState_8012779C;
-    fighter->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_801277AC;
-    func_8007D468(fighter);
+    Fighter* fp = fighterObj->user_data;
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x16C, 0xC4C588E, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
+    fp->cb.x21DC_callback_OnTakeDamage = &ftPikachu_SetState_8012779C;
+    fp->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_801277AC;
+    func_8007D468(fp);
 }
 
 void ftPikachu_ActionChange_80127B4C(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D7FC(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x169, 0xC4C508E, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = fighterObj->user_data;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x169, 0xC4C508E, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 void ftPikachu_ActionChange_80127BAC(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D5D4(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x16D, 0xC4C508E, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
-    func_8007D468(fighter);
+    Fighter* fp = fighterObj->user_data;
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x16D, 0xC4C508E, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
+    func_8007D468(fp);
 }
 
 void ftPikachu_ActionChange_80127C14(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D7FC(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x16A, 0xC4C5086, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = fighterObj->user_data;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x16A, 0xC4C5086, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 }
 
 void ftPikachu_ActionChange_80127C74(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    func_8007D5D4(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x16E, 0xC4C5086, 0, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
-    func_8007D468(fighter);
+    Fighter* fp = fighterObj->user_data;
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x16E, 0xC4C5086, 0, fp->x894_currentAnimFrame, 1.0f, 0.0f);
+    func_8007D468(fp);
 }
 
 void ftPikachu_ActionChange_80127CDC(HSD_GObj* fighterObj) {
@@ -207,12 +207,12 @@ void ftPikachu_ActionChange_80127CDC(HSD_GObj* fighterObj) {
 
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
         Fighter *fighter_copy;
-        Fighter *fighter = fighterObj->user_data;
+        Fighter *fp = fighterObj->user_data;
         Fighter_ActionStateChange_800693AC(fighterObj, 0x168, 0x800, 0, 0.0f, 1.0f, 0.0f);
         fighter_copy = fighterObj->user_data;
         *((u32*)(&fighter_copy->x2210_ThrowFlags)) = 0;
         fighter_copy->cb.x21DC_callback_OnTakeDamage = &ftPikachu_SetState_8012779C;
-        fighter->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_801277AC;
+        fp->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_801277AC;
 
     }
 }
@@ -222,21 +222,21 @@ void ftPikachu_ActionChange_80127D60(HSD_GObj* fighterObj) {
 
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
         Fighter *fighter_copy;
-        Fighter *fighter = fighterObj->user_data;
+        Fighter *fp = fighterObj->user_data;
         Fighter_ActionStateChange_800693AC(fighterObj, 0x16C, 0x800, 0, 0.0f, 1.0f, 0.0f);
         fighter_copy = fighterObj->user_data;
         *((u32*)(&fighter_copy->x2210_ThrowFlags)) = 0;
         fighter_copy->cb.x21DC_callback_OnTakeDamage = &ftPikachu_SetState_8012779C;
-        fighter->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_801277AC;
+        fp->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_801277AC;
 
     }
 }
 
 void ftPikachu_ActionChange_80127DE4(HSD_GObj* fighterObj) {
     s32 unused[4];
-    Fighter* fighter = fighterObj->user_data;
-    if ((fighter->x2344_stateVar2_s32 == 3) || fighter->x2200_ftcmd_var0) {
-        fighter->cb.x21DC_callback_OnTakeDamage= 0;
+    Fighter* fp = fighterObj->user_data;
+    if ((fp->x2344_stateVar2_s32 == 3) || fp->x2200_ftcmd_var0) {
+        fp->cb.x21DC_callback_OnTakeDamage= 0;
         Fighter_ActionStateChange_800693AC(fighterObj, 0x16A, 0, 0, 0.0f, 1.0f, 0.0f);
         return;
     }
@@ -245,16 +245,16 @@ void ftPikachu_ActionChange_80127DE4(HSD_GObj* fighterObj) {
         Fighter_ActionStateChange_800693AC(fighterObj, 0x169, 0, 0, 0.0f, 1.0f, 0.0f);
         fighter_copy->x2200_ftcmd_var0 = 0;
         fighter_copy->cb.x21DC_callback_OnTakeDamage = 0;
-        fighter = fighterObj->user_data;
-        efAsync_Spawn(fighterObj, &fighter->x60C, 0, 0x4C0, fighter_copy->x5E8_fighterBones[0].x0_jobj);
+        fp = fighterObj->user_data;
+        efAsync_Spawn(fighterObj, &fp->x60C, 0, 0x4C0, fighter_copy->x5E8_fighterBones[0].x0_jobj);
     }
 }
 
 void ftPikachu_ActionChange_80127EC0(HSD_GObj* fighterObj) {
     s32 unused[8];
-    Fighter* fighter = fighterObj->user_data;
-    if ((fighter->x2344_stateVar2_s32 == 3) || fighter->x2200_ftcmd_var0) {
-        fighter->cb.x21DC_callback_OnTakeDamage= 0;
+    Fighter* fp = fighterObj->user_data;
+    if ((fp->x2344_stateVar2_s32 == 3) || fp->x2200_ftcmd_var0) {
+        fp->cb.x21DC_callback_OnTakeDamage= 0;
         Fighter_ActionStateChange_800693AC(fighterObj, 0x16E, 0, 0, 0.0f, 1.0f, 0.0f);
         return;
     }
@@ -265,23 +265,23 @@ void ftPikachu_ActionChange_80127EC0(HSD_GObj* fighterObj) {
         fighter_copy->x2200_ftcmd_var0 = 0;
         fighter_copy->cb.x21DC_callback_OnTakeDamage = 0;
         fighter_copy->x80_self_vel.y = (f32) pika_attr->xB4;
-        fighter = fighterObj->user_data;
-        efAsync_Spawn(fighterObj, &fighter->x60C, 0, 0x4C0, fighter_copy->x5E8_fighterBones[0].x0_jobj);
+        fp = fighterObj->user_data;
+        efAsync_Spawn(fighterObj, &fp->x60C, 0, 0x4C0, fighter_copy->x5E8_fighterBones[0].x0_jobj);
     }
 } 
 
 void ftPikachu_ActionChange_80127FB0(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    if (fighter->x2200_ftcmd_var0) {
-        fighter->cb.x21DC_callback_OnTakeDamage = 0;
+    Fighter* fp = fighterObj->user_data;
+    if (fp->x2200_ftcmd_var0) {
+        fp->cb.x21DC_callback_OnTakeDamage = 0;
         Fighter_ActionStateChange_800693AC(fighterObj, 0x16A, 0, 0, 0.0f, 1.0f, 0.0f);
     }
 }
 
 void ftPikachu_ActionChange_80128000(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    if (fighter->x2200_ftcmd_var0) {
-        fighter->cb.x21DC_callback_OnTakeDamage = 0;
+    Fighter* fp = fighterObj->user_data;
+    if (fp->x2200_ftcmd_var0) {
+        fp->cb.x21DC_callback_OnTakeDamage = 0;
         Fighter_ActionStateChange_800693AC(fighterObj, 0x16E, 0, 0, 0.0f, 1.0f, 0.0f);
     }
 }
@@ -320,12 +320,12 @@ void ftPikachu_80128148(HSD_GObj* fighterObj) {
 
 void ftPikachu_80128168(HSD_GObj* fighterObj) {
     s32 unused;
-    Fighter* fighter = fighterObj->user_data;
-    ftPikachuAttributes* pika_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
     f32 pika_B8 = pika_attr->xB8;
-    f32 terminal_velocity = fighter->x110_attr.x170_TerminalVelocity;
-    func_8007D494(fighter, pika_B8, terminal_velocity);
-    func_8007CF58(fighter);
+    f32 terminal_velocity = fp->x110_attr.x170_TerminalVelocity;
+    func_8007D494(fp, pika_B8, terminal_velocity);
+    func_8007CF58(fp);
 }
 
 void ftPikachu_801281AC(HSD_GObj* fighterObj) {

--- a/src/melee/ft/chara/ftPurin/ftpurin.c
+++ b/src/melee/ft/chara/ftPurin/ftpurin.c
@@ -26,95 +26,95 @@ void func_8013C360(HSD_GObj* fighterObj) {
     s32 unused;
 
     HSD_Joint** joint_list = lbl_8045A1E0;
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     
-    if (lbl_803D05B4[fighter->x619_costume_id]) {
-        void** item_list = fighter->x10C_ftData->x48_items;
+    if (lbl_803D05B4[fp->x619_costume_id]) {
+        void** item_list = fp->x10C_ftData->x48_items;
         void** item_list_shifted = item_list[1];
-        if (!joint_list[fighter->x619_costume_id]) {
-            UnkCostumeStruct* costume_list = CostumeListsForeachCharacter[fighter->x4_fighterKind].costume_list;
-            joint_list[fighter->x619_costume_id] = HSD_ArchiveGetPublicAddress(costume_list[fighter->x619_costume_id].x14_archive, lbl_803D05B4[fighter->x619_costume_id]);
+        if (!joint_list[fp->x619_costume_id]) {
+            UnkCostumeStruct* costume_list = CostumeListsForeachCharacter[fp->x4_fighterKind].costume_list;
+            joint_list[fp->x619_costume_id] = HSD_ArchiveGetPublicAddress(costume_list[fp->x619_costume_id].x14_archive, lbl_803D05B4[fp->x619_costume_id]);
         }
 
-        fighter->sa.purin.x2244 = HSD_ObjAlloc(&lbl_80459080);
+        fp->sa.purin.x2244 = HSD_ObjAlloc(&lbl_80459080);
         func_80074148();
-        fighter->sa.purin.x223C = HSD_JObjLoadJoint(joint_list[fighter->x619_costume_id]);
-        fighter->x2225_flag.bits.b2 = 1;
+        fp->sa.purin.x223C = HSD_JObjLoadJoint(joint_list[fp->x619_costume_id]);
+        fp->x2225_flag.bits.b2 = 1;
         func_80074170();
-        func_80075650(fighterObj, fighter->sa.purin.x223C, &fighter->sa.purin.x2240);
+        func_80075650(fighterObj, fp->sa.purin.x223C, &fp->sa.purin.x2240);
 
-        func_8007487C(&item_list_shifted[1], &fighter->sa.purin.x2248, fighter->x619_costume_id, &fighter->sa.purin.x2240, &fighter->sa.purin.x2240);
-        func_8009DC54(fighter);
+        func_8007487C(&item_list_shifted[1], &fp->sa.purin.x2248, fp->x619_costume_id, &fp->sa.purin.x2240, &fp->sa.purin.x2240);
+        func_8009DC54(fp);
         return;
     }
-    fighter->sa.purin.x223C = 0;
+    fp->sa.purin.x223C = 0;
 }
 
 void func_8013C494(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    HSD_JObj* jobj = fighter->sa.purin.x223C;
+    Fighter* fp = fighterObj->user_data;
+    HSD_JObj* jobj = fp->sa.purin.x223C;
     
     if (jobj) {
-        HSD_JObjRemoveAll(fighter->sa.purin.x223C);
-        fighter->sa.purin.x223C = NULL;
-        HSD_ObjFree(&lbl_80459080, fighter->sa.purin.x2244);
-        fighter->sa.purin.x2244 = NULL;
+        HSD_JObjRemoveAll(fp->sa.purin.x223C);
+        fp->sa.purin.x223C = NULL;
+        HSD_ObjFree(&lbl_80459080, fp->sa.purin.x2244);
+        fp->sa.purin.x2244 = NULL;
     }
 }
 
 void func_8013C4F0(HSD_GObj* fighterObj, s32 arg1, s32 arg2) {
   s32 unused[2];
 
-  Fighter *fighter = fighterObj->user_data;
+  Fighter *fp = fighterObj->user_data;
     
-    if (fighter->sa.purin.x223C && fighter->x2225_flag.bits.b2) {
+    if (fp->sa.purin.x223C && fp->x2225_flag.bits.b2) {
     
         Mtx *mtx;
         HSD_JObj *jobj;
-        HSD_JObj* bone_jobj = fighter->x5E8_fighterBones[6].x0_jobj;
-        HSD_JObjGetMtx(fighter->x5E8_fighterBones[6].x0_jobj);
+        HSD_JObj* bone_jobj = fp->x5E8_fighterBones[6].x0_jobj;
+        HSD_JObjGetMtx(fp->x5E8_fighterBones[6].x0_jobj);
         mtx = (0, &bone_jobj->mtx);
-        jobj = fighter->sa.purin.x223C;
-        HSD_JObjCopyMtx(fighter->sa.purin.x223C, *mtx);
+        jobj = fp->sa.purin.x223C;
+        HSD_JObjCopyMtx(fp->sa.purin.x223C, *mtx);
         jobj->flags |= 0x03800000;
         HSD_JObjSetMtxDirty(jobj);
           
-        func_803709DC(fighter->sa.purin.x223C, arg2, func_80390EB8(arg1), 0);
+        func_803709DC(fp->sa.purin.x223C, arg2, func_80390EB8(arg1), 0);
     }
 
 }
 
 
-void func_8013C614(Fighter* fighter, s32 arg1, s32 arg2) {
-    if (fighter->sa.purin.x223C) {
+void func_8013C614(Fighter* fp, s32 arg1, s32 arg2) {
+    if (fp->sa.purin.x223C) {
         if (arg2) {
-            func_80074CA0(&fighter->sa.purin.x2248, arg1, &fighter->sa.purin.x2240);
+            func_80074CA0(&fp->sa.purin.x2248, arg1, &fp->sa.purin.x2240);
             return;
         }
-        func_80074D7C(&fighter->sa.purin.x2248, arg1, &fighter->sa.purin.x2240);
+        func_80074D7C(&fp->sa.purin.x2248, arg1, &fp->sa.purin.x2240);
     }
 }
 
 void* func_8013C664(HSD_GObj* fighterObj) {
-    Fighter *fighter = fighterObj->user_data;
-    if (fighter->sa.purin.x223C) {
-        return fighter->sa.purin.x223C;
+    Fighter *fp = fighterObj->user_data;
+    if (fp->sa.purin.x223C) {
+        return fp->sa.purin.x223C;
     }
     return fighterObj;
 }
 
 void ftPurin_OnLoad(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    PUSH_ATTRS(fighter, ftPurinAttributes);
-    fighter->x2222_flag.bits.b1 = 1;
-    fighter->x2D0 = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    PUSH_ATTRS(fp, ftPurinAttributes);
+    fp->x2222_flag.bits.b1 = 1;
+    fp->x2D0 = fp->x2D4_specialAttributes;
     func_8013C360(fighterObj);
 }
 
 void ftPurin_OnItemPickup(HSD_GObj* fighterObj, BOOL bool) {
-    Fighter *fighter = getFighter(fighterObj);            
-    if (!func_8026B2B4(fighter->x1974_heldItem)) {        
-        switch (func_8026B320(fighter->x1974_heldItem)) {
+    Fighter *fp = getFighter(fighterObj);            
+    if (!func_8026B2B4(fp->x1974_heldItem)) {        
+        switch (func_8026B320(fp->x1974_heldItem)) {
             case 1:
                 break;
             case 2:
@@ -133,18 +133,18 @@ void ftPurin_OnItemPickup(HSD_GObj* fighterObj, BOOL bool) {
 }
 
 void ftPurin_OnItemInvisible(HSD_GObj *fighterObj) {
-    Fighter* ft = getFighter(fighterObj);
-    if (ft->x1974_heldItem) {
-        if (!func_8026B2B4(ft->x1974_heldItem)) {
+    Fighter* fp = getFighter(fighterObj);
+    if (fp->x1974_heldItem) {
+        if (!func_8026B2B4(fp->x1974_heldItem)) {
             func_80070CC4(fighterObj, 0);
         }
     }
 }
 
 void ftPurin_OnItemVisible(HSD_GObj *fighterObj) {
-    Fighter* ft = getFighter(fighterObj);
-    if (ft->x1974_heldItem) {
-        if (!func_8026B2B4(ft->x1974_heldItem)) {
+    Fighter* fp = getFighter(fighterObj);
+    if (fp->x1974_heldItem) {
+        if (!func_8026B2B4(fp->x1974_heldItem)) {
             func_80070C48(fighterObj, 0);
         }
     }

--- a/src/melee/ft/chara/ftSamus/ftsamus.h
+++ b/src/melee/ft/chara/ftSamus/ftsamus.h
@@ -66,23 +66,23 @@ void ftSamus_8012B5F0(HSD_GObj* fighterObj);
 void ftSamus_8012B668(HSD_GObj* fighterObj);
 
 inline void ftSamus_updateDamageDeathCBs(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
-    fighter->cb.x21DC_callback_OnTakeDamage = &ftSamus_80128428;
-    fighter->cb.x21E4_callback_OnDeath2 = &ftSamus_80128428;
+    Fighter* fp = getFighterPlus(fighterObj);
+    fp->cb.x21DC_callback_OnTakeDamage = &ftSamus_80128428;
+    fp->cb.x21E4_callback_OnDeath2 = &ftSamus_80128428;
 }
 
 //// only used in ftsamus3 so far (maybe move to there)
 inline void ftSamus_SetAttrx2334(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    fighter->sa.samus.x2234 = 0;
+    Fighter* fp = fighterObj->user_data;
+    fp->sa.samus.x2234 = 0;
 }
 
 inline void ftSamus_destroyAllEF(HSD_GObj* fighterObj) {
     if (fighterObj) {
-        Fighter* fighter = getFighterPlus(fighterObj);
-        if (fighter->sa.samus.x2234) {
+        Fighter* fp = getFighterPlus(fighterObj);
+        if (fp->sa.samus.x2234) {
             efLib_DestroyAll(fighterObj);
-            fighter->sa.samus.x2234 = 0;
+            fp->sa.samus.x2234 = 0;
         }
     }
 }
@@ -90,11 +90,11 @@ inline void ftSamus_destroyAllEF(HSD_GObj* fighterObj) {
 inline void ftSamus_UnkAndDestroyAllEF(HSD_GObj* fighterObj) {
 
     if (fighterObj) {
-        Fighter* fighter = fighterObj->user_data;
-        u32 x222C = fighter->sa.samus.x222C;
+        Fighter* fp = fighterObj->user_data;
+        u32 x222C = fp->sa.samus.x222C;
         if (x222C) {
             func_802B5974(x222C);
-            fighter->sa.samus.x222C = 0;
+            fp->sa.samus.x222C = 0;
         }
         ftSamus_destroyAllEF(fighterObj);
     } 

--- a/src/melee/ft/chara/ftSamus/ftsamus1.c
+++ b/src/melee/ft/chara/ftSamus/ftsamus1.c
@@ -1,24 +1,24 @@
 #include <ftsamus.h>
 
 void ftSamus_OnDeath(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     func_80074A4C(fighterObj, 0, 0);
-    fighter->sa.samus.x222C = 0;
-    fighter->sa.samus.x2230 = 0;
-    fighter->sa.samus.x2238 = 0;
-    fighter->sa.samus.x2244 = 0;
-    fighter->sa.samus.x223C = 0;
-    fighter->sa.samus.x2240 = 0;
+    fp->sa.samus.x222C = 0;
+    fp->sa.samus.x2230 = 0;
+    fp->sa.samus.x2238 = 0;
+    fp->sa.samus.x2244 = 0;
+    fp->sa.samus.x223C = 0;
+    fp->sa.samus.x2240 = 0;
 }
 
 void ftSamus_OnLoad(HSD_GObj* fighterObj) {
 
-    Fighter* fighter = fighterObj->user_data;
-    void** item_list = fighter->x10C_ftData->x48_items;
+    Fighter* fp = fighterObj->user_data;
+    void** item_list = fp->x10C_ftData->x48_items;
 
-    fighter->x2224_flag.bits.b7 = 1;
+    fp->x2224_flag.bits.b7 = 1;
 
-    PUSH_ATTRS(fighter, ftSamusAttributes);
+    PUSH_ATTRS(fp, ftSamusAttributes);
     
     func_8026B3F8(item_list[0], 0x5DU);
     func_8026B3F8(item_list[1], 0x5EU);
@@ -49,21 +49,21 @@ void ftSamus_OnItemDrop(HSD_GObj* fighterObj, BOOL bool1) {
 }
 
 void ftSamus_80128628(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    ftSamusAttributes* attr = fighter->x2D4_specialAttributes;
-    s32 samus_x2230 = fighter->sa.samus.x2230;
+    Fighter* fp = getFighter(fighterObj);
+    ftSamusAttributes* attr = fp->x2D4_specialAttributes;
+    s32 samus_x2230 = fp->sa.samus.x2230;
     if (samus_x2230 == attr->x18) {
-        func_800BFFD0(fighter, 0x35, 0);
+        func_800BFFD0(fp, 0x35, 0);
     }
 }
 
 void ftSamus_LoadSpecialAttrs(HSD_GObj* fighterObj) {
     COPY_ATTRS(fighterObj, ftSamusAttributes);
-    if (ft->x34_scale.y != 1.0f) {                                        
-        sA2->x8 *= ft->x34_scale.y;                                       
-        sA2->x74_vec.y *= ft->x34_scale.y;    
-        sA2->x54 *= ft->x34_scale.y;                                                                              
-        sA2->x58 *= ft->x34_scale.y;    
+    if (fp->x34_scale.y != 1.0f) {                                        
+        sA2->x8 *= fp->x34_scale.y;                                       
+        sA2->x74_vec.y *= fp->x34_scale.y;    
+        sA2->x54 *= fp->x34_scale.y;                                                                              
+        sA2->x58 *= fp->x34_scale.y;    
         SCALE_HEIGHT_ATTRS(6);                                                                   
     }  
 }
@@ -79,13 +79,13 @@ void ftSamus_801287C4(HSD_GObj* fighterObj, s32 index, f32 argf) {
     Fighter *fighter_copy;
     Vec scale;
 
-    Fighter* fighter = getFighter(fighterObj);
-    void** item_list = fighter->x10C_ftData->x48_items;
+    Fighter* fp = getFighter(fighterObj);
+    void** item_list = fp->x10C_ftData->x48_items;
     struct UNK_SAMUS_S1* unkItemType = item_list[4];
-    func_8007E620(fighter, unkItemType->x0_joint); 
+    func_8007E620(fp, unkItemType->x0_joint); 
     
-    scale.x = scale.y = scale.z = fighter->x34_scale.y;
-    HSD_JObjSetScale((fighter_copy = fighter)->x20A0_accessory, &scale);  
+    scale.x = scale.y = scale.z = fp->x34_scale.y;
+    HSD_JObjSetScale((fighter_copy = fp)->x20A0_accessory, &scale);  
     
 
     HSD_JObjAddAnimAll(fighter_copy->x20A0_accessory, unkItemType->x8_anim_joint, unkItemType->xC_matanim_joint, 0);

--- a/src/melee/ft/chara/ftSamus/ftsamus2.c
+++ b/src/melee/ft/chara/ftSamus/ftsamus2.c
@@ -16,17 +16,17 @@ extern s32 func_800D695C(HSD_GObj*);
 extern s32 func_800D8990(HSD_GObj*); 
 
 void ftSamus_80128944(HSD_GObj* fighterObj, f32 farg1, f32 farg2) {
-    Fighter* fighter = fighterObj->user_data; 
-    ftSamusAttributes* attr = getFtSpecialAttrs(fighter);
+    Fighter* fp = fighterObj->user_data; 
+    ftSamusAttributes* attr = getFtSpecialAttrs(fp);
     f32 float_result = ftSamus_80128AC8(fighterObj, farg1, farg2);
     if (!func_8007B868(fighterObj)) {
-        switch(fighter->x2071_b0_3) {
+        switch(fp->x2071_b0_3) {
             case 0:
             case 2:
             case 3:
             case 4:
-                if ((fighter->x2073 == 0x14) || ((fighter->x2071_b5) == 0)) {
-                    if (fighter->x5F5 == 2) {
+                if ((fp->x2073 == 0x14) || ((fp->x2071_b5) == 0)) {
+                    if (fp->x5F5 == 2) {
                         ftSamus_80128B1C(fighterObj, float_result, attr->x0, 1.0f);
                     } else {
                         ftSamus_80128B1C(fighterObj, float_result, 0.0f, 1.0f);
@@ -39,11 +39,11 @@ void ftSamus_80128944(HSD_GObj* fighterObj, f32 farg1, f32 farg2) {
 }
 
 s32 ftSamus_80128A1C(HSD_GObj* fighterObj, s32 arg1, f32 farg1) {
-    Fighter* fighter = getFighter(fighterObj); 
+    Fighter* fp = getFighter(fighterObj); 
     s32 i; 
 
-    for (i = 0; i < fighter->x119E_hurtboxNum; i++) {
-        if (func_80008248(arg1, &fighter->x11A0_fighterHurtbox[i], func_8007F804(fighter), farg1, fighter->x34_scale.y, fighter->xB0_pos.z)) {
+    for (i = 0; i < fp->x119E_hurtboxNum; i++) {
+        if (func_80008248(arg1, &fp->x11A0_fighterHurtbox[i], func_8007F804(fp), farg1, fp->x34_scale.y, fp->xB0_pos.z)) {
             return 1;
         }
     }
@@ -51,9 +51,9 @@ s32 ftSamus_80128A1C(HSD_GObj* fighterObj, s32 arg1, f32 farg1) {
 }
 
 f32 ftSamus_80128AC8(HSD_GObj* fighterObj, f32 farg1, f32 farg2) {
-    Fighter* fighter = getFighter(fighterObj);
-    ftSamusAttributes* attr = getFtSpecialAttrs(fighter);
-    f32 value = (fighter->xB0_pos.x - farg1) / farg2;
+    Fighter* fp = getFighter(fighterObj);
+    ftSamusAttributes* attr = getFtSpecialAttrs(fp);
+    f32 value = (fp->xB0_pos.x - farg1) / farg2;
     if (value >= 1.0f) {  
         value = 1.0f; 
     }
@@ -65,27 +65,27 @@ f32 ftSamus_80128AC8(HSD_GObj* fighterObj, f32 farg1, f32 farg2) {
 
 inline void ftSamus_80128B1C_inner(HSD_GObj *fighterObj, f32 angle) {
     
-    Fighter *fighter = getFighter(fighterObj);
-    struct attr* ftAttr = &fighter->x110_attr;
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
+    Fighter *fp = getFighter(fighterObj);
+    struct attr* ftAttr = &fp->x110_attr;
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
 
-    fighter = getFighter(fighterObj);
-    fighter->x80_self_vel.x = samus_attr->x8 * cosf(angle);
-    fighter->x80_self_vel.y = samus_attr->x8 * sinf(angle);
-    func_8007D440(fighter, ftAttr->x17C_AerialDriftMax * samus_attr->x10);
+    fp = getFighter(fighterObj);
+    fp->x80_self_vel.x = samus_attr->x8 * cosf(angle);
+    fp->x80_self_vel.y = samus_attr->x8 * sinf(angle);
+    func_8007D440(fp, ftAttr->x17C_AerialDriftMax * samus_attr->x10);
 }
 
 void ftSamus_80128B1C(HSD_GObj *fighterObj, f32 angle, f32 arg9, f32 argA)
 {
-    Fighter *fighter;
+    Fighter *fp;
     Fighter *fighter2;
-    fighter = fighter2 = getFighterPlus(fighterObj);
+    fp = fighter2 = getFighterPlus(fighterObj);
     func_8007DB58(fighterObj);
     ftSamus_80128B1C_inner(fighterObj, angle);
-    fighter->x2200_ftcmd_var0 = 0;
-    fighter->x2204_ftcmd_var1 = 0;
-    fighter->x2340_stateVar1 = 0;
-    if (fighter->xE0_ground_or_air == GA_Ground)
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2340_stateVar1 = 0;
+    if (fp->xE0_ground_or_air == GA_Ground)
     {
         func_8007D5D4(fighter2);
     }
@@ -94,14 +94,14 @@ void ftSamus_80128B1C(HSD_GObj *fighterObj, f32 angle, f32 arg9, f32 argA)
 }
 
 void ftSamus_80128C04(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    if (( fighter->x2200_ftcmd_var0) && (!fighter->x2340_stateVar1)) {
+    Fighter* fp = fighterObj->user_data;
+    if (( fp->x2200_ftcmd_var0) && (!fp->x2340_stateVar1)) {
         ftSamus_8012AEBC(fighterObj);
-        fighter->x2340_stateVar1 = 1;
+        fp->x2340_stateVar1 = 1;
     }
-    if ((!fighter->x2200_ftcmd_var0) && (fighter->x2340_stateVar1)) {
+    if ((!fp->x2200_ftcmd_var0) && (fp->x2340_stateVar1)) {
         ftSamus_8012AF38(fighterObj);
-        fighter->x2340_stateVar1 = 0;
+        fp->x2340_stateVar1 = 0;
     }
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
         func_8008A2BC(fighterObj);
@@ -109,14 +109,14 @@ void ftSamus_80128C04(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_80128CA0(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    if (( fighter->x2200_ftcmd_var0) && (!fighter->x2340_stateVar1)) {
+    Fighter* fp = fighterObj->user_data;
+    if (( fp->x2200_ftcmd_var0) && (!fp->x2340_stateVar1)) {
         ftSamus_8012AEBC(fighterObj);
-        fighter->x2340_stateVar1 = 1;
+        fp->x2340_stateVar1 = 1;
     }
-    if ((!fighter->x2200_ftcmd_var0) && (fighter->x2340_stateVar1)) {
+    if ((!fp->x2200_ftcmd_var0) && (fp->x2340_stateVar1)) {
         ftSamus_8012AF38(fighterObj);
-        fighter->x2340_stateVar1 = 0;
+        fp->x2340_stateVar1 = 0;
     }
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
         func_800CC730(fighterObj);
@@ -124,10 +124,10 @@ void ftSamus_80128CA0(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_80128D3C(HSD_GObj* fighterObj) { 
-    Fighter* fighter = getFighterPlus(fighterObj);
-    ftSamusAttributes* samus_attr = fighter->x2D4_specialAttributes;
-    if ((fighter->x2204_ftcmd_var1) && (fighter->input.x624_lstick_y < samus_attr->x14)) {
-        fighter->x2204_ftcmd_var1 = 0;
+    Fighter* fp = getFighterPlus(fighterObj);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
+    if ((fp->x2204_ftcmd_var1) && (fp->input.x624_lstick_y < samus_attr->x14)) {
+        fp->x2204_ftcmd_var1 = 0;
         func_800D638C(fighterObj);
         return;
     }
@@ -153,14 +153,14 @@ void ftSamus_80128E68(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_80128E88(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
-    struct attr* ftAttr = &fighter->x110_attr;
+    Fighter* fp = getFighter(fighterObj);
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    struct attr* ftAttr = &fp->x110_attr;
 
-    if (fighter->x2200_ftcmd_var0) {
+    if (fp->x2200_ftcmd_var0) {
         f32 samus_attr_xC = samus_attr->xC;
         func_8007CADC(
-            fighter, 
+            fp, 
             0.0f, 
             ftAttr->x110_WalkInitialVelocity * samus_attr_xC, 
             ftAttr->x118_WalkMaximumVelocity * samus_attr_xC
@@ -172,12 +172,12 @@ void ftSamus_80128E88(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_80128EF8(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
-    struct attr* ftAttr = &fighter->x110_attr;
-    func_8007D4B8(fighter);
+    Fighter* fp = fighterObj->user_data;
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    struct attr* ftAttr = &fp->x110_attr;
+    func_8007D4B8(fp);
     func_8007D344(
-        fighter, 
+        fp, 
         0.0f, 
         ftAttr->x154_GroundToAirJumpMomentumMultiplier  * samus_attr->x10, 
         ftAttr->x158_JumpHMaxVelocity * samus_attr->x10
@@ -185,9 +185,9 @@ void ftSamus_80128EF8(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_80128F60(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
-    ftSamusAttributes* samus_attr = fighter->x2D4_specialAttributes;
-    if (fighter->x2200_ftcmd_var0) {
+    Fighter* fp = getFighterPlus(fighterObj);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
+    if (fp->x2200_ftcmd_var0) {
         if (!func_80082888(fighterObj, &samus_attr->height_attributes)) {
             ftSamus_80129048(fighterObj);
         }
@@ -197,9 +197,9 @@ void ftSamus_80128F60(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_80128FD4(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
-    ftSamusAttributes* samus_attr = fighter->x2D4_specialAttributes;
-    if (fighter->x2200_ftcmd_var0) {
+    Fighter* fp = getFighterPlus(fighterObj);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
+    if (fp->x2200_ftcmd_var0) {
         if (func_800824A0(fighterObj, &samus_attr->height_attributes)) {
             ftSamus_801290A4(fighterObj);
         }
@@ -209,25 +209,25 @@ void ftSamus_80128FD4(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_80129048(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    func_8007D5D4(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x156, 0x10, 0, fighter->x894_currentAnimFrame, fighter->x89C_frameSpeedMul, 0.0f);
+    Fighter* fp = getFighter(fighterObj);
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x156, 0x10, 0, fp->x894_currentAnimFrame, fp->x89C_frameSpeedMul, 0.0f);
 }
 
 void ftSamus_801290A4(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    func_8007D7FC(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x155, 0x10, 0, fighter->x894_currentAnimFrame, fighter->x89C_frameSpeedMul, 0.0f);
+    Fighter* fp = getFighter(fighterObj);
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x155, 0x10, 0, fp->x894_currentAnimFrame, fp->x89C_frameSpeedMul, 0.0f);
 }
 
 s32 ftSamus_80129100(HSD_GObj* fighterObj, s32* arg1, s32* arg2) {
 
     if (fighterObj) {
-        Fighter* fighter = fighterObj->user_data;
-        ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
-        if (!fighter->sa.samus.x222C) return -1;
+        Fighter* fp = fighterObj->user_data;
+        ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+        if (!fp->sa.samus.x222C) return -1;
         
-        *arg1 = fighter->sa.samus.x2230;
+        *arg1 = fp->sa.samus.x2230;
         *arg2 = samus_attr->x18;
         return 0;
     }
@@ -237,8 +237,8 @@ s32 ftSamus_80129100(HSD_GObj* fighterObj, s32* arg1, s32* arg2) {
 s32 ftSamus_80129158(HSD_GObj* fighterObj) {
     
     if (fighterObj) {
-        Fighter* fighter = getFighter(fighterObj);
-        s32 action_state_index = fighter->x10_action_state_index;
+        Fighter* fp = getFighter(fighterObj);
+        s32 action_state_index = fp->x10_action_state_index;
         switch (action_state_index) {
             case 0x157:
             case 0x158:
@@ -246,7 +246,7 @@ s32 ftSamus_80129158(HSD_GObj* fighterObj) {
             case 0x15A:
             case 0x15B:
             case 0x15C:
-                if (fighter->x2071_b6) {
+                if (fp->x2071_b6) {
                     return 1;
                 }
             return 0;
@@ -259,8 +259,8 @@ s32 ftSamus_80129158(HSD_GObj* fighterObj) {
 
 s32 ftSamus_801291A8(HSD_GObj* fighterObj) {
     if (fighterObj) {
-        Fighter* fighter = getFighter(fighterObj);
-        s32 action_state_index = fighter->x10_action_state_index;
+        Fighter* fp = getFighter(fighterObj);
+        s32 action_state_index = fp->x10_action_state_index;
 
         switch (action_state_index) {
             case 0x157:

--- a/src/melee/ft/chara/ftSamus/ftsamus3.c
+++ b/src/melee/ft/chara/ftSamus/ftsamus3.c
@@ -1,17 +1,17 @@
 #include <ftsamus.h>
 
 void ftSamus_801293BC_inner(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
-    ftSamusAttributes* samus_attr = fighter->x2D4_specialAttributes;
-    s32 x2230 = fighter->sa.samus.x2230;
-    fighter->x80_self_vel.x = (fighter->x2C_facing_direction * (samus_attr->x1C * x2230));
+    Fighter* fp = getFighterPlus(fighterObj);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
+    s32 x2230 = fp->sa.samus.x2230;
+    fp->x80_self_vel.x = (fp->x2C_facing_direction * (samus_attr->x1C * x2230));
 }
 
 void ftSamus_801291F0(HSD_GObj* fighterObj){
     if (fighterObj) {
-        Fighter* fighter = getFighter(fighterObj);
-        if (fighter->sa.samus.x222C) {
-            fighter->sa.samus.x222C = 0;
+        Fighter* fp = getFighter(fighterObj);
+        if (fp->sa.samus.x222C) {
+            fp->sa.samus.x222C = 0;
         }
         ftSamus_destroyAllEF(fighterObj);
     } 
@@ -21,9 +21,9 @@ void ftSamus_801291F0(HSD_GObj* fighterObj){
 void ftSamus_80129258(HSD_GObj* fighterObj) {
     
     if (fighterObj) {
-        Fighter* fighter = getFighter(fighterObj);
+        Fighter* fp = getFighter(fighterObj);
         ftSamus_UnkAndDestroyAllEF(fighterObj);
-        fighter->sa.samus.x2230 = 0;
+        fp->sa.samus.x2230 = 0;
     }
 }
 
@@ -33,21 +33,21 @@ s32 ftSamus_801292E4(HSD_GObj* fighterObj) {
     Vec vec2;
     
     u32 result;
-    Fighter* fighter = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
     
-    if ((fighter->x2200_ftcmd_var0 == 1U) && (!fighter->sa.samus.x222C)) {
-        fighter->x2200_ftcmd_var0 = 0U;
+    if ((fp->x2200_ftcmd_var0 == 1U) && (!fp->sa.samus.x222C)) {
+        fp->x2200_ftcmd_var0 = 0U;
         vec2.z = 4.0f;
         vec2.y = 0.0f;
         vec2.x = 0.0f;
-        func_8000B1CC(fighter->x5E8_fighterBones[50].x0_jobj, &vec2, &vec1);
+        func_8000B1CC(fp->x5E8_fighterBones[50].x0_jobj, &vec2, &vec1);
         vec1.z = 0.0f;
-        result = func_802B55C8(fighterObj, &vec1, 0x32, 0x5E, fighter->x2C_facing_direction);
-        fighter->sa.samus.x222C = result;
+        result = func_802B55C8(fighterObj, &vec1, 0x32, 0x5E, fp->x2C_facing_direction);
+        fp->sa.samus.x222C = result;
         if (result) {
             ftSamus_updateDamageDeathCBs(fighterObj);
         } else {
-            fighter->sa.samus.x222C = 0U;
+            fp->sa.samus.x222C = 0U;
             return 1;
         }
     }
@@ -57,78 +57,78 @@ s32 ftSamus_801292E4(HSD_GObj* fighterObj) {
 void ftSamus_801293BC(HSD_GObj* fighterObj) {
     ftSamusAttributes* samus_attr;
     HSD_GObj* held_item;
-    Fighter* fighter;
+    Fighter* fp;
     f64 var_f0;
     s32 unused[5]; // could not match all the stack without this
 
-    fighter = getFighterPlus(fighterObj);
-    samus_attr = getFtSpecialAttrs(fighter);
+    fp = getFighterPlus(fighterObj);
+    samus_attr = getFtSpecialAttrs(fp);
 
-    if ((fighter->x2204_ftcmd_var1 == 1) && (fighter->sa.samus.x222C)) {
+    if ((fp->x2204_ftcmd_var1 == 1) && (fp->sa.samus.x222C)) {
         Vec vec1;
         u32 x2230; 
 
-        fighter->x2204_ftcmd_var1 = 2;
-        func_8000B1CC(fighter->x5E8_fighterBones[51].x0_jobj, NULL, &vec1);
+        fp->x2204_ftcmd_var1 = 2;
+        func_8000B1CC(fp->x5E8_fighterBones[51].x0_jobj, NULL, &vec1);
         vec1.z = 0.0f;
-        held_item = fighter->x1974_heldItem; 
-        if (1.0f == fighter->x2C_facing_direction) {
+        held_item = fp->x1974_heldItem; 
+        if (1.0f == fp->x2C_facing_direction) {
             var_f0 = 0.0;
         } else {
             var_f0 = M_PI;
         }
-        x2230 = fighter->sa.samus.x2230; 
-        func_802B56E4(fighter->sa.samus.x222C, &vec1, var_f0, x2230, samus_attr->x18);
-        if ((fighter->x10_action_state_index == 0x15C) ||  (fighter->xE0_ground_or_air == GA_Air)) {
+        x2230 = fp->sa.samus.x2230; 
+        func_802B56E4(fp->sa.samus.x222C, &vec1, var_f0, x2230, samus_attr->x18);
+        if ((fp->x10_action_state_index == 0x15C) ||  (fp->xE0_ground_or_air == GA_Air)) {
             ftSamus_801293BC_inner(fighterObj);
         }
-        fighter->sa.samus.x2230 = 0U;
+        fp->sa.samus.x2230 = 0U;
         
         ftSamus_801291F0(fighterObj);
-        ef_Spawn(0x486, fighterObj, &vec1, &fighter->x2C_facing_direction);
-        fighter->x1974_heldItem = held_item;
+        ef_Spawn(0x486, fighterObj, &vec1, &fp->x2C_facing_direction);
+        fp->x1974_heldItem = held_item;
     }
 }
 
 void ftSamus_SpecialN_StartAction(HSD_GObj* fighterObj) {
     Vec* self_vel;
-    Fighter* fighter = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
     Fighter_ActionStateChange_800693AC(fighterObj, 0x157, 0, NULL, 0.0f, 1.0f, 0.0f);
-    fighter->x220C_ftcmd_var3 = 0;
-    fighter->x2208_ftcmd_var2 = 0;
-    fighter->x2204_ftcmd_var1 = 0;
-    fighter->x2200_ftcmd_var0 = 0;
-    func_8007D7FC(fighter);
-    self_vel = &fighter->x80_self_vel;
+    fp->x220C_ftcmd_var3 = 0;
+    fp->x2208_ftcmd_var2 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    func_8007D7FC(fp);
+    self_vel = &fp->x80_self_vel;
     self_vel->y = 0.0f;
     ftSamus_updateDamageDeathCBs(fighterObj);
-    fighter->x2340_stateVar1 = 0;
-    fighter->x2344_stateVar2 = 0;
-    fighter->x2348_stateVar3_f32 = 0.0f;
+    fp->x2340_stateVar1 = 0;
+    fp->x2344_stateVar2 = 0;
+    fp->x2348_stateVar3_f32 = 0.0f;
     func_8006EBA4(fighterObj);
 }  
 
 void ftSamus_SpecialAirN_StartAction(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
     Fighter_ActionStateChange_800693AC(fighterObj, 0x15B, 0, NULL, 0.0f, 1.0f, 0.0f);
-    fighter->x220C_ftcmd_var3 = 0;
-    fighter->x2208_ftcmd_var2 = 0;
-    fighter->x2204_ftcmd_var1 = 0;
-    fighter->x2200_ftcmd_var0 = 0;
+    fp->x220C_ftcmd_var3 = 0;
+    fp->x2208_ftcmd_var2 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
     ftSamus_updateDamageDeathCBs(fighterObj);
-    fighter->x2340_stateVar1 = 1;
-    fighter->x2344_stateVar2 = 0;
-    fighter->x2348_stateVar3_f32 = 0.0f;
+    fp->x2340_stateVar1 = 1;
+    fp->x2344_stateVar2 = 0;
+    fp->x2348_stateVar3_f32 = 0.0f;
     func_8006EBA4(fighterObj);
 }
 
 
 void ftSamus_80129684(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    ftSamusAttributes* samus_attr = fighter->x2D4_specialAttributes;
+    Fighter* fp = fighterObj->user_data;
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
     ftSamus_801292E4(fighterObj);
     if (ftAnim_IsFramesRemaining(fighterObj) == 0) {
-        if ((fighter->x2340_stateVar1 == 1) || (fighter->sa.samus.x2230 == samus_attr->x18)) {
+        if ((fp->x2340_stateVar1 == 1) || (fp->sa.samus.x2230 == samus_attr->x18)) {
             Fighter_ActionStateChange_800693AC(fighterObj, 0x15A, 0, NULL, 0.0f, 1.0f, 0.0f);
         } else {
             Fighter_ActionStateChange_800693AC(fighterObj, 0x158, 0, NULL, 0.0f, 1.0f, 0.0f);
@@ -144,13 +144,13 @@ extern s32 lbl_803CE6B8[]; // TODO
 void ftSamus_80129774(HSD_GObj *fighterObj)
 {
   s32 unused;
-  Fighter *fighter;
+  Fighter *fp;
   Fighter *fighter2;
   ftSamusAttributes *samus_attr;
   ftSamusAttributes *samus_attr2;
 
-  fighter = fighter2 = getFighterPlus(fighterObj);
-  samus_attr = samus_attr2 = getFtSpecialAttrs(fighter);
+  fp = fighter2 = getFighterPlus(fighterObj);
+  samus_attr = samus_attr2 = getFtSpecialAttrs(fp);
   if (fighter2->x2208_ftcmd_var2) {
     /// this block might be an inline, but couldn't get the regalloc to behave
     f32 var_f1;
@@ -166,15 +166,15 @@ void ftSamus_80129774(HSD_GObj *fighterObj)
     func_80088510(fighter2, lbl_803CE6B8[index], 0x7F, 0x40);
   }
     
-  fighter->x2344_stateVar2 += 1;
-  if (fighter->x2344_stateVar2_s32 > samus_attr->x20)
+  fp->x2344_stateVar2 += 1;
+  if (fp->x2344_stateVar2_s32 > samus_attr->x20)
   {
-    fighter->x2344_stateVar2 = 0;
-    fighter->sa.samus.x2230 += 1;
-    if (fighter->sa.samus.x2230 >= samus_attr->x18)
+    fp->x2344_stateVar2 = 0;
+    fp->sa.samus.x2230 += 1;
+    if (fp->sa.samus.x2230 >= samus_attr->x18)
     {
-      func_800BFFD0(fighter, 0x35, 0);
-      fighter->sa.samus.x2230 = samus_attr->x18;
+      func_800BFFD0(fp, 0x35, 0);
+      fp->sa.samus.x2230 = samus_attr->x18;
       Fighter_ActionStateChange_800693AC(fighterObj, 0x159, 0, 0, 0.0f, 1.0f, 0.0f);
       ftSamus_UnkAndDestroyAllEF(fighterObj);
       ftSamus_updateDamageDeathCBs(fighterObj);
@@ -202,9 +202,9 @@ void ftSamus_801299D0(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_80129A14(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     ftSamus_801292E4(fighterObj);
-    fighter->x2340_stateVar1 = 1;
+    fp->x2340_stateVar1 = 1;
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
         Fighter_ActionStateChange_800693AC(fighterObj, 0x15C, 0, NULL, 0.0f, 1.0f, 0.0f);
         ftSamus_updateDamageDeathCBs(fighterObj);
@@ -212,8 +212,8 @@ void ftSamus_80129A14(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_80129A98(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
+    Fighter* fp = getFighter(fighterObj);
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
     ftSamus_801293BC(fighterObj);
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
         if (samus_attr->x24 == 0.0f) {
@@ -227,18 +227,18 @@ void ftSamus_80129A98(HSD_GObj* fighterObj) {
 void ftSamus_80129B18(HSD_GObj* fighterObj) {}
 
 void ftSamus_80129B1C(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     HSD_GObj *fighterObj2;
     if (func_8009917C(fighterObj)) {
         fighterObj2 = fighterObj;
         ftSamus_UnkAndDestroyAllEF(fighterObj2);
     } else {
-        if ((fighter->input.x668 & 0x200)) {
+        if ((fp->input.x668 & 0x200)) {
             Fighter_ActionStateChange_800693AC(fighterObj, 0x15A, 0, NULL, 0.0f, 1.0f, 0.0f);
             ftSamus_updateDamageDeathCBs(fighterObj);
             return;
         }
-        if ((fighter->input.x668 & 0x80000000)) {
+        if ((fp->input.x668 & 0x80000000)) {
             Fighter_ActionStateChange_800693AC(fighterObj, 0x159, 0, NULL, 0.0f, 1.0f, 0.0f);
             ftSamus_UnkAndDestroyAllEF(fighterObj);
             ftSamus_updateDamageDeathCBs(fighterObj);
@@ -279,98 +279,98 @@ void ftSamus_80129D28(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_80129D48(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     if (!func_80082708(fighterObj)) {
-        func_8007D5D4(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x15B, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        func_8007D5D4(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x15B, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftSamus_updateDamageDeathCBs(fighterObj);
     }
 }
 
 void ftSamus_80129DC8(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     if (!func_80082708(fighterObj)) {
-        func_8007D5D4(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x15C, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        func_8007D5D4(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x15C, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftSamus_updateDamageDeathCBs(fighterObj);
-        func_80088148(fighter, 0x3F7B5U, 0x7FU, 0x40U);
-        fighter->x2204_ftcmd_var1 = 1;
+        func_80088148(fp, 0x3F7B5U, 0x7FU, 0x40U);
+        fp->x2204_ftcmd_var1 = 1;
     }
 }
 
 void ftSamus_80129E68(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     if (!func_80082708(fighterObj)) {
-        func_8007D5D4(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x15C, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        func_8007D5D4(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x15C, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftSamus_updateDamageDeathCBs(fighterObj);
     }
 }
 
 void ftSamus_80129EE8(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     if (!func_80082708(fighterObj)) {
-        func_8007D5D4(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x15C, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        func_8007D5D4(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x15C, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftSamus_updateDamageDeathCBs(fighterObj);
     }
 }
 
 void ftSamus_80129F68(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     if (func_80081D0C(fighterObj) == 1) {
-        func_8007D7FC(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x157, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        func_8007D7FC(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x157, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftSamus_updateDamageDeathCBs(fighterObj);
     }
 }
 
 void ftSamus_80129FE8(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     if (func_80081D0C(fighterObj) == 1) {
-        func_8007D7FC(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x15A, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+        func_8007D7FC(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x15A, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftSamus_updateDamageDeathCBs(fighterObj);
     }
 }
 
 
 s32 ftSamus_8012A068(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    return fighter->sa.samus.x2238;
+    Fighter* fp = fighterObj->user_data;
+    return fp->sa.samus.x2238;
 }
 
 void ftSamus_8012A074(HSD_GObj* fighterObj) {
     BOOL bool1;
-    Fighter* fighter = getFighterPlus(fighterObj);
-    ftSamusAttributes* samus_attr = fighter->x2D4_specialAttributes;
-    if (fighter->x2210_ThrowFlags.b0) {
-        fighter->x2210_ThrowFlags.b0 = 0;
+    Fighter* fp = getFighterPlus(fighterObj);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
+    if (fp->x2210_ThrowFlags.b0) {
+        fp->x2210_ThrowFlags.b0 = 0;
         bool1 = 1;
     } else {
         bool1 = 0;
     }
     if (bool1) {
         Vec position;
-        fighter->sa.samus.x2238++;
-        func_8000B1CC(fighter->x5E8_fighterBones[56].x0_jobj, NULL, &position);
-        position.x += (samus_attr->x34 * fighter->x2C_facing_direction);
-        if ((fighter->x10_action_state_index == 0x15D) || (fighter->x10_action_state_index == 0x15F)) {
-            func_802B62D0(fighterObj, &position, 0, fighter->x2C_facing_direction);
+        fp->sa.samus.x2238++;
+        func_8000B1CC(fp->x5E8_fighterBones[56].x0_jobj, NULL, &position);
+        position.x += (samus_attr->x34 * fp->x2C_facing_direction);
+        if ((fp->x10_action_state_index == 0x15D) || (fp->x10_action_state_index == 0x15F)) {
+            func_802B62D0(fighterObj, &position, 0, fp->x2C_facing_direction);
         } else {
-            func_802B62D0(fighterObj, &position, 1, fighter->x2C_facing_direction);
+            func_802B62D0(fighterObj, &position, 1, fp->x2C_facing_direction);
         }
         ftSamus_8012A168(fighterObj, &position);
-        fighter->cb.x21BC_callback_Accessory4 = 0;
+        fp->cb.x21BC_callback_Accessory4 = 0;
     }
 }
 
 void ftSamus_8012A168(HSD_GObj* fighterObj, Vec* spawnlocation) {
-    Fighter* fighter = getFighter(fighterObj);
-    if (!fighter->x2219_flag.bits.b0) {
+    Fighter* fp = getFighter(fighterObj);
+    if (!fp->x2219_flag.bits.b0) {
         ef_Spawn(0x483, fighterObj, spawnlocation);
-        fighter->x2219_flag.bits.b0 = 1;
+        fp->x2219_flag.bits.b0 = 1;
     }
-    fighter->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-    fighter->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
 }

--- a/src/melee/ft/chara/ftSamus/ftsamus4.c
+++ b/src/melee/ft/chara/ftSamus/ftsamus4.c
@@ -1,17 +1,17 @@
 #include <ftsamus.h>
 
 void ftSamus_ClearThrowFlagsUnk(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    fighter->x2210_ThrowFlags.flags = 0;
-    fighter->cb.x21BC_callback_Accessory4 = &ftSamus_8012A074;
+    Fighter* fp = fighterObj->user_data;
+    fp->x2210_ThrowFlags.flags = 0;
+    fp->cb.x21BC_callback_Accessory4 = &ftSamus_8012A074;
 }
 
 void ftSamus_SpecialS_StartAction(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
-    fighter->xEC_ground_vel /= samus_attr->x2C; 
-    fighter->x80_self_vel.y = 0.0f;
-    if (fighter->x673 < samus_attr->x28) {
+    Fighter* fp = getFighter(fighterObj);
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    fp->xEC_ground_vel /= samus_attr->x2C; 
+    fp->x80_self_vel.y = 0.0f;
+    if (fp->x673 < samus_attr->x28) {
         Fighter_ActionStateChange_800693AC(fighterObj, 0x15E, 0, NULL, 0.0f, 1.0f, 0.0f);
         func_8006EBA4(fighterObj);
     } else {
@@ -22,10 +22,10 @@ void ftSamus_SpecialS_StartAction(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_SpecialAirS_StartAction(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
-    fighter->x80_self_vel.x /= samus_attr->x2C; 
-    if (fighter->x673 < samus_attr->x28) {
+    Fighter* fp = getFighter(fighterObj);
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    fp->x80_self_vel.x /= samus_attr->x2C; 
+    if (fp->x673 < samus_attr->x28) {
         Fighter_ActionStateChange_800693AC(fighterObj, 0x160, 0, NULL, 0.0f, 1.0f, 0.0f);
         func_8006EBA4(fighterObj);
     } else {
@@ -60,11 +60,11 @@ void ftSamus_8012A400(HSD_GObj* fighterObj) {
 void ftSamus_8012A420(HSD_GObj *fighterObj)
 {
     s32 unused[5];
-    Fighter *fighter = getFighterPlus(fighterObj);
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
+    Fighter *fp = getFighterPlus(fighterObj);
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
     Fighter *fighter2;
-    func_8007D4B8(fighter);
-    fighter2 = fighter;
+    func_8007D4B8(fp);
+    fighter2 = fp;
     func_8007CE94(fighter2, samus_attr->x30);
 }
 
@@ -106,14 +106,14 @@ void ftSamus_8012A580(HSD_GObj *fighterObj)
 {
     s32 unused[8];  /// this func is so strange
     Fighter *fighter2;
-    Fighter *fighter;
+    Fighter *fp;
     ftSamusAttributes *samus_attr;
     ftSamusAttributes *samus_attr2;
-    fighter = fighter2 = getFighterPlus(fighterObj);
-    samus_attr = getFtSpecialAttrs(fighter);
-    func_8007D4B8(fighter);
+    fp = fighter2 = getFighterPlus(fighterObj);
+    samus_attr = getFtSpecialAttrs(fp);
+    func_8007D4B8(fp);
     samus_attr2 = samus_attr; 
-    func_8007CE94(fighter, samus_attr2->x30);
+    func_8007CE94(fp, samus_attr2->x30);
 }
 
 void ftSamus_8012A5C8(HSD_GObj* fighterObj) {
@@ -129,7 +129,7 @@ void ftSamus_8012A604(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_8012A640(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
+    Fighter* fp = getFighterPlus(fighterObj);
     efLib_DestroyAll(fighterObj);
-    fighter->sa.samus.x2244 = 0; 
+    fp->sa.samus.x2244 = 0; 
 }

--- a/src/melee/ft/chara/ftSamus/ftsamus5.c
+++ b/src/melee/ft/chara/ftSamus/ftsamus5.c
@@ -1,58 +1,58 @@
 #include <ftsamus.h>
 
 void ftSamus_SpecialHi_StartAction(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
+    Fighter* fp = getFighterPlus(fighterObj);
     Fighter_ActionStateChange_800693AC(fighterObj, 0x161, 0, NULL, 0.0f, 1.0f, 0.0f);
     ftSamus_updateDamageDeathCBs(fighterObj);
-    fighter->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-    fighter->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
-    func_8007D7FC(fighter);
-    fighter->x220C_ftcmd_var3 = 0;
-    fighter->x2208_ftcmd_var2 = 0;
-    fighter->x2204_ftcmd_var1 = 0;
-    fighter->x2200_ftcmd_var0 = 0;
-    fighter->x2340_stateVar1 = 0;
+    fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    func_8007D7FC(fp);
+    fp->x220C_ftcmd_var3 = 0;
+    fp->x2208_ftcmd_var2 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2340_stateVar1 = 0;
     func_8006EBA4(fighterObj);
-    ef_Spawn(0x482, fighterObj, fighter->x5E8_fighterBones[3].x0_jobj);
-    fighter->sa.samus.x2244 = 1;
+    ef_Spawn(0x482, fighterObj, fp->x5E8_fighterBones[3].x0_jobj);
+    fp->sa.samus.x2244 = 1;
 }
 
 void ftSamus_SpecialAirHi_StartAction(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    ftSamusAttributes* samus_attr = fighter->x2D4_specialAttributes; 
+    Fighter* fp = getFighter(fighterObj);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes; 
     Fighter_ActionStateChange_800693AC(fighterObj, 0x162, 0, NULL, 0.0f, 1.0f, 0.0f);
     ftSamus_updateDamageDeathCBs(fighterObj);
-    fighter->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-    fighter->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
-    func_8007D60C(fighter);
-    fighter->x220C_ftcmd_var3 = 0;
-    fighter->x2208_ftcmd_var2 = 0;
-    fighter->x2204_ftcmd_var1 = 0;
-    fighter->x2200_ftcmd_var0 = 0;
-    fighter->x2340_stateVar1 = 0;
-    fighter->x80_self_vel.y = samus_attr->x44;
-    func_8007D440(fighter, samus_attr->x40);
+    fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    func_8007D60C(fp);
+    fp->x220C_ftcmd_var3 = 0;
+    fp->x2208_ftcmd_var2 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2340_stateVar1 = 0;
+    fp->x80_self_vel.y = samus_attr->x44;
+    func_8007D440(fp, samus_attr->x40);
     func_8006EBA4(fighterObj);
-    ef_Spawn(0x482, fighterObj, fighter->x5E8_fighterBones[3].x0_jobj);
-    fighter->sa.samus.x2244 = 1;
+    ef_Spawn(0x482, fighterObj, fp->x5E8_fighterBones[3].x0_jobj);
+    fp->sa.samus.x2244 = 1;
 }
 
 
 void ftSamus_DestroyAllUnsetx2444(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     efLib_DestroyAll(fighterObj);
-    fighter->sa.samus.x2244 = 0;
+    fp->sa.samus.x2244 = 0;
 }
 
 void ftSamus_8012A81C(HSD_GObj *fighterObj)
 {
-    Fighter *fighter = fighterObj->user_data;
+    Fighter *fp = fighterObj->user_data;
     ftSamusAttributes* samus_attr;
     ftSamusAttributes* samus_attr2;
-    samus_attr = samus_attr2 = getFtSpecialAttrs(fighter); 
+    samus_attr = samus_attr2 = getFtSpecialAttrs(fp); 
     if (!ftAnim_IsFramesRemaining(fighterObj))
     {
-        Fighter *fighter2 = fighter;
+        Fighter *fighter2 = fp;
         ftSamus_DestroyAllUnsetx2444(fighterObj);
         func_8007D60C(fighter2);
         if (samus_attr->x50 == 0.0f)
@@ -67,13 +67,13 @@ void ftSamus_8012A81C(HSD_GObj *fighterObj)
 
 void ftSamus_8012A8C4(HSD_GObj* fighterObj) {
  
-    Fighter *fighter = fighterObj->user_data;
+    Fighter *fp = fighterObj->user_data;
     ftSamusAttributes* samus_attr;
     ftSamusAttributes* samus_attr2;
-    samus_attr = samus_attr2 = getFtSpecialAttrs(fighter); 
+    samus_attr = samus_attr2 = getFtSpecialAttrs(fp); 
  
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
-        Fighter* fighter2 = fighter;
+        Fighter* fighter2 = fp;
         ftSamus_DestroyAllUnsetx2444(fighterObj);
         func_8007D60C(fighter2);
         if (samus_attr->x50 == 0.0f) {
@@ -87,21 +87,21 @@ void ftSamus_8012A8C4(HSD_GObj* fighterObj) {
 void ftSamus_8012A96C(HSD_GObj* fighterObj) {
     f32 mag;
     f32 lstick_x;
-    Fighter* fighter = fighterObj->user_data;
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
-    if ((!fighter->x2204_ftcmd_var1) && (!fighter->x2340_stateVar1)) {
-        if ((lstick_x = fighter->input.x620_lstick_x) < 0.0f) {
+    Fighter* fp = fighterObj->user_data;
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    if ((!fp->x2204_ftcmd_var1) && (!fp->x2340_stateVar1)) {
+        if ((lstick_x = fp->input.x620_lstick_x) < 0.0f) {
             mag = -lstick_x;
         } else {
             mag = lstick_x;
         }
         if (mag > samus_attr->x4C) {
-            if (((fighter->x2C_facing_direction == 1.0f ) && (lstick_x < 0.0f)) 
-                || ((fighter->x2C_facing_direction == -1.0f) && (lstick_x > 0.0f))) {
-                fighter->x2204_ftcmd_var1 = 1;
-                fighter->x2340_stateVar1 = 1;
-                func_8007D9FC(fighter);
-                func_80075AF0(fighter, 0, M_PI_2 * fighter->x2C_facing_direction);
+            if (((fp->x2C_facing_direction == 1.0f ) && (lstick_x < 0.0f)) 
+                || ((fp->x2C_facing_direction == -1.0f) && (lstick_x > 0.0f))) {
+                fp->x2204_ftcmd_var1 = 1;
+                fp->x2340_stateVar1 = 1;
+                func_8007D9FC(fp);
+                func_80075AF0(fp, 0, M_PI_2 * fp->x2C_facing_direction);
             }
         }
     }
@@ -110,63 +110,63 @@ void ftSamus_8012A96C(HSD_GObj* fighterObj) {
 void ftSamus_8012AA3C(HSD_GObj* fighterObj) {
     f32 mag;
     f32 lstick_x;
-    Fighter* fighter = fighterObj->user_data;
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
-    if ((!fighter->x2204_ftcmd_var1) && (!fighter->x2340_stateVar1)) {
-        if ((lstick_x = fighter->input.x620_lstick_x) < 0.0f) {
+    Fighter* fp = fighterObj->user_data;
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    if ((!fp->x2204_ftcmd_var1) && (!fp->x2340_stateVar1)) {
+        if ((lstick_x = fp->input.x620_lstick_x) < 0.0f) {
             mag = -lstick_x;
         } else {
             mag = lstick_x;
         }
         if (mag > samus_attr->x4C) {
-            if (((fighter->x2C_facing_direction == 1.0f ) && (lstick_x < 0.0f)) 
-                || ((fighter->x2C_facing_direction == -1.0f) && (lstick_x > 0.0f))) {
-                fighter->x2204_ftcmd_var1 = 1;
-                fighter->x2340_stateVar1 = 1;
-                func_8007D9FC(fighter);
-                func_80075AF0(fighter, 0, M_PI_2 * fighter->x2C_facing_direction);
+            if (((fp->x2C_facing_direction == 1.0f ) && (lstick_x < 0.0f)) 
+                || ((fp->x2C_facing_direction == -1.0f) && (lstick_x > 0.0f))) {
+                fp->x2204_ftcmd_var1 = 1;
+                fp->x2340_stateVar1 = 1;
+                func_8007D9FC(fp);
+                func_80075AF0(fp, 0, M_PI_2 * fp->x2C_facing_direction);
             }
         }
     }
 }
 
 void ftSamus_8012AB0C(HSD_GObj* fighterObj) {
-    Fighter *fighter = getFighter(fighterObj);
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
+    Fighter *fp = getFighter(fighterObj);
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
     
-    if (fighter->x2200_ftcmd_var0) {
-        func_8007D60C(fighter);
-        fighter->x2200_ftcmd_var0 = 0;
-        fighter->x80_self_vel.x = samus_attr->x38 * fighter->x2C_facing_direction;
+    if (fp->x2200_ftcmd_var0) {
+        func_8007D60C(fp);
+        fp->x2200_ftcmd_var0 = 0;
+        fp->x80_self_vel.x = samus_attr->x38 * fp->x2C_facing_direction;
     }
-    if (fighter->xE0_ground_or_air == 1) {
+    if (fp->xE0_ground_or_air == 1) {
         func_800851C0(fighterObj);
-        func_8007D344(fighter, 0.0f, samus_attr->x3C, samus_attr->x40);
-        func_8007D268(fighter);
+        func_8007D344(fp, 0.0f, samus_attr->x3C, samus_attr->x40);
+        func_8007D268(fp);
         return;
     }
     func_80084F3C(fighterObj);
 }
 
 void ftSamus_8012ABB4(HSD_GObj* fighterObj) {
-    Fighter *fighter = fighterObj->user_data;
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
+    Fighter *fp = fighterObj->user_data;
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
     func_80084DB0(fighterObj);
-    func_8007D344(fighter, 0.0f, samus_attr->x3C, samus_attr->x40);
+    func_8007D344(fp, 0.0f, samus_attr->x3C, samus_attr->x40);
 }
 
 void ftSamus_8012AC00(HSD_GObj* fighterObj) {
-    Fighter *fighter = getFighter(fighterObj);
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
+    Fighter *fp = getFighter(fighterObj);
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
     
-    if (fighter->xE0_ground_or_air == GA_Air) {
+    if (fp->xE0_ground_or_air == GA_Air) {
         s32 direction;
 
-        if (fighter->x80_self_vel.y >= 0.0f) {
+        if (fp->x80_self_vel.y >= 0.0f) {
             func_80081D0C(fighterObj);
             return;
         }
-        if (fighter->x2C_facing_direction == 1.0f) {
+        if (fp->x2C_facing_direction == 1.0f) {
             direction = 1;
         } else {
             direction = -1;
@@ -186,17 +186,17 @@ void ftSamus_8012AC00(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_8012ACF8(HSD_GObj* fighterObj) {
-    Fighter *fighter = getFighter(fighterObj);
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
+    Fighter *fp = getFighter(fighterObj);
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
     
-    if (fighter->xE0_ground_or_air == GA_Air) {
+    if (fp->xE0_ground_or_air == GA_Air) {
         s32 direction;
 
-        if (fighter->x80_self_vel.y >= 0.0f) {
+        if (fp->x80_self_vel.y >= 0.0f) {
             func_80081D0C(fighterObj);
             return;
         }
-        if (fighter->x2C_facing_direction == 1.0f) {
+        if (fp->x2C_facing_direction == 1.0f) {
             direction = 1;
         } else {
             direction = -1;

--- a/src/melee/ft/chara/ftSamus/ftsamus6.c
+++ b/src/melee/ft/chara/ftSamus/ftsamus6.c
@@ -3,31 +3,31 @@
 void ftSamus_8012ADF0(HSD_GObj* fighterObj) {
     Vec vec;
     BOOL bool1;
-    Fighter *fighter = getFighterPlus(fighterObj);
-    ftSamusAttributes* samus_attr = fighter->x2D4_specialAttributes;
+    Fighter *fp = getFighterPlus(fighterObj);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
     
-    if (fighter->x2210_ThrowFlags.b0) {
-        fighter->x2210_ThrowFlags.b0 = 0;
+    if (fp->x2210_ThrowFlags.b0) {
+        fp->x2210_ThrowFlags.b0 = 0;
         bool1 = 1;
     } else {
         bool1 = 0;
     }
     if (bool1) {
         f32 vec_x; 
-        func_8000B1CC(fighter->x5E8_fighterBones[0].x0_jobj, NULL, &vec);
+        func_8000B1CC(fp->x5E8_fighterBones[0].x0_jobj, NULL, &vec);
         vec_x = samus_attr->x74_vec.x;
-        vec.x += (vec_x * fighter->x2C_facing_direction);
+        vec.x += (vec_x * fp->x2C_facing_direction);
         vec.y += samus_attr->x74_vec.y;
         vec.z += samus_attr->x74_vec.z;
-        func_802B4AC8(fighterObj, &vec, fighter->x2C_facing_direction, vec_x);
-        fighter->cb.x21BC_callback_Accessory4 = 0;
+        func_802B4AC8(fighterObj, &vec, fp->x2C_facing_direction, vec_x);
+        fp->cb.x21BC_callback_Accessory4 = 0;
     }
 }
 
 
 void ftSamus_8012AEBC(HSD_GObj* fighterObj) {
     struct UNK_SAMUS_S2 unk_struct;
-    Fighter* fighter = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
     func_8007B0C0(fighterObj, 2);
     
     
@@ -37,7 +37,7 @@ void ftSamus_8012AEBC(HSD_GObj* fighterObj) {
     unk_struct.vec1.x = unk_struct.vec1.y = unk_struct.vec1.z = 0.0f; 
     unk_struct.vec2.x = unk_struct.vec2.y = unk_struct.vec2.z = 0.0f;
     unk_struct.single_float = 3.0f; 
-    func_8007B5AC(fighter, &fighter->x11A0_fighterHurtbox[0], &unk_struct); 
+    func_8007B5AC(fp, &fp->x11A0_fighterHurtbox[0], &unk_struct); 
 }
 
 void ftSamus_8012AF38(HSD_GObj* fighterObj) {
@@ -45,27 +45,27 @@ void ftSamus_8012AF38(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_SpecialLw_StartAction_inner(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    fighter->x2208_ftcmd_var2 = 0;
-    fighter->x2204_ftcmd_var1 = 0;
-    fighter->x2200_ftcmd_var0 = 0;
-    fighter->x2210_ThrowFlags.b0 = 0;
-    fighter->x2340_stateVar1 = 0;
-    if (fighter->x894_currentAnimFrame == 3.0f) {
-        fighter->x2204_ftcmd_var1 = 1;
+    Fighter* fp = getFighter(fighterObj);
+    fp->x2208_ftcmd_var2 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x2210_ThrowFlags.b0 = 0;
+    fp->x2340_stateVar1 = 0;
+    if (fp->x894_currentAnimFrame == 3.0f) {
+        fp->x2204_ftcmd_var1 = 1;
     }
-    fighter->cb.x21BC_callback_Accessory4 = &ftSamus_8012ADF0;
+    fp->cb.x21BC_callback_Accessory4 = &ftSamus_8012ADF0;
 }
 
 void ftSamus_SpecialLw_StartAction(HSD_GObj* fighterObj) {
-    Fighter *fighter = getFighter(fighterObj);
-    ftSamusAttributes* samus_attr = fighter->x2D4_specialAttributes;
+    Fighter *fp = getFighter(fighterObj);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
     
-    fighter->xEC_ground_vel *= samus_attr->x6C;
-    if (fighter->x10_action_state_index == 0x28) {
+    fp->xEC_ground_vel *= samus_attr->x6C;
+    if (fp->x10_action_state_index == 0x28) {
         Fighter_ActionStateChange_800693AC(fighterObj, 0x163, 0, NULL, 3.0f, 1.0f, 0.0f);
         ftSamus_SpecialLw_StartAction_inner(fighterObj);
-        fighter->x2204_ftcmd_var1 = 2;
+        fp->x2204_ftcmd_var1 = 2;
         ftSamus_8012B5F0(fighterObj);
         return;
     }
@@ -75,11 +75,11 @@ void ftSamus_SpecialLw_StartAction(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_SpecialAirLw_StartAction(HSD_GObj* fighterObj) {
-    Fighter *fighter = getFighterPlus(fighterObj);
-    ftSamusAttributes* samus_attr = fighter->x2D4_specialAttributes;
+    Fighter *fp = getFighterPlus(fighterObj);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
     
-    fighter->x80_self_vel.x *= samus_attr->x70;
-    fighter->x80_self_vel.y = samus_attr->x58;
+    fp->x80_self_vel.x *= samus_attr->x70;
+    fp->x80_self_vel.y = samus_attr->x58;
 
     Fighter_ActionStateChange_800693AC(fighterObj, 0x164, 0, NULL, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(fighterObj);
@@ -89,20 +89,20 @@ void ftSamus_SpecialAirLw_StartAction(HSD_GObj* fighterObj) {
 ///// what the heck is up with the stack in this function... can't get rid of unused params
 void ftSamus_8012B150(HSD_GObj* fighterObj, s32 a, s32 b, s32 c, s32 d) {
 
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    if (fighter->x2204_ftcmd_var1 == 1) {
-        fighter->x2204_ftcmd_var1 = 2;
+    if (fp->x2204_ftcmd_var1 == 1) {
+        fp->x2204_ftcmd_var1 = 2;
         ftSamus_8012B5F0(fighterObj);
         return; 
     }
-    if ((fighter->x2200_ftcmd_var0) && (!fighter->x2340_stateVar1)) {
+    if ((fp->x2200_ftcmd_var0) && (!fp->x2340_stateVar1)) {
         ftSamus_8012AEBC(fighterObj);
-        fighter->x2340_stateVar1 = 1;
+        fp->x2340_stateVar1 = 1;
     }
-    if ((!fighter->x2200_ftcmd_var0) && ( fighter->x2340_stateVar1)) {
+    if ((!fp->x2200_ftcmd_var0) && ( fp->x2340_stateVar1)) {
         func_8007B0C0(fighterObj, 0);
-        fighter->x2340_stateVar1 = 0;
+        fp->x2340_stateVar1 = 0;
     }
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
         func_8008A2BC(fighterObj);
@@ -111,15 +111,15 @@ void ftSamus_8012B150(HSD_GObj* fighterObj, s32 a, s32 b, s32 c, s32 d) {
 
 void ftSamus_8012B264(HSD_GObj* fighterObj, s32 a, s32 b) {
 
-    Fighter* fighter = getFighterPlus(fighterObj);
+    Fighter* fp = getFighterPlus(fighterObj);
 
-    if ((fighter->x2200_ftcmd_var0) && (!fighter->x2340_stateVar1)) {
+    if ((fp->x2200_ftcmd_var0) && (!fp->x2340_stateVar1)) {
         ftSamus_8012AEBC(fighterObj);
-        fighter->x2340_stateVar1 = 1;
+        fp->x2340_stateVar1 = 1;
     }
-    if ((!fighter->x2200_ftcmd_var0) && ( fighter->x2340_stateVar1)) {
+    if ((!fp->x2200_ftcmd_var0) && ( fp->x2340_stateVar1)) {
         func_8007B0C0(fighterObj, 0);
-        fighter->x2340_stateVar1 = 0;
+        fp->x2340_stateVar1 = 0;
     }
     if (!ftAnim_IsFramesRemaining(fighterObj)) {
         func_800CC730(fighterObj);
@@ -127,10 +127,10 @@ void ftSamus_8012B264(HSD_GObj* fighterObj, s32 a, s32 b) {
 }
 
 void ftSamus_8012B358(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    ftSamusAttributes* samus_attr = fighter->x2D4_specialAttributes;
-    if ((fighter->x2208_ftcmd_var2) && (fighter->input.x624_lstick_y < samus_attr->x80)) {
-        fighter->x2208_ftcmd_var2 = 0;
+    Fighter* fp = fighterObj->user_data;
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
+    if ((fp->x2208_ftcmd_var2) && (fp->input.x624_lstick_y < samus_attr->x80)) {
+        fp->x2208_ftcmd_var2 = 0;
         func_800D638C(fighterObj);
     }
 }
@@ -138,13 +138,13 @@ void ftSamus_8012B358(HSD_GObj* fighterObj) {
 void ftSamus_8012B3A4(HSD_GObj* fighterObj) {}
 
 void ftSamus_8012B3A8(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
-    attr* ft_attr = &fighter->x110_attr;
+    Fighter* fp = getFighter(fighterObj);
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    attr* ft_attr = &fp->x110_attr;
  
-    if (fighter->x2200_ftcmd_var0) {
+    if (fp->x2200_ftcmd_var0) {
         func_8007CADC(
-            fighter, 
+            fp, 
             0.0f, 
             ft_attr->x110_WalkInitialVelocity * samus_attr->x64, 
             ft_attr->x118_WalkMaximumVelocity * samus_attr->x5C
@@ -156,13 +156,13 @@ void ftSamus_8012B3A8(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_8012B41C(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
-    attr* ft_attr = &fighter->x110_attr;
+    Fighter* fp = fighterObj->user_data;
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    attr* ft_attr = &fp->x110_attr;
  
-    func_8007D4B8(fighter);
+    func_8007D4B8(fp);
     func_8007D3A8(
-        fighter, 
+        fp, 
         0.0f, 
         ft_attr->x174_AerialDriftStickMult * samus_attr->x68, 
         ft_attr->x17C_AerialDriftMax * samus_attr->x60
@@ -170,10 +170,10 @@ void ftSamus_8012B41C(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_8012B488(HSD_GObj* fighterObj) {
-    Fighter *fighter = fighterObj->user_data;
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
+    Fighter *fp = fighterObj->user_data;
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
     
-    if (fighter->x2200_ftcmd_var0) {
+    if (fp->x2200_ftcmd_var0) {
         if (!func_80082888(fighterObj, &samus_attr->height_attributes)) {
             ftSamus_8012B570(fighterObj);
         }
@@ -183,10 +183,10 @@ void ftSamus_8012B488(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_8012B4FC(HSD_GObj* fighterObj) {
-    Fighter *fighter = fighterObj->user_data;
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
+    Fighter *fp = fighterObj->user_data;
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
     
-    if (fighter->x2200_ftcmd_var0) {
+    if (fp->x2200_ftcmd_var0) {
         if (func_800824A0(fighterObj, &samus_attr->height_attributes)) {
             ftSamus_8012B668(fighterObj);
         }
@@ -196,31 +196,31 @@ void ftSamus_8012B4FC(HSD_GObj* fighterObj) {
 }
 
 void ftSamus_UnkSetStateAndCb(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    fighter->x2204_ftcmd_var1 = 2;
-    fighter->x2340_stateVar1 = 0;
-    fighter->cb.x21BC_callback_Accessory4 = &ftSamus_8012ADF0;
+    Fighter* fp = getFighter(fighterObj);
+    fp->x2204_ftcmd_var1 = 2;
+    fp->x2340_stateVar1 = 0;
+    fp->cb.x21BC_callback_Accessory4 = &ftSamus_8012ADF0;
 }
 
 void ftSamus_8012B570(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    func_8007D5D4(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x164, 0x0C4C509C, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = getFighter(fighterObj);
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x164, 0x0C4C509C, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
     ftSamus_UnkSetStateAndCb(fighterObj);
 }
 
 void ftSamus_8012B5F0(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fighter);
-    fighter->x80_self_vel.y = samus_attr->x54;
-    func_8007D5D4(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x164, 0x0C4C509C, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
-    fighter->cb.x21BC_callback_Accessory4 = ftSamus_8012ADF0;
+    Fighter* fp = fighterObj->user_data;
+    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    fp->x80_self_vel.y = samus_attr->x54;
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x164, 0x0C4C509C, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
+    fp->cb.x21BC_callback_Accessory4 = ftSamus_8012ADF0;
 }
 
 void ftSamus_8012B668(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    func_8007D7FC(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x163, 0x0C4C509C, NULL, fighter->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter* fp = getFighter(fighterObj);
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x163, 0x0C4C509C, NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
     ftSamus_UnkSetStateAndCb(fighterObj);
 }

--- a/src/melee/ft/chara/ftSandbag/ftsandbag.c
+++ b/src/melee/ft/chara/ftSandbag/ftsandbag.c
@@ -10,46 +10,46 @@ void ftSandbag_OnDeath(void) {
 }
 
 void ftSandbag_OnLoad(HSD_GObj* gobj) {
-    Fighter* fighter = gobj->user_data;
+    Fighter* fp = gobj->user_data;
 
 
-    PUSH_ATTRS(fighter, ftSandbagAttributes);
+    PUSH_ATTRS(fp, ftSandbagAttributes);
 
-    fighter->x2228_flag.bits.b2 = 1;
-    fighter->x2226_flag.bits.b0 = 1;
+    fp->x2228_flag.bits.b2 = 1;
+    fp->x2226_flag.bits.b0 = 1;
 
-    func_8014FA30(fighter);
+    func_8014FA30(fp);
 }
 
-void func_8014FA30(Fighter* fighter)
+void func_8014FA30(Fighter* fp)
 {
-    FighterBone* bones = fighter->x5E8_fighterBones;
+    FighterBone* bones = fp->x5E8_fighterBones;
     func_8000C1C0(bones[5].x0_jobj, bones[12].x0_jobj);
-    bones = fighter->x5E8_fighterBones;
+    bones = fp->x5E8_fighterBones;
     func_8000C1C0(bones[5].x4_jobj2, bones[12].x4_jobj2);
-    bones = fighter->x5E8_fighterBones;
+    bones = fp->x5E8_fighterBones;
     func_8000C1C0(bones[5].x0_jobj, bones[17].x0_jobj);
-    bones = fighter->x5E8_fighterBones;
+    bones = fp->x5E8_fighterBones;
     func_8000C1C0(bones[5].x4_jobj2, bones[17].x4_jobj2);
-    bones = fighter->x5E8_fighterBones;
+    bones = fp->x5E8_fighterBones;
     func_8000C228(bones[7].x0_jobj, bones[37].x0_jobj);
-    bones = fighter->x5E8_fighterBones;
+    bones = fp->x5E8_fighterBones;
     func_8000C228(bones[7].x4_jobj2, bones[37].x4_jobj2);
 
-    func_8000C420(fighter->x5E8_fighterBones[7].x0_jobj, 1, -1.57079637f);
-    func_8000C420(fighter->x5E8_fighterBones[7].x0_jobj, 2, -1.57079637f);
-    func_8000C420(fighter->x5E8_fighterBones[7].x4_jobj2, 1, -1.57079637f);
-    func_8000C420(fighter->x5E8_fighterBones[7].x4_jobj2, 2, -1.57079637f);
+    func_8000C420(fp->x5E8_fighterBones[7].x0_jobj, 1, -1.57079637f);
+    func_8000C420(fp->x5E8_fighterBones[7].x0_jobj, 2, -1.57079637f);
+    func_8000C420(fp->x5E8_fighterBones[7].x4_jobj2, 1, -1.57079637f);
+    func_8000C420(fp->x5E8_fighterBones[7].x4_jobj2, 2, -1.57079637f);
 
-    bones = fighter->x5E8_fighterBones;
+    bones = fp->x5E8_fighterBones;
     func_8000C228(bones[6].x0_jobj, bones[5].x0_jobj);
-    bones = fighter->x5E8_fighterBones;
+    bones = fp->x5E8_fighterBones;
     func_8000C228(bones[6].x4_jobj2, bones[5].x4_jobj2);
 
-    func_8000C420(fighter->x5E8_fighterBones[6].x0_jobj, 1, -1.50098311f);
-    func_8000C420(fighter->x5E8_fighterBones[6].x0_jobj, 2, -1.50098311f);
-    func_8000C420(fighter->x5E8_fighterBones[6].x4_jobj2, 1, -1.50098311f);
-    func_8000C420(fighter->x5E8_fighterBones[6].x4_jobj2, 2, -1.50098311f);
+    func_8000C420(fp->x5E8_fighterBones[6].x0_jobj, 1, -1.50098311f);
+    func_8000C420(fp->x5E8_fighterBones[6].x0_jobj, 2, -1.50098311f);
+    func_8000C420(fp->x5E8_fighterBones[6].x4_jobj2, 1, -1.50098311f);
+    func_8000C420(fp->x5E8_fighterBones[6].x4_jobj2, 2, -1.50098311f);
 }
 
 void ftSandbag_LoadSpecialAttrs(HSD_GObj* gobj)
@@ -65,13 +65,13 @@ void func_8014FBA4(HSD_GObj* gobj)
 {
     f32 temp_f1;
 
-    Fighter* fighter = gobj->user_data;
-    if ((s32) fighter->xE0_ground_or_air == GA_Air) {
-        func_8007D7FC(fighter);
+    Fighter* fp = gobj->user_data;
+    if ((s32) fp->xE0_ground_or_air == GA_Air) {
+        func_8007D7FC(fp);
     }
 
     Fighter_ActionStateChange_800693AC(gobj, 0x155, 0, 0, 0.0f, 1.0f, 0.0f);
-    func_8007EFC0(fighter, p_ftCommonData->x5F0);
+    func_8007EFC0(fp, p_ftCommonData->x5F0);
 }
 
 void func_8014FC20(void) {

--- a/src/melee/ft/chara/ftSandbag/ftsandbag.h
+++ b/src/melee/ft/chara/ftSandbag/ftsandbag.h
@@ -11,7 +11,7 @@
 
 void ftSandbag_OnDeath(void);
 void ftSandbag_OnLoad(HSD_GObj* gobj);
-void func_8014FA30(Fighter* fighter);
+void func_8014FA30(Fighter* fp);
 void ftSandbag_LoadSpecialAttrs(HSD_GObj* gobj);
 
 void ftSandbag_OnKnockbackEnter(void);

--- a/src/melee/ft/chara/ftSeak/ftseak.c
+++ b/src/melee/ft/chara/ftSeak/ftseak.c
@@ -1,21 +1,21 @@
 #include <ftseak.h>
 
 void ftSeak_OnDeath(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    fighter->sa.seak.x222C = 0;
-    fighter->sa.seak.x2230 = 0;
-    fighter->sa.seak.x2234 = 0;
+    Fighter* fp = fighterObj->user_data;
+    fp->sa.seak.x222C = 0;
+    fp->sa.seak.x2230 = 0;
+    fp->sa.seak.x2234 = 0;
     func_80074A4C(fighterObj, 0, 0);
     func_80074A4C(fighterObj, 1, -1);
 }
 
 void ftSeak_OnLoad(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    void** item_list = fighter->x10C_ftData->x48_items;
+    Fighter* fp = fighterObj->user_data;
+    void** item_list = fp->x10C_ftData->x48_items;
 
-    fighter->x2224_flag.bits.b7 = 1;
+    fp->x2224_flag.bits.b7 = 1;
     
-    PUSH_ATTRS(fighter, ftSeakAttributes);
+    PUSH_ATTRS(fp, ftSeakAttributes);
     
     func_8026B3F8(item_list[0], 0x4FU);
     func_8026B3F8(item_list[1], 0x50U);
@@ -29,9 +29,9 @@ void ftSeak_80110198(HSD_GObj* fighterObj) {
 }
 
 void ftSeak_801101CC(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    if (fighter->sa.seak.x222C == 6) {
-        func_800BFFD0(fighter, 0x56, 0);
+    Fighter* fp = fighterObj->user_data;
+    if (fp->sa.seak.x222C == 6) {
+        func_800BFFD0(fp, 0x56, 0);
     }
 }
 
@@ -67,7 +67,7 @@ void ftSeak_OnKnockbackExit(HSD_GObj* fighterObj) {
 // 8011412C - 80114160
 // https://decomp.me/scratch/b1oIZ
 // void lbl_8011412C(HSD_GObj* fighterObj) {
-//     Fighter* fighter = fighterObj->user_data;
-//     fighter->cb.x21BC_callback_Accessory4 = 0;
+//     Fighter* fp = fighterObj->user_data;
+//     fp->cb.x21BC_callback_Accessory4 = 0;
 //     func_8007EFC8(fighterObj, &ftZelda_8013B4D8);
 // }

--- a/src/melee/ft/chara/ftYoshi/ftyoshi.c
+++ b/src/melee/ft/chara/ftYoshi/ftyoshi.c
@@ -2,7 +2,7 @@
 
 
 ///https://decomp.me/scratch/ufrFK
-void func_8012B6E8(Fighter* fighter, struct S_UNK_YOSHI1* unk_struct_arg) {
+void func_8012B6E8(Fighter* fp, struct S_UNK_YOSHI1* unk_struct_arg) {
 
     s32 filler[5];
 
@@ -13,14 +13,14 @@ void func_8012B6E8(Fighter* fighter, struct S_UNK_YOSHI1* unk_struct_arg) {
     s32 i;
     f32 zero_float;
     
-    attr_r26 = fighter->x10C_ftData->ext_attr;
+    attr_r26 = fp->x10C_ftData->ext_attr;
     index = (unk_struct1 = unk_struct_arg)->unk_struct->xC_start_index;
     ptr2EndIndex = (s32 *) (&unk_struct1->unk_struct->x8_end_index);
     zero_float = 0.0f;
     
     for (i = 0; i < *ptr2EndIndex; i++) {
 
-        HSD_DObj* dobj_r3 = fighter->x5F0[index[i]];
+        HSD_DObj* dobj_r3 = fp->x5F0[index[i]];
         HSD_MObj *mobj_r3;
         HSD_AObj *aobj_r24;
 
@@ -46,7 +46,7 @@ void func_8012B6E8(Fighter* fighter, struct S_UNK_YOSHI1* unk_struct_arg) {
     }
 }
 
-void func_8012B804(Fighter* fighter, struct S_UNK_YOSHI1* unk_struct_arg, f32 start_frame) {
+void func_8012B804(Fighter* fp, struct S_UNK_YOSHI1* unk_struct_arg, f32 start_frame) {
 
     s32 filler[2];
 
@@ -62,7 +62,7 @@ void func_8012B804(Fighter* fighter, struct S_UNK_YOSHI1* unk_struct_arg, f32 st
         
         for (i = 0; i < *ptr2EndIndex; i++) {
 
-            HSD_DObj* dobj_r3 = fighter->x5F0[index[i]];
+            HSD_DObj* dobj_r3 = fp->x5F0[index[i]];
             HSD_MObj* mobj_r3;
             HSD_MObj* mobj;
 
@@ -83,25 +83,25 @@ void func_8012B804(Fighter* fighter, struct S_UNK_YOSHI1* unk_struct_arg, f32 st
 
 void func_8012B8A4(HSD_GObj* fighterObj) {
     s32 unused[4];
-    Fighter* fighter = fighterObj->user_data;
-    ftYoshiAttributes *attr = fighter->x2D4_specialAttributes;
-    f32 tempf = attr->xC * (1.0f - (fighter->x1998_shieldHealth / p_ftCommonData->x260_startShieldHealth));
-    func_8012B804(fighter, (struct S_UNK_YOSHI1*)fighter->x5B8, tempf);
-    func_8012B804(fighter, (struct S_UNK_YOSHI1*)fighter->x5BC, tempf);
+    Fighter* fp = fighterObj->user_data;
+    ftYoshiAttributes *attr = fp->x2D4_specialAttributes;
+    f32 tempf = attr->xC * (1.0f - (fp->x1998_shieldHealth / p_ftCommonData->x260_startShieldHealth));
+    func_8012B804(fp, (struct S_UNK_YOSHI1*)fp->x5B8, tempf);
+    func_8012B804(fp, (struct S_UNK_YOSHI1*)fp->x5BC, tempf);
 }
 
 
 void func_8012B918(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    func_8012B804(fighter, (struct S_UNK_YOSHI1*)fighter->x5B8, 0.0f);
-    func_8012B804(fighter, (struct S_UNK_YOSHI1*)fighter->x5BC, 0.0f);
+    func_8012B804(fp, (struct S_UNK_YOSHI1*)fp->x5B8, 0.0f);
+    func_8012B804(fp, (struct S_UNK_YOSHI1*)fp->x5BC, 0.0f);
 }
 
 void ftYoshi_OnDeath(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     func_80074A4C(fighterObj, 0, 0);
-    fighter->sa.yoshi.x2238 = 0;
+    fp->sa.yoshi.x2238 = 0;
 }
 
 
@@ -113,12 +113,12 @@ void ftYoshi_OnLoad(HSD_GObj* fighterObj) {
     struct S_UNK_YOSHI1* temp;
     ftData *fighter_data;
     struct S_UNK_YOSHI1* temp_r27;
-    Fighter *fighter;
+    Fighter *fp;
     
-    fighter = fighterObj->user_data;
-    temp = temp_r27 = (struct S_UNK_YOSHI1*) fighter->x5B8;
-    fighter_data = fighter->x10C_ftData;
-    temp_r28 = (struct S_UNK_YOSHI1*)fighter->x5BC;
+    fp = fighterObj->user_data;
+    temp = temp_r27 = (struct S_UNK_YOSHI1*) fp->x5B8;
+    fighter_data = fp->x10C_ftData;
+    temp_r28 = (struct S_UNK_YOSHI1*)fp->x5BC;
     item_list = fighter_data->x48_items;
     other_attr = fighter_data->ext_attr;
     
@@ -129,13 +129,13 @@ void ftYoshi_OnLoad(HSD_GObj* fighterObj) {
     }
 
     other_attr->xC = 0.0f;
-    func_8012B6E8(fighter, temp_r27);
-    func_8012B6E8(fighter, temp_r28);
-    PUSH_ATTRS(fighter, ftYoshiAttributes);
+    func_8012B6E8(fp, temp_r27);
+    func_8012B6E8(fp, temp_r28);
+    PUSH_ATTRS(fp, ftYoshiAttributes);
     func_8026B3F8(item_list[0], 0x56U);
     func_8026B3F8(item_list[1], 0x58U);
     func_8026B3F8(item_list[2], 0x57U);
-    fighter->x2226_flag.bits.b1 = 1;
+    fp->x2226_flag.bits.b1 = 1;
   
 }
 
@@ -144,8 +144,8 @@ void ftYoshi_8012BA8C(HSD_GObj* fighterObj) {
     func_8012DF18(fighterObj);
 }
 
-f32 ftYoshi_8012BAC0(Fighter* fighter) {
-    ftYoshiAttributes *attr = fighter->x2D4_specialAttributes;
+f32 ftYoshi_8012BAC0(Fighter* fp) {
+    ftYoshiAttributes *attr = fp->x2D4_specialAttributes;
     return attr->x120;
 }
 

--- a/src/melee/ft/chara/ftYoshi/ftyoshi.h
+++ b/src/melee/ft/chara/ftYoshi/ftyoshi.h
@@ -36,5 +36,5 @@ struct S_UNK_YOSHI1 {
     struct S_UNK_YOSHI2* unk_struct;
 };
 
-void func_8012B6E8(Fighter* fighter, struct S_UNK_YOSHI1* unk_struct_arg);
-void func_8012B804(Fighter* fighter, struct S_UNK_YOSHI1* unk_struct_arg, f32 start_frame);
+void func_8012B6E8(Fighter* fp, struct S_UNK_YOSHI1* unk_struct_arg);
+void func_8012B804(Fighter* fp, struct S_UNK_YOSHI1* unk_struct_arg, f32 start_frame);

--- a/src/melee/ft/chara/ftZakoBoy/ftzakoboy.c
+++ b/src/melee/ft/chara/ftZakoBoy/ftzakoboy.c
@@ -26,9 +26,9 @@ void ftZakoBoy_OnItemDrop(HSD_GObj* fighterObj, BOOL bool1) {
 
 void ftZakoBoy_OnLoad(HSD_GObj* gobj)
 {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
 
-    PUSH_ATTRS(ft, ftZakoboyAttributes);
+    PUSH_ATTRS(fp, ftZakoboyAttributes);
 
 
 }

--- a/src/melee/ft/chara/ftZakoGirl/ftzakogirl.c
+++ b/src/melee/ft/chara/ftZakoGirl/ftzakogirl.c
@@ -7,8 +7,8 @@ void ftZakoGirl_OnDeath(HSD_GObj* gobj)
 
 void ftZakoGirl_OnLoad(HSD_GObj* gobj)
 {
-    Fighter* ft = gobj->user_data;
-    PUSH_ATTRS(ft, s32);
+    Fighter* fp = gobj->user_data;
+    PUSH_ATTRS(fp, s32);
 }
 
 void ftZakoGirl_OnItemPickup(HSD_GObj* fighterObj, BOOL bool) {

--- a/src/melee/ft/chara/ftZelda/ftzelda1.c
+++ b/src/melee/ft/chara/ftZelda/ftzelda1.c
@@ -1,17 +1,17 @@
 #include <ftzelda.h>
 
 void ftZelda_OnDeath(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     func_80074A4C(fighterObj, 0, 0);
     func_80074A4C(fighterObj, 1, 0);
-    fighter->sa.zelda.x222C = 0;
+    fp->sa.zelda.x222C = 0;
 }
 
 void ftZelda_OnLoad(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    void** item_list = fighter->x10C_ftData->x48_items;
+    Fighter* fp = fighterObj->user_data;
+    void** item_list = fp->x10C_ftData->x48_items;
     
-    PUSH_ATTRS(fighter, ftZeldaAttributes);
+    PUSH_ATTRS(fp, ftZeldaAttributes);
     
     func_8026B3F8(item_list[0], 0x6CU);
     func_8026B3F8(item_list[1], 0x6DU);

--- a/src/melee/ft/chara/ftZelda/ftzelda2.c
+++ b/src/melee/ft/chara/ftZelda/ftzelda2.c
@@ -6,31 +6,31 @@
 // 801396AC - 801396E0 (0x34 bytes)
 // https://decomp.me/scratch/UHxFc
 void ftZelda_801396AC(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
     ftZelda_801396E0(fighterObj);
-    fighter->cb.x21BC_callback_Accessory4 = 0;
+    fp->cb.x21BC_callback_Accessory4 = 0;
 }
 
 // 801396E0 - 8013979C (0xBC bytes)
 // https://decomp.me/scratch/ZIrBS
 void ftZelda_801396E0(HSD_GObj* fighterObj) {
     Point3d sp10;
-    Fighter* fighter = getFighter(fighterObj);
-    u8 flag = fighter->x2219_flag.bits.b0;
+    Fighter* fp = getFighter(fighterObj);
+    u8 flag = fp->x2219_flag.bits.b0;
     
     if (flag == 0) {
-        func_8000B1CC(fighter->x5E8_fighterBones[4].x0_jobj, NULL, &sp10);
+        func_8000B1CC(fp->x5E8_fighterBones[4].x0_jobj, NULL, &sp10);
 
-        if ((s32) fighter->xE0_ground_or_air == 0) {
-            ef_Spawn(0x4F6, fighterObj, fighter->x5E8_fighterBones->x0_jobj);
+        if ((s32) fp->xE0_ground_or_air == 0) {
+            ef_Spawn(0x4F6, fighterObj, fp->x5E8_fighterBones->x0_jobj);
         } else {
-            ef_Spawn(0x4F7, fighterObj, fighter->x5E8_fighterBones->x0_jobj);
+            ef_Spawn(0x4F7, fighterObj, fp->x5E8_fighterBones->x0_jobj);
         }
-        fighter->x2219_flag.bits.b0 = 1L;
+        fp->x2219_flag.bits.b0 = 1L;
     }
 
-    fighter->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-    fighter->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
 }
 
 // 8013979C - 80139834 (0x98 bytes)
@@ -38,26 +38,26 @@ void ftZelda_801396E0(HSD_GObj* fighterObj) {
 void ftZelda_8013979C(HSD_GObj* fighterObj) {
     Point3d sp10;
     u8 flag;
-    Fighter* fighter = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
 
-    func_8000B1CC(fighter->x5E8_fighterBones[4].x0_jobj, NULL, &sp10);
+    func_8000B1CC(fp->x5E8_fighterBones[4].x0_jobj, NULL, &sp10);
 
-    flag = fighter->x2219_flag.bits.b0;
+    flag = fp->x2219_flag.bits.b0;
     if (flag == 0) {
         ef_Spawn(0x505, fighterObj, &sp10);
-        fighter->x2219_flag.bits.b0 = 1;
+        fp->x2219_flag.bits.b0 = 1;
     }
 
-    fighter->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-    fighter->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
-    fighter->cb.x21BC_callback_Accessory4 = 0;
+    fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    fp->cb.x21BC_callback_Accessory4 = 0;
 }
 
 // AS_ZeldaUpBStartGround
 // 80139834 - 801398E8 (0xB4 bytes)
 // https://decomp.me/scratch/KUdnf (with helper)
 // https://decomp.me/scratch/52XE3 (as single function)
-void ftZelda_SpecialHi_StartAction_Helper(Fighter* fighter) {
+void ftZelda_SpecialHi_StartAction_Helper(Fighter* fp) {
     HSD_JObj* jObj;
     s32 boneIndex;
     s32 unused[1];
@@ -65,30 +65,30 @@ void ftZelda_SpecialHi_StartAction_Helper(Fighter* fighter) {
 
     unused[0] = 1.5; // Trick to use more stack space
 
-    boneIndex = func_8007500C(fighter, 4);
-    jObj = fighter->x5E8_fighterBones[boneIndex].x0_jobj;
+    boneIndex = func_8007500C(fp, 4);
+    jObj = fp->x5E8_fighterBones[boneIndex].x0_jobj;
 
     func_8000B1CC(jObj, NULL, &sp24);
 
     func_800119DC(&sp24, 0x78, 1.5, 0.019999999552965164, 1.0471975803375244);
 }
 void ftZelda_SpecialHi_StartAction(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighterPlus(fighterObj);
+    Fighter* fp = getFighterPlus(fighterObj);
 
-    fighter->xEC_ground_vel = 0.0f;
-    fighter->x80_self_vel.y = 0.0f;
-    fighter->x80_self_vel.x = 0.0f;
+    fp->xEC_ground_vel = 0.0f;
+    fp->x80_self_vel.y = 0.0f;
+    fp->x80_self_vel.x = 0.0f;
 
     Fighter_ActionStateChange_800693AC(fighterObj, 0x15D, 0, NULL, 0.0f, 1.0, 0.0f);
     func_8006EBA4(fighterObj);
 
-    fighter = getFighterPlus(fighterObj);
-    fighter->x2200_ftcmd_var0 = 0;
-    fighter->x234C_stateVar4 = 0;
+    fp = getFighterPlus(fighterObj);
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x234C_stateVar4 = 0;
 
-    ftZelda_SpecialHi_StartAction_Helper(fighter);
+    ftZelda_SpecialHi_StartAction_Helper(fp);
 
-    fighter->cb.x21BC_callback_Accessory4 = &ftZelda_801396AC;
+    fp->cb.x21BC_callback_Accessory4 = &ftZelda_801396AC;
 }
 
 // AS_ZeldaUpBStartAir
@@ -98,26 +98,26 @@ void ftZelda_SpecialAirHi_StartAction(HSD_GObj* fighterObj) {
     Point3d sp28;
     s32 unused[7];
     s32 boneIndex;
-    Fighter* fighter = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
     HSD_JObj* jObj;
-    ftZeldaAttributes* attributes = fighter->x2D4_specialAttributes;
+    ftZeldaAttributes* attributes = fp->x2D4_specialAttributes;
 
-    fighter->x80_self_vel.x = (f32) fighter->x80_self_vel.x / attributes->x38;
-    fighter->x80_self_vel.y = (f32) fighter->x80_self_vel.y / attributes->x3C;
+    fp->x80_self_vel.x = (f32) fp->x80_self_vel.x / attributes->x38;
+    fp->x80_self_vel.y = (f32) fp->x80_self_vel.y / attributes->x3C;
 
     Fighter_ActionStateChange_800693AC(fighterObj, 0x160, 0, NULL, 0, 1.0, 0); // lbl_804D9BA4, lbl_804D9BA8
     func_8006EBA4(fighterObj);
 
-    fighter = getFighter(fighterObj);
-    fighter->x2200_ftcmd_var0 = 0;
-    fighter->x234C_stateVar4 = 0;
+    fp = getFighter(fighterObj);
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x234C_stateVar4 = 0;
 
-    boneIndex = func_8007500C(fighter, 4);
-    jObj = fighter->x5E8_fighterBones[boneIndex].x0_jobj;
+    boneIndex = func_8007500C(fp, 4);
+    jObj = fp->x5E8_fighterBones[boneIndex].x0_jobj;
     func_8000B1CC(jObj, NULL, &sp28);
 
     func_800119DC(&sp28, 0x78, 1.5, 0.019999999552965164, 1.0471975803375244); // lbl_804D9B98, lbl_804D9B9C, lbl_804D9BA0
-    fighter->cb.x21BC_callback_Accessory4 = &ftZelda_801396AC;
+    fp->cb.x21BC_callback_Accessory4 = &ftZelda_801396AC;
 }
 
 // 801399B4 - 801399F0 (0x3C bytes)
@@ -149,16 +149,16 @@ void ftZelda_80139A34(HSD_GObj* fighterObj) {
 // https://decomp.me/scratch/dA7X6
 void ftZelda_80139A54(HSD_GObj* fighterObj) {
     f32 attrs[2];
-    Fighter* fighter;
+    Fighter* fp;
     ftZeldaAttributes* attributes;
 
-    fighter = fighterObj->user_data;
-    attributes = fighter->x2D4_specialAttributes;
+    fp = fighterObj->user_data;
+    attributes = fp->x2D4_specialAttributes;
     attrs[0] = attributes->x40;
     attrs[1] = attributes->x44;
     
-    func_8007D494(fighter, attrs[0], attrs[1]);
-    func_8007CEF4(fighter);
+    func_8007D494(fp, attrs[0], attrs[1]);
+    func_8007CEF4(fp);
 }
 
 // 80139A98 - 80139AD4 (0x3C bytes)
@@ -175,8 +175,8 @@ void ftZelda_80139AD4(HSD_GObj* fighterObj) {
     f32 facingDirection;
     s32 ledgeGrabDir;
 
-    Fighter* fighter = fighterObj->user_data;
-    facingDirection = fighter->x2C_facing_direction;
+    Fighter* fp = fighterObj->user_data;
+    facingDirection = fp->x2C_facing_direction;
     
     if (facingDirection < 0) { // lbl_804D9BA4
         ledgeGrabDir = -1;
@@ -197,33 +197,33 @@ void ftZelda_80139AD4(HSD_GObj* fighterObj) {
 // 80139B44 - 80139BB0 (0x6C bytes)
 // https://decomp.me/scratch/XI2m5
 void ftZelda_80139B44(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
-    func_8007D60C(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x160, 0x0C4C508E, NULL, fighter->x894_currentAnimFrame, 1.0, 0); // lbl_804D9BA8, lbl_804D9BA4
-    fighter->cb.x21BC_callback_Accessory4 = &ftZelda_801396AC;
+    fp = fighterObj->user_data;
+    func_8007D60C(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x160, 0x0C4C508E, NULL, fp->x894_currentAnimFrame, 1.0, 0); // lbl_804D9BA8, lbl_804D9BA4
+    fp->cb.x21BC_callback_Accessory4 = &ftZelda_801396AC;
 }
 
 // 80139BB0 - 80139C1C (0x6C bytes)
 // https://decomp.me/scratch/KOA33
 void ftZelda_80139BB0(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
-    func_8007D7FC(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x15D, 0x0C4C508E, NULL, fighter->x894_currentAnimFrame, 1.0, 0); // lbl_804D9BA8, lbl_804D9BA4
-    fighter->cb.x21BC_callback_Accessory4 = &ftZelda_801396AC;
+    fp = fighterObj->user_data;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x15D, 0x0C4C508E, NULL, fp->x894_currentAnimFrame, 1.0, 0); // lbl_804D9BA8, lbl_804D9BA4
+    fp->cb.x21BC_callback_Accessory4 = &ftZelda_801396AC;
 }
 
 // 80139C1C - 80139C58 (0x3C bytes)
 // https://decomp.me/scratch/VCHRF
 void ftZelda_80139C1C(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = getFighter(fighterObj);
-    fighter->x2340_stateVar1 = (s32) (fighter->x2340_stateVar1 - 1);
-    if ((s32) fighter->x2340_stateVar1 <= 0) {
+    fp = getFighter(fighterObj);
+    fp->x2340_stateVar1 = (s32) (fp->x2340_stateVar1 - 1);
+    if ((s32) fp->x2340_stateVar1 <= 0) {
         ftZelda_8013A6A8(fighterObj);
     }
 }
@@ -231,11 +231,11 @@ void ftZelda_80139C1C(HSD_GObj* fighterObj) {
 // 80139C58 - 80139C94 (0x3C bytes)
 // https://decomp.me/scratch/VCHRF
 void ftZelda_80139C58(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = getFighter(fighterObj);
-    fighter->x2340_stateVar1 = (s32) (fighter->x2340_stateVar1 - 1);
-    if ((s32) fighter->x2340_stateVar1 <= 0) {
+    fp = getFighter(fighterObj);
+    fp->x2340_stateVar1 = (s32) (fp->x2340_stateVar1 - 1);
+    if ((s32) fp->x2340_stateVar1 <= 0) {
         ftZelda_8013A764(fighterObj);
     }
 }
@@ -253,17 +253,17 @@ void ftZelda_80139CBC(HSD_GObj* fighterObj) {return;}
 // 80139CC0 - 80139D60 (0xA0 bytes)
 // https://decomp.me/scratch/UKBQL
 void ftZelda_80139CC0(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
     s32 envFlags;
     CollData* collData;
 
-    fighter = fighterObj->user_data;
-    collData = &fighter->x6F0_collData;
+    fp = fighterObj->user_data;
+    collData = &fp->x6F0_collData;
     
     if (func_80082708(fighterObj) == 0) {
         envFlags = collData->x134_envFlags;
         if (((envFlags & 0x3F) != 0) || ((envFlags & 0xFC0) != 0)) {
-            func_8007D60C(fighter);
+            func_8007D60C(fp);
             ftZelda_8013A764(fighterObj);
             return;
         }
@@ -302,18 +302,18 @@ void ftZelda_80139D60(HSD_GObj* fighterObj) {
     s32 ledgeGrabDir;
     BOOL returnVar;
     f32 angle1, angle2, angle3;
-    Fighter* fighter; // r31
+    Fighter* fp; // r31
     ftZeldaAttributes* attributes; // r30
     CollData* collData; // r29
 
     // Get the character, collision data, and character attributes
-    fighter = fighterObj->user_data;
-    collData = &fighter->x6F0_collData;
-    attributes = fighter->x2D4_specialAttributes;
-    fighter->x234C_stateVar4_s32++;
+    fp = fighterObj->user_data;
+    collData = &fp->x6F0_collData;
+    attributes = fp->x2D4_specialAttributes;
+    fp->x234C_stateVar4_s32++;
 
     // Determine facing direction
-    if (fighter->x2C_facing_direction < 0.0f) {
+    if (fp->x2C_facing_direction < 0.0f) {
         ledgeGrabDir = -1;
     } else {
         ledgeGrabDir = 1;
@@ -329,19 +329,19 @@ void ftZelda_80139D60(HSD_GObj* fighterObj) {
     
     if (func_80081298(fighterObj) == 0) {
         if ((collData->x134_envFlags & 0x6000) != 0) {
-            f32 angle1 = lbvector_AngleXY(&collData->x190_vec, &fighter->x80_self_vel);
+            f32 angle1 = lbvector_AngleXY(&collData->x190_vec, &fp->x80_self_vel);
             if (angle1 > (DEG_TO_RAD * (90.0f + attributes->x60))) {
                 ftZelda_8013A764(fighterObj);
             }
         }
         if ((collData->x134_envFlags & 0x3F) != 0) {
-            f32 angle2 = lbvector_AngleXY(&collData->x168_vec, &fighter->x80_self_vel);
+            f32 angle2 = lbvector_AngleXY(&collData->x168_vec, &fp->x80_self_vel);
             if (angle2 > (DEG_TO_RAD * (90.0f + attributes->x60))) {
                 ftZelda_8013A764(fighterObj);
             }
         }
         if ((collData->x134_envFlags & 0xFC0) != 0) {
-            f32 angle3 = lbvector_AngleXY(&collData->x17C_vec, &fighter->x80_self_vel);
+            f32 angle3 = lbvector_AngleXY(&collData->x17C_vec, &fp->x80_self_vel);
             if (angle3 > (DEG_TO_RAD * (90.0f + attributes->x60))) {
                 ftZelda_8013A764(fighterObj);
             }
@@ -352,34 +352,34 @@ void ftZelda_80139D60(HSD_GObj* fighterObj) {
 // 80139F6C - 80139FE8 (0x7C bytes)
 // https://decomp.me/scratch/HtMY4
 void ftZelda_80139F6C(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
     f32 temp_f2;
     s32 unused;
 
-    fighter = getFighter(fighterObj);
+    fp = getFighter(fighterObj);
 
-    func_8007D60C(fighter);
+    func_8007D60C(fp);
     
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x161, 0x0C4C508E, NULL, fighter->x894_currentAnimFrame, 0.0f, 0.0f);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x161, 0x0C4C508E, NULL, fp->x894_currentAnimFrame, 0.0f, 0.0f);
     
-    fighter->x2223_flag.bits.b4 = 1;
-    fighter->x221E_flag.bits.b0 = 1;
+    fp->x2223_flag.bits.b4 = 1;
+    fp->x221E_flag.bits.b0 = 1;
 }
 
 // AS_ZeldaUpBGround
 // 80139FE8 - 8013A058 (0x70 bytes)
 // https://decomp.me/scratch/Jcxch
 void ftZelda_80139FE8(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
     f32 temp_f2;
 
-    fighter = fighterObj->user_data;
+    fp = fighterObj->user_data;
 
-    func_8007D7FC(fighter);
+    func_8007D7FC(fp);
 
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x15E, 0x0C4C508E, NULL, fighter->x894_currentAnimFrame, 0.0f, 0.0f);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x15E, 0x0C4C508E, NULL, fp->x894_currentAnimFrame, 0.0f, 0.0f);
     
-    fighter->x221E_flag.bits.b0 = 1;
+    fp->x221E_flag.bits.b0 = 1;
 }
 
 // AS_ZeldaUpBTravelGround
@@ -391,7 +391,7 @@ void ftZelda_8013A058(HSD_GObj* fighterObj) {
     volatile float y;
     f64 _three;
     f64 _half;
-    Fighter* fighter; // r30
+    Fighter* fp; // r30
     ftZeldaAttributes* attributes; // r31
     f32 temp_f0;
     f32 temp_f1;
@@ -405,11 +405,11 @@ void ftZelda_8013A058(HSD_GObj* fighterObj) {
     CollData* collData;
     f32 unused[3];
 
-    fighter = fighterObj->user_data;
-    attributes = fighter->x2D4_specialAttributes;
-    collData = &fighter->x6F0_collData;
-    temp_f2 = fighter->input.x620_lstick_x;
-    temp_f1 = fighter->input.x624_lstick_y;
+    fp = fighterObj->user_data;
+    attributes = fp->x2D4_specialAttributes;
+    collData = &fp->x6F0_collData;
+    temp_f2 = fp->input.x620_lstick_x;
+    temp_f1 = fp->input.x624_lstick_y;
     temp_f2 = temp_f2 * temp_f2;
     temp_f1 = temp_f1 * temp_f1;
     temp_f5 = temp_f2 + temp_f1;
@@ -436,40 +436,40 @@ void ftZelda_8013A058(HSD_GObj* fighterObj) {
 
     if (!(var_f31 < attributes->x50)) {
         groundVector = &collData->x154_groundNormal;
-        inputVector.x = fighter->input.x620_lstick_x;
-        inputVector.y = fighter->input.x624_lstick_y;
+        inputVector.x = fp->input.x620_lstick_x;
+        inputVector.y = fp->input.x624_lstick_y;
         inputVector.z = 0;
 
         if (!(lbvector_AngleXY(groundVector, (Point3d* ) &inputVector.x) < HALF_PI)) {
             if (func_8009A134(fighterObj) == 0) {
-                func_8007D9FC(fighter);
+                func_8007D9FC(fp);
                 
-                temp_f5 = atan2f(fighter->input.x624_lstick_y, fighter->input.x620_lstick_x * fighter->x2C_facing_direction);
+                temp_f5 = atan2f(fp->input.x624_lstick_y, fp->input.x620_lstick_x * fp->x2C_facing_direction);
                 
-                fighter->x2344_f32 = inputVector.x;
-                fighter->x2348_stateVar3_f32 = inputVector.y;
+                fp->x2344_f32 = inputVector.x;
+                fp->x2348_stateVar3_f32 = inputVector.y;
 
                 // Update ground velocity
                 temp_f6 = ((attributes->x54 * var_f31) + attributes->x58) * cosf(temp_f5);
-                fighter->xEC_ground_vel = fighter->x2C_facing_direction * temp_f6;
+                fp->xEC_ground_vel = fp->x2C_facing_direction * temp_f6;
                 
                 Fighter_ActionStateChange_800693AC(fighterObj, 0x15E, 0, NULL, 35.0, 1.0, 0);
                 func_8006EBA4(fighterObj);
                 ftAnim_SetAnimRate(fighterObj, 0);
                 
-                fighter = fighterObj->user_data;
-                attributes = fighter->x2D4_specialAttributes;
-                fighter->x2340_stateVar1 = attributes->x48;
-                fighter->x1968_jumpsUsed = (u8) fighter->x110_attr.x168_MaxJumps;
-                fighter->x2223_flag.bits.b4 = 1;
+                fp = fighterObj->user_data;
+                attributes = fp->x2D4_specialAttributes;
+                fp->x2340_stateVar1 = attributes->x48;
+                fp->x1968_jumpsUsed = (u8) fp->x110_attr.x168_MaxJumps;
+                fp->x2223_flag.bits.b4 = 1;
                 
                 func_8007B62C(fighterObj, 2, attributes);
-                fighter->x221E_flag.bits.b0 = 1;
+                fp->x221E_flag.bits.b0 = 1;
                 return;
             }
         }
     }
-    func_8007D60C(fighter);
+    func_8007D60C(fp);
     ftZelda_8013A244(fighterObj);
 }
 
@@ -478,7 +478,7 @@ void ftZelda_8013A058(HSD_GObj* fighterObj) {
 // https://decomp.me/scratch/70TAa
 void ftZelda_8013A244(HSD_GObj* fighterObj) {
     volatile float y;
-    Fighter* fighter; // r30
+    Fighter* fp; // r30
     ftZeldaAttributes* attributes; // r31
     f32 temp_f1;
     f32 temp_f2;
@@ -492,10 +492,10 @@ void ftZelda_8013A244(HSD_GObj* fighterObj) {
     f64 _three;
     f64 guess;
     
-    fighter = fighterObj->user_data;
-    temp_f2 = fighter->input.x620_lstick_x;
-    temp_f1 = fighter->input.x624_lstick_y;
-    attributes = fighter->x2D4_specialAttributes;
+    fp = fighterObj->user_data;
+    temp_f2 = fp->input.x620_lstick_x;
+    temp_f1 = fp->input.x624_lstick_y;
+    attributes = fp->x2D4_specialAttributes;
     temp_f1 = temp_f1 * temp_f1;
     temp_f2 = temp_f2 * temp_f2;
     var_f5 = temp_f2 + temp_f1;
@@ -521,39 +521,39 @@ void ftZelda_8013A244(HSD_GObj* fighterObj) {
     }
 
     if (var_f31 > attributes->x50) {
-        temp_f1 = fighter->input.x620_lstick_x;
+        temp_f1 = fp->input.x620_lstick_x;
         if (temp_f1 < 0) {
             temp_f1 = -temp_f1;
         }
         if (temp_f1 > 0.0010000000474974513f) {
-            func_8007D9FC(fighter);
+            func_8007D9FC(fp);
         }
-        var_f30 = atan2f(fighter->input.x624_lstick_y, fighter->input.x620_lstick_x * fighter->x2C_facing_direction);
-        fighter->x2344_f32 = fighter->input.x620_lstick_x;
-        fighter->x2348_stateVar3_f32 = fighter->input.x624_lstick_y;
+        var_f30 = atan2f(fp->input.x624_lstick_y, fp->input.x620_lstick_x * fp->x2C_facing_direction);
+        fp->x2344_f32 = fp->input.x620_lstick_x;
+        fp->x2348_stateVar3_f32 = fp->input.x624_lstick_y;
     } else {
-        func_8007DA24(fighter);
+        func_8007DA24(fp);
         var_f30 = HALF_PI;
-        fighter->x2344_f32 = 0;
-        var_f31 = fighter->x2348_stateVar3_f32 = 1.0;
+        fp->x2344_f32 = 0;
+        var_f31 = fp->x2348_stateVar3_f32 = 1.0;
     }
 
-    fighter->x80_self_vel.x = fighter->x2C_facing_direction * (((attributes->x54 * var_f31) + attributes->x58) * cosf(var_f30));
-    fighter->x80_self_vel.y = ((attributes->x54 * var_f31) + attributes->x58) * sinf(var_f30);
+    fp->x80_self_vel.x = fp->x2C_facing_direction * (((attributes->x54 * var_f31) + attributes->x58) * cosf(var_f30));
+    fp->x80_self_vel.y = ((attributes->x54 * var_f31) + attributes->x58) * sinf(var_f30);
     
     Fighter_ActionStateChange_800693AC(fighterObj, 0x161, 0, NULL, 35.0, 1.0, 0);
     func_8006EBA4(fighterObj);
     ftAnim_SetAnimRate(fighterObj, 0);
     
-    fighter = fighterObj->user_data;
-    attributes = fighter->x2D4_specialAttributes;
-    fighter->x2340_stateVar1 = (s32) attributes->x48;
-    fighter->x1968_jumpsUsed = fighter->x110_attr.x168_MaxJumps;
-    fighter->x2223_flag.bits.b4 = 1;
+    fp = fighterObj->user_data;
+    attributes = fp->x2D4_specialAttributes;
+    fp->x2340_stateVar1 = (s32) attributes->x48;
+    fp->x1968_jumpsUsed = fp->x110_attr.x168_MaxJumps;
+    fp->x2223_flag.bits.b4 = 1;
     
     func_8007B62C(fighterObj, 2, attributes);
     
-    fighter->x221E_flag.bits.b0 = 1;
+    fp->x221E_flag.bits.b0 = 1;
 }
 
 // 8013A448 - 8013A484 (0x3C bytes)
@@ -569,12 +569,12 @@ void ftZelda_8013A448(HSD_GObj* fighterObj) {
 // https://decomp.me/scratch/8Hjri
 void ftZelda_8013A484(HSD_GObj* fighterObj) {
     ftZeldaAttributes* attributes; // r31
-    Fighter* fighter; // r4
+    Fighter* fp; // r4
     f32 attr1, attr2; // f1, f2
     u32 unused;
 
-    fighter = fighterObj->user_data;
-    attributes = fighter->x2D4_specialAttributes;
+    fp = fighterObj->user_data;
+    attributes = fp->x2D4_specialAttributes;
     
     if (ftAnim_IsFramesRemaining(fighterObj) == 0) {
         attr1 = attributes->x68;
@@ -595,24 +595,24 @@ void ftZelda_8013A4EC(HSD_GObj* fighterObj) {
 // 8013A50C - 8013A588 (0x7C bytes)
 // https://decomp.me/scratch/9VS7Q
 void ftZelda_8013A50C(HSD_GObj* fighterObj) {
-    Fighter* fighter; // r31
+    Fighter* fp; // r31
     f32 temp_f1;
     ftZeldaAttributes* attributes; // r30
     u32 unused[2];
 
-    fighter = fighterObj->user_data;
-    attributes = fighter->x2D4_specialAttributes;
+    fp = fighterObj->user_data;
+    attributes = fp->x2D4_specialAttributes;
 
-    if ((u32) fighter->x2200_ftcmd_var0 != 0) {
-        func_8007D4B8(fighter);
-        func_8007D440(fighter, attributes->x5C * fighter->x110_attr.x17C_AerialDriftMax);
+    if ((u32) fp->x2200_ftcmd_var0 != 0) {
+        func_8007D4B8(fp);
+        func_8007D440(fp, attributes->x5C * fp->x110_attr.x17C_AerialDriftMax);
         return;
     }
 
-    temp_f1 = fighter->x80_self_vel.y;
-    fighter->x80_self_vel.y = temp_f1 - (temp_f1 / 10.0f);
+    temp_f1 = fp->x80_self_vel.y;
+    fp->x80_self_vel.y = temp_f1 - (temp_f1 / 10.0f);
 
-    func_8007CEF4(fighter);
+    func_8007CEF4(fp);
 }
 
 // Collision_ZeldaUpBEndGround
@@ -626,16 +626,16 @@ void ftZelda_8013A588(HSD_GObj* fighterObj) {
 // 8013A5C4 - 8013A648 (0x84 bytes)
 // https://decomp.me/scratch/nLZxP
 void ftZelda_8013A5C4(HSD_GObj* fighterObj) {
-    Fighter* fighter; // r3
+    Fighter* fp; // r3
     ftZeldaAttributes* attributes; // r31
     s32 ledgeGrabDir;
     BOOL result;
     s32 unused[2];
 
-    fighter = fighterObj->user_data;
-    attributes = fighter->x2D4_specialAttributes;
+    fp = fighterObj->user_data;
+    attributes = fp->x2D4_specialAttributes;
     
-    if (fighter->x2C_facing_direction < 0) {
+    if (fp->x2C_facing_direction < 0) {
         ledgeGrabDir = -1;
     } else {
         ledgeGrabDir = 1;
@@ -655,11 +655,11 @@ void ftZelda_8013A5C4(HSD_GObj* fighterObj) {
 // AS_ZeldaUpBEndAir?
 // 8013A648 - 8013A6A8 (0x60 bytes)
 void ftZelda_8013A648(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
-    func_8007D60C(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x162, 0x0C4C508A, NULL, fighter->x894_currentAnimFrame, 1.0, 0);
+    fp = fighterObj->user_data;
+    func_8007D60C(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x162, 0x0C4C508A, NULL, fp->x894_currentAnimFrame, 1.0, 0);
 }
 
 // AS_ZeldaUpBEndGround
@@ -667,14 +667,14 @@ void ftZelda_8013A648(HSD_GObj* fighterObj) {
 // https://decomp.me/scratch/5iU4R
 void ftZelda_8013A6A8(HSD_GObj* fighterObj) {
     f32 temp_f0;
-    Fighter* fighter; // r31
+    Fighter* fp; // r31
     ftZeldaAttributes* attributes; // r30
     Fighter* fighter2;
     s32 unused[3];
 
     temp_f0 = 0;
-    fighter = fighterObj->user_data;
-    attributes = fighter->x2D4_specialAttributes;
+    fp = fighterObj->user_data;
+    attributes = fp->x2D4_specialAttributes;
 
     Fighter_ActionStateChange_800693AC(fighterObj, 0x15F, 0, NULL, temp_f0, 1.0f, temp_f0);
     func_8006EBA4(fighterObj);
@@ -688,7 +688,7 @@ void ftZelda_8013A6A8(HSD_GObj* fighterObj) {
     fighter2->xEC_ground_vel = 0;
     fighter2->x221E_flag.bits.b0 = 0;
     fighter2->cb.x21BC_callback_Accessory4 = &ftZelda_8013979C;
-    fighter->xEC_ground_vel = (f32) (fighter->x2358_stateVar7 * attributes->x64);
+    fp->xEC_ground_vel = (f32) (fp->x2358_stateVar7 * attributes->x64);
 }
 
 // AS_ZeldaUpBEndAir?
@@ -696,14 +696,14 @@ void ftZelda_8013A6A8(HSD_GObj* fighterObj) {
 // https://decomp.me/scratch/8Fjwf
 void ftZelda_8013A764(HSD_GObj* fighterObj) {
     f32 temp_f0;
-    Fighter* fighter; // r31
+    Fighter* fp; // r31
     ftZeldaAttributes* attributes; // r30
     Fighter* fighter2; // r5
     f32 unused[3];
 
     temp_f0 = 0;
-    fighter = fighterObj->user_data;
-    attributes = fighter->x2D4_specialAttributes;
+    fp = fighterObj->user_data;
+    attributes = fp->x2D4_specialAttributes;
 
     Fighter_ActionStateChange_800693AC(fighterObj, 0x162, 0, NULL, temp_f0, 1.0, temp_f0);
     func_8006EBA4(fighterObj);
@@ -717,6 +717,6 @@ void ftZelda_8013A764(HSD_GObj* fighterObj) {
     fighter2->xEC_ground_vel = 0;
     fighter2->x221E_flag.bits.b0 = 0;
     fighter2->cb.x21BC_callback_Accessory4 = &ftZelda_8013979C;
-    fighter->x80_self_vel.x = (f32) (fighter->x2350_stateVar5_f32 * attributes->x64);
-    fighter->x80_self_vel.y = (f32) (fighter->x2354_stateVar6_f32 * attributes->x64);
+    fp->x80_self_vel.x = (f32) (fp->x2350_stateVar5_f32 * attributes->x64);
+    fp->x80_self_vel.y = (f32) (fp->x2354_stateVar6_f32 * attributes->x64);
 }

--- a/src/melee/ft/chara/ftZelda/ftzelda3.c
+++ b/src/melee/ft/chara/ftZelda/ftzelda3.c
@@ -3,44 +3,44 @@
 // 8013A830 - 8013A8AC (0x7C bytes)
 // https://decomp.me/scratch/6v90P
 void ftZelda_8013A830(HSD_GObj* fighterObj) {
-    Fighter* fighter; // r31
+    Fighter* fp; // r31
 
-    fighter = fighterObj->user_data;
-    if (fighter->x2219_flag.bits.b0 == 0) {
-        ef_Spawn(0x4F4, fighterObj, fighter->x5E8_fighterBones[1].x0_jobj);
-        fighter->x2219_flag.bits.b0 = 1;
+    fp = fighterObj->user_data;
+    if (fp->x2219_flag.bits.b0 == 0) {
+        ef_Spawn(0x4F4, fighterObj, fp->x5E8_fighterBones[1].x0_jobj);
+        fp->x2219_flag.bits.b0 = 1;
     }
-    fighter->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-    fighter->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
-    fighter->cb.x21BC_callback_Accessory4 = 0;
+    fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    fp->cb.x21BC_callback_Accessory4 = 0;
 }
 
 // 8013A8AC - 8013A928 (0x7C bytes)
 // https://decomp.me/scratch/rfSO5
 void ftZelda_8013A8AC(HSD_GObj* fighterObj) {
-    Fighter* fighter; // r31
+    Fighter* fp; // r31
 
-    fighter = fighterObj->user_data;
-    if (fighter->x2219_flag.bits.b0 == 0) {
-        ef_Spawn(0x4F5, fighterObj, fighter->x5E8_fighterBones[1].x0_jobj);
-        fighter->x2219_flag.bits.b0 = 1;
+    fp = fighterObj->user_data;
+    if (fp->x2219_flag.bits.b0 == 0) {
+        ef_Spawn(0x4F5, fighterObj, fp->x5E8_fighterBones[1].x0_jobj);
+        fp->x2219_flag.bits.b0 = 1;
     }
-    fighter->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-    fighter->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
-    fighter->cb.x21BC_callback_Accessory4 = 0;
+    fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    fp->cb.x21BC_callback_Accessory4 = 0;
 }
 
 // 8013A928 - 8013A9A4 (0x7C bytes)
 // https://decomp.me/scratch/arJgt
 void ftZelda_SpecialN_StartAction(HSD_GObj* fighterObj) {
     f32 temp_f1;
-    Fighter* fighter; // r31
+    Fighter* fp; // r31
     Fighter* fighter2; // r5
     ftZeldaAttributes* attributes;
     f32 unused[5];
 
     temp_f1 = 0;
-    fighter = fighterObj->user_data;
+    fp = fighterObj->user_data;
 
     Fighter_ActionStateChange_800693AC(fighterObj, 0x155, 0, NULL, temp_f1, 1.0, temp_f1);
     func_8006EBA4(fighterObj);
@@ -49,21 +49,21 @@ void ftZelda_SpecialN_StartAction(HSD_GObj* fighterObj) {
     attributes = fighter2->x2D4_specialAttributes;
     fighter2->x2200_ftcmd_var0 = 0;
     fighter2->x2340_stateVar1 = attributes->x4;
-    fighter->cb.x21BC_callback_Accessory4 = &ftZelda_8013A830;
+    fp->cb.x21BC_callback_Accessory4 = &ftZelda_8013A830;
 }
 
 // 8013A9A4 - 8013AA38 (0x94 bytes)
 // https://decomp.me/scratch/DgO7D
 void ftZelda_SpecialAirN_StartAction(HSD_GObj* fighterObj) {
-    Fighter* fighter; // r31
+    Fighter* fp; // r31
     Fighter* fighter2;
     ftZeldaAttributes* attributes;
     f32 unused[5];
 
-    fighter = fighterObj->user_data;
-    attributes = fighter->x2D4_specialAttributes;
-    fighter->x80_self_vel.y = 0;
-    fighter->x80_self_vel.x = fighter->x80_self_vel.x / attributes->x8;
+    fp = fighterObj->user_data;
+    attributes = fp->x2D4_specialAttributes;
+    fp->x80_self_vel.y = 0;
+    fp->x80_self_vel.x = fp->x80_self_vel.x / attributes->x8;
 
     Fighter_ActionStateChange_800693AC(fighterObj, 0x156, 0, NULL, 0, 1.0, 0);
     func_8006EBA4(fighterObj);
@@ -72,26 +72,26 @@ void ftZelda_SpecialAirN_StartAction(HSD_GObj* fighterObj) {
     attributes = fighter2->x2D4_specialAttributes;
     fighter2->x2200_ftcmd_var0 = 0;
     fighter2->x2340_stateVar1 = attributes->x4;
-    fighter->cb.x21BC_callback_Accessory4 = &ftZelda_8013A8AC;
+    fp->cb.x21BC_callback_Accessory4 = &ftZelda_8013A8AC;
 }
 
 // 8013AA38 - 8013AACC (0x94 bytes)
 // https://decomp.me/scratch/XcH4E
 void ftZelda_8013AA38(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
     s32 attributes;
     s32 unused[5];
 
-    fighter = fighterObj->user_data;
-    attributes = ((u32)fighter->x2D4_specialAttributes);
+    fp = fighterObj->user_data;
+    attributes = ((u32)fp->x2D4_specialAttributes);
     
-    if ((u32) fighter->x2200_ftcmd_var0 == 1) {
-        fighter->x2200_ftcmd_var0 = 2;
+    if ((u32) fp->x2200_ftcmd_var0 == 1) {
+        fp->x2200_ftcmd_var0 = 2;
         ftColl_CreateReflectHit(fighterObj, attributes + 0x84, &ftZelda_8013ADB0);
     }
 
-    if ((u32) fighter->x2200_ftcmd_var0 == 0) {
-        fighter->x2218_flag.bits.b3 = 0;
+    if ((u32) fp->x2200_ftcmd_var0 == 0) {
+        fp->x2218_flag.bits.b3 = 0;
     }
 
     if (ftAnim_IsFramesRemaining(fighterObj) == 0) {
@@ -102,20 +102,20 @@ void ftZelda_8013AA38(HSD_GObj* fighterObj) {
 // 8013AACC - 8013AB60 (0x94 bytes)
 // https://decomp.me/scratch/ttWvN
 void ftZelda_8013AACC(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
     s32 attributes;
     s32 unused[5];
 
-    fighter = fighterObj->user_data;
-    attributes = ((u32)fighter->x2D4_specialAttributes);
+    fp = fighterObj->user_data;
+    attributes = ((u32)fp->x2D4_specialAttributes);
     
-    if ((u32) fighter->x2200_ftcmd_var0 == 1U) {
-        fighter->x2200_ftcmd_var0 = 2U;
+    if ((u32) fp->x2200_ftcmd_var0 == 1U) {
+        fp->x2200_ftcmd_var0 = 2U;
         ftColl_CreateReflectHit(fighterObj, attributes + 0x84, &ftZelda_8013ADB0);
     }
 
-    if ((u32) fighter->x2200_ftcmd_var0 == 0U) {
-        fighter->x2218_flag.bits.b3 = 0;
+    if ((u32) fp->x2200_ftcmd_var0 == 0U) {
+        fp->x2218_flag.bits.b3 = 0;
     }
 
     if (ftAnim_IsFramesRemaining(fighterObj) == 0) {
@@ -135,27 +135,27 @@ void ftZelda_8013AB68(HSD_GObj* fighterObj) {
 // 8013AB9C - 8013AC10 (0x74 bytes)
 // https://decomp.me/scratch/juoPH
 void ftZelda_8013AB9C(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
     s32 stateVar1;
     attr* fighterAttr;
     ftZeldaAttributes* charAttr;
     f32 arg2, arg3;
     s32 unused[2];
 
-    fighter = fighterObj->user_data;
-    stateVar1 = fighter->x2340_stateVar1;
-    fighterAttr = &fighter->x110_attr;
-    charAttr = fighter->x2D4_specialAttributes;
+    fp = fighterObj->user_data;
+    stateVar1 = fp->x2340_stateVar1;
+    fighterAttr = &fp->x110_attr;
+    charAttr = fp->x2D4_specialAttributes;
     
     if (stateVar1 != 0) {
-        fighter->x2340_stateVar1 = stateVar1 - 1;
+        fp->x2340_stateVar1 = stateVar1 - 1;
     } else {
         arg2 = charAttr->xC;
         arg3 = fighterAttr->x170_TerminalVelocity;
-        func_8007D494(fighter, arg2, arg3) ;
+        func_8007D494(fp, arg2, arg3) ;
     }
 
-    func_8007CF58(fighter);
+    func_8007CF58(fp);
     func_8007AEF8(fighterObj);
 }
 
@@ -179,13 +179,13 @@ void ftZelda_8013AC4C(HSD_GObj* fighterObj) {
 // https://decomp.me/scratch/B9loR
 void ftZelda_8013AC88(HSD_GObj* fighterObj) {
     s32 attributes;
-    Fighter* fighter;
+    Fighter* fp;
     Fighter* fighter2;
     s32 unused[5];
 
-    fighter = fighterObj->user_data;
-    func_8007D5D4(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x156, 0x0C4C508E, NULL, fighter->x894_currentAnimFrame, 1.0, 0);
+    fp = fighterObj->user_data;
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x156, 0x0C4C508E, NULL, fp->x894_currentAnimFrame, 1.0, 0);
     
     fighter2 = fighterObj->user_data;
     attributes = ((u32)fighter2->x2D4_specialAttributes);
@@ -193,20 +193,20 @@ void ftZelda_8013AC88(HSD_GObj* fighterObj) {
     if ((u32) fighter2->x2200_ftcmd_var0 == 2U) {
         ftColl_CreateReflectHit(fighterObj, attributes + 0x84, &ftZelda_8013ADB0);
     }
-    fighter->cb.x21BC_callback_Accessory4 = &ftZelda_8013A8AC;
+    fp->cb.x21BC_callback_Accessory4 = &ftZelda_8013A8AC;
 }
 
 // 8013AD1C - 8013ADB0 (0x94 bytes)
 // https://decomp.me/scratch/pQ6Xn
 void ftZelda_8013AD1C(HSD_GObj* fighterObj) {
     s32 attributes;
-    Fighter* fighter;
+    Fighter* fp;
     Fighter* fighter2;
     s32 unused[5];
 
-    fighter = fighterObj->user_data;
-    func_8007D7FC(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x155, 0x0C4C508E, NULL, fighter->x894_currentAnimFrame, 1.0, 0);
+    fp = fighterObj->user_data;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x155, 0x0C4C508E, NULL, fp->x894_currentAnimFrame, 1.0, 0);
 
     fighter2 = fighterObj->user_data;
     attributes = ((u32)fighter2->x2D4_specialAttributes);
@@ -214,7 +214,7 @@ void ftZelda_8013AD1C(HSD_GObj* fighterObj) {
     if ((u32) fighter2->x2200_ftcmd_var0 == 2U) {
         ftColl_CreateReflectHit(fighterObj, attributes + 0x84, &ftZelda_8013ADB0);
     }
-    fighter->cb.x21BC_callback_Accessory4 = &ftZelda_8013A830;
+    fp->cb.x21BC_callback_Accessory4 = &ftZelda_8013A830;
 }
 
 void ftZelda_8013ADB0(HSD_GObj* fighterObj) {return;}

--- a/src/melee/ft/chara/ftZelda/ftzelda4.c
+++ b/src/melee/ft/chara/ftZelda/ftzelda4.c
@@ -3,33 +3,33 @@
 // 8013ADB4 - 8013AE30 (0x7C bytes)
 // https://decomp.me/scratch/LbMVE
 void ftZelda_8013ADB4(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
-    if ((u8) fighter->x2219_flag.bits.b0 == 0) {
-        ef_Spawn(0x4FC, fighterObj, fighter->x5E8_fighterBones[0x68].x0_jobj);
-        fighter->x2219_flag.bits.b0 = 1;
+    fp = fighterObj->user_data;
+    if ((u8) fp->x2219_flag.bits.b0 == 0) {
+        ef_Spawn(0x4FC, fighterObj, fp->x5E8_fighterBones[0x68].x0_jobj);
+        fp->x2219_flag.bits.b0 = 1;
     }
 
-    fighter->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-    fighter->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
-    fighter->cb.x21BC_callback_Accessory4 = 0;
+    fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    fp->cb.x21BC_callback_Accessory4 = 0;
 }
 
 // 8013AE30 - 8013AEAC (0x7C bytes)
 // https://decomp.me/scratch/iojLO
 void ftZelda_8013AE30(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
-    if ((u8) fighter->x2219_flag.bits.b0 == 0) {
-        ef_Spawn(0x4FD, fighterObj, fighter->x5E8_fighterBones[4].x0_jobj);
-        fighter->x2219_flag.bits.b0 = 1;
+    fp = fighterObj->user_data;
+    if ((u8) fp->x2219_flag.bits.b0 == 0) {
+        ef_Spawn(0x4FD, fighterObj, fp->x5E8_fighterBones[4].x0_jobj);
+        fp->x2219_flag.bits.b0 = 1;
     }
 
-    fighter->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
-    fighter->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
-    fighter->cb.x21BC_callback_Accessory4 = 0;
+    fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
+    fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
+    fp->cb.x21BC_callback_Accessory4 = 0;
 }
 
 // Zelda_TransformToSubcharacter
@@ -37,10 +37,10 @@ void ftZelda_8013AE30(HSD_GObj* fighterObj) {
 // https://decomp.me/scratch/iINH1
 void func_80114758(HSD_GObj*);                      /* extern */
 void ftZelda_8013AEAC(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
-    fighter->cb.x21BC_callback_Accessory4 = 0;
+    fp = fighterObj->user_data;
+    fp->cb.x21BC_callback_Accessory4 = 0;
 
     func_8007EFC8(fighterObj, func_80114758);
 }
@@ -48,21 +48,21 @@ void ftZelda_8013AEAC(HSD_GObj* fighterObj) {
 // Helper function for both ftZelda_SpecialLw_StartAction / ftZelda_SpecialAirLw_StartAction
 void ftZelda_SpecialLw_StartAction_Helper(HSD_GObj* fighterObj) {
     Point3d sp20;
-    Fighter* fighter; // r31
+    Fighter* fp; // r31
     ftZeldaAttributes* attributes; // r3
     
-    fighter = getFighterPlus(fighterObj);
-    attributes = getFtSpecialAttrs(fighter);
+    fp = getFighterPlus(fighterObj);
+    attributes = getFtSpecialAttrs(fp);
     
-    fighter->x2200_ftcmd_var0 = 0;
-    fighter->x80_self_vel.x = (f32) (fighter->x80_self_vel.x / attributes->x70);
-    fighter->x80_self_vel.y = (f32) (fighter->x80_self_vel.y / attributes->x74);
-    fighter->xEC_ground_vel = (f32) (fighter->xEC_ground_vel / attributes->x70);
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x80_self_vel.x = (f32) (fp->x80_self_vel.x / attributes->x70);
+    fp->x80_self_vel.y = (f32) (fp->x80_self_vel.y / attributes->x74);
+    fp->xEC_ground_vel = (f32) (fp->xEC_ground_vel / attributes->x70);
     
-    func_8000B1CC(fighter->x5E8_fighterBones[0].x0_jobj, NULL, &sp20);
+    func_8000B1CC(fp->x5E8_fighterBones[0].x0_jobj, NULL, &sp20);
     func_800119DC(&sp20, 0x78, 0.4000000059604645, 0.003000000026077032, 1.0471975803375244);
     
-    fighter->cb.x21BC_callback_Accessory4 = &ftZelda_8013ADB4;
+    fp->cb.x21BC_callback_Accessory4 = &ftZelda_8013ADB4;
 }
 
 // Zelda_AS_355_Transform_Grounded
@@ -92,22 +92,22 @@ void ftZelda_SpecialAirLw_StartAction(HSD_GObj* fighterObj) {
 // 8013B068 - 8013B0A8 (0x40 bytes)
 // https://decomp.me/scratch/DrRr5
 void ftZelda_8013B068(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
+    fp = fighterObj->user_data;
     if (ftAnim_IsFramesRemaining(fighterObj) == 0) {
-        fighter->cb.x21BC_callback_Accessory4 = &ftZelda_8013AEAC;
+        fp->cb.x21BC_callback_Accessory4 = &ftZelda_8013AEAC;
     }
 }
 
 // 8013B0A8 - 8013B0E8 (0x40 bytes)
 // https://decomp.me/scratch/DrRr5
 void ftZelda_8013B0A8(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
+    fp = fighterObj->user_data;
     if (ftAnim_IsFramesRemaining(fighterObj) == 0) {
-        fighter->cb.x21BC_callback_Accessory4 = &ftZelda_8013AEAC;
+        fp->cb.x21BC_callback_Accessory4 = &ftZelda_8013AEAC;
     }
 }
 
@@ -122,15 +122,15 @@ void ftZelda_8013B0F0(HSD_GObj* fighterObj) {
 // 8013B110 - 8013B154 (0x44 bytes)
 // https://decomp.me/scratch/Nm958
 void ftZelda_8013B110(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
     ftZeldaAttributes* attributes;
     f32 unused[3];
 
-    fighter = fighterObj->user_data;
-    attributes = fighter->x2D4_specialAttributes;
+    fp = fighterObj->user_data;
+    attributes = fp->x2D4_specialAttributes;
 
-    func_8007D494(fighter, attributes->x78, attributes->x7C);
-    func_8007CEF4(fighter);
+    func_8007D494(fp, attributes->x78, attributes->x7C);
+    func_8007CEF4(fp);
 }
 
 // 8013B154 - 8013B190 (0x3C bytes)
@@ -152,22 +152,22 @@ void ftZelda_8013B190(HSD_GObj* fighterObj) {
 // 8013B1CC - 8013B238 (0x6C bytes)
 // https://decomp.me/scratch/w04qW
 void ftZelda_8013B1CC(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
-    func_8007D5D4(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x165, 0x0C4C508E, NULL, fighter->x894_currentAnimFrame, 1.0, 0);
-    fighter->cb.x21BC_callback_Accessory4 = &ftZelda_8013ADB4;
+    fp = fighterObj->user_data;
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x165, 0x0C4C508E, NULL, fp->x894_currentAnimFrame, 1.0, 0);
+    fp->cb.x21BC_callback_Accessory4 = &ftZelda_8013ADB4;
 }
 
 // 8013B238 - 8013B2A4 (0x6C bytes)
 void ftZelda_8013B238(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
-    func_8007D7FC(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x163, 0x0C4C508E, NULL, fighter->x894_currentAnimFrame, 1.0, 0);
-    fighter->cb.x21BC_callback_Accessory4 = &ftZelda_8013ADB4;
+    fp = fighterObj->user_data;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x163, 0x0C4C508E, NULL, fp->x894_currentAnimFrame, 1.0, 0);
+    fp->cb.x21BC_callback_Accessory4 = &ftZelda_8013ADB4;
 }
 
 // 8013B2A4 - 8013B2E0 (0x3C bytes)
@@ -195,15 +195,15 @@ void ftZelda_8013B324(HSD_GObj* fighterObj) {
 // 8013B344 - 8013B388 (0x44 bytes)
 // https://decomp.me/scratch/r3T6y
 void ftZelda_8013B344(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
     ftZeldaAttributes* attributes;
     f32 unused[3];
 
-    fighter = fighterObj->user_data;
-    attributes = fighter->x2D4_specialAttributes;
+    fp = fighterObj->user_data;
+    attributes = fp->x2D4_specialAttributes;
 
-    func_8007D494(fighter, attributes->x78, attributes->x7C);
-    func_8007CEF4(fighter);
+    func_8007D494(fp, attributes->x78, attributes->x7C);
+    func_8007CEF4(fp);
 }
 
 // 8013B388 - 8013B3C4 (0x3C bytes)
@@ -225,57 +225,57 @@ void ftZelda_8013B3C4(HSD_GObj* fighterObj) {
 // 8013B400 - 8013B46C (0x6C bytes)
 // https://decomp.me/scratch/EZlpO
 void ftZelda_8013B400(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
-    func_8007D5D4(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x166, 0x0C4C508E, NULL, fighter->x894_currentAnimFrame, 1.0, 0);
-    fighter->cb.x21BC_callback_Accessory4 = &ftZelda_8013AE30;
+    fp = fighterObj->user_data;
+    func_8007D5D4(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x166, 0x0C4C508E, NULL, fp->x894_currentAnimFrame, 1.0, 0);
+    fp->cb.x21BC_callback_Accessory4 = &ftZelda_8013AE30;
 }
 
 // 8013B46C - 8013B4D8 (0x6C bytes)
 // https://decomp.me/scratch/EZlpO
 void ftZelda_8013B46C(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
-    func_8007D7FC(fighter);
-    Fighter_ActionStateChange_800693AC(fighterObj, 0x164, 0x0C4C508E, NULL, fighter->x894_currentAnimFrame, 1.0, 0);
-    fighter->cb.x21BC_callback_Accessory4 = &ftZelda_8013AE30;
+    fp = fighterObj->user_data;
+    func_8007D7FC(fp);
+    Fighter_ActionStateChange_800693AC(fighterObj, 0x164, 0x0C4C508E, NULL, fp->x894_currentAnimFrame, 1.0, 0);
+    fp->cb.x21BC_callback_Accessory4 = &ftZelda_8013AE30;
 }
 
 // AS_ZeldaFinishTransformation
 // 8013B4D8 - 8013B540 (0x68 bytes)
 // https://decomp.me/scratch/wpEbJ
 void ftZelda_8013B4D8(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
     ftZeldaAttributes* attributes;
     s32 var_r4;
     s32 unused[1];
 
-    fighter = getFighter(fighterObj);
-    attributes = fighter->x2D4_specialAttributes;
+    fp = getFighter(fighterObj);
+    attributes = fp->x2D4_specialAttributes;
     
-    if (fighter->xE0_ground_or_air == 0) {
+    if (fp->xE0_ground_or_air == 0) {
         var_r4 = 0x164;
     } else {
         var_r4 = 0x166;
     }
 
     Fighter_ActionStateChange_800693AC(fighterObj, var_r4, 0, NULL, attributes->x80, 1.0, 0);
-    fighter->cb.x21BC_callback_Accessory4 = &ftZelda_8013AE30;
+    fp->cb.x21BC_callback_Accessory4 = &ftZelda_8013AE30;
 }
 
 // 8013B540 - 8013B574 (0x34 bytes)
 // https://decomp.me/scratch/L6UUI
 s32 ftZelda_8013B540(HSD_GObj* fighterObj) {
     s32 actionStateIndex;
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
-    actionStateIndex = fighter->x10_action_state_index;
+    fp = fighterObj->user_data;
+    actionStateIndex = fp->x10_action_state_index;
 
-    if (((actionStateIndex == 0x158) || (actionStateIndex == 0x15B)) && (fighter->sa.zelda.x222C != 0U)) {
+    if (((actionStateIndex == 0x158) || (actionStateIndex == 0x15B)) && (fp->sa.zelda.x222C != 0U)) {
         return 1;
     }
     return 0;
@@ -286,16 +286,16 @@ s32 ftZelda_8013B540(HSD_GObj* fighterObj) {
 // https://decomp.me/scratch/pTAiQ
 s32 ftZelda_8013B574(HSD_GObj* fighterObj) {
     s32 temp_r0;
-    Fighter* fighter; // r3
+    Fighter* fp; // r3
 
-    fighter = fighterObj->user_data;
+    fp = fighterObj->user_data;
     
-    if ((u32) fighter->sa.zelda.x222C != 0U) {
-        switch(fighter->x10_action_state_index) {
+    if ((u32) fp->sa.zelda.x222C != 0U) {
+        switch(fp->x10_action_state_index) {
             case 0x15C:
             case 0x159:
-                if (fighter->x2204_ftcmd_var1 == 1) {
-                    fighter->x2204_ftcmd_var1 = 0;
+                if (fp->x2204_ftcmd_var1 == 1) {
+                    fp->x2204_ftcmd_var1 = 0;
                     return 1;
                 }
             break;
@@ -308,28 +308,28 @@ s32 ftZelda_8013B574(HSD_GObj* fighterObj) {
 // 8013B5C4 - 8013B5EC ( bytes)
 // https://decomp.me/scratch/VdBYJ
 void ftZelda_8013B5C4(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
-    if ((u32) fighter->sa.zelda.x222C != 0U) {
-        fighter->sa.zelda.x222C = 0U;
+    fp = fighterObj->user_data;
+    if ((u32) fp->sa.zelda.x222C != 0U) {
+        fp->sa.zelda.x222C = 0U;
     }
 
-    fighter->cb.x21E4_callback_OnDeath2 = 0;
-    fighter->cb.x21DC_callback_OnTakeDamage = 0;
+    fp->cb.x21E4_callback_OnDeath2 = 0;
+    fp->cb.x21DC_callback_OnTakeDamage = 0;
 }
 
 // 8013B5EC - 8013B638 (0x4C bytes)
 // https://decomp.me/scratch/8QoCa
 void ftZelda_8013B5EC(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
-    if ((u32) fighter->sa.zelda.x222C != 0) {
-        func_802C3D44(fighter->sa.zelda.x222C);
-        fighter->sa.zelda.x222C = 0;
+    fp = fighterObj->user_data;
+    if ((u32) fp->sa.zelda.x222C != 0) {
+        func_802C3D44(fp->sa.zelda.x222C);
+        fp->sa.zelda.x222C = 0;
     }
 
-    fighter->cb.x21E4_callback_OnDeath2 = 0;
-    fighter->cb.x21DC_callback_OnTakeDamage = 0;
+    fp->cb.x21E4_callback_OnDeath2 = 0;
+    fp->cb.x21DC_callback_OnTakeDamage = 0;
 }

--- a/src/melee/ft/chara/ftZelda/ftzelda5.c
+++ b/src/melee/ft/chara/ftZelda/ftzelda5.c
@@ -4,18 +4,18 @@
 // https://decomp.me/scratch/QnXK1
 void ftZelda_SpecialS_StartAction(HSD_GObj* fighterObj) {
     f32 temp_f1;
-    Fighter* fighter; // r31
+    Fighter* fp; // r31
     ftZeldaAttributes* attributes;
     Fighter* fighter2;
     s32 unused[7];
 
     temp_f1 = 0;
-    fighter = fighterObj->user_data;
+    fp = fighterObj->user_data;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x157, 0, NULL, temp_f1, 1.0, temp_f1);
-    fighter->x220C_ftcmd_var3 = 0;
-    fighter->x2208_ftcmd_var2 = 0;
-    fighter->x2204_ftcmd_var1 = 0;
-    fighter->x2200_ftcmd_var0 = 0;
+    fp->x220C_ftcmd_var3 = 0;
+    fp->x2208_ftcmd_var2 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
     fighter2 = fighterObj->user_data;
     attributes = fighter2->x2D4_specialAttributes;
     fighter2->x2340_stateVar1 = (s32) attributes->x10;
@@ -32,19 +32,19 @@ void ftZelda_SpecialS_StartAction(HSD_GObj* fighterObj) {
 // https://decomp.me/scratch/F0dW9
 void ftZelda_SpecialAirS_StartAction(HSD_GObj* fighterObj) {
     f32 temp_f1;
-    Fighter* fighter;
+    Fighter* fp;
     ftZeldaAttributes* attributes;
     Fighter* fighter2;
     s32 unused[7];
 
     temp_f1 = 0;
-    fighter = fighterObj->user_data;
+    fp = fighterObj->user_data;
     Fighter_ActionStateChange_800693AC(fighterObj, 0x15A, 0, NULL, temp_f1, 1.0, temp_f1);
-    fighter->x220C_ftcmd_var3 = 0;
-    fighter->x2208_ftcmd_var2 = 0;
-    fighter->x2204_ftcmd_var1 = 0;
-    fighter->x2200_ftcmd_var0 = 0;
-    fighter->x80_self_vel.y = (f32) 0;
+    fp->x220C_ftcmd_var3 = 0;
+    fp->x2208_ftcmd_var2 = 0;
+    fp->x2204_ftcmd_var1 = 0;
+    fp->x2200_ftcmd_var0 = 0;
+    fp->x80_self_vel.y = (f32) 0;
     fighter2 = fighterObj->user_data;
     attributes = fighter2->x2D4_specialAttributes;
     fighter2->x2340_stateVar1 = (s32) attributes->x10;
@@ -65,35 +65,35 @@ void ftZelda_8013B780(HSD_GObj* fighterObj) {
     f32 temp_f2;
     u32 temp_r3;
     ftZeldaAttributes* attributes; // r31
-    Fighter* fighter; // r30
+    Fighter* fp; // r30
     f32 unused[6];
 
-    fighter = fighterObj->user_data;
-    attributes = fighter->x2D4_specialAttributes;
+    fp = fighterObj->user_data;
+    attributes = fp->x2D4_specialAttributes;
 
-    if (((u32) fighter->x2200_ftcmd_var0 == 1U) && ((u32) fighter->sa.zelda.x222C == 0U)) {
-        fighter->x2200_ftcmd_var0 = 0U;
-        func_8000B1CC(fighter->x5E8_fighterBones[0x59].x0_jobj, NULL, &sp24);
+    if (((u32) fp->x2200_ftcmd_var0 == 1U) && ((u32) fp->sa.zelda.x222C == 0U)) {
+        fp->x2200_ftcmd_var0 = 0U;
+        func_8000B1CC(fp->x5E8_fighterBones[0x59].x0_jobj, NULL, &sp24);
 
         sp24.z = 0;
         temp_f2 = attributes->x20;
-        sp24.x = (temp_f2 * fighter->x2C_facing_direction) + sp24.x;
+        sp24.x = (temp_f2 * fp->x2C_facing_direction) + sp24.x;
         sp24.y += attributes->x24;
 
-        temp_r3 = func_802C3BAC(fighterObj, &sp24, fighter->x2C_facing_direction, temp_f2);
-        fighter->sa.zelda.x222C = temp_r3;
+        temp_r3 = func_802C3BAC(fighterObj, &sp24, fp->x2C_facing_direction, temp_f2);
+        fp->sa.zelda.x222C = temp_r3;
 
         if (temp_r3 != 0) {
-            fighter->cb.x21E4_callback_OnDeath2 = &ftZelda_801393AC;
-            fighter->cb.x21DC_callback_OnTakeDamage = &ftZelda_801393AC;
+            fp->cb.x21E4_callback_OnDeath2 = &ftZelda_801393AC;
+            fp->cb.x21DC_callback_OnTakeDamage = &ftZelda_801393AC;
         }
-        ef_Spawn(0x4FB, fighterObj, fighter->x5E8_fighterBones[0x4C].x0_jobj);
+        ef_Spawn(0x4FB, fighterObj, fp->x5E8_fighterBones[0x4C].x0_jobj);
     }
 
     if (ftAnim_IsFramesRemaining(fighterObj) == 0) {
         temp_f1 = 0;
         Fighter_ActionStateChange_800693AC(fighterObj, 0x158, 0, NULL, temp_f1, 1.0, temp_f1);
-        fighter->x1968_jumpsUsed = fighter->x110_attr.x168_MaxJumps;
+        fp->x1968_jumpsUsed = fp->x110_attr.x168_MaxJumps;
     }
 }
 
@@ -102,55 +102,55 @@ void ftZelda_8013B780(HSD_GObj* fighterObj) {
 void ftZelda_8013B89C(HSD_GObj* fighterObj) {
     Point3d sp20;
     ftZeldaAttributes* attributes;
-    Fighter* fighter; // r30
+    Fighter* fp; // r30
     f32 temp_f1;
     f32 temp_f2;
     s32 temp_r3;
     u32 temp_r3_u32;
     f32 unused[5];
 
-    fighter = fighterObj->user_data;
-    attributes = fighter->x2D4_specialAttributes;
+    fp = fighterObj->user_data;
+    attributes = fp->x2D4_specialAttributes;
 
-    if ((fighter->x2200_ftcmd_var0 == 1U) && (fighter->sa.zelda.x222C == 0U)) {
-        fighter->x2200_ftcmd_var0 = 0U;
-        func_8000B1CC(fighter->x5E8_fighterBones[0x59].x0_jobj, NULL, &sp20);
+    if ((fp->x2200_ftcmd_var0 == 1U) && (fp->sa.zelda.x222C == 0U)) {
+        fp->x2200_ftcmd_var0 = 0U;
+        func_8000B1CC(fp->x5E8_fighterBones[0x59].x0_jobj, NULL, &sp20);
 
         sp20.z = 0;
         temp_f2 = attributes->x20;
-        sp20.x = (temp_f2 * fighter->x2C_facing_direction) + sp20.x;
+        sp20.x = (temp_f2 * fp->x2C_facing_direction) + sp20.x;
         sp20.y += attributes->x24;
 
-        temp_r3_u32 = func_802C3BAC(fighterObj, &sp20, fighter->x2C_facing_direction, temp_f2);
-        fighter->sa.zelda.x222C = temp_r3_u32;
+        temp_r3_u32 = func_802C3BAC(fighterObj, &sp20, fp->x2C_facing_direction, temp_f2);
+        fp->sa.zelda.x222C = temp_r3_u32;
 
         if (temp_r3_u32 != 0) {
-            fighter->cb.x21E4_callback_OnDeath2 = &ftZelda_801393AC;
-            fighter->cb.x21DC_callback_OnTakeDamage = &ftZelda_801393AC;
+            fp->cb.x21E4_callback_OnDeath2 = &ftZelda_801393AC;
+            fp->cb.x21DC_callback_OnTakeDamage = &ftZelda_801393AC;
         }
-        ef_Spawn(0x4FB, fighterObj, fighter->x5E8_fighterBones[0x4C].x0_jobj);
+        ef_Spawn(0x4FB, fighterObj, fp->x5E8_fighterBones[0x4C].x0_jobj);
     }
 
-    temp_r3 = fighter->x2340_stateVar1;
+    temp_r3 = fp->x2340_stateVar1;
     if (temp_r3 != 0) {
-        fighter->x2340_stateVar1 = (s32) (temp_r3 - 1);
+        fp->x2340_stateVar1 = (s32) (temp_r3 - 1);
     }
 
-    temp_r3 = fighter->x2344_stateVar2_s32;
+    temp_r3 = fp->x2344_stateVar2_s32;
     if (temp_r3 != 0) {
-        fighter->x2344_stateVar2_s32 = (s32) (temp_r3 - 1);
+        fp->x2344_stateVar2_s32 = (s32) (temp_r3 - 1);
     }
 
-    temp_r3_u32 = fighter->sa.zelda.x222C;
+    temp_r3_u32 = fp->sa.zelda.x222C;
     if (temp_r3_u32 == 0) {
-        if ((fighter->x2340_stateVar1 <= 0) && (fighter->x2344_stateVar2_s32 <= 0)) {
+        if ((fp->x2340_stateVar1 <= 0) && (fp->x2344_stateVar2_s32 <= 0)) {
             temp_f1 = 0;
             Fighter_ActionStateChange_800693AC(fighterObj, 0x159, 0, NULL, temp_f1, 1.0, temp_f1);
         }
     } else {
-        temp_r3 = func_802C3AF0(fighter->sa.zelda.x222C);
+        temp_r3 = func_802C3AF0(fp->sa.zelda.x222C);
         if (temp_r3 != (u32) fighterObj) {
-            fighter->sa.zelda.x222C = 0;
+            fp->sa.zelda.x222C = 0;
         }
     }
 }
@@ -158,24 +158,24 @@ void ftZelda_8013B89C(HSD_GObj* fighterObj) {
 // 8013BA04 - 8013BA8C (0x88 bytes)
 // https://decomp.me/scratch/TSoo9
 void ftZelda_8013BA04(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
     ftZeldaAttributes* attributes;
 
-    fighter = getFighter(fighterObj);
+    fp = getFighter(fighterObj);
 
-    func_8007592C(fighter, 0, 0);
+    func_8007592C(fp, 0, 0);
     
     if (ftAnim_IsFramesRemaining(fighterObj) == 0) {
-        fighter = getFighter(fighterObj);
-        attributes = getFtSpecialAttrs(fighter);
+        fp = getFighter(fighterObj);
+        attributes = getFtSpecialAttrs(fp);
         
-        fighter->x2340_stateVar1 = (s32) attributes->x10;
-        fighter->x2344_stateVar2_s32 = (s32) attributes->x14;
-        fighter->x2348_stateVar3_s32 = (s32) attributes->x18;
-        fighter->sa.zelda.x222C = 0;
-        fighter->x234C_stateVar4_s32 = (s32) attributes->x1C;
-        fighter->cb.x21E4_callback_OnDeath2 = 0;
-        fighter->cb.x21DC_callback_OnTakeDamage = 0;
+        fp->x2340_stateVar1 = (s32) attributes->x10;
+        fp->x2344_stateVar2_s32 = (s32) attributes->x14;
+        fp->x2348_stateVar3_s32 = (s32) attributes->x18;
+        fp->sa.zelda.x222C = 0;
+        fp->x234C_stateVar4_s32 = (s32) attributes->x1C;
+        fp->cb.x21E4_callback_OnDeath2 = 0;
+        fp->cb.x21DC_callback_OnTakeDamage = 0;
         
         func_8008A2BC(fighterObj);
     }
@@ -190,34 +190,34 @@ void ftZelda_8013BA8C(HSD_GObj* fighterObj) {
     s32 temp_cr0_eq;
     u32 temp_r3;
     ftZeldaAttributes* attributes; // r31
-    Fighter* fighter; // r30
+    Fighter* fp; // r30
     s32 unused[5];
 
-    fighter = fighterObj->user_data;
-    attributes = fighter->x2D4_specialAttributes;
-    if (((u32) fighter->x2200_ftcmd_var0 == 1U) && ((u32) fighter->sa.zelda.x222C == 0U)) {
-        fighter->x2200_ftcmd_var0 = 0U;
-        func_8000B1CC(fighter->x5E8_fighterBones[0x59].x0_jobj, NULL, &sp24);
+    fp = fighterObj->user_data;
+    attributes = fp->x2D4_specialAttributes;
+    if (((u32) fp->x2200_ftcmd_var0 == 1U) && ((u32) fp->sa.zelda.x222C == 0U)) {
+        fp->x2200_ftcmd_var0 = 0U;
+        func_8000B1CC(fp->x5E8_fighterBones[0x59].x0_jobj, NULL, &sp24);
 
         sp24.z = 0;
         temp_f2 = attributes->x20;
-        sp24.x = (temp_f2 * fighter->x2C_facing_direction) + sp24.x;
+        sp24.x = (temp_f2 * fp->x2C_facing_direction) + sp24.x;
         sp24.y += attributes->x24;
 
-        temp_r3 = func_802C3BAC(fighterObj, &sp24, fighter->x2C_facing_direction, temp_f2);
-        fighter->sa.zelda.x222C = temp_r3;
+        temp_r3 = func_802C3BAC(fighterObj, &sp24, fp->x2C_facing_direction, temp_f2);
+        fp->sa.zelda.x222C = temp_r3;
 
         if (temp_r3 != 0) {
-            fighter->cb.x21E4_callback_OnDeath2 = &ftZelda_801393AC;
-            fighter->cb.x21DC_callback_OnTakeDamage = &ftZelda_801393AC;
+            fp->cb.x21E4_callback_OnDeath2 = &ftZelda_801393AC;
+            fp->cb.x21DC_callback_OnTakeDamage = &ftZelda_801393AC;
         }
-        ef_Spawn(0x4FB, fighterObj, fighter->x5E8_fighterBones[0x4C].x0_jobj);
+        ef_Spawn(0x4FB, fighterObj, fp->x5E8_fighterBones[0x4C].x0_jobj);
     }
 
     if (ftAnim_IsFramesRemaining(fighterObj) == 0) {
         temp_f1 = 0;
         Fighter_ActionStateChange_800693AC(fighterObj, 0x15B, 0, NULL, temp_f1, 1.0, temp_f1);
-        fighter->x1968_jumpsUsed = fighter->x110_attr.x168_MaxJumps;
+        fp->x1968_jumpsUsed = fp->x110_attr.x168_MaxJumps;
     }
 }
 
@@ -230,50 +230,50 @@ void ftZelda_8013BBA8(HSD_GObj* fighterObj) {
     s32 temp_r3_s32;
     u32 temp_r3;
     ftZeldaAttributes* attributes; // r31
-    Fighter* fighter; // r30
+    Fighter* fp; // r30
     s32 unused[5];
 
-    fighter = fighterObj->user_data;
-    attributes = fighter->x2D4_specialAttributes;
+    fp = fighterObj->user_data;
+    attributes = fp->x2D4_specialAttributes;
     
-    if (((u32) fighter->x2200_ftcmd_var0 == 1U) && ((u32) fighter->sa.zelda.x222C == 0U)) {
-        fighter->x2200_ftcmd_var0 = 0U;
-        func_8000B1CC(fighter->x5E8_fighterBones[0x59].x0_jobj, NULL, &sp20);
+    if (((u32) fp->x2200_ftcmd_var0 == 1U) && ((u32) fp->sa.zelda.x222C == 0U)) {
+        fp->x2200_ftcmd_var0 = 0U;
+        func_8000B1CC(fp->x5E8_fighterBones[0x59].x0_jobj, NULL, &sp20);
 
         sp20.z = 0;
         temp_f2 = attributes->x20;
-        sp20.x = (temp_f2 * fighter->x2C_facing_direction) + sp20.x;
+        sp20.x = (temp_f2 * fp->x2C_facing_direction) + sp20.x;
         sp20.y += attributes->x24;
 
-        temp_r3 = func_802C3BAC(fighterObj, &sp20, fighter->x2C_facing_direction, temp_f2);
-        fighter->sa.zelda.x222C = temp_r3;
+        temp_r3 = func_802C3BAC(fighterObj, &sp20, fp->x2C_facing_direction, temp_f2);
+        fp->sa.zelda.x222C = temp_r3;
 
         if (temp_r3 != 0) {
-            fighter->cb.x21E4_callback_OnDeath2 = &ftZelda_801393AC;
-            fighter->cb.x21DC_callback_OnTakeDamage = &ftZelda_801393AC;
+            fp->cb.x21E4_callback_OnDeath2 = &ftZelda_801393AC;
+            fp->cb.x21DC_callback_OnTakeDamage = &ftZelda_801393AC;
         }
-        ef_Spawn(0x4FB, fighterObj, fighter->x5E8_fighterBones[0x4C].x0_jobj);
+        ef_Spawn(0x4FB, fighterObj, fp->x5E8_fighterBones[0x4C].x0_jobj);
     }
 
-    temp_r3_s32 = fighter->x2340_stateVar1;
+    temp_r3_s32 = fp->x2340_stateVar1;
     if (temp_r3_s32 != 0) {
-        fighter->x2340_stateVar1 = (s32) (temp_r3_s32 - 1);
+        fp->x2340_stateVar1 = (s32) (temp_r3_s32 - 1);
     }
 
-    temp_r3_s32 = fighter->x2344_stateVar2_s32;
+    temp_r3_s32 = fp->x2344_stateVar2_s32;
     if (temp_r3_s32 != 0) {
-        fighter->x2344_stateVar2_s32 = (s32) (temp_r3_s32 - 1);
+        fp->x2344_stateVar2_s32 = (s32) (temp_r3_s32 - 1);
     }
 
-    if ((u32) fighter->sa.zelda.x222C == 0U) {
-        if (((s32) fighter->x2340_stateVar1 <= 0) && ((s32) fighter->x2344_stateVar2_s32 <= 0)) {
+    if ((u32) fp->sa.zelda.x222C == 0U) {
+        if (((s32) fp->x2340_stateVar1 <= 0) && ((s32) fp->x2344_stateVar2_s32 <= 0)) {
             temp_f1 = 0;
             Fighter_ActionStateChange_800693AC(fighterObj, 0x15C, 0, NULL, temp_f1, 1.0, temp_f1);
         }
     } else {
-        temp_r3 = func_802C3AF0(fighter->sa.zelda.x222C);
+        temp_r3 = func_802C3AF0(fp->sa.zelda.x222C);
         if (temp_r3 != (u32) fighterObj) {
-            fighter->sa.zelda.x222C = 0;
+            fp->sa.zelda.x222C = 0;
         }
     }
 }
@@ -281,28 +281,28 @@ void ftZelda_8013BBA8(HSD_GObj* fighterObj) {
 // 8013BD10 - 8013BDD0 (0xC0 bytes)
 // https://decomp.me/scratch/fsXpu
 void ftZelda_8013BD10(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
     f32 temp_f2;
     ftZeldaAttributes* attributes; // r31
     ftZeldaAttributes* attributes2;
     f32 unused[3];
 
-    fighter = getFighter(fighterObj);
-    attributes = fighter->x2D4_specialAttributes;
+    fp = getFighter(fighterObj);
+    attributes = fp->x2D4_specialAttributes;
     
-    func_8007592C(fighter, 0, 0);
+    func_8007592C(fp, 0, 0);
     
     if (ftAnim_IsFramesRemaining(fighterObj) == 0) {
-        fighter = getFighter(fighterObj);
-        attributes2 = getFtSpecialAttrs(fighter);
+        fp = getFighter(fighterObj);
+        attributes2 = getFtSpecialAttrs(fp);
 
-        fighter->x2340_stateVar1 = (s32) attributes2->x10;
-        fighter->x2344_stateVar2_s32 = (s32) attributes2->x14;
-        fighter->x2348_stateVar3_s32 = (s32) attributes2->x18;
-        fighter->sa.zelda.x222C = 0;
-        fighter->x234C_stateVar4_s32 = (s32) attributes2->x1C;
-        fighter->cb.x21E4_callback_OnDeath2 = 0;
-        fighter->cb.x21DC_callback_OnTakeDamage = 0;
+        fp->x2340_stateVar1 = (s32) attributes2->x10;
+        fp->x2344_stateVar2_s32 = (s32) attributes2->x14;
+        fp->x2348_stateVar3_s32 = (s32) attributes2->x18;
+        fp->sa.zelda.x222C = 0;
+        fp->x234C_stateVar4_s32 = (s32) attributes2->x1C;
+        fp->cb.x21E4_callback_OnDeath2 = 0;
+        fp->cb.x21DC_callback_OnTakeDamage = 0;
         
         if (0 == attributes->x34) {
             func_800CC730(fighterObj);
@@ -319,19 +319,19 @@ void ftZelda_8013BDD0(HSD_GObj* fighterObj) {return;}
 void ftZelda_8013BDD4(HSD_GObj* fighterObj) {
     f32 temp_f1;
     s32 var_r0;
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
-    fighter->x234C_stateVar4_s32 = (s32) (fighter->x234C_stateVar4_s32 - 1);
+    fp = fighterObj->user_data;
+    fp->x234C_stateVar4_s32 = (s32) (fp->x234C_stateVar4_s32 - 1);
     
-    if ((s32) fighter->x234C_stateVar4_s32 <= 0) {
-        fighter->x234C_stateVar4_s32 = 0;
+    if ((s32) fp->x234C_stateVar4_s32 <= 0) {
+        fp->x234C_stateVar4_s32 = 0;
         var_r0 = 1;
     } else {
         var_r0 = 0;
     }
     
-    if ((var_r0 == 1) && !(fighter->input.x65C_heldInputs & 0x200)) {
+    if ((var_r0 == 1) && !(fp->input.x65C_heldInputs & 0x200)) {
         temp_f1 = 0;
         Fighter_ActionStateChange_800693AC(fighterObj, 0x159, 0, NULL, temp_f1, 1.0, temp_f1);
     }
@@ -345,19 +345,19 @@ void ftZelda_8013BE54(HSD_GObj* fighterObj) {return;}
 void ftZelda_8013BE58(HSD_GObj* fighterObj) {
     f32 temp_f1;
     s32 var_r0;
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
-    fighter->x234C_stateVar4_s32 = (s32) (fighter->x234C_stateVar4_s32 - 1);
+    fp = fighterObj->user_data;
+    fp->x234C_stateVar4_s32 = (s32) (fp->x234C_stateVar4_s32 - 1);
 
-    if ((s32) fighter->x234C_stateVar4_s32 <= 0) {
-        fighter->x234C_stateVar4_s32 = 0;
+    if ((s32) fp->x234C_stateVar4_s32 <= 0) {
+        fp->x234C_stateVar4_s32 = 0;
         var_r0 = 1;
     } else {
         var_r0 = 0;
     }
 
-    if ((var_r0 == 1) && !(fighter->input.x65C_heldInputs & 0x200)) {
+    if ((var_r0 == 1) && !(fp->input.x65C_heldInputs & 0x200)) {
         temp_f1 = 0;
         Fighter_ActionStateChange_800693AC(fighterObj, 0x15C, 0, NULL, temp_f1, 1.0, temp_f1);
     }
@@ -369,13 +369,13 @@ void ftZelda_8013BED4(HSD_GObj* fighterObj) {return;}
 // https://decomp.me/scratch/Sb7RS
 void ftZelda_8013BED8(HSD_GObj* fighterObj) {
     s32 stateVar;
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = getFighter(fighterObj);
-    stateVar = fighter->x2348_stateVar3;
+    fp = getFighter(fighterObj);
+    stateVar = fp->x2348_stateVar3;
     
     if (stateVar) {
-        fighter->x2348_stateVar3 = (s32) (stateVar - 1);
+        fp->x2348_stateVar3 = (s32) (stateVar - 1);
     }
     
     func_80084F3C(fighterObj);
@@ -394,142 +394,142 @@ void ftZelda_8013BF30(HSD_GObj* fighterObj) {
 // 8013BF50 - 8013BFB0 (0x60 bytes)
 // https://decomp.me/scratch/suE14
 void ftZelda_8013BF50(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
     s32 temp_r3;
     ftZeldaAttributes* charAttr;
     attr* fighterAttr;
     f32 aerialFriction;
     f32 unused[3];
 
-    fighter = fighterObj->user_data;
-    temp_r3 = fighter->x2348_stateVar3;
-    charAttr = fighter->x2D4_specialAttributes;
+    fp = fighterObj->user_data;
+    temp_r3 = fp->x2348_stateVar3;
+    charAttr = fp->x2D4_specialAttributes;
 
     if (temp_r3 != 0) {
-        fighter->x2348_stateVar3 = temp_r3 - 1;
+        fp->x2348_stateVar3 = temp_r3 - 1;
     } else {
-        fighterAttr = &fighter->x110_attr;
-        func_8007D494(fighter, charAttr->x2C, fighterAttr->x170_TerminalVelocity);
+        fighterAttr = &fp->x110_attr;
+        func_8007D494(fp, charAttr->x2C, fighterAttr->x170_TerminalVelocity);
     }
 
-    aerialFriction = fighter->x110_attr.x180_AerialFriction;
-    func_8007CE94(fighter, aerialFriction);
+    aerialFriction = fp->x110_attr.x180_AerialFriction;
+    func_8007CE94(fp, aerialFriction);
 }
 
 // 8013BFB0 - 8013C010 (0x60 bytes)
 // https://decomp.me/scratch/BxLXt
 void ftZelda_8013BFB0(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
     s32 temp_r3;
     ftZeldaAttributes* charAttr;
     attr* fighterAttr;
     f32 aerialFriction;
     f32 unused[3];
 
-    fighter = fighterObj->user_data;
-    temp_r3 = fighter->x2348_stateVar3;
-    charAttr = fighter->x2D4_specialAttributes;
+    fp = fighterObj->user_data;
+    temp_r3 = fp->x2348_stateVar3;
+    charAttr = fp->x2D4_specialAttributes;
 
     if (temp_r3 != 0) {
-        fighter->x2348_stateVar3 = temp_r3 - 1;
+        fp->x2348_stateVar3 = temp_r3 - 1;
     } else {
-        fighterAttr = &fighter->x110_attr;
-        func_8007D494(fighter, charAttr->x2C, fighterAttr->x170_TerminalVelocity);
+        fighterAttr = &fp->x110_attr;
+        func_8007D494(fp, charAttr->x2C, fighterAttr->x170_TerminalVelocity);
     }
 
-    aerialFriction = fighter->x110_attr.x180_AerialFriction;
-    func_8007CE94(fighter, aerialFriction);
+    aerialFriction = fp->x110_attr.x180_AerialFriction;
+    func_8007CE94(fp, aerialFriction);
 }
 
 // 8013C010 - 8013C070 (0x60 bytes)
 // https://decomp.me/scratch/54a1x
 void ftZelda_8013C010(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
     s32 temp_r3;
     ftZeldaAttributes* charAttr;
     attr* fighterAttr;
     f32 aerialFriction;
     f32 unused[3];
 
-    fighter = fighterObj->user_data;
-    temp_r3 = fighter->x2348_stateVar3;
-    charAttr = fighter->x2D4_specialAttributes;
+    fp = fighterObj->user_data;
+    temp_r3 = fp->x2348_stateVar3;
+    charAttr = fp->x2D4_specialAttributes;
 
     if (temp_r3 != 0) {
-        fighter->x2348_stateVar3 = temp_r3 - 1;
+        fp->x2348_stateVar3 = temp_r3 - 1;
     } else {
-        fighterAttr = &fighter->x110_attr;
-        func_8007D494(fighter, charAttr->x2C, fighterAttr->x170_TerminalVelocity);
+        fighterAttr = &fp->x110_attr;
+        func_8007D494(fp, charAttr->x2C, fighterAttr->x170_TerminalVelocity);
     }
 
-    aerialFriction = fighter->x110_attr.x180_AerialFriction;
-    func_8007CE94(fighter, aerialFriction);
+    aerialFriction = fp->x110_attr.x180_AerialFriction;
+    func_8007CE94(fp, aerialFriction);
 }
 
 // 8013C070 - 8013C0DC (0x6C bytes)
 // https://decomp.me/scratch/947er
 void ftZelda_8013C070(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
+    fp = fighterObj->user_data;
     if (func_80082708(fighterObj) == 0) {
-        func_8007D5D4(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x15A, 0x0C4C5082, NULL, fighter->x894_currentAnimFrame, 1.0, 0);
+        func_8007D5D4(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x15A, 0x0C4C5082, NULL, fp->x894_currentAnimFrame, 1.0, 0);
     }
 }
 
 // 8013C0DC - 8013C148 (0x6C bytes)
 // https://decomp.me/scratch/x1Nmd
 void ftZelda_8013C0DC(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
+    fp = fighterObj->user_data;
     if (func_80082708(fighterObj) == 0) {
-        func_8007D5D4(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x15B, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0, 0);
+        func_8007D5D4(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x15B, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0, 0);
     }
 }
 
 // 8013C148 - 8013C1B4 (0x6C bytes)
 void ftZelda_8013C148(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
+    fp = fighterObj->user_data;
     if (func_80082708(fighterObj) == 0) {
-        func_8007D5D4(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x15C, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0, 0);
+        func_8007D5D4(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x15C, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0, 0);
     }
 }
 
 // 8013C1B4 - 8013C220 (0x6C bytes)
 void ftZelda_8013C1B4(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
+    fp = fighterObj->user_data;
     if (func_80081D0C(fighterObj) != 0) {
-        func_8007D7FC(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x157, 0x0C4C5082, NULL, fighter->x894_currentAnimFrame, 1.0, 0);
+        func_8007D7FC(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x157, 0x0C4C5082, NULL, fp->x894_currentAnimFrame, 1.0, 0);
     }
 }
 
 // 8013C220 - 8013C28C (0x6C bytes)
 void ftZelda_8013C220(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
+    fp = fighterObj->user_data;
     if (func_80081D0C(fighterObj) != 0) {
-        func_8007D7FC(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x158, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0, 0);
+        func_8007D7FC(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x158, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0, 0);
     }
 }
 
 // 8013C28C - 8013C2F8 (0x6C bytes)
 void ftZelda_8013C28C(HSD_GObj* fighterObj) {
-    Fighter* fighter;
+    Fighter* fp;
 
-    fighter = fighterObj->user_data;
+    fp = fighterObj->user_data;
     if (func_80081D0C(fighterObj) != 0) {
-        func_8007D7FC(fighter);
-        Fighter_ActionStateChange_800693AC(fighterObj, 0x159, 0x0C4C5080, NULL, fighter->x894_currentAnimFrame, 1.0, 0);
+        func_8007D7FC(fp);
+        Fighter_ActionStateChange_800693AC(fighterObj, 0x159, 0x0C4C5080, NULL, fp->x894_currentAnimFrame, 1.0, 0);
     }
 }

--- a/src/melee/ft/fighter.c
+++ b/src/melee/ft/fighter.c
@@ -176,9 +176,9 @@ void Fighter_LoadCommonData()
 	lbl_804D64FC = pData[22];
 } 
 
-inline void Fighter_InitScale(Fighter *ft, Vec *scale, f32 modelScale) {
-    if (ft->x34_scale.z != 1.0f)
-        scale->x = ft->x34_scale.z;
+inline void Fighter_InitScale(Fighter *fp, Vec *scale, f32 modelScale) {
+    if (fp->x34_scale.z != 1.0f)
+        scale->x = fp->x34_scale.z;
     else
         scale->x = modelScale;
     
@@ -188,628 +188,627 @@ inline void Fighter_InitScale(Fighter *ft, Vec *scale, f32 modelScale) {
 
 void Fighter_UpdateModelScale(HSD_GObj* fighterObj)
 {
-    Fighter* fighter = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
     HSD_JObj* jobj = getHSDJObj(fighterObj);
-    f32 modelScale_f1 = Fighter_GetModelScale(fighter);
+    f32 modelScale_f1 = Fighter_GetModelScale(fp);
     Vec scale;
 
-    Fighter_InitScale(fighter, &scale, modelScale_f1);
+    Fighter_InitScale(fp, &scale, modelScale_f1);
     HSD_JObjSetScale_Hack(jobj, &scale);
 }
 
-void Fighter_UnkInitReset_80067C98(Fighter* fighter) {
+void Fighter_UnkInitReset_80067C98(Fighter* fp) {
 	Vec3 player_coords;
 	f32 x,y,z;
 
-	fighter->x8_spawnNum = Fighter_NewSpawn_80068E40();
-	Player_LoadPlayerCoords(fighter->xC_playerID, &player_coords);
-	fighter->x2C_facing_direction = Player_GetFacingDirection(fighter->xC_playerID);
+	fp->x8_spawnNum = Fighter_NewSpawn_80068E40();
+	Player_LoadPlayerCoords(fp->xC_playerID, &player_coords);
+	fp->x2C_facing_direction = Player_GetFacingDirection(fp->xC_playerID);
 
-	player_coords.x = fighter->x2C_facing_direction * func_800804EC(fighter) + player_coords.x;
+	player_coords.x = fp->x2C_facing_direction * func_800804EC(fp) + player_coords.x;
 	x = player_coords.x;
-	fighter->xB0_pos.x = x;
-	fighter->xBC_prevPos.x = x;
+	fp->xB0_pos.x = x;
+	fp->xBC_prevPos.x = x;
 
 	y = player_coords.y;
-	fighter->xB0_pos.y = y;
-	fighter->xBC_prevPos.y = y;
+	fp->xB0_pos.y = y;
+	fp->xBC_prevPos.y = y;
 
 	z = player_coords.z;
-	fighter->xB0_pos.z = z;
-	fighter->xBC_prevPos.z = z;
+	fp->xB0_pos.z = z;
+	fp->xBC_prevPos.z = z;
 
-	fighter->x30_facingDirectionRepeated = fighter->x2C_facing_direction;
-	fighter->x34_scale.y = fighter->x34_scale.x;
+	fp->x30_facingDirectionRepeated = fp->x2C_facing_direction;
+	fp->x34_scale.y = fp->x34_scale.x;
 
-	fighter->x2220_flag.bits.b5 = 0;
-	fighter->x2220_flag.bits.b6 = 0;
+	fp->x2220_flag.bits.b5 = 0;
+	fp->x2220_flag.bits.b6 = 0;
 
-	fighter->x200C = 0;
-	fighter->x2010 = 0;
-	fighter->x2008 = 0;
+	fp->x200C = 0;
+	fp->x2010 = 0;
+	fp->x2008 = 0;
 
-	fighter->x2219_flag.bits.b1 = 0;
-	fighter->x2219_flag.bits.b2 = 0;
-	fighter->x2219_flag.bits.b3 = 0;
-	fighter->x2219_flag.bits.b4 = 0;
-	fighter->x221A_flag.bits.b5 = 0;
-	fighter->x221A_flag.bits.b6 = 0;
-	fighter->x221D_flag.bits.b2 = 0;
-	fighter->x221E_flag.bits.b7 = 0;
-	fighter->x2220_flag.bits.b7 = 0;
-	fighter->x2221_flag.bits.b4 = 0;
-	fighter->x2221_flag.bits.b5 = 0;
-	fighter->x2221_flag.bits.b6 = 1;
-	fighter->x2221_flag.bits.b7 = 0;
+	fp->x2219_flag.bits.b1 = 0;
+	fp->x2219_flag.bits.b2 = 0;
+	fp->x2219_flag.bits.b3 = 0;
+	fp->x2219_flag.bits.b4 = 0;
+	fp->x221A_flag.bits.b5 = 0;
+	fp->x221A_flag.bits.b6 = 0;
+	fp->x221D_flag.bits.b2 = 0;
+	fp->x221E_flag.bits.b7 = 0;
+	fp->x2220_flag.bits.b7 = 0;
+	fp->x2221_flag.bits.b4 = 0;
+	fp->x2221_flag.bits.b5 = 0;
+	fp->x2221_flag.bits.b6 = 1;
+	fp->x2221_flag.bits.b7 = 0;
 
-	fighter->x61D = 255;
+	fp->x61D = 255;
 
-	fighter->xC8_pos_delta.z = 0.0f; 
-	fighter->xC8_pos_delta.y = 0.0f; 
-	fighter->xC8_pos_delta.x = 0.0f; 
-	fighter->x894_currentAnimFrame = 0.0f; 
-	fighter->x898_unk = 0.0f; 
+	fp->xC8_pos_delta.z = 0.0f; 
+	fp->xC8_pos_delta.y = 0.0f; 
+	fp->xC8_pos_delta.x = 0.0f; 
+	fp->x894_currentAnimFrame = 0.0f; 
+	fp->x898_unk = 0.0f; 
 
-	fighter->x89C_frameSpeedMul = 1.0f; 
-	fighter->x8A0_unk = 1.0f; 
-	fighter->dmg.x1850_forceApplied = 0.0f; 
-	fighter->dmg.x18A4_knockbackMagnitude = 0.0f; 
-	fighter->dmg.x18A8 = 0.0f; 
-	fighter->dmg.x18ac_time_since_hit = -1;
-	fighter->dmg.x18B0 = 0.0f; 
-	fighter->dmg.x18B4_armor = 0.0f; 
-	fighter->x1828 = 0;
+	fp->x89C_frameSpeedMul = 1.0f; 
+	fp->x8A0_unk = 1.0f; 
+	fp->dmg.x1850_forceApplied = 0.0f; 
+	fp->dmg.x18A4_knockbackMagnitude = 0.0f; 
+	fp->dmg.x18A8 = 0.0f; 
+	fp->dmg.x18ac_time_since_hit = -1;
+	fp->dmg.x18B0 = 0.0f; 
+	fp->dmg.x18B4_armor = 0.0f; 
+	fp->x1828 = 0;
 
-	fighter->x221C_flag.bits.b6 = 0;
+	fp->x221C_flag.bits.b6 = 0;
 
-	fighter->dmg.x18a0 = 0.0f; 
-	fighter->x1968_jumpsUsed = 0;
-	fighter->x1969_walljumpUsed = 0;
-	fighter->x196C_hitlag_mult = 0.0f; 
-	fighter->x2064_ledgeCooldown = 0;
+	fp->dmg.x18a0 = 0.0f; 
+	fp->x1968_jumpsUsed = 0;
+	fp->x1969_walljumpUsed = 0;
+	fp->x196C_hitlag_mult = 0.0f; 
+	fp->x2064_ledgeCooldown = 0;
 
-	fighter->dmg.x1830_percent = Player_GetDamage(fighter->xC_playerID);
+	fp->dmg.x1830_percent = Player_GetDamage(fp->xC_playerID);
 
-	fighter->dmg.x1838_percentTemp = 0.0f; 
+	fp->dmg.x1838_percentTemp = 0.0f; 
 
-	fighter->dmg.x183C_applied = 0;
-	fighter->dmg.x18C0 = 0;
+	fp->dmg.x183C_applied = 0;
+	fp->dmg.x18C0 = 0;
 
-	fighter->dmg.x18c4_source_ply = 6;
-	fighter->dmg.x18C8 = -1;
-	fighter->dmg.x18F0 = 0;
-	fighter->dmg.x18CC = 0;
-	fighter->dmg.x18D0 = -10;
+	fp->dmg.x18c4_source_ply = 6;
+	fp->dmg.x18C8 = -1;
+	fp->dmg.x18F0 = 0;
+	fp->dmg.x18CC = 0;
+	fp->dmg.x18D0 = -10;
 
-	fighter->x221F_flag.bits.b5 = 0;
-	fighter->x2221_flag.bits.b1 = 0;
+	fp->x221F_flag.bits.b5 = 0;
+	fp->x2221_flag.bits.b1 = 0;
 
-	fighter->dmg.x18F4 = 0;
-	fighter->dmg.x18F8 = 1;
-	fighter->dmg.x18fa_model_shift_frames = 0;
-	fighter->dmg.x18FD = 0;
-	fighter->dmg.x18FC = 0;
-	fighter->dmg.x1834 = 0.0f;
+	fp->dmg.x18F4 = 0;
+	fp->dmg.x18F8 = 1;
+	fp->dmg.x18fa_model_shift_frames = 0;
+	fp->dmg.x18FD = 0;
+	fp->dmg.x18FC = 0;
+	fp->dmg.x1834 = 0.0f;
 
-	fighter->x2222_flag.bits.b2 = 0;
+	fp->x2222_flag.bits.b2 = 0;
 
-	fighter->dmg.x1840 = 0;
+	fp->dmg.x1840 = 0;
 
-	fighter->x2219_flag.bits.b5 = 0; 
-	fighter->x2219_flag.bits.b6 = 0;
-	fighter->x2219_flag.bits.b7 = 0;
-	fighter->x221A_flag.bits.b0 = 0;
-	fighter->x221A_flag.bits.b1 = 0;
+	fp->x2219_flag.bits.b5 = 0; 
+	fp->x2219_flag.bits.b6 = 0;
+	fp->x2219_flag.bits.b7 = 0;
+	fp->x221A_flag.bits.b0 = 0;
+	fp->x221A_flag.bits.b1 = 0;
 
-	fighter->dmg.x1954 = 0.0f;
-	fighter->dmg.x1958 = 0.0f;
+	fp->dmg.x1954 = 0.0f;
+	fp->dmg.x1958 = 0.0f;
 
-	fighter->x221A_flag.bits.b2 = 0;
+	fp->x221A_flag.bits.b2 = 0;
 
-	fighter->dmg.x195c_hitlag_frames = 0.0f;
+	fp->dmg.x195c_hitlag_frames = 0.0f;
 
-	fighter->x221A_flag.bits.b3 = 0;
-	fighter->x1960_vibrateMult = 1.0f;
-	fighter->x1964 = 0.0f;
-	fighter->dmg.x189C_unk_num_frames = 0.0f;
+	fp->x221A_flag.bits.b3 = 0;
+	fp->x1960_vibrateMult = 1.0f;
+	fp->x1964 = 0.0f;
+	fp->dmg.x189C_unk_num_frames = 0.0f;
 
-	fighter->x2220_flag.bits.b3 = 0;
-	fighter->x2220_flag.bits.b4 = 0;
+	fp->x2220_flag.bits.b3 = 0;
+	fp->x2220_flag.bits.b4 = 0;
 
-	fighter->dmg.x1914 = 0;
-	fighter->dmg.x1918 = 0;
-	fighter->dmg.x191C = 0.0f;
-	fighter->dmg.x1924 = 0;
-	fighter->dmg.x1928 = 0.0f;
+	fp->dmg.x1914 = 0;
+	fp->dmg.x1918 = 0;
+	fp->dmg.x191C = 0.0f;
+	fp->dmg.x1924 = 0;
+	fp->dmg.x1928 = 0.0f;
 
-	fighter->x2223_flag.bits.b5 = 0;
+	fp->x2223_flag.bits.b5 = 0;
 
-	fighter->dmg.x1950 = 0;
-	fighter->dmg.x1948 = 0;
+	fp->dmg.x1950 = 0;
+	fp->dmg.x1948 = 0;
 
-	fighter->x2223_flag.bits.b4 = 0;
+	fp->x2223_flag.bits.b4 = 0;
 
-	fighter->xF8_playerNudgeVel.y = 0.0f;
-	fighter->xF8_playerNudgeVel.x = 0.0f;
-	fighter->x100 = -1.0f;
+	fp->xF8_playerNudgeVel.y = 0.0f;
+	fp->xF8_playerNudgeVel.x = 0.0f;
+	fp->x100 = -1.0f;
 
-	fighter->x2222_flag.bits.b7 = 0;
-	fighter->x2223_flag.bits.b0 = 0;
-	fighter->x221A_flag.bits.b4 = 0;
-	fighter->x2219_flag.bits.b0 = 0;
+	fp->x2222_flag.bits.b7 = 0;
+	fp->x2223_flag.bits.b0 = 0;
+	fp->x221A_flag.bits.b4 = 0;
+	fp->x2219_flag.bits.b0 = 0;
 
-	fighter->x20A0_accessory = 0;
-	fighter->x2210_ThrowFlags.flags = 0;
-	fighter->x2214 = 0.0f; 
-	fighter->x1974_heldItem = 0;
-	fighter->x1978 = 0;
+	fp->x20A0_accessory = 0;
+	fp->x2210_ThrowFlags.flags = 0;
+	fp->x2214 = 0.0f; 
+	fp->x1974_heldItem = 0;
+	fp->x1978 = 0;
 
-	fighter->x221E_flag.bits.b3 = 1;
+	fp->x221E_flag.bits.b3 = 1;
 
-	fighter->x1984_heldItemSpec = 0;
-	fighter->x1988 = 0;
-	fighter->x198C = 0;
+	fp->x1984_heldItemSpec = 0;
+	fp->x1988 = 0;
+	fp->x198C = 0;
 
-	fighter->x2221_flag.bits.b0 = 0;
+	fp->x2221_flag.bits.b0 = 0;
 
-	fighter->x1990 = 0;
-	fighter->x1994 = 0;
+	fp->x1990 = 0;
+	fp->x1994 = 0;
 
-	fighter->x221D_flag.bits.b6 = 0;
-	fighter->x221B_flag.bits.b5 = 0;
+	fp->x221D_flag.bits.b6 = 0;
+	fp->x221B_flag.bits.b5 = 0;
 
-	fighter->x1A58_interactedFighter = 0;
-	fighter->x1A5C = 0;
+	fp->x1A58_interactedFighter = 0;
+	fp->x1A5C = 0;
 
-	fighter->x221B_flag.bits.b6 = 0;
+	fp->x221B_flag.bits.b6 = 0;
 
-	fighter->x1A60 = 0;
-	fighter->x1A64 = 0;
+	fp->x1A60 = 0;
+	fp->x1A64 = 0;
 
-	fighter->x221B_flag.bits.b7 = 0;
-	fighter->x221C_flag.bits.b0 = 0;
+	fp->x221B_flag.bits.b7 = 0;
+	fp->x221C_flag.bits.b0 = 0;
 
-	fighter->x1064_thrownHitbox.x134 = 0;
-	fighter->x221C_u16_y = 0;
-	fighter->x20AC = NULL;
-	fighter->x221C_flag.bits.b5 = 0;
+	fp->x1064_thrownHitbox.x134 = 0;
+	fp->x221C_u16_y = 0;
+	fp->x20AC = NULL;
+	fp->x221C_flag.bits.b5 = 0;
 
-    fighter->x2150 = 
-	fighter->x2154 = 
-	fighter->x2158 = 
-	fighter->x215C = 
-	fighter->x2160 = 
-	fighter->x2144 = 
-	fighter->x2148 =   
-	fighter->x214C = -1;
+    fp->x2150 = 
+	fp->x2154 = 
+	fp->x2158 = 
+	fp->x215C = 
+	fp->x2160 = 
+	fp->x2144 = 
+	fp->x2148 =   
+	fp->x214C = -1;
     
-	fighter->x2168 = 0;
-	fighter->x2164 = 0;
-	fighter->x208C = 0;
-	fighter->x2090 = 0;
-	fighter->x2098 = 0;
-	fighter->x2092 = 0;
-	fighter->x2094 = 0;
-	fighter->x1998_shieldHealth = p_ftCommonData->x260_startShieldHealth;
+	fp->x2168 = 0;
+	fp->x2164 = 0;
+	fp->x208C = 0;
+	fp->x2090 = 0;
+	fp->x2098 = 0;
+	fp->x2092 = 0;
+	fp->x2094 = 0;
+	fp->x1998_shieldHealth = p_ftCommonData->x260_startShieldHealth;
 
-	fighter->x221A_flag.bits.b7 = 0;
-    fighter->x221B_flag.bits.b0 = 0;
-	fighter->x221B_flag.bits.b1 = 0;
-	fighter->x221B_flag.bits.b3 = 0;
-	fighter->x221B_flag.bits.b4 = 0;
-	fighter->x221C_flag.bits.b3 = 0;
-	fighter->x221C_flag.bits.b1 = 0;
-	fighter->x221C_flag.bits.b2 = 0;
+	fp->x221A_flag.bits.b7 = 0;
+    fp->x221B_flag.bits.b0 = 0;
+	fp->x221B_flag.bits.b1 = 0;
+	fp->x221B_flag.bits.b3 = 0;
+	fp->x221B_flag.bits.b4 = 0;
+	fp->x221C_flag.bits.b3 = 0;
+	fp->x221C_flag.bits.b1 = 0;
+	fp->x221C_flag.bits.b2 = 0;
 
-	fighter->x19A0_shieldDamageTaken = 0;
-	fighter->x19A4 = 0;
-	fighter->x199C_shieldLightshieldAmt = 0.0f;
-	fighter->x19A8 = 0;
-	fighter->x19B4_shieldUnk = 0.0f;
-	fighter->x19B8_shieldUnk = 0.0f;
-	fighter->x19BC_shieldDamageTaken3 = 6;
+	fp->x19A0_shieldDamageTaken = 0;
+	fp->x19A4 = 0;
+	fp->x199C_shieldLightshieldAmt = 0.0f;
+	fp->x19A8 = 0;
+	fp->x19B4_shieldUnk = 0.0f;
+	fp->x19B8_shieldUnk = 0.0f;
+	fp->x19BC_shieldDamageTaken3 = 6;
 
-	fighter->x221F_flag.bits.b6 = 0;
-	fighter->x2218_flag.bits.b3 = 0;
-	fighter->x2218_flag.bits.b4 = 0;
-	fighter->ReflectAttr.x1A3C_damageOver = 0;
-	fighter->ReflectAttr.x1A2C_reflectHitDirection = 0.0f;
-	fighter->x2218_flag.bits.b6 = 0; 
-	fighter->x2218_flag.bits.b7 = 0;
+	fp->x221F_flag.bits.b6 = 0;
+	fp->x2218_flag.bits.b3 = 0;
+	fp->x2218_flag.bits.b4 = 0;
+	fp->ReflectAttr.x1A3C_damageOver = 0;
+	fp->ReflectAttr.x1A2C_reflectHitDirection = 0.0f;
+	fp->x2218_flag.bits.b6 = 0; 
+	fp->x2218_flag.bits.b7 = 0;
 
 
-	fighter->AbsorbAttr.x1A40_absorbHitDirection = 0.0f;
+	fp->AbsorbAttr.x1A40_absorbHitDirection = 0.0f;
 
-	fighter->AbsorbAttr.x1A44_damageTaken = 0;
-	fighter->AbsorbAttr.x1A48_hitsTaken = 0;
+	fp->AbsorbAttr.x1A44_damageTaken = 0;
+	fp->AbsorbAttr.x1A48_hitsTaken = 0;
 
-	fighter->x68C_transNPos.z = 0.0f;
-	fighter->x68C_transNPos.y = 0.0f;
-	fighter->x68C_transNPos.x = 0.0f;
-	fighter->x6A4_transNOffset.z = 0.0f;
-	fighter->x6A4_transNOffset.y = 0.0f;
-	fighter->x6A4_transNOffset.x = 0.0f;
-	fighter->x6BC_inputStickangle = 0.0f;
+	fp->x68C_transNPos.z = 0.0f;
+	fp->x68C_transNPos.y = 0.0f;
+	fp->x68C_transNPos.x = 0.0f;
+	fp->x6A4_transNOffset.z = 0.0f;
+	fp->x6A4_transNOffset.y = 0.0f;
+	fp->x6A4_transNOffset.x = 0.0f;
+	fp->x6BC_inputStickangle = 0.0f;
 
-	fighter->x6C0.z = 0.0f; 
-	fighter->x6C0.y = 0.0f; 
-	fighter->x6C0.x = 0.0f; 
+	fp->x6C0.z = 0.0f; 
+	fp->x6C0.y = 0.0f; 
+	fp->x6C0.x = 0.0f; 
 
-	fighter->x6D8.z = 0.0f; 
-	fighter->x6D8.y = 0.0f; 
-	fighter->x6D8.x = 0.0f; 
+	fp->x6D8.z = 0.0f; 
+	fp->x6D8.y = 0.0f; 
+	fp->x6D8.x = 0.0f; 
 
-	fighter->x209C = 0;
-	fighter->x2224_flag.bits.b1 = 0;
-	fighter->cb.x21E4_callback_OnDeath2 = 0;
-	fighter->x2100 = -1;
-	fighter->x2101_bits_0to6 = 0;
-	fighter->cb.x21B4_callback_Accessory2 = 0;
-	fighter->cb.x21B8_callback_Accessory3 = 0;
-	fighter->cb.x21E0_callback_OnDeath = 0;
-	fighter->cb.x21E8_callback_OnDeath3 = 0;
-	fighter->x221E_flag.bits.b4 = 1;
-	fighter->x197C = 0;
-	fighter->x2223_flag.bits.b7 = 0;
-	fighter->x2028 = 0;
-	fighter->x202C = 0;
+	fp->x209C = 0;
+	fp->x2224_flag.bits.b1 = 0;
+	fp->cb.x21E4_callback_OnDeath2 = 0;
+	fp->x2100 = -1;
+	fp->x2101_bits_0to6 = 0;
+	fp->cb.x21B4_callback_Accessory2 = 0;
+	fp->cb.x21B8_callback_Accessory3 = 0;
+	fp->cb.x21E0_callback_OnDeath = 0;
+	fp->cb.x21E8_callback_OnDeath3 = 0;
+	fp->x221E_flag.bits.b4 = 1;
+	fp->x197C = 0;
+	fp->x2223_flag.bits.b7 = 0;
+	fp->x2028 = 0;
+	fp->x202C = 0;
 
-	func_800C88A0(fighter);
+	func_800C88A0(fp);
 
-	fighter->x2227_flag.bits.b3 = 0;
-	fighter->x2034 = 0;
-	fighter->x2038 = 0;
-	fighter->x1980 = 0;
+	fp->x2227_flag.bits.b3 = 0;
+	fp->x2034 = 0;
+	fp->x2038 = 0;
+	fp->x1980 = 0;
 
-	fighter->x2224_flag.bits.b2 = fighter->x2224_flag.bits.b3 = 0;
+	fp->x2224_flag.bits.b2 = fp->x2224_flag.bits.b3 = 0;
 
-	fighter->x2224_flag.bits.b4 = 0;
-	fighter->x2108 = 0;
-	fighter->x2224_flag.bits.b5 = 0;
-	fighter->x1A53 = 0;
-	fighter->x1A52 = 0;
-	fighter->x210C_walljumpInputTimer = 254;
-	fighter->dmg.x1910 = 0;
-	fighter->x2225_flag.bits.b0 = 0;
-	fighter->x2225_flag.bits.b2 = 1;
-	fighter->x2225_flag.bits.b4 = 0;
-	func_800DEEA8(fighter->x0_fighter);
-	fighter->dmg.x18BC = 0.0f; 
-	fighter->dmg.x18B8 = 0.0f; 
-	fighter->x2226_flag.bits.b2 = 0;
-	fighter->x2170 = 0.0f; 
-	fighter->x2225_flag.bits.b6 = fighter->x2225_flag.bits.b5;
-	fighter->dmg.x1908 = -1;
-	fighter->dmg.x190C = 0;
-	fighter->x2227_flag.bits.b4 = 0;
-	fighter->x2114_SmashAttr.x2138_smashSinceHitbox = -1.0f;
-	fighter->x213C = -1;
-	fighter->x2227_flag.bits.b5 = 0;
-	fighter->x2228_flag.bits.b1 = 0;
-	fighter->x2140 = 0.0f;
-	fighter->x2227_flag.bits.b6 = 0;
-	fighter->x2180 = 6;
-	fighter->x2229_b4 = 1;
+	fp->x2224_flag.bits.b4 = 0;
+	fp->x2108 = 0;
+	fp->x2224_flag.bits.b5 = 0;
+	fp->x1A53 = 0;
+	fp->x1A52 = 0;
+	fp->x210C_walljumpInputTimer = 254;
+	fp->dmg.x1910 = 0;
+	fp->x2225_flag.bits.b0 = 0;
+	fp->x2225_flag.bits.b2 = 1;
+	fp->x2225_flag.bits.b4 = 0;
+	func_800DEEA8(fp->x0_fighter);
+	fp->dmg.x18BC = 0.0f; 
+	fp->dmg.x18B8 = 0.0f; 
+	fp->x2226_flag.bits.b2 = 0;
+	fp->x2170 = 0.0f; 
+	fp->x2225_flag.bits.b6 = fp->x2225_flag.bits.b5;
+	fp->dmg.x1908 = -1;
+	fp->dmg.x190C = 0;
+	fp->x2227_flag.bits.b4 = 0;
+	fp->x2114_SmashAttr.x2138_smashSinceHitbox = -1.0f;
+	fp->x213C = -1;
+	fp->x2227_flag.bits.b5 = 0;
+	fp->x2228_flag.bits.b1 = 0;
+	fp->x2140 = 0.0f;
+	fp->x2227_flag.bits.b6 = 0;
+	fp->x2180 = 6;
+	fp->x2229_b4 = 1;
 }
 
 void Fighter_UnkProcessDeath_80068354(HSD_GObj* fighterObj) {
-    Fighter* ft = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
     
-    Fighter_UnkInitReset_80067C98(ft);
-    HSD_JObjSetTranslate(fighterObj->hsd_obj, &ft->xB0_pos);
+    Fighter_UnkInitReset_80067C98(fp);
+    HSD_JObjSetTranslate(fighterObj->hsd_obj, &fp->xB0_pos);
 
     func_800D105C(fighterObj);
     func_800C09B4(fighterObj);
     func_8007E2FC(fighterObj);
-    func_80088A50(ft);
-    func_800890BC(ft);
-    func_800892D4(ft);
+    func_80088A50(fp);
+    func_800890BC(fp);
+    func_800892D4(fp);
     func_80081B38(fighterObj);
     func_80081938(fighterObj);
 
-    if (ft->x2114_SmashAttr.x2135 == -1)
+    if (fp->x2114_SmashAttr.x2135 == -1)
     {
-        if (func_80082A68(fighterObj) && !ft->x2229_b6)
-            func_8007D6A4(ft);
+        if (func_80082A68(fighterObj) && !fp->x2229_b6)
+            func_8007D6A4(fp);
         else
-            func_8007D5D4(ft);
+            func_8007D5D4(fp);
     }
     else
-        func_8007D5D4(ft);
-    func_80076064(ft);
+        func_8007D5D4(fp);
+    func_80076064(fp);
     
-    HSD_JObjSetTranslate(fighterObj->hsd_obj, &ft->xB0_pos);
+    HSD_JObjSetTranslate(fighterObj->hsd_obj, &fp->xB0_pos);
     Fighter_UnkApplyTransformation_8006C0F0(fighterObj);
     Fighter_UpdateModelScale(fighterObj);
 
-    func_800BFFAC(ft);
-    func_800C0074(ft);
+    func_800BFFAC(fp);
+    func_800C0074(fp);
     func_800C8438(fighterObj);
     func_800C89A0(fighterObj);
     func_800C8FC4(fighterObj);
     func_8007AFF8(fighterObj);
     func_8007B0C0(fighterObj, 0);
 
-    if (ft_OnDeath[ft->x4_fighterKind])
-        ft_OnDeath[ft->x4_fighterKind](fighterObj);
+    if (ft_OnDeath[fp->x4_fighterKind])
+        ft_OnDeath[fp->x4_fighterKind](fighterObj);
 
-    func_800A101C(ft, Player_GetCpuType(ft->xC_playerID), Player_GetCpuLevel(ft->xC_playerID), 0);
+    func_800A101C(fp, Player_GetCpuType(fp->xC_playerID), Player_GetCpuLevel(fp->xC_playerID), 0);
 
-    func_80067688(&ft->x60C);
+    func_80067688(&fp->x60C);
     func_8007C17C(fighterObj);
     func_8007C630(fighterObj);
 }
 
 void Fighter_UnkUpdateCostumeJoint_800686E4(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
     HSD_JObj *jobj;
     
-    fighter->x108_costume_joint = CostumeListsForeachCharacter[fighter->x4_fighterKind].costume_list[fighter->x619_costume_id].joint;
+    fp->x108_costume_joint = CostumeListsForeachCharacter[fp->x4_fighterKind].costume_list[fp->x619_costume_id].joint;
     func_80074148();
-    jobj = HSD_JObjLoadJoint(fighter->x108_costume_joint);
+    jobj = HSD_JObjLoadJoint(fp->x108_costume_joint);
     func_80074170();
     func_80073758(jobj);
     
     func_80390A70(fighterObj, lbl_804D7849, jobj);
 }
 
-void Fighter_UnkUpdateVecFromBones_8006876C(Fighter* fighter) {
+void Fighter_UnkUpdateVecFromBones_8006876C(Fighter* fp) {
     Vec vec;
     Vec vec2;
-    HSD_JObj* jobj = fighter->x5E8_fighterBones[func_8007500C(fighter, 2)].x0_jobj;
+    HSD_JObj* jobj = fp->x5E8_fighterBones[func_8007500C(fp, 2)].x0_jobj;
 
     HSD_JObjGetTranslation(jobj, &vec);
 
-    fighter->x1A6C = (vec.y / 8.55f);
+    fp->x1A6C = (vec.y / 8.55f);
 
     func_8000B1CC(jobj, 0, &vec);
-    func_8000B1CC(fighter->x5E8_fighterBones[func_8007500C(fighter, 1)].x0_jobj, 0, &vec2);
-    fighter->x1A70.x = vec2.x - vec.x;
-    fighter->x1A70.y = vec2.y - vec.y;
-    fighter->x1A70.z = vec2.z - vec.z;
+    func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 1)].x0_jobj, 0, &vec2);
+    fp->x1A70.x = vec2.x - vec.x;
+    fp->x1A70.y = vec2.y - vec.y;
+    fp->x1A70.z = vec2.z - vec.z;
 }
 
 
 void Fighter_ResetInputData_80068854(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
 
-    fighter->input.x620_lstick_x = 
-    fighter->input.x624_lstick_y = 
-    fighter->input.x628_lstick_x2 = 
-    fighter->input.x62C_lstick_y2 = 0.0f;
+    fp->input.x620_lstick_x = 
+    fp->input.x624_lstick_y = 
+    fp->input.x628_lstick_x2 = 
+    fp->input.x62C_lstick_y2 = 0.0f;
 
-    fighter->input.x644_lsubStick_y2 = 0.0f;
-    fighter->input.x640_lsubStick_x2 = 0.0f;
-    fighter->input.x63C_lsubStick_y = 0.0f;
-    fighter->input.x638_lsubStick_x = 0.0f;
+    fp->input.x644_lsubStick_y2 = 0.0f;
+    fp->input.x640_lsubStick_x2 = 0.0f;
+    fp->input.x63C_lsubStick_y = 0.0f;
+    fp->input.x638_lsubStick_x = 0.0f;
 
-    fighter->input.x654 = 0.0f;
-    fighter->input.x650 = 0.0f;
+    fp->input.x654 = 0.0f;
+    fp->input.x650 = 0.0f;
 
-    fighter->input.x660 = 0;
-    fighter->input.x66C = 0;
-    fighter->input.x668 = 0;
-    fighter->input.x65C_heldInputs = 0;
+    fp->input.x660 = 0;
+    fp->input.x66C = 0;
+    fp->input.x668 = 0;
+    fp->input.x65C_heldInputs = 0;
 
-    fighter->x672_input_timer_counter = 0xFE;
-    fighter->x671_timer_lstick_tilt_y = 0xFE;
-    fighter->x670_timer_lstick_tilt_x = 0xFE;
+    fp->x672_input_timer_counter = 0xFE;
+    fp->x671_timer_lstick_tilt_y = 0xFE;
+    fp->x670_timer_lstick_tilt_x = 0xFE;
 
-    fighter->x675 = 0xFE;
-    fighter->x674 = 0xFE;
-    fighter->x673 = 0xFE;
+    fp->x675 = 0xFE;
+    fp->x674 = 0xFE;
+    fp->x673 = 0xFE;
 
-    fighter->x678 = 0xFE;
-    fighter->x677_y = 0xFE;
-    fighter->x676_x = 0xFE;
+    fp->x678 = 0xFE;
+    fp->x677_y = 0xFE;
+    fp->x676_x = 0xFE;
 
-    fighter->x67B = 0xFE;
-    fighter->x67A_y = 0xFE;
-    fighter->x679_x = 0xFE;
+    fp->x67B = 0xFE;
+    fp->x67A_y = 0xFE;
+    fp->x679_x = 0xFE;
 
-    fighter->x68B = 0xFF;
-    fighter->x68A = 0xFF;
-    fighter->x689 = 0xFF;
-    fighter->x688 = 0xFF;
-    fighter->x687 = 0xFF;
-    fighter->x686 = 0xFF;
-    fighter->x685 = 0xFF;
-    fighter->x684 = 0xFF;
-    fighter->x683 = 0xFF;
+    fp->x68B = 0xFF;
+    fp->x68A = 0xFF;
+    fp->x689 = 0xFF;
+    fp->x688 = 0xFF;
+    fp->x687 = 0xFF;
+    fp->x686 = 0xFF;
+    fp->x685 = 0xFF;
+    fp->x684 = 0xFF;
+    fp->x683 = 0xFF;
 
-    fighter->x680 = 0xFF;
-    fighter->x67F = 0xFF;
+    fp->x680 = 0xFF;
+    fp->x67F = 0xFF;
 
-    fighter->x682 = 0xFF;
-    fighter->x681 = 0xFF;
+    fp->x682 = 0xFF;
+    fp->x681 = 0xFF;
 
-    fighter->x67E = 0xFF;
-    fighter->x67D = 0xFF;
-    fighter->x67C = 0xFF;
+    fp->x67E = 0xFF;
+    fp->x67D = 0xFF;
+    fp->x67C = 0xFF;
 }
 
 static void Fighter_UnkInitLoad_80068914_Inner1(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
     
-    fighter->input.x650 = 
-    fighter->input.x654 = 
-    fighter->input.x638_lsubStick_x = 
-    fighter->input.x63C_lsubStick_y = 
-    fighter->input.x640_lsubStick_x2 = 
-    fighter->input.x644_lsubStick_y2 = 
-    fighter->input.x620_lstick_x = 
-    fighter->input.x624_lstick_y = 
-    fighter->input.x628_lstick_x2 = 
-    fighter->input.x62C_lstick_y2 = 0.0f;
+    fp->input.x650 = 
+    fp->input.x654 = 
+    fp->input.x638_lsubStick_x = 
+    fp->input.x63C_lsubStick_y = 
+    fp->input.x640_lsubStick_x2 = 
+    fp->input.x644_lsubStick_y2 = 
+    fp->input.x620_lstick_x = 
+    fp->input.x624_lstick_y = 
+    fp->input.x628_lstick_x2 = 
+    fp->input.x62C_lstick_y2 = 0.0f;
 
-    fighter->input.x660 = 0;
-    fighter->input.x66C = 0;
-    fighter->input.x668 = 0;
-    fighter->input.x65C_heldInputs = 0;
+    fp->input.x660 = 0;
+    fp->input.x66C = 0;
+    fp->input.x668 = 0;
+    fp->input.x65C_heldInputs = 0;
     
-    fighter->x679_x = 
-    fighter->x67A_y = 
-    fighter->x67B = 
+    fp->x679_x = 
+    fp->x67A_y = 
+    fp->x67B = 
 
-    fighter->x676_x = 
-    fighter->x677_y = 
-    fighter->x678 = 
+    fp->x676_x = 
+    fp->x677_y = 
+    fp->x678 = 
 
-    fighter->x673 = 
-    fighter->x674 = 
-    fighter->x675 = 
+    fp->x673 = 
+    fp->x674 = 
+    fp->x675 = 
 
-    fighter->x670_timer_lstick_tilt_x = 
-    fighter->x671_timer_lstick_tilt_y = 
-    fighter->x672_input_timer_counter = 0xFE;
+    fp->x670_timer_lstick_tilt_x = 
+    fp->x671_timer_lstick_tilt_y = 
+    fp->x672_input_timer_counter = 0xFE;
 
-    fighter->x67C = 
-    fighter->x67D = 
-    fighter->x67E = 
-    fighter->x681 = 
-    fighter->x682 = 
-    fighter->x67F = 
-    fighter->x680 = 
-    fighter->x683 = 
-    fighter->x684 = 
-    fighter->x685 = 
-    fighter->x686 = 
-    fighter->x687 = 
-    fighter->x688 = 
-    fighter->x689 = 
-    fighter->x68A = 
-    fighter->x68B = 0xFF;
+    fp->x67C = 
+    fp->x67D = 
+    fp->x67E = 
+    fp->x681 = 
+    fp->x682 = 
+    fp->x67F = 
+    fp->x680 = 
+    fp->x683 = 
+    fp->x684 = 
+    fp->x685 = 
+    fp->x686 = 
+    fp->x687 = 
+    fp->x688 = 
+    fp->x689 = 
+    fp->x68A = 
+    fp->x68B = 0xFF;
 }
 
 void Fighter_UnkInitLoad_80068914(HSD_GObj* fighterObj, struct S_TEMP1* argdata) {
-    Fighter* fighter = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
     u32 controller_index;
     struct RGBA* color;
     ftData** ftDataList;
     s32 costume_id;
+    fp->x4_fighterKind = argdata->fighterKind;
+    fp->xC_playerID = argdata->playerID;
 
-    fighter->x4_fighterKind = argdata->fighterKind;
-    fighter->xC_playerID = argdata->playerID;
+    fp->x221F_flag.bits.b4 = argdata->flags.bits.b0;
 
-    fighter->x221F_flag.bits.b4 = argdata->flags.bits.b0;
+    fp->x34_scale.x = Player_GetModelScale(fp->xC_playerID);
+    fp->x61C = argdata->unk5;
+    fp->x618_player_id = Player_GetPlayerId(fp->xC_playerID);
+    fp->x61A_controller_index = Player_GetControllerIndex(fp->xC_playerID);
+    fp->x2223_flag.bits.b6 = Player_GetFlagsBit5(fp->xC_playerID);
+    fp->x2226_flag.bits.b3 = Player_GetFlagsBit6(fp->xC_playerID);
+    fp->x2226_flag.bits.b6 = Player_GetFlagsBit7(fp->xC_playerID);
+    fp->x2225_flag.bits.b5 = Player_GetMoreFlagsBit1(fp->xC_playerID);
+    fp->x2225_flag.bits.b7 = Player_GetMoreFlagsBit2(fp->xC_playerID);
+    fp->x2228_flag.bits.b3 = Player_GetMoreFlagsBit6(fp->xC_playerID);
+    fp->x2229_b1 = Player_GetFlagsAEBit0(fp->xC_playerID);
 
-    fighter->x34_scale.x = Player_GetModelScale(fighter->xC_playerID);
-    fighter->x61C = argdata->unk5;
-    fighter->x618_player_id = Player_GetPlayerId(fighter->xC_playerID);
-    fighter->x61A_controller_index = Player_GetControllerIndex(fighter->xC_playerID);
-    fighter->x2223_flag.bits.b6 = Player_GetFlagsBit5(fighter->xC_playerID);
-    fighter->x2226_flag.bits.b3 = Player_GetFlagsBit6(fighter->xC_playerID);
-    fighter->x2226_flag.bits.b6 = Player_GetFlagsBit7(fighter->xC_playerID);
-    fighter->x2225_flag.bits.b5 = Player_GetMoreFlagsBit1(fighter->xC_playerID);
-    fighter->x2225_flag.bits.b7 = Player_GetMoreFlagsBit2(fighter->xC_playerID);
-    fighter->x2228_flag.bits.b3 = Player_GetMoreFlagsBit6(fighter->xC_playerID);
-    fighter->x2229_b1 = Player_GetFlagsAEBit0(fighter->xC_playerID);
-
-    if (fighter->x61A_controller_index > 4) {
+    if (fp->x61A_controller_index > 4) {
         OSReport("fighter sub color num over!\n");
         __assert(__FILE__, 0x33C, "0");
     }
 
-    controller_index = fighter->x61A_controller_index;
+    controller_index = fp->x61A_controller_index;
     if (controller_index != 0) {
         color = &p_ftCommonData->x6DC_colorsByPlayer[controller_index - 1];
-        fighter->x610_color_rgba[0].r = (color->r * color->a) / 0xff;
-        fighter->x610_color_rgba[0].g = (color->g * color->a) / 0xff;
-        fighter->x610_color_rgba[0].b = (color->b * color->a) / 0xff;
-        fighter->x610_color_rgba[0].a = color->a;
+        fp->x610_color_rgba[0].r = (color->r * color->a) / 0xff;
+        fp->x610_color_rgba[0].g = (color->g * color->a) / 0xff;
+        fp->x610_color_rgba[0].b = (color->b * color->a) / 0xff;
+        fp->x610_color_rgba[0].a = color->a;
     }
 
-    costume_id = Player_GetCostumeId(fighter->xC_playerID);
-    if (costume_id >= CostumeListsForeachCharacter[fighter->x4_fighterKind].numCostumes) {
+    costume_id = Player_GetCostumeId(fp->xC_playerID);
+    if (costume_id >= CostumeListsForeachCharacter[fp->x4_fighterKind].numCostumes) {
         costume_id = 0;
     }
     
-    fighter->x619_costume_id = costume_id;
-    fighter->x61B_team = Player_GetTeam(fighter->xC_playerID);
+    fp->x619_costume_id = costume_id;
+    fp->x61B_team = Player_GetTeam(fp->xC_playerID);
     ftDataList = gFtDataList;
-    fighter->x0_fighter = fighterObj;
-    fighter->x10C_ftData = ftDataList[fighter->x4_fighterKind];
+    fp->x0_fighter = fighterObj;
+    fp->x10C_ftData = ftDataList[fp->x4_fighterKind];
     func_800D0FA0(fighterObj);
-    fighter->x2CC = 0;
-    fighter->x2D0 = 0;
-    fighter->x18 = 0x155;
-    fighter->x1C_actionStateList = ActionStateList;
-    fighter->x20_actionStateList = ActionStateTableByCharacter[fighter->x4_fighterKind];
-    fighter->x24 = fighter->x10C_ftData->xC;
-    fighter->x28 = fighter->x10C_ftData->x10;
+    fp->x2CC = 0;
+    fp->x2D0 = 0;
+    fp->x18 = 0x155;
+    fp->x1C_actionStateList = ActionStateList;
+    fp->x20_actionStateList = ActionStateTableByCharacter[fp->x4_fighterKind];
+    fp->x24 = fp->x10C_ftData->xC;
+    fp->x28 = fp->x10C_ftData->x10;
 
-    fighter->input.x634 = 0.0f;
-    fighter->input.x630 = 0.0f;
-    fighter->input.x64C = 0.0f;
-    fighter->input.x648 = 0.0f;
-    fighter->input.x658 = 0.0f;
-    fighter->input.x664 = 0;
+    fp->input.x634 = 0.0f;
+    fp->input.x630 = 0.0f;
+    fp->input.x64C = 0.0f;
+    fp->input.x648 = 0.0f;
+    fp->input.x658 = 0.0f;
+    fp->input.x664 = 0;
 
     Fighter_UnkInitLoad_80068914_Inner1(fighterObj);
 
-    fighter->x594_s32 = 0;
-    fighter->x21FC = 1;
+    fp->x594_s32 = 0;
+    fp->x21FC = 1;
 
-    fighter->x221E_flag.bits.b0 = 0;
-    fighter->x221E_flag.bits.b1 = 0;
-    fighter->x221E_flag.bits.b2 = 0;
-    fighter->x221F_flag.bits.b1 = 0;
-    fighter->x221F_flag.bits.b2 = 0;
+    fp->x221E_flag.bits.b0 = 0;
+    fp->x221E_flag.bits.b1 = 0;
+    fp->x221E_flag.bits.b2 = 0;
+    fp->x221F_flag.bits.b1 = 0;
+    fp->x221F_flag.bits.b2 = 0;
 
-    fighter->x209A = 0;
-    fighter->x221E_flag.bits.b5 = 0;
-    fighter->x221F_flag.bits.b0 = 0;
-    fighter->cb.x21EC_callback = 0;
+    fp->x209A = 0;
+    fp->x221E_flag.bits.b5 = 0;
+    fp->x221F_flag.bits.b0 = 0;
+    fp->cb.x21EC_callback = 0;
 
-    fighter->x221D_flag.bits.b3 = 0;
-    fighter->x221D_flag.bits.b4 = 0;
+    fp->x221D_flag.bits.b3 = 0;
+    fp->x221D_flag.bits.b4 = 0;
 
-    fighter->x221F_flag.bits.b3 = 0;
+    fp->x221F_flag.bits.b3 = 0;
 
-    fighter->x2220_flag.bits.b0 = 0;
+    fp->x2220_flag.bits.b0 = 0;
 
-    fighter->x2221_flag.bits.b2 = 0;
+    fp->x2221_flag.bits.b2 = 0;
 
-    fighter->x2229_b5_no_normal_motion = 0;
-    fighter->x2229_b6 = 0;
-    fighter->x2229_b7 = 0;
+    fp->x2229_b5_no_normal_motion = 0;
+    fp->x2229_b6 = 0;
+    fp->x2229_b7 = 0;
 
-    fighter->x222A_flag.bits.b0 = 0;
-    fighter->x222A_flag.bits.b1 = 0;
+    fp->x222A_flag.bits.b0 = 0;
+    fp->x222A_flag.bits.b1 = 0;
 
-    fighter->x2228_flag.bits.b5 = 0;
-    fighter->x2228_flag.bits.b6 = 0;
+    fp->x2228_flag.bits.b5 = 0;
+    fp->x2228_flag.bits.b6 = 0;
 
-    fighter->x2221_flag.bits.b3 = 0;
+    fp->x2221_flag.bits.b3 = 0;
 
-    fighter->x2222_flag.bits.b0 = 0;
-    fighter->x2222_flag.bits.b1 = 0;
-    fighter->x2222_flag.bits.b4 = 0;
-    fighter->x2222_flag.bits.b5 = 0;
-    fighter->x2222_flag.bits.b6 = 0;
+    fp->x2222_flag.bits.b0 = 0;
+    fp->x2222_flag.bits.b1 = 0;
+    fp->x2222_flag.bits.b4 = 0;
+    fp->x2222_flag.bits.b5 = 0;
+    fp->x2222_flag.bits.b6 = 0;
 
 
-    fighter->x2223_flag.bits.b1 = 0;
+    fp->x2223_flag.bits.b1 = 0;
 
-    fighter->x40 = 0.0f;
+    fp->x40 = 0.0f;
 
-    fighter->x2224_flag.bits.b7 = 0;
+    fp->x2224_flag.bits.b7 = 0;
 
-    fighter->x60C = 0;
+    fp->x60C = 0;
 
-    fighter->x2225_flag.bits.b3 = 0;
-    fighter->x2228_flag.bits.b2 = 0;
+    fp->x2225_flag.bits.b3 = 0;
+    fp->x2228_flag.bits.b2 = 0;
 
-    fighter->x2226_flag.bits.b0 = 0;
-    fighter->x2226_flag.bits.b1 = 0;
+    fp->x2226_flag.bits.b0 = 0;
+    fp->x2226_flag.bits.b1 = 0;
 
-    fighter->x2227_flag.bits.b0 = 0;
-    fighter->x2224_flag.bits.b0 = 0;
+    fp->x2227_flag.bits.b0 = 0;
+    fp->x2224_flag.bits.b0 = 0;
 
-    fighter->x2114_SmashAttr.x2135 = -1;
-    fighter->x2184 = NULL;
+    fp->x2114_SmashAttr.x2135 = -1;
+    fp->x2184 = NULL;
 
-    fighter->x2229_b3 = 0;
+    fp->x2229_b3 = 0;
 }
 
 
@@ -822,12 +821,12 @@ u32 Fighter_NewSpawn_80068E40()
 }
 
 void Fighter_80068E64(HSD_GObj* fighterObj) {
-    Fighter* fighter = (void*)getFighter(fighterObj); // bit of a fake void* cast, but a sacrifice well worth getting rid of an fp_temp and filler. TODO: Maybe we can still do better?
+    Fighter* fp = (void*)getFighter(fighterObj); // bit of a fake void* cast, but a sacrifice well worth getting rid of an fp_temp and filler. TODO: Maybe we can still do better?
 
     if (stage_info.internal_stage_id == 0x1B) {
-        fighter->x34_scale.z = p_ftCommonData->x7E4_scaleZ;
+        fp->x34_scale.z = p_ftCommonData->x7E4_scaleZ;
     } else {
-        fighter->x34_scale.z = 1.0f;
+        fp->x34_scale.z = 1.0f;
     }
 }
 
@@ -939,56 +938,56 @@ inline f32 pickValue(f32 argA, u8* unk_byte_ptr)
 
 void Fighter_ActionStateChange_800693AC(HSD_GObj* fighterObj, s32 new_action_state_index, s32 arg2, HSD_GObj* otherObj, f32 arg8, f32 arg9, f32 argA) {
     HSD_JObj* jobj = fighterObj->hsd_obj;
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     struct ActionState* new_action_state;
     struct S_TEMP4* unk_struct_x18;
     s32 bone_index;
     u8* unk_byte_ptr;
     BOOL animflags_bool;
 
-    fighter->x10_action_state_index = new_action_state_index;
-    fighter->x30_facingDirectionRepeated = fighter->x2C_facing_direction;
+    fp->x10_action_state_index = new_action_state_index;
+    fp->x30_facingDirectionRepeated = fp->x2C_facing_direction;
         
-    HSD_JObjSetTranslate(jobj, &fighter->xB0_pos);
-    func_80067624(fighterObj, &fighter->x60C);
+    HSD_JObjSetTranslate(jobj, &fp->xB0_pos);
+    func_80067624(fighterObj, &fp->x60C);
     
     if ((arg2 & FIGHTER_HIT_NOUPDATE) == 0) {
-        if (fighter->x2219_flag.bits.b3 != 0) {
+        if (fp->x2219_flag.bits.b3 != 0) {
             func_8007AFF8(fighterObj);
         }
-        if (fighter->x2219_flag.bits.b4 != 0) {
+        if (fp->x2219_flag.bits.b4 != 0) {
             func_8007C114(fighterObj);
         }
     }
 
     if ((arg2 & FIGHTER_THROW_EXCEPTION_NOUPDATE) == 0) {
-        fighter->x1064_thrownHitbox.x134 = 0;
+        fp->x1064_thrownHitbox.x134 = 0;
     }
 
     if ((arg2 & FIGHTER_HITSTATUS_COLANIM_PRESERVE) == 0) {
-        if (fighter->x1988 != 0) {
+        if (fp->x1988 != 0) {
             func_8007B62C(fighterObj, 0);
         }
-        if (fighter->x221A_flag.bits.b5 != 0) {
+        if (fp->x221A_flag.bits.b5 != 0) {
             func_8007B0C0(fighterObj, 0);
         }
     }
 
-    if (fighter->x221A_flag.bits.b6 != 0) {
+    if (fp->x221A_flag.bits.b6 != 0) {
         func_8007B4E0(fighterObj);
     }
     
 
-    if (((arg2 & FIGHTER_MODEL_NOUPDATE) == 0) && (fighter->x221D_flag.bits.b2 != 0U)) {
+    if (((arg2 & FIGHTER_MODEL_NOUPDATE) == 0) && (fp->x221D_flag.bits.b2 != 0U)) {
         func_80074A8C(fighterObj);
     }
 
-    if (((arg2 & FIGHTER_MATANIM_NOUPDATE) == 0) && ((fighter->x221E_flag.bits.b7) != 0)) {
+    if (((arg2 & FIGHTER_MATANIM_NOUPDATE) == 0) && ((fp->x221E_flag.bits.b7) != 0)) {
         func_80070654(fighterObj);
     }
 
     if ((arg2 & FIGHTER_PARASOL_NOUPDATE) == 0) {
-        fighter->x2221_flag.bits.b4 = 0;
+        fp->x2221_flag.bits.b4 = 0;
         if ((ftGetParasolStatus(fighterObj) != -1) && (ftGetParasolStatus(fighterObj) != 6)) {
             func_8007E83C(fighterObj, 6, 0.0f);
         }
@@ -996,200 +995,200 @@ void Fighter_ActionStateChange_800693AC(HSD_GObj* fighterObj, s32 new_action_sta
     
     func_80070F28(fighterObj);
     func_80070E74(fighterObj);
-    func_8007ECD4(fighter, 7);
-    func_8007ECD4(fighter, 8);
-    func_8007ECD4(fighter, 0x24);
+    func_8007ECD4(fp, 7);
+    func_8007ECD4(fp, 8);
+    func_8007ECD4(fp, 0x24);
 
     if ((arg2 & FIGHTER_RUMBLE_NOUPDATE) == 0) {
-        func_8007ECD4(fighter, 1);
-        func_8007ECD4(fighter, 0x19);
+        func_8007ECD4(fp, 1);
+        func_8007ECD4(fp, 0x19);
     }
 
-    if (((arg2 & FIGHTER_PART_HITSTATUS_COLANIM_PRESERVE) == 0) && (fighter->x2221_flag.bits.b1 != 0U)) {
+    if (((arg2 & FIGHTER_PART_HITSTATUS_COLANIM_PRESERVE) == 0) && (fp->x2221_flag.bits.b1 != 0U)) {
         func_8007B6EC(fighterObj);
         func_8007B760(fighterObj, p_ftCommonData->x134);
-        fighter->x2221_flag.bits.b1 = 0;
+        fp->x2221_flag.bits.b1 = 0;
     }
-    func_8007E2F4(fighter, 0);
+    func_8007E2F4(fp, 0);
 
-    if (fighter->dmg.x18F4 != 0) {
-        fighter->dmg.x18F4 = 0;
-        fighter->x2220_flag.bits.b4 = 0;
+    if (fp->dmg.x18F4 != 0) {
+        fp->dmg.x18F4 = 0;
+        fp->x2220_flag.bits.b4 = 0;
     }
 
     if ((arg2 & FIGHTER_SKIP_UNK_0x2222) == 0) {
-        fighter->x2222_flag.bits.b2 = 0;
+        fp->x2222_flag.bits.b2 = 0;
     }
 
     if ((arg2 & FIGHTER_METALB_NOUPDATE) == 0) {
-        fighter->x2223_flag.bits.b4 = 0;
+        fp->x2223_flag.bits.b4 = 0;
     }
 
     if ((arg2 & FIGHTER_UNK_0x2227) == 0) {
-        fighter->x2227_flag.bits.b2 = 0;
+        fp->x2227_flag.bits.b2 = 0;
     }
 
-    if (((arg2 & FIGHTER_HITSTUN_FLAG_NOUPDATE) == 0) && (fighter->x221C_flag.bits.b6 != 0U)) {
-        fighter->x221C_flag.bits.b6 = 0;
-        fighter->x2098 = p_ftCommonData->x4CC;
+    if (((arg2 & FIGHTER_HITSTUN_FLAG_NOUPDATE) == 0) && (fp->x221C_flag.bits.b6 != 0U)) {
+        fp->x221C_flag.bits.b6 = 0;
+        fp->x2098 = p_ftCommonData->x4CC;
     }
 
     
-    fighter->x221F_flag.bits.b3 = 0;
-    fighter->x2219_flag.bits.b1 = 0;
-    fighter->x2219_flag.bits.b2 = 0;
+    fp->x221F_flag.bits.b3 = 0;
+    fp->x2219_flag.bits.b1 = 0;
+    fp->x2219_flag.bits.b2 = 0;
 
-    fighter->dmg.x182c_behavior = 1.0f;
-    fighter->dmg.x1850_forceApplied = 0.0f;
-    fighter->dmg.x18A8 = 0.0f;
-    fighter->dmg.x18B4_armor = 0.0f;
-    fighter->dmg.x18a0 = 0.0f;
+    fp->dmg.x182c_behavior = 1.0f;
+    fp->dmg.x1850_forceApplied = 0.0f;
+    fp->dmg.x18A8 = 0.0f;
+    fp->dmg.x18B4_armor = 0.0f;
+    fp->dmg.x18a0 = 0.0f;
 
-    fighter->x221A_flag.bits.b7 = 0;
-    fighter->x221B_flag.bits.b0 = 0;
-    fighter->x221C_flag.bits.b3 = 0;
+    fp->x221A_flag.bits.b7 = 0;
+    fp->x221B_flag.bits.b0 = 0;
+    fp->x221C_flag.bits.b3 = 0;
 
-    fighter->x19B4_shieldUnk = 0.0f;
-    fighter->x19B8_shieldUnk = 0.0f;
+    fp->x19B4_shieldUnk = 0.0f;
+    fp->x19B8_shieldUnk = 0.0f;
 
-    fighter->x221D_flag.bits.b5 = 0;
-    fighter->x2218_flag.bits.b3 = 0;
-    fighter->x2218_flag.bits.b6 = 0;
-    fighter->x221C_flag.bits.b4 = 0;
+    fp->x221D_flag.bits.b5 = 0;
+    fp->x2218_flag.bits.b3 = 0;
+    fp->x2218_flag.bits.b6 = 0;
+    fp->x221C_flag.bits.b4 = 0;
 
 
-    fighter->x1A6A = 0;
+    fp->x1A6A = 0;
 
-    fighter->x221D_flag.bits.b7 = 0;
-    fighter->x221E_flag.bits.b0 = 0;
-    fighter->x221E_flag.bits.b1 = 0;
-    fighter->x221E_flag.bits.b2 = 0;
-    fighter->x221F_flag.bits.b1 = 0;
-    fighter->x221E_flag.bits.b5 = 0;
-    fighter->x221E_flag.bits.b6 = 0;
-    fighter->x2220_flag.bits.b3 = 0;
-    fighter->x2220_flag.bits.b7 = 0;
+    fp->x221D_flag.bits.b7 = 0;
+    fp->x221E_flag.bits.b0 = 0;
+    fp->x221E_flag.bits.b1 = 0;
+    fp->x221E_flag.bits.b2 = 0;
+    fp->x221F_flag.bits.b1 = 0;
+    fp->x221E_flag.bits.b5 = 0;
+    fp->x221E_flag.bits.b6 = 0;
+    fp->x2220_flag.bits.b3 = 0;
+    fp->x2220_flag.bits.b7 = 0;
 
-    fighter->x209C = 0;
+    fp->x209C = 0;
 
-    fighter->x2223_flag.bits.b0 = 0;
-    fighter->x2222_flag.bits.b3 = 0;
-    fighter->x2224_flag.bits.b5 = 0;
-    fighter->x2225_flag.bits.b1 = 0;
-    fighter->x2225_flag.bits.b4 = 0;
+    fp->x2223_flag.bits.b0 = 0;
+    fp->x2222_flag.bits.b3 = 0;
+    fp->x2224_flag.bits.b5 = 0;
+    fp->x2225_flag.bits.b1 = 0;
+    fp->x2225_flag.bits.b4 = 0;
 
-    func_8004CBF4(&fighter->x6F0_collData);
+    func_8004CBF4(&fp->x6F0_collData);
 
     func_800DEEA8(fighterObj);
 
-    fighter->x2114_SmashAttr.x2138_smashSinceHitbox = -1.0f;
-    fighter->x2224_flag.bits.b4 = 0;
+    fp->x2114_SmashAttr.x2138_smashSinceHitbox = -1.0f;
+    fp->x2224_flag.bits.b4 = 0;
 
     if ((arg2 & FIGHTER_ITEMVIS_NOUPDATE) == 0) {
-        fighter->x221E_flag.bits.b3 = 1;
-    } else if (fighter->x221E_flag.bits.b3 == 0U) {
+        fp->x221E_flag.bits.b3 = 1;
+    } else if (fp->x221E_flag.bits.b3 == 0U) {
         func_8007F578(fighterObj);
     }
 
     if ((arg2 & FIGHTER_MODELPART_VIS_NOUPDATE) == 0) {
-        fighter->x221E_flag.bits.b4 = 1;
+        fp->x221E_flag.bits.b4 = 1;
     }
 
     if ((arg2 & FIGHTER_MODEL_FLAG_NOUPDATE) == 0) {
-        fighter->x2225_flag.bits.b2 = 1;
+        fp->x2225_flag.bits.b2 = 1;
     }
 
     if ((arg2 & FIGHTER_FASTFALL_PRESERVE) == 0) {
-        fighter->x221A_flag.bits.b4 = 0;
+        fp->x221A_flag.bits.b4 = 0;
     }
 
     if ((arg2 & FIGHTER_COLANIM_NOUPDATE) == 0) {
-        func_800C0134(fighter);
+        func_800C0134(fp);
     }
 
-    if (((arg2 & FIGHTER_GFX_PRESERVE) == 0) && (fighter->x2219_flag.bits.b0 != 0U)) {
+    if (((arg2 & FIGHTER_GFX_PRESERVE) == 0) && (fp->x2219_flag.bits.b0 != 0U)) {
         func_8007DB24(fighterObj);
     }
 
-    if (((arg2 & FIGHTER_ACCESSORY_PRESERVE) == 0) && ((u32) fighter->x20A0_accessory != 0U)) {
-        HSD_JObjRemoveAll(fighter->x20A0_accessory);
-        fighter->x20A0_accessory = 0U;
+    if (((arg2 & FIGHTER_ACCESSORY_PRESERVE) == 0) && ((u32) fp->x20A0_accessory != 0U)) {
+        HSD_JObjRemoveAll(fp->x20A0_accessory);
+        fp->x20A0_accessory = 0U;
     }
 
-    if (fighter->xE0_ground_or_air == 0) {
-        if (fighter->x4_fighterKind == 9) {
-            fighter->sa.peach.x222C = 1;
+    if (fp->xE0_ground_or_air == 0) {
+        if (fp->x4_fighterKind == 9) {
+            fp->sa.peach.x222C = 1;
         }
-        fighter->x2221_flag.bits.b5 = 0;
-        fighter->x2221_flag.bits.b7 = 1;
-        fighter->x2221_flag.bits.b6 = 1;
-        fighter->x2224_flag.bits.b1 = 0;
-        fighter->x2227_flag.bits.b1 = 0;
-        fighter->x213C = -1;
+        fp->x2221_flag.bits.b5 = 0;
+        fp->x2221_flag.bits.b7 = 1;
+        fp->x2221_flag.bits.b6 = 1;
+        fp->x2224_flag.bits.b1 = 0;
+        fp->x2227_flag.bits.b1 = 0;
+        fp->x213C = -1;
 
-        if (fighter->x2227_flag.bits.b4 != 0U) {
-            func_8003FE1C(fighter->xC_playerID, fighter->x221F_flag.bits.b4);
-            fighter->x2227_flag.bits.b4 = 0;
+        if (fp->x2227_flag.bits.b4 != 0U) {
+            func_8003FE1C(fp->xC_playerID, fp->x221F_flag.bits.b4);
+            fp->x2227_flag.bits.b4 = 0;
         }
-        fighter->x2227_flag.bits.b5 = 0;
-        func_80040330(fighter->xC_playerID, fighter->x221F_flag.bits.b4, fighter->x2140);
-        fighter->x2140 = 0.0f;
-        fighter->x2228_flag.bits.b6 = 0;
-        fighter->x2180 = 6;
+        fp->x2227_flag.bits.b5 = 0;
+        func_80040330(fp->xC_playerID, fp->x221F_flag.bits.b4, fp->x2140);
+        fp->x2140 = 0.0f;
+        fp->x2228_flag.bits.b6 = 0;
+        fp->x2180 = 6;
 
     }
     
 
     if ((new_action_state_index != 0xE) && (new_action_state_index != 0xF) && (new_action_state_index != 0x10) && (new_action_state_index != 0x11)) {
-        fighter->x196C_hitlag_mult = 0.0f;
+        fp->x196C_hitlag_mult = 0.0f;
     }
 
     if ((arg2 & FIGHTER_SFX_PRESERVE) == 0) {
-        func_80088884(fighter);
-        func_800888E0(fighter);
-        func_800887CC(fighter);
+        func_80088884(fp);
+        func_800888E0(fp);
+        func_800887CC(fp);
     }
 
     if ((arg2 & FIGHTER_SWORDTRAIL_PRESERVE) == 0) {
-        fighter->x2100 = -1;
+        fp->x2100 = -1;
     }
     if ((arg2 & FIGHTER_NAMETAGVIS_NOUPDATE) == 0) {
-        fighter->x209A = 0;
+        fp->x209A = 0;
     }
 
-    fighter->x2222_flag.bits.b7 = 0;
+    fp->x2222_flag.bits.b7 = 0;
 
     if ((arg2 & FIGHTER_PHYS_UNKUPDATE) != 0) {
-        fighter->x100 = 0.0f;
+        fp->x100 = 0.0f;
     } else {
-        fighter->x100 = -1.0f;
+        fp->x100 = -1.0f;
     }
 
     if ((arg2 & FIGHTER_UNK_0x1000000) == 0) {
-        fighter->x221C_u16_y = 0;
+        fp->x221C_u16_y = 0;
     }
 
-    fighter->x6BC_inputStickangle = 0.0f;
+    fp->x6BC_inputStickangle = 0.0f;
 
-    func_8007592C(fighter, 0, 0.0f);
-    func_80075AF0(fighter, 0, (HALF_PI * fighter->x2C_facing_direction));
-    func_80075CB4(fighter, 0, 0.0f);
+    func_8007592C(fp, 0, 0.0f);
+    func_80075AF0(fp, 0, (HALF_PI * fp->x2C_facing_direction));
+    func_80075CB4(fp, 0, 0.0f);
 
-    if (new_action_state_index >= fighter->x18) {
-        new_action_state = &fighter->x20_actionStateList[(new_action_state_index - fighter->x18)];
+    if (new_action_state_index >= fp->x18) {
+        new_action_state = &fp->x20_actionStateList[(new_action_state_index - fp->x18)];
     } else {
-        new_action_state = &fighter->x1C_actionStateList[new_action_state_index];
+        new_action_state = &fp->x1C_actionStateList[new_action_state_index];
     }
 
     
 
-    if (fighter->xE0_ground_or_air == GA_Ground) {
+    if (fp->xE0_ground_or_air == GA_Ground) {
         if ((arg2 & 0x40) == 0) {
-            if (new_action_state->x9_flags.bits.b1 != 0  && fighter->dmg.x18C8 == -1) {
+            if (new_action_state->x9_flags.bits.b1 != 0  && fp->dmg.x18C8 == -1) {
                 if (p_ftCommonData->x814 > 0) {
-                    fighter->dmg.x18C8 = p_ftCommonData->x814;
+                    fp->dmg.x18C8 = p_ftCommonData->x814;
                 } else {
-                    fighter->dmg.x18C8 = 1;
+                    fp->dmg.x18C8 = 1;
                 }
             }
         }
@@ -1199,137 +1198,137 @@ void Fighter_ActionStateChange_800693AC(HSD_GObj* fighterObj, s32 new_action_sta
     // TODO: There has to be some way to get rid of this while maintaining the
     // effect it has on the stack.
     if (1) {
-        volatile s32 volatile_integer = fighter->x2070_int;
-        func_800890D0(fighter, new_action_state->move_id);
-        func_800895E0(fighter, new_action_state->x4_flags);
-        fighter->x2225_flag.bits.b3 = new_action_state->x9_flags.bits.b0;
+        volatile s32 volatile_integer = fp->x2070_int;
+        func_800890D0(fp, new_action_state->move_id);
+        func_800895E0(fp, new_action_state->x4_flags);
+        fp->x2225_flag.bits.b3 = new_action_state->x9_flags.bits.b0;
 
-        if (fighter->x2226_flag.bits.b4 != 0U) {
-            if (fighter->x2071_b5 != 0U) {
-                func_800C8B2C(fighter, 0x7E, 0);
+        if (fp->x2226_flag.bits.b4 != 0U) {
+            if (fp->x2071_b5 != 0U) {
+                func_800C8B2C(fp, 0x7E, 0);
             }
-            if (fighter->x2071_b6 != 0U) {
-                func_800C8B2C(fighter, 0x7F, 0);
+            if (fp->x2071_b6 != 0U) {
+                func_800C8B2C(fp, 0x7F, 0);
             }
         }
 
-        if (fighter->cb.x21EC_callback) {
-            fighter->cb.x21EC_callback(fighterObj);
-            fighter->cb.x21EC_callback = 0U;
+        if (fp->cb.x21EC_callback) {
+            fp->cb.x21EC_callback(fighterObj);
+            fp->cb.x21EC_callback = 0U;
         }
 
         if ((arg2 & FIGHTER_ATTACKCOUNT_NOUPDATE) == 0) {
             func_80037C60(fighterObj, volatile_integer);
         }
 
-        fighter->x14_action_id = new_action_state->action_id;
-        fighter->x89C_frameSpeedMul = arg9;
-        fighter->x8A0_unk = arg9;
+        fp->x14_action_id = new_action_state->action_id;
+        fp->x89C_frameSpeedMul = arg9;
+        fp->x8A0_unk = arg9;
     
-        fighter->x894_currentAnimFrame = (arg8 - fighter->x89C_frameSpeedMul);
-        fighter->x898_unk = 0.0f;
+        fp->x894_currentAnimFrame = (arg8 - fp->x89C_frameSpeedMul);
+        fp->x898_unk = 0.0f;
     
         
         
-        if ((fighter->x594_animCurrFlags1.bits.b0) || (fighter->x594_animCurrFlags1.bits.b5)) {
+        if ((fp->x594_animCurrFlags1.bits.b0) || (fp->x594_animCurrFlags1.bits.b5)) {
             animflags_bool = TRUE;
         } else {
             animflags_bool = FALSE;
         }
     
-        if (fighter->x14_action_id != -1) {
+        if (fp->x14_action_id != -1) {
             Vec translation;
             Quaternion quat;
 
-            bone_index = fighter->x596_bits.x7;
+            bone_index = fp->x596_bits.x7;
 
             if ((arg2 & FIGHTER_FREEZESTATE) != 0) {
-                fighter->x2223_flag.bits.b0 = 1;
-                fighter->x104 = 0x14;
-                fighter->x89C_frameSpeedMul = 0.0f;
+                fp->x2223_flag.bits.b0 = 1;
+                fp->x104 = 0x14;
+                fp->x89C_frameSpeedMul = 0.0f;
                 arg9 = 0.0f;
             }
     
             if (otherObj != NULL) {
-                unk_struct_x18 = &((Fighter*)otherObj->user_data)->x24[fighter->x14_action_id];
-                unk_byte_ptr = &((Fighter*)otherObj->user_data)->x28[fighter->x14_action_id << 1];
+                unk_struct_x18 = &((Fighter*)otherObj->user_data)->x24[fp->x14_action_id];
+                unk_byte_ptr = &((Fighter*)otherObj->user_data)->x28[fp->x14_action_id << 1];
             } else {
-                unk_struct_x18 = &fighter->x24[fighter->x14_action_id];
-                unk_byte_ptr = &fighter->x28[fighter->x14_action_id << 1];
+                unk_struct_x18 = &fp->x24[fp->x14_action_id];
+                unk_byte_ptr = &fp->x28[fp->x14_action_id << 1];
             }
-            fighter->x594_s32 = unk_struct_x18->x10_animCurrFlags;
-            func_8009E7B4(fighter, unk_byte_ptr);
+            fp->x594_s32 = unk_struct_x18->x10_animCurrFlags;
+            func_8009E7B4(fp, unk_byte_ptr);
             if ((arg2 & FIGHTER_ANIM_NOUPDATE) == 0) {
     
                 if (otherObj != 0U) {
-                    func_80085CD8(fighter, getFighter(otherObj), fighter->x14_action_id);
-                    func_8007B8CC(fighter, otherObj);
+                    func_80085CD8(fp, getFighter(otherObj), fp->x14_action_id);
+                    func_8007B8CC(fp, otherObj);
                 } else {
-                    func_80085CD8(fighter, fighter, fighter->x14_action_id);
+                    func_80085CD8(fp, fp, fp->x14_action_id);
                 }
-                fighter->x3EC = unk_struct_x18->xC;
-                fighter->x3F0 = 0;
+                fp->x3EC = unk_struct_x18->xC;
+                fp->x3F0 = 0;
     
                 
                 if (arg8) {
-                    if (fighter->x590 != 0U) {
+                    if (fp->x590 != 0U) {
                         func_8006EBE8(fighterObj, arg8 - arg9, arg9, pickValue(argA, unk_byte_ptr));
                     }
                     func_8006E9B4(fighterObj);
-                    if (fighter->x594_animCurrFlags1.bits.b0 != 0U) {
+                    if (fp->x594_animCurrFlags1.bits.b0 != 0U) {
                         float c = 0.0f;
-                        fighter->x6B0.x = fighter->x6B0.y = fighter->x6B0.z = c;
-                        fighter->x6A4_transNOffset.x = fighter->x6A4_transNOffset.y = fighter->x6A4_transNOffset.z = c;
-                        fighter->x698 = fighter->x68C_transNPos;
+                        fp->x6B0.x = fp->x6B0.y = fp->x6B0.z = c;
+                        fp->x6A4_transNOffset.x = fp->x6A4_transNOffset.y = fp->x6A4_transNOffset.z = c;
+                        fp->x698 = fp->x68C_transNPos;
                     }
                     
-                    if (fighter->x594_animCurrFlags1.bits.b5 != 0U) {
+                    if (fp->x594_animCurrFlags1.bits.b5 != 0U) {
                         float c = 0.0f;
-                        fighter->x6E4.x = fighter->x6E4.y = fighter->x6E4.z = c;
-                        fighter->x6D8.x = fighter->x6D8.y = fighter->x6D8.z = c;
-                        fighter->x6CC = fighter->x6C0;
+                        fp->x6E4.x = fp->x6E4.y = fp->x6E4.z = c;
+                        fp->x6D8.x = fp->x6D8.y = fp->x6D8.z = c;
+                        fp->x6CC = fp->x6C0;
                     }
-                    fighter->x3E4 = -arg8;
+                    fp->x3E4 = -arg8;
                 } else {
-                    if (fighter->x590 != 0U) {
+                    if (fp->x590 != 0U) {
                         func_8006EBE8(fighterObj, arg8, arg9, pickValue(argA, unk_byte_ptr));
                     }
-                    fighter->x3E4 = 0.0f;
+                    fp->x3E4 = 0.0f;
                 }
     
                 func_8006E9B4(fighterObj);
                 if ((bone_index != 0) && (*unk_byte_ptr != 0U)) {
-                    HSD_JObj* temp_joint = fighter->x5E8_fighterBones[bone_index].x4_jobj2;
+                    HSD_JObj* temp_joint = fp->x5E8_fighterBones[bone_index].x4_jobj2;
     
                     HSD_JObjGetTranslation(temp_joint, &translation);
-                    HSD_JObjSetTranslate(fighter->x5E8_fighterBones[bone_index].x0_jobj, &translation);
+                    HSD_JObjSetTranslate(fp->x5E8_fighterBones[bone_index].x0_jobj, &translation);
                     HSD_JObjGetRotation(temp_joint, &quat);
-                    func_8007584C(fighter->x5E8_fighterBones[bone_index].x0_jobj, &quat);
+                    func_8007584C(fp->x5E8_fighterBones[bone_index].x0_jobj, &quat);
                 }
     
-                if (fighter->x594_animCurrFlags1.bits.b0 != 0U) {
+                if (fp->x594_animCurrFlags1.bits.b0 != 0U) {
                     if (!arg8) {
                         float c = 0.0f;
-                        fighter->x6B0.x = fighter->x6B0.y = fighter->x6B0.z = c;
-                        fighter->x6A4_transNOffset.x = fighter->x6A4_transNOffset.y = fighter->x6A4_transNOffset.z = c;
-                        fighter->x698 = fighter->x68C_transNPos;
-                    } else if (((arg2 & FIGHTER_ANIMVEL_NOUPDATE) == 0) && (fighter->xE0_ground_or_air == GA_Ground)) {
-                        f32 temp_vel = fighter->x6A4_transNOffset.z * fighter->x2C_facing_direction;
-                        fighter->x80_self_vel.x = temp_vel;
-                        fighter->xEC_ground_vel = temp_vel;
+                        fp->x6B0.x = fp->x6B0.y = fp->x6B0.z = c;
+                        fp->x6A4_transNOffset.x = fp->x6A4_transNOffset.y = fp->x6A4_transNOffset.z = c;
+                        fp->x698 = fp->x68C_transNPos;
+                    } else if (((arg2 & FIGHTER_ANIMVEL_NOUPDATE) == 0) && (fp->xE0_ground_or_air == GA_Ground)) {
+                        f32 temp_vel = fp->x6A4_transNOffset.z * fp->x2C_facing_direction;
+                        fp->x80_self_vel.x = temp_vel;
+                        fp->xEC_ground_vel = temp_vel;
                     }
                 }
     
-                if (fighter->x594_animCurrFlags1.bits.b5 != 0U) {
+                if (fp->x594_animCurrFlags1.bits.b5 != 0U) {
                     if (!arg8) {
                         float c = 0.0f;
-                        fighter->x6E4.x = fighter->x6E4.y = fighter->x6E4.z = c;
-                        fighter->x6D8.x = fighter->x6D8.y = fighter->x6D8.z = c;
-                        fighter->x6CC = fighter->x6C0;
-                    } else if (((arg2 & FIGHTER_ANIMVEL_NOUPDATE) == 0) && (fighter->xE0_ground_or_air == GA_Ground)) {
-                        f32 temp_vel = fighter->x6D8.z * fighter->x2C_facing_direction;
-                        fighter->x80_self_vel.x = temp_vel;
-                        fighter->xEC_ground_vel = temp_vel;
+                        fp->x6E4.x = fp->x6E4.y = fp->x6E4.z = c;
+                        fp->x6D8.x = fp->x6D8.y = fp->x6D8.z = c;
+                        fp->x6CC = fp->x6C0;
+                    } else if (((arg2 & FIGHTER_ANIMVEL_NOUPDATE) == 0) && (fp->xE0_ground_or_air == GA_Ground)) {
+                        f32 temp_vel = fp->x6D8.z * fp->x2C_facing_direction;
+                        fp->x80_self_vel.x = temp_vel;
+                        fp->xEC_ground_vel = temp_vel;
                     }
                 }
                 if ((arg2 & FIGHTER_CMD_UPDATE) != 0) {
@@ -1341,240 +1340,240 @@ void Fighter_ActionStateChange_800693AC(HSD_GObj* fighterObj, s32 new_action_sta
                     func_80073240(fighterObj);
                 }
             } else {
-                fighter->x14_action_id = -1;
+                fp->x14_action_id = -1;
             }
         }
     
         
     
-        if (fighter->x14_action_id == -1) {
-            fighter->x594_s32 = 0;
+        if (fp->x14_action_id == -1) {
+            fp->x594_s32 = 0;
             func_80070758(jobj);
-            func_80070758(fighter->x8AC_animSkeleton);
-            fighter->x3EC = 0;
-            fighter->x8A4_animBlendFrames = 0;
-            fighter->x8A8_unk = 0;
+            func_80070758(fp->x8AC_animSkeleton);
+            fp->x3EC = 0;
+            fp->x8A4_animBlendFrames = 0;
+            fp->x8A8_unk = 0;
         }
     
         if (animflags_bool) {
-            if (!fighter->x594_animCurrFlags1.bits.b0 && !fighter->x594_animCurrFlags1.bits.b0) {
-                !fighter;
-                func_8007CC78(fighter, fighter->x110_attr.x138_DashrunTerminalVelocity);
+            if (!fp->x594_animCurrFlags1.bits.b0 && !fp->x594_animCurrFlags1.bits.b0) {
+                !fp;
+                func_8007CC78(fp, fp->x110_attr.x138_DashrunTerminalVelocity);
             }
         }
     
-        fighter->cb.x21A0_callback_Anim = new_action_state->cb_Anim;
-        fighter->cb.x219C_callback_IASA = new_action_state->cb_Input;
-        fighter->cb.x21A4_callback_Phys = new_action_state->cb_Physics;
-        fighter->cb.x21A8_callback_Coll = new_action_state->cb_Collision;
-        fighter->cb.x21AC_callback_Cam = new_action_state->cb_Camera;
+        fp->cb.x21A0_callback_Anim = new_action_state->cb_Anim;
+        fp->cb.x219C_callback_IASA = new_action_state->cb_Input;
+        fp->cb.x21A4_callback_Phys = new_action_state->cb_Physics;
+        fp->cb.x21A8_callback_Coll = new_action_state->cb_Collision;
+        fp->cb.x21AC_callback_Cam = new_action_state->cb_Camera;
     
-        fighter->cb.x21B0_callback_Accessory1 = 0;
-        fighter->cb.x21BC_callback_Accessory4 = 0;
-        fighter->cb.x21C0_callback_OnGiveDamage = 0;
-        fighter->cb.x21C4_callback_OnShieldHit = 0;
-        fighter->cb.x21C8_callback_OnReflectHit = 0;
-        fighter->cb.x21D0_callback_EveryHitlag = 0;
-        fighter->cb.x21CC_callback = 0;
-        fighter->cb.x21D8_callback_ExitHitlag = 0;
-        fighter->cb.x21D4_callback_EnterHitlag = 0;
-        fighter->cb.x21DC_callback_OnTakeDamage = 0;
-        fighter->cb.x21F0_callback = 0;
-        fighter->cb.x21F4_callback = 0;
-        fighter->cb.x21F8_callback = 0;
-        fighter->cb.x21E4_callback_OnDeath2 = 0;
+        fp->cb.x21B0_callback_Accessory1 = 0;
+        fp->cb.x21BC_callback_Accessory4 = 0;
+        fp->cb.x21C0_callback_OnGiveDamage = 0;
+        fp->cb.x21C4_callback_OnShieldHit = 0;
+        fp->cb.x21C8_callback_OnReflectHit = 0;
+        fp->cb.x21D0_callback_EveryHitlag = 0;
+        fp->cb.x21CC_callback = 0;
+        fp->cb.x21D8_callback_ExitHitlag = 0;
+        fp->cb.x21D4_callback_EnterHitlag = 0;
+        fp->cb.x21DC_callback_OnTakeDamage = 0;
+        fp->cb.x21F0_callback = 0;
+        fp->cb.x21F4_callback = 0;
+        fp->cb.x21F8_callback = 0;
+        fp->cb.x21E4_callback_OnDeath2 = 0;
     }
 }
 
 void Fighter_8006A1BC(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    if (!fighter->x221F_flag.bits.b3) {
-        if (fighter->dmg.x1954 > 0.0f) {
-            fighter->dmg.x1954 -= 1.0f;
-            if (fighter->dmg.x1954 <= 0.0f) {
-                fighter->dmg.x1954 = 0.0f;
-                if (!fighter->x221A_flag.bits.b2 && !fighter->x2219_flag.bits.b7) {
+    if (!fp->x221F_flag.bits.b3) {
+        if (fp->dmg.x1954 > 0.0f) {
+            fp->dmg.x1954 -= 1.0f;
+            if (fp->dmg.x1954 <= 0.0f) {
+                fp->dmg.x1954 = 0.0f;
+                if (!fp->x221A_flag.bits.b2 && !fp->x2219_flag.bits.b7) {
                     Fighter_8006D10C(fighterObj);
                 }
             }
         }
 
-        if (fighter->x221A_flag.bits.b1) {
+        if (fp->x221A_flag.bits.b1) {
             Fighter_8006CFE0(fighterObj);
-            fighter->x221A_flag.bits.b1 = 0;
+            fp->x221A_flag.bits.b1 = 0;
         }
 
-        if (fighter->dmg.x195c_hitlag_frames > 0.0f) {
-            fighter->dmg.x195c_hitlag_frames -= 1.0f;
-            if (fighter->dmg.x195c_hitlag_frames <= 0.0f) {
-                fighter->dmg.x195c_hitlag_frames = 0.0f;
-                if (fighter->x221A_flag.bits.b3) {
-                    func_80090718(fighter);
-                    fighter->x221A_flag.bits.b3 = 0;
+        if (fp->dmg.x195c_hitlag_frames > 0.0f) {
+            fp->dmg.x195c_hitlag_frames -= 1.0f;
+            if (fp->dmg.x195c_hitlag_frames <= 0.0f) {
+                fp->dmg.x195c_hitlag_frames = 0.0f;
+                if (fp->x221A_flag.bits.b3) {
+                    func_80090718(fp);
+                    fp->x221A_flag.bits.b3 = 0;
                 }
-                if ((!fighter->dmg.x1954) && !fighter->x2219_flag.bits.b7) {
+                if ((!fp->dmg.x1954) && !fp->x2219_flag.bits.b7) {
                     Fighter_8006D10C(fighterObj);
                 }
-                fighter->x221A_flag.bits.b2 = 0;
+                fp->x221A_flag.bits.b2 = 0;
             }
         }
         func_800C37A0(fighterObj);
 
-        while (fighter->x200C != 0) {
+        while (fp->x200C != 0) {
             func_800D14E4(fighterObj);
-            fighter->x200C--;
+            fp->x200C--;
         }
 
-        while (fighter->x2010 != 0) {
+        while (fp->x2010 != 0) {
             func_800D1E80(fighterObj);
-            fighter->x2010--;
+            fp->x2010--;
         }
 
         func_800819A8(fighterObj);
-        fighter->x2219_flag.bits.b6 = fighter->x2219_flag.bits.b5;
+        fp->x2219_flag.bits.b6 = fp->x2219_flag.bits.b5;
     }
 }
 
 void Fighter_8006A360(HSD_GObj* fighterObj) {
     Vec vec1;
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    if (!fighter->x221F_flag.bits.b3) {
-        fighter->xC8_pos_delta.x = fighter->xB0_pos.x - fighter->xBC_prevPos.x;
-        fighter->xC8_pos_delta.y = fighter->xB0_pos.y - fighter->xBC_prevPos.y;
-        fighter->xC8_pos_delta.z = fighter->xB0_pos.z - fighter->xBC_prevPos.z;
+    if (!fp->x221F_flag.bits.b3) {
+        fp->xC8_pos_delta.x = fp->xB0_pos.x - fp->xBC_prevPos.x;
+        fp->xC8_pos_delta.y = fp->xB0_pos.y - fp->xBC_prevPos.y;
+        fp->xC8_pos_delta.z = fp->xB0_pos.z - fp->xBC_prevPos.z;
 
-        fighter->xBC_prevPos = fighter->xB0_pos;
+        fp->xBC_prevPos = fp->xB0_pos;
 
-        if (fighter->dmg.x18C8 != -1 && fighter->dmg.x18C8 > 0) {
-            fighter->dmg.x18C8--;
-            if (fighter->dmg.x18C8 == 0) {
-                fighter->dmg.x18c4_source_ply = 6;
-                fighter->dmg.x18C8 = -1;
-                fighter->dmg.x18D0 = -0xA;
+        if (fp->dmg.x18C8 != -1 && fp->dmg.x18C8 > 0) {
+            fp->dmg.x18C8--;
+            if (fp->dmg.x18C8 == 0) {
+                fp->dmg.x18c4_source_ply = 6;
+                fp->dmg.x18C8 = -1;
+                fp->dmg.x18D0 = -0xA;
             }
         }
 
-        if (fighter->x1990) {
-            fighter->x1990--;
-            if (fighter->x1990 == 0 && !fighter->x2221_flag.bits.b0) {
-                fighter->x198C = fighter->x1994 != 0 ? 1 : 0;
+        if (fp->x1990) {
+            fp->x1990--;
+            if (fp->x1990 == 0 && !fp->x2221_flag.bits.b0) {
+                fp->x198C = fp->x1994 != 0 ? 1 : 0;
 
-                if (func_800C0694(fighter) == 9) {
-                    func_800C0200(fighter, 9);
+                if (func_800C0694(fp) == 9) {
+                    func_800C0200(fp, 9);
                 }
             }
         }
 
-        if (fighter->x1994) {
-            fighter->x1994--;
-            if (fighter->x1994 == 0) {
-                fighter->x198C = (fighter->x2221_flag.bits.b0 || fighter->x1990 != 0) ? 2 : 0;
+        if (fp->x1994) {
+            fp->x1994--;
+            if (fp->x1994 == 0) {
+                fp->x198C = (fp->x2221_flag.bits.b0 || fp->x1990 != 0) ? 2 : 0;
 
-                if (func_800C0694(fighter) == 9) {
-                    func_800C0200(fighter, 9);
+                if (func_800C0694(fp) == 9) {
+                    func_800C0200(fp, 9);
                 }
             }
         }
 
-        if (fighter->x221D_flag.bits.b6) {
-            if (fighter->x2004) {
-                fighter->x2004--;
-                if (fighter->x2004 == 0) {
-                    fighter->x221D_flag.bits.b6 = 0;
-                    if (func_800C0694(fighter) == 0x6B) {
-                        func_800C0200(fighter, 0x6B);
+        if (fp->x221D_flag.bits.b6) {
+            if (fp->x2004) {
+                fp->x2004--;
+                if (fp->x2004 == 0) {
+                    fp->x221D_flag.bits.b6 = 0;
+                    if (func_800C0694(fp) == 0x6B) {
+                        func_800C0200(fp, 0x6B);
                     }
-                } else if (fighter->x2004 == func_8026B588()) {
-                    func_800880D8(fighter);
+                } else if (fp->x2004 == func_8026B588()) {
+                    func_800880D8(fp);
                 }
             }
         }
 
-        if (fighter->x2220_flag.bits.b5 || fighter->x2220_flag.bits.b6) {
-            if (fighter->x2008) fighter->x2008--;
+        if (fp->x2220_flag.bits.b5 || fp->x2220_flag.bits.b6) {
+            if (fp->x2008) fp->x2008--;
 
-            if (fighter->x2008 == 0) {
-                if (fighter->x2220_flag.bits.b5) {
+            if (fp->x2008 == 0) {
+                if (fp->x2220_flag.bits.b5) {
                     func_800D1A8C(fighterObj);
-                } else if (fighter->x2220_flag.bits.b6) {
+                } else if (fp->x2220_flag.bits.b6) {
                     func_800D237C(fighterObj);
                 }
             }
         }
 
-        if (fighter->x197C) {
-            if (fighter->x2014) {
-                fighter->x2014--;
-                if (fighter->x2014 == 0) {
+        if (fp->x197C) {
+            if (fp->x2014) {
+                fp->x2014--;
+                if (fp->x2014 == 0) {
                     func_8007F8E8(fighterObj);
-                    func_8026A8EC(fighter->x197C);
+                    func_8026A8EC(fp->x197C);
                     func_8007F9B4(fighterObj);
                 }
             }
         }
 
-        if (fighter->x2223_flag.bits.b7) {
-            if (fighter->x2028) {
-                fighter->x2028--;
-                if (!fighter->x2028 || fighter->x202C <= 0) {
+        if (fp->x2223_flag.bits.b7) {
+            if (fp->x2028) {
+                fp->x2028--;
+                if (!fp->x2028 || fp->x202C <= 0) {
                     func_800C8540(fighterObj);
                 }
             }
         }
 
         
-        if (fighter->x2227_flag.bits.b3) {
-            if (fighter->x2034) {
-                fighter->x2034--;
-                if (!fighter->x2034 || fighter->x2038 <= 0) {
+        if (fp->x2227_flag.bits.b3) {
+            if (fp->x2034) {
+                fp->x2034--;
+                if (!fp->x2034 || fp->x2038 <= 0) {
                     func_800C9034(fighterObj);
                     return;
                 }
             }
         }
 
-        if (fighter->x1980) {
-            fighter->x2018--;
-            fighter->x201C--;
+        if (fp->x1980) {
+            fp->x2018--;
+            fp->x201C--;
 
-            if (fighter->x201C == 0) {
-                Fighter_TakeDamage_8006CC7C(fighter, p_ftCommonData->x6F4_unkDamage);
-                fighter->x201C = p_ftCommonData->x6F8;
+            if (fp->x201C == 0) {
+                Fighter_TakeDamage_8006CC7C(fp, p_ftCommonData->x6F4_unkDamage);
+                fp->x201C = p_ftCommonData->x6F8;
             }
 
-            if (fighter->x2018 <= 0) {
+            if (fp->x2018 <= 0) {
                 vec1 = lbl_803B7488;
 
                 func_8007F8E8(fighterObj);
-                func_8026ABD8(fighter->x1980, &vec1, 0.0f);
+                func_8026ABD8(fp->x1980, &vec1, 0.0f);
                 func_8007FF74(fighterObj);
             }
         }
 
 
-        if (fighter->x2226_flag.bits.b4) {
-            if (fighter->x2030) {
-                fighter->x2030--;
-                if (fighter->x2030 == 0) {
+        if (fp->x2226_flag.bits.b4) {
+            if (fp->x2030) {
+                fp->x2030--;
+                if (fp->x2030 == 0) {
                     func_800C8A64(fighterObj);
                     return;
                 }
-                if (!fighter->x2226_flag.bits.b3 && fighter->x2030 == p_ftCommonData->x7D0 && func_800C8B2C(fighter, 0x7D, 0)) {
-                    fighter->x2226_flag.bits.b7 = 1;
+                if (!fp->x2226_flag.bits.b3 && fp->x2030 == p_ftCommonData->x7D0 && func_800C8B2C(fp, 0x7D, 0)) {
+                    fp->x2226_flag.bits.b7 = 1;
                 }
             }
         }
 
-        if (fighter->x2221_flag.bits.b4) {
-            if (fighter->x2104) {
-                fighter->x2104--;
-                if (fighter->x2104 == 0) {
-                    fighter->x2221_flag.bits.b4 = 0;
+        if (fp->x2221_flag.bits.b4) {
+            if (fp->x2104) {
+                fp->x2104--;
+                if (fp->x2104 == 0) {
+                    fp->x2221_flag.bits.b4 = 0;
 
-                    if (fighter->x1974_heldItem && itGetKind(fighter->x1974_heldItem) == 0x67) {
-                        fighter->x2221_flag.bits.b5 = 1;
+                    if (fp->x1974_heldItem && itGetKind(fp->x1974_heldItem) == 0x67) {
+                        fp->x2221_flag.bits.b5 = 1;
                         func_800968C8(fighterObj);
                     } else {
                         func_80095744(fighterObj, 0);
@@ -1584,104 +1583,104 @@ void Fighter_8006A360(HSD_GObj* fighterObj) {
             }
         }
 
-        if (!fighter->x221F_flag.bits.b4 && func_80031144() == 1.0f) {
-            if (fighter->dmg.x1830_percent < p_ftCommonData->x7B0) {
-                if (func_802FC998(fighter->xC_playerID) && (Player_GetMoreFlagsBit3(fighter->xC_playerID) != 0)) {
-                    fighter->dmg.x1910++;
+        if (!fp->x221F_flag.bits.b4 && func_80031144() == 1.0f) {
+            if (fp->dmg.x1830_percent < p_ftCommonData->x7B0) {
+                if (func_802FC998(fp->xC_playerID) && (Player_GetMoreFlagsBit3(fp->xC_playerID) != 0)) {
+                    fp->dmg.x1910++;
                 } else {
-                    fighter->dmg.x1910 = 0;
+                    fp->dmg.x1910 = 0;
                 }
 
-                if (fighter->dmg.x1910 >= p_ftCommonData->x7AC) {
-                    Fighter_TakeDamage_8006CC7C(fighter, p_ftCommonData->x7B4_unkDamage);
-                    fighter->dmg.x1910 = 0;
+                if (fp->dmg.x1910 >= p_ftCommonData->x7AC) {
+                    Fighter_TakeDamage_8006CC7C(fp, p_ftCommonData->x7B4_unkDamage);
+                    fp->dmg.x1910 = 0;
                 }
             }
         }
 
-        if (fighter->dmg.x18F0) {
-            fighter->dmg.x18F0--;
-            if (fighter->dmg.x1830_percent > 0.0f) {
-                fighter->dmg.x1830_percent--;
-                func_80088640(fighter, 0x7D, 0x7F, 0x40);
-                Player_SetHPByIndex(fighter->xC_playerID, fighter->x221F_flag.bits.b4, fighter->dmg.x1830_percent);
-                func_80040B8C(fighter->xC_playerID, fighter->x221F_flag.bits.b4, 1);
+        if (fp->dmg.x18F0) {
+            fp->dmg.x18F0--;
+            if (fp->dmg.x1830_percent > 0.0f) {
+                fp->dmg.x1830_percent--;
+                func_80088640(fp, 0x7D, 0x7F, 0x40);
+                Player_SetHPByIndex(fp->xC_playerID, fp->x221F_flag.bits.b4, fp->dmg.x1830_percent);
+                func_80040B8C(fp->xC_playerID, fp->x221F_flag.bits.b4, 1);
             }
 
-            if (fighter->dmg.x1830_percent <= 0.0f) {
-                fighter->dmg.x1830_percent = 0.0f;
-                fighter->dmg.x18F0 = 0;
+            if (fp->dmg.x1830_percent <= 0.0f) {
+                fp->dmg.x1830_percent = 0.0f;
+                fp->dmg.x18F0 = 0;
             }
 
-            if (fighter->dmg.x18F0 == 0) {
-                if (func_800C0694(fighter) == 8) {
-                    func_800C0200(fighter, 8);
+            if (fp->dmg.x18F0 == 0) {
+                if (func_800C0694(fp) == 8) {
+                    func_800C0200(fp, 8);
                 }
-                func_8007ECD4(fighter, 2);
+                func_8007ECD4(fp, 2);
             }
         }
 
-        if (fighter->x1974_heldItem) {
-            if (itGetKind(fighter->x1974_heldItem) != 0x1C) {
+        if (fp->x1974_heldItem) {
+            if (itGetKind(fp->x1974_heldItem) != 0x1C) {
                 // im not sure of whatever is here, but a void ptr downcast to get rid of filler seems like a better tradeoff...
-                void *fighterVoid = fighter;
+                void *fighterVoid = fp;
                 (void)fighterVoid;
             } else {
                 func_800C511C(fighterObj);
             }
         }
 
-        if (fighter->dmg.x18fa_model_shift_frames) {
-            fighter->dmg.x18fa_model_shift_frames--;
-            fighter->dmg.x18FC++;
-            if (fighter->dmg.x18FC >= fighter->dmg.x18FD) {
-                fighter->dmg.x18FC = 0;
+        if (fp->dmg.x18fa_model_shift_frames) {
+            fp->dmg.x18fa_model_shift_frames--;
+            fp->dmg.x18FC++;
+            if (fp->dmg.x18FC >= fp->dmg.x18FD) {
+                fp->dmg.x18FC = 0;
             }
         }
 
-        if (lbl_803C1DB4[fighter->x4_fighterKind]) {
-            lbl_803C1DB4[fighter->x4_fighterKind](fighterObj);
+        if (lbl_803C1DB4[fp->x4_fighterKind]) {
+            lbl_803C1DB4[fp->x4_fighterKind](fighterObj);
         }
 
-        if (fighter->cb.x21CC_callback) {
-            fighter->cb.x21CC_callback(fighterObj);
+        if (fp->cb.x21CC_callback) {
+            fp->cb.x21CC_callback(fighterObj);
         }
 
-        if (!fighter->x2219_flag.bits.b5) {
-            if (fighter->x209A > 1  &&  !fighter->x221D_flag.bits.b4) {
-                fighter->x209A--;
+        if (!fp->x2219_flag.bits.b5) {
+            if (fp->x209A > 1  &&  !fp->x221D_flag.bits.b4) {
+                fp->x209A--;
             }
-            if (fighter->x2223_flag.bits.b0) {
-                if (fighter->x104 == 0x14U) {
+            if (fp->x2223_flag.bits.b0) {
+                if (fp->x104 == 0x14U) {
                     func_8006F0FC(fighterObj, 0.0f);
                 } else {
-                    fighter->x89C_frameSpeedMul += fighter->x8A0_unk;
+                    fp->x89C_frameSpeedMul += fp->x8A0_unk;
                 }
-                fighter->x104--;
-                if (fighter->x104 == 0) {
-                    func_8006F0FC(fighterObj, fighter->x89C_frameSpeedMul);
-                    fighter->x104 = 0x14U;
+                fp->x104--;
+                if (fp->x104 == 0) {
+                    func_8006F0FC(fighterObj, fp->x89C_frameSpeedMul);
+                    fp->x104 = 0x14U;
                 }
             }
 
-            if (fighter->x2114_SmashAttr.x2138_smashSinceHitbox != -1.0f) {
-                fighter->x2114_SmashAttr.x2138_smashSinceHitbox++;
+            if (fp->x2114_SmashAttr.x2138_smashSinceHitbox != -1.0f) {
+                fp->x2114_SmashAttr.x2138_smashSinceHitbox++;
             }
 
-            if (fighter->dmg.x18ac_time_since_hit != -1) {
-                fighter->dmg.x18ac_time_since_hit++;
+            if (fp->dmg.x18ac_time_since_hit != -1) {
+                fp->dmg.x18ac_time_since_hit++;
             }
             func_8006EBA4(fighterObj);
             func_800D71D8(fighterObj);
             func_800764DC(fighterObj);
 
-            if (!fighter->x221C_flag.bits.b6) {
-                func_800411C4(fighter->xC_playerID, fighter->x221F_flag.bits.b4);
+            if (!fp->x221C_flag.bits.b6) {
+                func_800411C4(fp->xC_playerID, fp->x221F_flag.bits.b4);
             }
             func_800DEF38(fighterObj);
 
-            if (fighter->cb.x21A0_callback_Anim) {
-                fighter->cb.x21A0_callback_Anim(fighterObj);
+            if (fp->cb.x21A0_callback_Anim) {
+                fp->cb.x21A0_callback_Anim(fighterObj);
             }
             
         }
@@ -1702,37 +1701,37 @@ void Fighter_8006ABA0(HSD_GObj* fighterObj) {
 //https://decomp.me/scratch/A7CgG
 void Fighter_UnkIncrementCounters_8006ABEC(HSD_GObj* fighterObj) {
     
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
     if (func_800CAE80()) {
-        fighter->x68A = fighter->x685;
-        fighter->x685 = 0;
-    } else if (fighter->x685 < 0xFF) {
-        fighter->x685++;
+        fp->x68A = fp->x685;
+        fp->x685 = 0;
+    } else if (fp->x685 < 0xFF) {
+        fp->x685++;
     }
 
-    if (func_800D6928(fighter)) {
-        fighter->x68B = fighter->x686;
-        fighter->x686 = 0;
-    } else if (fighter->x686 < 0xFF) {
-        fighter->x686++;
+    if (func_800D6928(fp)) {
+        fp->x68B = fp->x686;
+        fp->x686 = 0;
+    } else if (fp->x686 < 0xFF) {
+        fp->x686++;
     }
 
-    if (func_800D688C(fighter)) {
-        fighter->x687 = 0;
-    } else if (fighter->x687 < 0xFF) {
-        fighter->x687++;
+    if (func_800D688C(fp)) {
+        fp->x687 = 0;
+    } else if (fp->x687 < 0xFF) {
+        fp->x687++;
     }
-    if (func_800964FC(fighter)) {
-        fighter->x688 = 0;
-    } else if (fighter->x688 < 0xFF) {
-        fighter->x688++;
+    if (func_800964FC(fp)) {
+        fp->x688 = 0;
+    } else if (fp->x688 < 0xFF) {
+        fp->x688++;
     }
 
-    if (func_800D67C4(fighter)) {
-        fighter->x689 = 0;
-    } else if (fighter->x689 < 0xFF) {
-        fighter->x689++;
+    if (func_800D67C4(fp)) {
+        fp->x689 = 0;
+    } else if (fp->x689 < 0xFF) {
+        fp->x689++;
     }
 }
 
@@ -1752,329 +1751,329 @@ void Fighter_UnkIncrementCounters_8006ABEC(HSD_GObj* fighterObj) {
         stick[1] = 0.0f; \
     } while(0)
 
-static void Fighter_Spaghetti_8006AD10_Inner1(Fighter* fighter) {
+static void Fighter_Spaghetti_8006AD10_Inner1(Fighter* fp) {
     s32 temp0_loc[2];
 
-    temp0_loc[0] = (fighter->input.x65C_heldInputs & (fighter->input.x660 ^ fighter->input.x65C_heldInputs));
-    temp0_loc[1] = (fighter->input.x660 & (fighter->input.x660 ^ fighter->input.x65C_heldInputs));
+    temp0_loc[0] = (fp->input.x65C_heldInputs & (fp->input.x660 ^ fp->input.x65C_heldInputs));
+    temp0_loc[1] = (fp->input.x660 & (fp->input.x660 ^ fp->input.x65C_heldInputs));
 
-    if (fighter->x2219_flag.bits.b5) {
-        fighter->input.x668 |= temp0_loc[0];
-        fighter->input.x66C |= temp0_loc[1];
+    if (fp->x2219_flag.bits.b5) {
+        fp->input.x668 |= temp0_loc[0];
+        fp->input.x66C |= temp0_loc[1];
     } else {
-        fighter->input.x668 = temp0_loc[0];
-        fighter->input.x66C = temp0_loc[1];
+        fp->input.x668 = temp0_loc[0];
+        fp->input.x66C = temp0_loc[1];
     }
 }
 
 void Fighter_Spaghetti_8006AD10(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
     f32 tempf1;
     f32 tempf0;
 
-    if (!fighter->x221F_flag.bits.b3) {
-        if (!fighter->x2224_flag.bits.b2) {
+    if (!fp->x221F_flag.bits.b3) {
+        if (!fp->x2224_flag.bits.b2) {
             
-            if (!fighter->x221D_flag.bits.b3) {
-                SET_STICKS(fighter->input.x628_lstick_x2, fighter->input.x62C_lstick_y2, fighter->input.x630, fighter->input.x634);
-                SET_STICKS(fighter->input.x640_lsubStick_x2, fighter->input.x644_lsubStick_y2, fighter->input.x648, fighter->input.x64C);
-                fighter->input.x654 = fighter->input.x658;
-                fighter->input.x660 = fighter->input.x664;
-                fighter->x221D_flag.bits.b3 = 1;
+            if (!fp->x221D_flag.bits.b3) {
+                SET_STICKS(fp->input.x628_lstick_x2, fp->input.x62C_lstick_y2, fp->input.x630, fp->input.x634);
+                SET_STICKS(fp->input.x640_lsubStick_x2, fp->input.x644_lsubStick_y2, fp->input.x648, fp->input.x64C);
+                fp->input.x654 = fp->input.x658;
+                fp->input.x660 = fp->input.x664;
+                fp->x221D_flag.bits.b3 = 1;
             } else {
-                SET_STICKS(fighter->input.x628_lstick_x2, fighter->input.x62C_lstick_y2, fighter->input.x620_lstick_x, fighter->input.x624_lstick_y);
-                SET_STICKS(fighter->input.x640_lsubStick_x2, fighter->input.x644_lsubStick_y2, fighter->input.x638_lsubStick_x, fighter->input.x63C_lsubStick_y);
-                fighter->input.x654 = fighter->input.x650;
-                fighter->input.x660 = fighter->input.x65C_heldInputs;
+                SET_STICKS(fp->input.x628_lstick_x2, fp->input.x62C_lstick_y2, fp->input.x620_lstick_x, fp->input.x624_lstick_y);
+                SET_STICKS(fp->input.x640_lsubStick_x2, fp->input.x644_lsubStick_y2, fp->input.x638_lsubStick_x, fp->input.x63C_lsubStick_y);
+                fp->input.x654 = fp->input.x650;
+                fp->input.x660 = fp->input.x65C_heldInputs;
             }
 
-            if (func_800A2040(fighter)) {
-                SET_STICKS(fighter->input.x620_lstick_x, fighter->input.x624_lstick_y, func_800A17E4(fighter), func_800A1874(fighter));
+            if (func_800A2040(fp)) {
+                SET_STICKS(fp->input.x620_lstick_x, fp->input.x624_lstick_y, func_800A17E4(fp), func_800A1874(fp));
                 if (g_debugLevel < 3  &&  func_8016B41C() == 0) {
-                    SET_STICKS(fighter->input.x638_lsubStick_x, fighter->input.x63C_lsubStick_y, func_800A1994(fighter), func_800A1A24(fighter));
+                    SET_STICKS(fp->input.x638_lsubStick_x, fp->input.x63C_lsubStick_y, func_800A1994(fp), func_800A1A24(fp));
                 }
                 else {
-                    CLEAR_STICKS(fighter->input.x638_lsubStick_x);
+                    CLEAR_STICKS(fp->input.x638_lsubStick_x);
                 }
 
-                tempf0 = func_800A1904(fighter);
-                tempf1 = func_800A1948(fighter);
+                tempf0 = func_800A1904(fp);
+                tempf1 = func_800A1948(fp);
 
-                fighter->input.x650 = (tempf0 > tempf1) ? tempf0 : tempf1;
+                fp->input.x650 = (tempf0 > tempf1) ? tempf0 : tempf1;
 
             } else {
-                SET_STICKS(fighter->input.x620_lstick_x, fighter->input.x624_lstick_y, HSD_PadRumbleData[fighter->x618_player_id].nml_stickX, HSD_PadRumbleData[fighter->x618_player_id].nml_stickY);
+                SET_STICKS(fp->input.x620_lstick_x, fp->input.x624_lstick_y, HSD_PadRumbleData[fp->x618_player_id].nml_stickX, HSD_PadRumbleData[fp->x618_player_id].nml_stickY);
                 if (g_debugLevel < 3  &&  func_8016B41C() == 0) {
-                    SET_STICKS(fighter->input.x638_lsubStick_x, fighter->input.x63C_lsubStick_y, HSD_PadRumbleData[fighter->x618_player_id].nml_subStickX, HSD_PadRumbleData[fighter->x618_player_id].nml_subStickY);
+                    SET_STICKS(fp->input.x638_lsubStick_x, fp->input.x63C_lsubStick_y, HSD_PadRumbleData[fp->x618_player_id].nml_subStickX, HSD_PadRumbleData[fp->x618_player_id].nml_subStickY);
                 } else {
-                    CLEAR_STICKS(fighter->input.x638_lsubStick_x);
+                    CLEAR_STICKS(fp->input.x638_lsubStick_x);
                 }
 
-                tempf1 = HSD_PadRumbleData[fighter->x618_player_id].nml_analogR;
-                tempf0 = HSD_PadRumbleData[fighter->x618_player_id].nml_analogL;
+                tempf1 = HSD_PadRumbleData[fp->x618_player_id].nml_analogR;
+                tempf0 = HSD_PadRumbleData[fp->x618_player_id].nml_analogL;
 
-                fighter->input.x650 = (tempf0 > tempf1) ? tempf0 : tempf1;
+                fp->input.x650 = (tempf0 > tempf1) ? tempf0 : tempf1;
             }
 
-            if (fabs_inline(fighter->input.x620_lstick_x) <= p_ftCommonData->x0) {
-                fighter->input.x620_lstick_x = 0.0f; 
+            if (fabs_inline(fp->input.x620_lstick_x) <= p_ftCommonData->x0) {
+                fp->input.x620_lstick_x = 0.0f; 
             }
 
-            if (fabs_inline(fighter->input.x624_lstick_y) <= p_ftCommonData->x4) {
-                fighter->input.x624_lstick_y = 0.0f;
+            if (fabs_inline(fp->input.x624_lstick_y) <= p_ftCommonData->x4) {
+                fp->input.x624_lstick_y = 0.0f;
             }
 
-            if (fabs_inline(fighter->input.x638_lsubStick_x) <= p_ftCommonData->x0) {
-                fighter->input.x638_lsubStick_x = 0.0f;
+            if (fabs_inline(fp->input.x638_lsubStick_x) <= p_ftCommonData->x0) {
+                fp->input.x638_lsubStick_x = 0.0f;
             }
             
-            if (fabs_inline(fighter->input.x63C_lsubStick_y) <= p_ftCommonData->x4) {
-                fighter->input.x63C_lsubStick_y = 0.0f;
+            if (fabs_inline(fp->input.x63C_lsubStick_y) <= p_ftCommonData->x4) {
+                fp->input.x63C_lsubStick_y = 0.0f;
             }
 
-            if (fighter->input.x650 <= p_ftCommonData->x10) {
-                fighter->input.x650 = 0.0f;
+            if (fp->input.x650 <= p_ftCommonData->x10) {
+                fp->input.x650 = 0.0f;
             }
 
             
-            if (func_800A2040(fighter)) {
-                fighter->input.x65C_heldInputs = func_800A198C(fighter);
+            if (func_800A2040(fp)) {
+                fp->input.x65C_heldInputs = func_800A198C(fp);
             } else {
-                fighter->input.x65C_heldInputs = HSD_PadRumbleData[fighter->x618_player_id].button;
+                fp->input.x65C_heldInputs = HSD_PadRumbleData[fp->x618_player_id].button;
             }
 
             if (func_8016B0FC()) {
-                fighter->input.x650 = 0.0f;
-                if (func_800A2040(fighter)) {
-                    fighter->input.x65C_heldInputs = (fighter->input.x65C_heldInputs & 0xD00);
+                fp->input.x650 = 0.0f;
+                if (func_800A2040(fp)) {
+                    fp->input.x65C_heldInputs = (fp->input.x65C_heldInputs & 0xD00);
                 } else {
-                    fighter->input.x65C_heldInputs = (fighter->input.x65C_heldInputs & 0x100);
+                    fp->input.x65C_heldInputs = (fp->input.x65C_heldInputs & 0x100);
                 }
             } else {
-                if ((fighter->input.x65C_heldInputs & 0x60)) {
-                    fighter->input.x65C_heldInputs = (s32) (fighter->input.x65C_heldInputs | 0x80000000);
-                    fighter->input.x650 = 1.0f;
-                } else if (fighter->input.x650) {
-                    fighter->input.x65C_heldInputs = (fighter->input.x65C_heldInputs | 0x80000000);
+                if ((fp->input.x65C_heldInputs & 0x60)) {
+                    fp->input.x65C_heldInputs = (s32) (fp->input.x65C_heldInputs | 0x80000000);
+                    fp->input.x650 = 1.0f;
+                } else if (fp->input.x650) {
+                    fp->input.x65C_heldInputs = (fp->input.x65C_heldInputs | 0x80000000);
                 }
                 if (func_801A45E8(0) == 0) {
-                    if ((fighter->input.x65C_heldInputs & 0x10)) {
-                        fighter->input.x65C_heldInputs = (fighter->input.x65C_heldInputs | 0x80000000 | 0x100);
-                        fighter->input.x650 = p_ftCommonData->x14;
+                    if ((fp->input.x65C_heldInputs & 0x10)) {
+                        fp->input.x65C_heldInputs = (fp->input.x65C_heldInputs | 0x80000000 | 0x100);
+                        fp->input.x650 = p_ftCommonData->x14;
                     }
                 }
             }
 
-            Fighter_Spaghetti_8006AD10_Inner1(fighter);
+            Fighter_Spaghetti_8006AD10_Inner1(fp);
 
-            fighter->x676_x++;
-            if (fighter->x676_x > 0xFE) {
-                fighter->x676_x = 0xFE;
+            fp->x676_x++;
+            if (fp->x676_x > 0xFE) {
+                fp->x676_x = 0xFE;
             }
 
-            if (fighter->input.x620_lstick_x >= p_ftCommonData->x8_someStickThreshold) {
-                if (fighter->input.x628_lstick_x2 >= p_ftCommonData->x8_someStickThreshold) {
-                    fighter->x670_timer_lstick_tilt_x++;
-                    if (fighter->x670_timer_lstick_tilt_x > 0xFE) {
-                        fighter->x670_timer_lstick_tilt_x = 0xFE;
+            if (fp->input.x620_lstick_x >= p_ftCommonData->x8_someStickThreshold) {
+                if (fp->input.x628_lstick_x2 >= p_ftCommonData->x8_someStickThreshold) {
+                    fp->x670_timer_lstick_tilt_x++;
+                    if (fp->x670_timer_lstick_tilt_x > 0xFE) {
+                        fp->x670_timer_lstick_tilt_x = 0xFE;
                     }
-                    fighter->x673++;
-                    if (fighter->x673 > 0xFE) {
-                        fighter->x673 = 0xFE;
+                    fp->x673++;
+                    if (fp->x673 > 0xFE) {
+                        fp->x673 = 0xFE;
                     }
-                    fighter->x679_x++;
-                    if (fighter->x679_x > 0xFE) {
-                        fighter->x679_x = 0xFE;
+                    fp->x679_x++;
+                    if (fp->x679_x > 0xFE) {
+                        fp->x679_x = 0xFE;
                     }
                 } else {
-                    fighter->x676_x = 0;
-                    fighter->x673 = 0;
-                    fighter->x670_timer_lstick_tilt_x = 0;
-                    fighter->x2228_flag.bits.b7 = 1;
+                    fp->x676_x = 0;
+                    fp->x673 = 0;
+                    fp->x670_timer_lstick_tilt_x = 0;
+                    fp->x2228_flag.bits.b7 = 1;
                 }
-            } else if (fighter->input.x620_lstick_x <= -p_ftCommonData->x8_someStickThreshold) {
-                if (fighter->input.x628_lstick_x2 <= -p_ftCommonData->x8_someStickThreshold) {
-                    fighter->x670_timer_lstick_tilt_x++;
-                    if (fighter->x670_timer_lstick_tilt_x > 0xFE) {
-                        fighter->x670_timer_lstick_tilt_x = 0xFE;
+            } else if (fp->input.x620_lstick_x <= -p_ftCommonData->x8_someStickThreshold) {
+                if (fp->input.x628_lstick_x2 <= -p_ftCommonData->x8_someStickThreshold) {
+                    fp->x670_timer_lstick_tilt_x++;
+                    if (fp->x670_timer_lstick_tilt_x > 0xFE) {
+                        fp->x670_timer_lstick_tilt_x = 0xFE;
                     }
-                    fighter->x673++;
-                    if (fighter->x673 > 0xFE) {
-                        fighter->x673 = 0xFE;
+                    fp->x673++;
+                    if (fp->x673 > 0xFE) {
+                        fp->x673 = 0xFE;
                     }
-                    fighter->x679_x++;
-                    if (fighter->x679_x > 0xFE) {
-                        fighter->x679_x = 0xFE;
+                    fp->x679_x++;
+                    if (fp->x679_x > 0xFE) {
+                        fp->x679_x = 0xFE;
                     }
                 } else {
-                    fighter->x676_x = 0;
-                    fighter->x673 = 0;
-                    fighter->x670_timer_lstick_tilt_x = 0;
-                    fighter->x2228_flag.bits.b7 = 0;
+                    fp->x676_x = 0;
+                    fp->x673 = 0;
+                    fp->x670_timer_lstick_tilt_x = 0;
+                    fp->x2228_flag.bits.b7 = 0;
                 }
             } else {
-                fighter->x679_x = 0xFEU;
-                fighter->x673 = 0xFEU;
-                fighter->x670_timer_lstick_tilt_x = 0xFEU;
+                fp->x679_x = 0xFEU;
+                fp->x673 = 0xFEU;
+                fp->x670_timer_lstick_tilt_x = 0xFEU;
             }
         
 
-            fighter->x677_y++;
-            if (fighter->x677_y > 0xFE) {
-                fighter->x677_y = 0xFE;
+            fp->x677_y++;
+            if (fp->x677_y > 0xFE) {
+                fp->x677_y = 0xFE;
             }
             
-            if (fighter->input.x624_lstick_y >= p_ftCommonData->xC) {
-                if (fighter->input.x62C_lstick_y2 >= p_ftCommonData->xC) {
-                    fighter->x671_timer_lstick_tilt_y++;
-                    if (fighter->x671_timer_lstick_tilt_y > 0xFE) {
-                        fighter->x671_timer_lstick_tilt_y = 0xFE;
+            if (fp->input.x624_lstick_y >= p_ftCommonData->xC) {
+                if (fp->input.x62C_lstick_y2 >= p_ftCommonData->xC) {
+                    fp->x671_timer_lstick_tilt_y++;
+                    if (fp->x671_timer_lstick_tilt_y > 0xFE) {
+                        fp->x671_timer_lstick_tilt_y = 0xFE;
                     }
-                    fighter->x674++;
-                    if (fighter->x674 > 0xFE) {
-                        fighter->x674 = 0xFE;
+                    fp->x674++;
+                    if (fp->x674 > 0xFE) {
+                        fp->x674 = 0xFE;
                     }
-                    fighter->x67A_y++;
-                    if (fighter->x67A_y > 0xFE) {
-                        fighter->x67A_y = 0xFE;
+                    fp->x67A_y++;
+                    if (fp->x67A_y > 0xFE) {
+                        fp->x67A_y = 0xFE;
                     }
                 } else {
-                    fighter->x677_y = 0;
-                    fighter->x674 = 0;
-                    fighter->x671_timer_lstick_tilt_y = 0;
-                    fighter->x2229_b0 = 0;
+                    fp->x677_y = 0;
+                    fp->x674 = 0;
+                    fp->x671_timer_lstick_tilt_y = 0;
+                    fp->x2229_b0 = 0;
                 }
-            } else if (fighter->input.x624_lstick_y <= -p_ftCommonData->xC) {
-                if (fighter->input.x62C_lstick_y2 <= -p_ftCommonData->xC) {
-                    fighter->x671_timer_lstick_tilt_y++;
-                    if (fighter->x671_timer_lstick_tilt_y > 0xFE) {
-                        fighter->x671_timer_lstick_tilt_y = 0xFE;
+            } else if (fp->input.x624_lstick_y <= -p_ftCommonData->xC) {
+                if (fp->input.x62C_lstick_y2 <= -p_ftCommonData->xC) {
+                    fp->x671_timer_lstick_tilt_y++;
+                    if (fp->x671_timer_lstick_tilt_y > 0xFE) {
+                        fp->x671_timer_lstick_tilt_y = 0xFE;
                     }
-                    fighter->x674++;
-                    if (fighter->x674 > 0xFE) {
-                        fighter->x674 = 0xFE;
+                    fp->x674++;
+                    if (fp->x674 > 0xFE) {
+                        fp->x674 = 0xFE;
                     }
-                    fighter->x67A_y++;
-                    if (fighter->x67A_y > 0xFE) {
-                        fighter->x67A_y = 0xFE;
+                    fp->x67A_y++;
+                    if (fp->x67A_y > 0xFE) {
+                        fp->x67A_y = 0xFE;
                     }
                 } else {
-                    fighter->x677_y = 0;
-                    fighter->x674 = 0;
-                    fighter->x671_timer_lstick_tilt_y = 0;
-                    fighter->x2229_b0 = 1;
+                    fp->x677_y = 0;
+                    fp->x674 = 0;
+                    fp->x671_timer_lstick_tilt_y = 0;
+                    fp->x2229_b0 = 1;
                 }
             } else {
-                fighter->x67A_y = 0xFE;
-                fighter->x674 = 0xFE;
-                fighter->x671_timer_lstick_tilt_y = 0xFE;
+                fp->x67A_y = 0xFE;
+                fp->x674 = 0xFE;
+                fp->x671_timer_lstick_tilt_y = 0xFE;
             }
     
-            if (func_8000D148(fighter->input.x628_lstick_x2, fighter->input.x62C_lstick_y2, fighter->input.x620_lstick_x, fighter->input.x624_lstick_y, 0.0f, 0.0f, p_ftCommonData->x8_someStickThreshold)) {
-                fighter->x67A_y = 0;
-                fighter->x679_x = 0;
+            if (func_8000D148(fp->input.x628_lstick_x2, fp->input.x62C_lstick_y2, fp->input.x620_lstick_x, fp->input.x624_lstick_y, 0.0f, 0.0f, p_ftCommonData->x8_someStickThreshold)) {
+                fp->x67A_y = 0;
+                fp->x679_x = 0;
             }
         
-            fighter->x678++;
-            if (fighter->x678 > 0xFE) {
-                fighter->x678 = 0xFE;
+            fp->x678++;
+            if (fp->x678 > 0xFE) {
+                fp->x678 = 0xFE;
             }
         
-            if (fighter->input.x650 >= p_ftCommonData->x18) {
-                if (fighter->input.x654 >= p_ftCommonData->x18) {
-                    fighter->x672_input_timer_counter++;
-                    if (fighter->x672_input_timer_counter > 0xFE) {
-                        fighter->x672_input_timer_counter = 0xFE;
+            if (fp->input.x650 >= p_ftCommonData->x18) {
+                if (fp->input.x654 >= p_ftCommonData->x18) {
+                    fp->x672_input_timer_counter++;
+                    if (fp->x672_input_timer_counter > 0xFE) {
+                        fp->x672_input_timer_counter = 0xFE;
                     }
-                    fighter->x675++;
-                    if (fighter->x675 > 0xFE) {
-                        fighter->x675 = 0xFE;
+                    fp->x675++;
+                    if (fp->x675 > 0xFE) {
+                        fp->x675 = 0xFE;
                     }
-                    fighter->x67B++;
-                    if (fighter->x67B > 0xFE) {
-                        fighter->x67B = 0xFE;
+                    fp->x67B++;
+                    if (fp->x67B > 0xFE) {
+                        fp->x67B = 0xFE;
                     }
                 } else {
-                    fighter->x67B = 0;
-                    fighter->x678 = 0;
-                    fighter->x675 = 0;
-                    fighter->x672_input_timer_counter = 0;
+                    fp->x67B = 0;
+                    fp->x678 = 0;
+                    fp->x675 = 0;
+                    fp->x672_input_timer_counter = 0;
                 }
             } else {
-                fighter->x67B = 0xFE;
-                fighter->x675 = 0xFE;
-                fighter->x672_input_timer_counter = 0xFE;
+                fp->x67B = 0xFE;
+                fp->x675 = 0xFE;
+                fp->x672_input_timer_counter = 0xFE;
             }
         
-            if (fighter->input.x668 & 0x100) {
-                fighter->x683 = fighter->x67C;
-                fighter->x67C = 0;
-            } else if (fighter->x67C < 0xFF) {
-                fighter->x67C++;
+            if (fp->input.x668 & 0x100) {
+                fp->x683 = fp->x67C;
+                fp->x67C = 0;
+            } else if (fp->x67C < 0xFF) {
+                fp->x67C++;
             }
         
-            if (fighter->input.x668 & 0x200) {
-                fighter->x67D = 0;
-            } else if (fighter->x67D < 0xFF) {
-                fighter->x67D++;
+            if (fp->input.x668 & 0x200) {
+                fp->x67D = 0;
+            } else if (fp->x67D < 0xFF) {
+                fp->x67D++;
             }
         
-            if (fighter->input.x668 & 0xC00) {
-                fighter->x67E = 0;
-            } else if (fighter->x67E < 0xFF) {
-                fighter->x67E++;
+            if (fp->input.x668 & 0xC00) {
+                fp->x67E = 0;
+            } else if (fp->x67E < 0xFF) {
+                fp->x67E++;
             }
         
-            if (fighter->input.x668 & 8) {
-                fighter->x681 = 0;
-            } else if (fighter->x681 < 0xFF) {
-                fighter->x681++;
+            if (fp->input.x668 & 8) {
+                fp->x681 = 0;
+            } else if (fp->x681 < 0xFF) {
+                fp->x681++;
             }
         
-            if (fighter->input.x668 & 4) {
-                fighter->x682 = 0;
-            } else if (fighter->x682 < 0xFF) {
-                fighter->x682++;
+            if (fp->input.x668 & 4) {
+                fp->x682 = 0;
+            } else if (fp->x682 < 0xFF) {
+                fp->x682++;
             }
         
-            if (fighter->input.x668 & 0x80000000) {
-                fighter->x67F = 0;
-            } else if (fighter->x67F < 0xFF) {
-                fighter->x67F++;
+            if (fp->input.x668 & 0x80000000) {
+                fp->x67F = 0;
+            } else if (fp->x67F < 0xFF) {
+                fp->x67F++;
             }
         
-            if (fighter->input.x668 & 0x60) {
-                fighter->x684 = fighter->x680;
-                fighter->x680 = 0;
-            } else if (fighter->x680 < 0xFF) {
-                fighter->x680++;
+            if (fp->input.x668 & 0x60) {
+                fp->x684 = fp->x680;
+                fp->x680 = 0;
+            } else if (fp->x680 < 0xFF) {
+                fp->x680++;
             }
     
         }
     
-        if (fighter->x221D_flag.bits.b4 || fighter->x2224_flag.bits.b2 || func_801A45E8(2)) {
-            fighter->input.x630 = fighter->input.x620_lstick_x;
-            fighter->input.x634 = fighter->input.x624_lstick_y;
-            fighter->input.x648 = fighter->input.x638_lsubStick_x;
-            fighter->input.x64C = fighter->input.x63C_lsubStick_y;
-            fighter->input.x658 = fighter->input.x650;
-            fighter->input.x664 = fighter->input.x65C_heldInputs;
-            fighter->x221D_flag.bits.b3 = 0;
+        if (fp->x221D_flag.bits.b4 || fp->x2224_flag.bits.b2 || func_801A45E8(2)) {
+            fp->input.x630 = fp->input.x620_lstick_x;
+            fp->input.x634 = fp->input.x624_lstick_y;
+            fp->input.x648 = fp->input.x638_lsubStick_x;
+            fp->input.x64C = fp->input.x63C_lsubStick_y;
+            fp->input.x658 = fp->input.x650;
+            fp->input.x664 = fp->input.x65C_heldInputs;
+            fp->x221D_flag.bits.b3 = 0;
     
             Fighter_UnkInitLoad_80068914_Inner1(fighterObj);
         }
     
-        if (!fighter->x2219_flag.bits.b5) {
-            if (fighter->x1980) {
-               func_8007FFD8(fighter, p_ftCommonData->x6FC);
+        if (!fp->x2219_flag.bits.b5) {
+            if (fp->x1980) {
+               func_8007FFD8(fp, p_ftCommonData->x6FC);
             }
             func_800DF0D0(fighterObj);
             func_8008031C(fighterObj);
             Fighter_UnkIncrementCounters_8006ABEC(fighterObj);
     
-            if (fighter->cb.x219C_callback_IASA) {
-                fighter->cb.x219C_callback_IASA(fighterObj);
+            if (fp->cb.x219C_callback_IASA) {
+                fp->cb.x219C_callback_IASA(fighterObj);
             }
         }
 
@@ -2091,44 +2090,44 @@ void Fighter_Spaghetti_8006AD10(HSD_GObj* fighterObj) {
     } while(0)
 
 void Fighter_procUpdate(HSD_GObj* fighterObj, s32 dummy) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     Vec3 windOffset; 
 
-    if (fighter->x221F_flag.bits.b3) {
+    if (fp->x221F_flag.bits.b3) {
         return;
     }
     
-    if (!fighter->x2219_flag.bits.b5)
+    if (!fp->x2219_flag.bits.b5)
     {
         Vec3* p_kb_vel;
         Vec3* pAtkShieldKB;
         Vec3 selfVel;
         float kb_vel_x, kb_vel_y, atkShieldKB_X;
 
-        if (fighter->x2064_ledgeCooldown) 
-            fighter->x2064_ledgeCooldown -= 1;
+        if (fp->x2064_ledgeCooldown) 
+            fp->x2064_ledgeCooldown -= 1;
 
-        if (fighter->x2108) 
-            fighter->x2108 -= 1;
+        if (fp->x2108) 
+            fp->x2108 -= 1;
         
         func_800C0A98(fighterObj);
 
-		if (fighter->cb.x21A4_callback_Phys) {
-			fighter->cb.x21A4_callback_Phys(fighterObj);
+		if (fp->cb.x21A4_callback_Phys) {
+			fp->cb.x21A4_callback_Phys(fighterObj);
         }
 
-        p_kb_vel = &fighter->x8c_kb_vel;
+        p_kb_vel = &fp->x8c_kb_vel;
 		if ((kb_vel_x = p_kb_vel->x) != 0 || p_kb_vel->y != 0)
         {
-			if (fighter->xE0_ground_or_air == GA_Air) 
+			if (fp->xE0_ground_or_air == GA_Air) 
             {
 				kb_vel_x = p_kb_vel->x;
 				kb_vel_y = p_kb_vel->y;
 
-				if (fighter->x2228_flag.bits.b2) 
+				if (fp->x2228_flag.bits.b2) 
                 {
-                	p_kb_vel->x = func_8007CD6C(p_kb_vel->x, func_8007CDA4(fighter));;
-					p_kb_vel->y = func_8007CD6C(p_kb_vel->y, func_8007CDF8(fighter));;
+                	p_kb_vel->x = func_8007CD6C(p_kb_vel->x, func_8007CDA4(fp));;
+					p_kb_vel->y = func_8007CD6C(p_kb_vel->y, func_8007CDF8(fp));;
                 }
                 else 
                 {
@@ -2145,31 +2144,31 @@ void Fighter_procUpdate(HSD_GObj* fighterObj, s32 dummy) {
                     }
                 }
                 
-				fighter->xF0_ground_kb_vel = 0; 
+				fp->xF0_ground_kb_vel = 0; 
             }
 			else
             {
-                Vec3* pNormal = &fighter->x6F0_collData.x154_groundNormal;  
+                Vec3* pNormal = &fp->x6F0_collData.x154_groundNormal;  
                 struct attr* pAttr;
 
-				if (fighter->xF0_ground_kb_vel == 0)
-					fighter->xF0_ground_kb_vel = kb_vel_x;
+				if (fp->xF0_ground_kb_vel == 0)
+					fp->xF0_ground_kb_vel = kb_vel_x;
 
-                pAttr = &fighter->x110_attr; 
-                func_8007CCA0(fighter,
+                pAttr = &fp->x110_attr; 
+                func_8007CCA0(fp,
                     /*effective friction - ground multiplier is usually 1. last factor was 1 when I looked*/
-                    func_80084A40(fighter) * pAttr->x128_GroundFriction * p_ftCommonData->x200);
+                    func_80084A40(fp) * pAttr->x128_GroundFriction * p_ftCommonData->x200);
 
 				// set knockback velocity to ground_kb_vel * surfaceTangent
-                p_kb_vel->x =  pNormal->y * fighter->xF0_ground_kb_vel;
-                p_kb_vel->y = -pNormal->x * fighter->xF0_ground_kb_vel;
+                p_kb_vel->x =  pNormal->y * fp->xF0_ground_kb_vel;
+                p_kb_vel->y = -pNormal->x * fp->xF0_ground_kb_vel;
             }
         }
         //Now handle the attacker's shield knockback in a similar way
-        pAtkShieldKB = &fighter->x98_atk_shield_kb;
+        pAtkShieldKB = &fp->x98_atk_shield_kb;
         if ((atkShieldKB_X = pAtkShieldKB->x) != 0 || pAtkShieldKB->y != 0)
         {
-            if (fighter->xE0_ground_or_air == GA_Air)
+            if (fp->xE0_ground_or_air == GA_Air)
             {
                 float kb_x = pAtkShieldKB->x;
                 float kb_y = pAtkShieldKB->y;
@@ -2189,99 +2188,99 @@ void Fighter_procUpdate(HSD_GObj* fighterObj, s32 dummy) {
                     pAtkShieldKB->x -= p_ftCommonData->x3E8_shieldKnockbackFrameDecay * cosf(atkShieldKBAngle);
                     pAtkShieldKB->y -= p_ftCommonData->x3E8_shieldKnockbackFrameDecay * sinf(atkShieldKBAngle);
                 }
-                fighter->xF4_ground_attacker_shield_kb_vel = 0;
+                fp->xF4_ground_attacker_shield_kb_vel = 0;
             }
             else
             {
-                Vec3* pNormal = &fighter->x6F0_collData.x154_groundNormal; // ground_normal offset inside fighter is 0x844, surface normal points out of the surface. 
+                Vec3* pNormal = &fp->x6F0_collData.x154_groundNormal; // ground_normal offset inside fp is 0x844, surface normal points out of the surface. 
                 struct attr* pAttr;
                 
-                if (fighter->xF4_ground_attacker_shield_kb_vel == 0)
-                    fighter->xF4_ground_attacker_shield_kb_vel = atkShieldKB_X;
+                if (fp->xF4_ground_attacker_shield_kb_vel == 0)
+                    fp->xF4_ground_attacker_shield_kb_vel = atkShieldKB_X;
                 
-                pAttr = &fighter->x110_attr;
+                pAttr = &fp->x110_attr;
                 
-                func_8007CE4C(fighter,
+                func_8007CE4C(fp,
                     /* effectiveFriction - the last constant variable differs from the one for the knockback friction above*/
-                    func_80084A40(fighter) * pAttr->x128_GroundFriction * p_ftCommonData->x3EC_shieldGroundFrictionMultiplier);
+                    func_80084A40(fp) * pAttr->x128_GroundFriction * p_ftCommonData->x3EC_shieldGroundFrictionMultiplier);
                 
-                pAtkShieldKB->x =  pNormal->y * fighter->xF4_ground_attacker_shield_kb_vel;
-                pAtkShieldKB->y = -pNormal->x * fighter->xF4_ground_attacker_shield_kb_vel;
+                pAtkShieldKB->x =  pNormal->y * fp->xF4_ground_attacker_shield_kb_vel;
+                pAtkShieldKB->y = -pNormal->x * fp->xF4_ground_attacker_shield_kb_vel;
             }
         }
 
-		fighter->xEC_ground_vel += fighter->xE4_ground_accel_1 + fighter->xE8_ground_accel_2;
-        fighter->xE4_ground_accel_1 = fighter->xE8_ground_accel_2 = 0;
+		fp->xEC_ground_vel += fp->xE4_ground_accel_1 + fp->xE8_ground_accel_2;
+        fp->xE4_ground_accel_1 = fp->xE8_ground_accel_2 = 0;
 
         //self_vel += anim_vel
-		PSVECAdd(&fighter->x80_self_vel, &fighter->x74_anim_vel, &fighter->x80_self_vel);
-        VEC_CLEAR(fighter->x74_anim_vel);
+		PSVECAdd(&fp->x80_self_vel, &fp->x74_anim_vel, &fp->x80_self_vel);
+        VEC_CLEAR(fp->x74_anim_vel);
 		
 		//copy selfVel into a stack storage variable
-		selfVel = fighter->x80_self_vel;
+		selfVel = fp->x80_self_vel;
 		
 		// TODO: these double_lower_32bit variables are probably integer counters that get decremented each frame,
         // but I was not able to trigger the following condition.
 		// The double value construction then is only used as an interpolation tool between selfVel and some UnkVel2.
-		if (fighter->dmg.x1948 != 0)
+		if (fp->dmg.x1948 != 0)
         {
             // The compiler casts an u32 integer 'val' to a double type using
             // double v = *(double*)&(0x43300000_00000000 | val ^ 0x80000000) - *(double*)&43300000_80000000
             // which is all that happens in the lengthy assembly generated by this
 			float C1 = 1.0f;
-            float C2 = C1 - (float)fighter->dmg.x194C / (float)fighter->dmg.x1948;
+            float C2 = C1 - (float)fp->dmg.x194C / (float)fp->dmg.x1948;
 			
-            selfVel.x = C2 * (fighter->x80_self_vel.x - fighter->xA4_unk_vel.x) + fighter->xA4_unk_vel.x;
-            selfVel.y = C2 * (fighter->x80_self_vel.y - fighter->xA4_unk_vel.y) + fighter->xA4_unk_vel.y;
+            selfVel.x = C2 * (fp->x80_self_vel.x - fp->xA4_unk_vel.x) + fp->xA4_unk_vel.x;
+            selfVel.y = C2 * (fp->x80_self_vel.y - fp->xA4_unk_vel.y) + fp->xA4_unk_vel.y;
             
-            fighter->dmg.x194C--;
-			if (fighter->dmg.x194C == 0)
-				fighter->dmg.x1948 = 0;
+            fp->dmg.x194C--;
+			if (fp->dmg.x194C == 0)
+				fp->dmg.x1948 = 0;
         }
 
 		// add some horizontal+depth offset to the position? Why is there no vertical component?
-        fighter->xB0_pos.x += fighter->xF8_playerNudgeVel.x;
-        fighter->xB0_pos.y += 0;
-        fighter->xB0_pos.z += fighter->xF8_playerNudgeVel.y;
+        fp->xB0_pos.x += fp->xF8_playerNudgeVel.x;
+        fp->xB0_pos.y += 0;
+        fp->xB0_pos.z += fp->xF8_playerNudgeVel.y;
         
-        if (fighter->x2222_flag.bits.b6 && !fighter->x2222_flag.bits.b7)
+        if (fp->x2222_flag.bits.b6 && !fp->x2222_flag.bits.b7)
         {
             s32 bit;
 
-            // fighter->xD4_unk_vel += selfVel
-			PSVECAdd(&fighter->xD4_unk_vel, &selfVel, &fighter->xD4_unk_vel);
+            // fp->xD4_unk_vel += selfVel
+			PSVECAdd(&fp->xD4_unk_vel, &selfVel, &fp->xD4_unk_vel);
 			
-            fighter->xD4_unk_vel.x += p_kb_vel->x;
-            fighter->xD4_unk_vel.y += p_kb_vel->y;
-            fighter->xD4_unk_vel.z += 0.0f;
+            fp->xD4_unk_vel.x += p_kb_vel->x;
+            fp->xD4_unk_vel.y += p_kb_vel->y;
+            fp->xD4_unk_vel.z += 0.0f;
 
-            if (fighter->x2210_ThrowFlags.b2)
+            if (fp->x2210_ThrowFlags.b2)
             {
-			    fighter->x2210_ThrowFlags.b2 = 0;
+			    fp->x2210_ThrowFlags.b2 = 0;
                 bit = 1;
             }
             else
                 bit = 0;
 
-			if (bit || func_80070FD0(fighter) || fighter->x594_animCurrFlags1.bits.b7)
+			if (bit || func_80070FD0(fp) || fp->x594_animCurrFlags1.bits.b7)
             {
-                // fighter->xB0_position += fighter->xD4_unk_vel
-				PSVECAdd(&fighter->xB0_pos, &fighter->xD4_unk_vel, &fighter->xB0_pos);
+                // fp->xB0_position += fp->xD4_unk_vel
+				PSVECAdd(&fp->xB0_pos, &fp->xD4_unk_vel, &fp->xB0_pos);
 				// TODO: we set this velocity to 0 after applying it -> Is this SDI or ASDI?
-                VEC_CLEAR(fighter->xD4_unk_vel);
+                VEC_CLEAR(fp->xD4_unk_vel);
             }
-			// fighter->xB0_position += *pAtkShieldKB
-            PSVECAdd(&fighter->xB0_pos, (Vec3*)pAtkShieldKB, &fighter->xB0_pos);
+			// fp->xB0_position += *pAtkShieldKB
+            PSVECAdd(&fp->xB0_pos, (Vec3*)pAtkShieldKB, &fp->xB0_pos);
         }
 		else
         {
-            //fighter@r31.position@0xB0.xyz += selfVel + pAtkShieldKB
-			PSVECAdd(&fighter->xB0_pos, &selfVel, &fighter->xB0_pos);
-			fighter->xB0_pos.x += p_kb_vel->x;
-            fighter->xB0_pos.y += p_kb_vel->y;
-            fighter->xB0_pos.z += 0;
+            //fp@r31.position@0xB0.xyz += selfVel + pAtkShieldKB
+			PSVECAdd(&fp->xB0_pos, &selfVel, &fp->xB0_pos);
+			fp->xB0_pos.x += p_kb_vel->x;
+            fp->xB0_pos.y += p_kb_vel->y;
+            fp->xB0_pos.z += 0;
 
-            PSVECAdd(&fighter->xB0_pos, (Vec3*)pAtkShieldKB, &fighter->xB0_pos);
+            PSVECAdd(&fp->xB0_pos, (Vec3*)pAtkShieldKB, &fp->xB0_pos);
         }
 		//accumulate wind hazards into the windOffset vector
 		func_getWindOffsetVec_8007B924(fighterObj, /*result vec3*/&windOffset);
@@ -2293,65 +2292,65 @@ void Fighter_procUpdate(HSD_GObj* fighterObj, s32 dummy) {
     
     func_80076528(fighterObj);
     
-	if (fighter->cb.x21D0_callback_EveryHitlag) {
-        fighter->cb.x21D0_callback_EveryHitlag(fighterObj);
+	if (fp->cb.x21D0_callback_EveryHitlag) {
+        fp->cb.x21D0_callback_EveryHitlag(fighterObj);
     }
     
-	if (fighter->xE0_ground_or_air == GA_Ground)
+	if (fp->xE0_ground_or_air == GA_Ground)
     {
 		Vec3 difference; 
 		// I think this function always returns r3=1, but it contains two __assert functions. But I guess these just stop or reset the game.
 		// result is written to where r5 points to, which is 'difference' in this case
-		if (func_800567C0(fighter->x6F0_collData.x14C_groundIndex, &fighter->xB0_pos, &difference))
-			//fighter->position += difference
-			PSVECAdd(&fighter->xB0_pos, &difference, &fighter->xB0_pos);
+		if (func_800567C0(fp->x6F0_collData.x14C_groundIndex, &fp->xB0_pos, &difference))
+			//fp->position += difference
+			PSVECAdd(&fp->xB0_pos, &difference, &fp->xB0_pos);
     }
 
-    fighter->xB0_pos.x += windOffset.x;
-    fighter->xB0_pos.y += windOffset.y;
-    fighter->xB0_pos.z += windOffset.z;
+    fp->xB0_pos.x += windOffset.x;
+    fp->xB0_pos.y += windOffset.y;
+    fp->xB0_pos.z += windOffset.z;
 
     // TODO: do the bitflag tests here tell us if the player is dead?
 	func_800D3158(fighterObj);
     
-	if (fighter->x2225_flag.bits.b0)
+	if (fp->x2225_flag.bits.b0)
     {
 		// if position.y crossed (0.25*stage.blastBottom+0.75*stage.cameraBottom) + stage.crowdReactStart from below...
-		if (fighter->xBC_prevPos.y <= Stage_CalcUnkCamYBounds() &&
-		    fighter->xB0_pos.y >  Stage_CalcUnkCamYBounds()) {
-			    fighter->x2225_flag.bits.b0 = 0;
+		if (fp->xBC_prevPos.y <= Stage_CalcUnkCamYBounds() &&
+		    fp->xB0_pos.y >  Stage_CalcUnkCamYBounds()) {
+			    fp->x2225_flag.bits.b0 = 0;
             }
     }
 	else
     {
-		if (!fighter->x222A_flag.bits.b1 && !fighter->x2228_flag.bits.b5)
+		if (!fp->x222A_flag.bits.b1 && !fp->x2228_flag.bits.b5)
         {
 			// if position.y crossed 0.5*(stage.blastBottom+stage.cameraBottom) + stage.crowdReactStart from above...
-			if (fighter->xBC_prevPos.y >= Stage_CalcUnkCamY() &&
-			    fighter->xB0_pos.y <  Stage_CalcUnkCamY())
+			if (fp->xBC_prevPos.y >= Stage_CalcUnkCamY() &&
+			    fp->xB0_pos.y <  Stage_CalcUnkCamY())
             {
 				// plays this sound you always hear when you get close to the bottom blast zone
-				func_80088148(fighter, 96, 127, 64);
-				fighter->x2225_flag.bits.b0 = 1;
+				func_80088148(fp, 96, 127, 64);
+				fp->x2225_flag.bits.b0 = 1;
             }
         }
     }
 	
-	if (fighter->dmg.x18A4_knockbackMagnitude && 
-        !fighter->x221C_flag.bits.b6 &&
-		!func_80322258(fighter->xB0_pos.x))
+	if (fp->dmg.x18A4_knockbackMagnitude && 
+        !fp->x221C_flag.bits.b6 &&
+		!func_80322258(fp->xB0_pos.x))
     {
-		fighter->dmg.x18A4_knockbackMagnitude = 0.0f; 
+		fp->dmg.x18A4_knockbackMagnitude = 0.0f; 
     }
 
 	func_8007AF28(fighterObj);
 	
 	if (g_debugLevel >= 3 && 
-        (fpclassify(fighter->xB0_pos.x)==FP_NAN || 
-         fpclassify(fighter->xB0_pos.y)==FP_NAN || 
-         fpclassify(fighter->xB0_pos.z)==FP_NAN)) 
+        (fpclassify(fp->xB0_pos.x)==FP_NAN || 
+         fpclassify(fp->xB0_pos.y)==FP_NAN || 
+         fpclassify(fp->xB0_pos.z)==FP_NAN)) 
 	{
-		OSReport("fighter procUpdate pos error.\tpos.x=%f\tpos.y=%f\n", fighter->xB0_pos.x, fighter->xB0_pos.y);
+		OSReport("fighter procUpdate pos error.\tpos.x=%f\tpos.y=%f\n", fp->xB0_pos.x, fp->xB0_pos.y);
         __assert(__FILE__ , /*line*/2517, "0");
     }
 }
@@ -2364,9 +2363,9 @@ inline HSD_JObj* Fighter_UnkApplyTransformation_8006C0F0_Inner1(HSD_JObj* jobj, 
 
 void Fighter_UnkApplyTransformation_8006C0F0(HSD_GObj* fighterObj) 
 {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    if (fighter->x34_scale.z != 1.0f) {
+    if (fp->x34_scale.z != 1.0f) {
         HSD_JObj* jobj = fighterObj->hsd_obj;
         Mtx mtx1;
         Mtx mtx2;
@@ -2378,61 +2377,61 @@ void Fighter_UnkApplyTransformation_8006C0F0(HSD_GObj* fighterObj)
         HSD_JObjGetMtx(jobj);
         HSD_JObjGetScale(Fighter_UnkApplyTransformation_8006C0F0_Inner1(jobj, &mtx1), &scale);
 
-        scale.x = Fighter_GetModelScale(fighter);
+        scale.x = Fighter_GetModelScale(fp);
 
         HSD_JObjGetRotation(jobj, &rotation);
         HSD_JObjGetTranslation(jobj, &translation);
 
         func_8037A250(&mtx2, &scale, &rotation, &translation, 0);
-        PSMTXConcat(mtx2, mtx1, fighter->x44_mtx);
+        PSMTXConcat(mtx2, mtx1, fp->x44_mtx);
     }
 }
 
 void Fighter_8006C27C(HSD_GObj* fighterObj, s32 unused, s32 unused2, s32 unused3) {
 
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    if (!fighter->x221F_flag.bits.b3) {
+    if (!fp->x221F_flag.bits.b3) {
 
-        if (fighter->x6F0_collData.x19C) {
-            fighter->x6F0_collData.x19C = fighter->x6F0_collData.x19C - 1;
-            if (!fighter->x6F0_collData.x19C) {
-                func_8007D5BC(fighter);
+        if (fp->x6F0_collData.x19C) {
+            fp->x6F0_collData.x19C = fp->x6F0_collData.x19C - 1;
+            if (!fp->x6F0_collData.x19C) {
+                func_8007D5BC(fp);
             }
         }
 
-        fighter->x2223_flag.bits.b5 = 0;
+        fp->x2223_flag.bits.b5 = 0;
 
-        HSD_JObjSetTranslate(fighterObj->hsd_obj, &fighter->xB0_pos);
+        HSD_JObjSetTranslate(fighterObj->hsd_obj, &fp->xB0_pos);
 
-        if (fighter->cb.x21A8_callback_Coll) {
-            fighter->cb.x21A8_callback_Coll(fighterObj);
+        if (fp->cb.x21A8_callback_Coll) {
+            fp->cb.x21A8_callback_Coll(fighterObj);
             func_800F1D24(fighterObj);
         }
 
-        if (fighter->xE0_ground_or_air == GA_Ground) {
-            func_80041280(fighter->xC_playerID, fighter->x221F_flag.bits.b4);
+        if (fp->xE0_ground_or_air == GA_Ground) {
+            func_80041280(fp->xC_playerID, fp->x221F_flag.bits.b4);
         }
 
         if (g_debugLevel >= 3) {
-            if (fpclassify(fighter->xB0_pos.x) == FP_NAN ||
-                fpclassify(fighter->xB0_pos.y) == FP_NAN ||
-                fpclassify(fighter->xB0_pos.z) == FP_NAN)
+            if (fpclassify(fp->xB0_pos.x) == FP_NAN ||
+                fpclassify(fp->xB0_pos.y) == FP_NAN ||
+                fpclassify(fp->xB0_pos.z) == FP_NAN)
             {
-                OSReport("fighter procMap pos error.\tpos.x=%f\tpos.y=%f\n", fighter->xB0_pos.x, fighter->xB0_pos.y);
+                OSReport("fighter procMap pos error.\tpos.x=%f\tpos.y=%f\n", fp->xB0_pos.x, fp->xB0_pos.y);
                 __assert(__FILE__, 2590, "0");
             }
         }
 
-        HSD_JObjSetTranslate(fighterObj->hsd_obj, &fighter->xB0_pos);
+        HSD_JObjSetTranslate(fighterObj->hsd_obj, &fp->xB0_pos);
 
     }
 }
 
 void Fighter_8006C5F4(HSD_GObj* fighterObj)
 {
-    Fighter* fighter = fighterObj->user_data;
-	if (!fighter->x221F_flag.bits.b3)
+    Fighter* fp = fighterObj->user_data;
+	if (!fp->x221F_flag.bits.b3)
 		func_80089B08(fighterObj);
 }
 
@@ -2460,20 +2459,20 @@ void Fighter_CallAcessoryCallbacks_8006C624(HSD_GObj* fighterObj) {
     }
 }
 
-inline float Fighter_8006C80C_Inline_1(Fighter* fighter, Vec* cam_offset) {
-    return fighter->xB0_pos.y + cam_offset->y;
+inline float Fighter_8006C80C_Inline_1(Fighter* fp, Vec* cam_offset) {
+    return fp->xB0_pos.y + cam_offset->y;
 }
 
 void Fighter_8006C80C(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    if (!fighter->x221F_flag.bits.b3) {
-        func_80067624(fighterObj, &fighter->x60C);
+    if (!fp->x221F_flag.bits.b3) {
+        func_80067624(fighterObj, &fp->x60C);
         Fighter_UnkApplyTransformation_8006C0F0(fighterObj);
 
-        if (!fighter->x2219_flag.bits.b5) {
-            if (fighter->cb.x21BC_callback_Accessory4) {
-                fighter->cb.x21BC_callback_Accessory4(fighterObj);
+        if (!fp->x2219_flag.bits.b5) {
+            if (fp->cb.x21BC_callback_Accessory4) {
+                fp->cb.x21BC_callback_Accessory4(fighterObj);
             }
         }
 
@@ -2481,17 +2480,17 @@ void Fighter_8006C80C(HSD_GObj* fighterObj) {
         func_8007C224(fighterObj);
         func_8007C6DC(fighterObj);
 
-        if (fighter->x20A0_accessory) {
-            HSD_JObjAnimAll(fighter->x20A0_accessory);
+        if (fp->x20A0_accessory) {
+            HSD_JObjAnimAll(fp->x20A0_accessory);
         }
 
-        if (fighter->xE0_ground_or_air == GA_Air && fighter->xB0_pos.y < Stage_GetCamBoundsBottomOffset()) {
-            if (func_802FB6E8(fighter->xC_playerID) == 3) {
+        if (fp->xE0_ground_or_air == GA_Air && fp->xB0_pos.y < Stage_GetCamBoundsBottomOffset()) {
+            if (func_802FB6E8(fp->xC_playerID) == 3) {
                 Vec cam_offset;
                 Stage_UnkSetVec3TCam_Offset(&cam_offset);
             
-                if (Fighter_8006C80C_Inline_1(fighter, &cam_offset) < fighter->x2140) {
-                    fighter->x2140 = Fighter_8006C80C_Inline_1(fighter, &cam_offset);
+                if (Fighter_8006C80C_Inline_1(fp, &cam_offset) < fp->x2140) {
+                    fp->x2140 = Fighter_8006C80C_Inline_1(fp, &cam_offset);
                 }
             }
         }
@@ -2500,30 +2499,30 @@ void Fighter_8006C80C(HSD_GObj* fighterObj) {
 
 void Fighter_UnkProcessGrab_8006CA5C(HSD_GObj* fighterObj) {
 
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    if (!fighter->x221F_flag.bits.b3 && !func_8016B1C4()) {
+    if (!fp->x221F_flag.bits.b3 && !func_8016B1C4()) {
         func_8007BA0C(fighterObj);
-        if (fighter->x221E_flag.bits.b6) {
+        if (fp->x221E_flag.bits.b6) {
             func_80078A2C(fighterObj);
-            if (fighter->x1A58_interactedFighter) {
-                if (!fighter->x2225_flag.bits.b1) {
-                    func_80088148(fighter, fighter->x10C_ftData->x4C_collisionData->x30, 0x7F, 0x40);
+            if (fp->x1A58_interactedFighter) {
+                if (!fp->x2225_flag.bits.b1) {
+                    func_80088148(fp, fp->x10C_ftData->x4C_collisionData->x30, 0x7F, 0x40);
                 }
-                func_80078754(fighterObj, fighter->x1A58_interactedFighter, 0);
-                fighter->cb.x2190_callback_OnGrabFighter_Self(fighterObj);
-                fighter->cb.x2198_callback_OnGrabFighter_Victim(fighter->x1A58_interactedFighter, fighterObj);
+                func_80078754(fighterObj, fp->x1A58_interactedFighter, 0);
+                fp->cb.x2190_callback_OnGrabFighter_Self(fighterObj);
+                fp->cb.x2198_callback_OnGrabFighter_Victim(fp->x1A58_interactedFighter, fighterObj);
                 return;
             }
             func_8007BC90(fighterObj);
 
-            if (fighter->x1A60) {
-                if (!fighter->x2225_flag.bits.b1) {
-                    func_80088148(fighter, fighter->x10C_ftData->x4C_collisionData->x30, 0x7F, 0x40);
+            if (fp->x1A60) {
+                if (!fp->x2225_flag.bits.b1) {
+                    func_80088148(fp, fp->x10C_ftData->x4C_collisionData->x30, 0x7F, 0x40);
                 }
-                func_8027B4A4(fighterObj, fighter->x1A60);
-                if (fighter->cb.x2194_callback) {
-                    fighter->cb.x2194_callback(fighterObj);
+                func_8027B4A4(fighterObj, fp->x1A60);
+                if (fp->cb.x2194_callback) {
+                    fp->cb.x2194_callback(fighterObj);
                 }
             }
         }
@@ -2533,10 +2532,10 @@ void Fighter_UnkProcessGrab_8006CA5C(HSD_GObj* fighterObj) {
 
 
 void Fighter_8006CB94(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     f32 func_8007BBCC_float_output;
 
-    if (!fighter->x221F_flag.bits.b3 && !fighter->x2219_flag.bits.b1) {
+    if (!fp->x221F_flag.bits.b3 && !fp->x2219_flag.bits.b1) {
         func_800765E0();
         func_80078C70(fighterObj);
         func_8007C77C(fighterObj);
@@ -2553,213 +2552,213 @@ void Fighter_8006CB94(HSD_GObj* fighterObj) {
 }
 
 
-void Fighter_UnkTakeDamage_8006CC30(Fighter* fighter, f32 arg0) {
-    Fighter_TakeDamage_8006CC7C(fighter, arg0);
-    func_8007EA90(fighter, arg0);
+void Fighter_UnkTakeDamage_8006CC30(Fighter* fp, f32 arg0) {
+    Fighter_TakeDamage_8006CC7C(fp, arg0);
+    func_8007EA90(fp, arg0);
 }
 
-void Fighter_TakeDamage_8006CC7C(Fighter* fighter, f32 damage_amount) {
+void Fighter_TakeDamage_8006CC7C(Fighter* fp, f32 damage_amount) {
 
-    if (!fighter->x2226_flag.bits.b4 || fighter->x2226_flag.bits.b3) {
-        fighter->dmg.x1830_percent += damage_amount;
-        if (fighter->x2028) {
-            fighter->x202C -= damage_amount;
+    if (!fp->x2226_flag.bits.b4 || fp->x2226_flag.bits.b3) {
+        fp->dmg.x1830_percent += damage_amount;
+        if (fp->x2028) {
+            fp->x202C -= damage_amount;
         }
 
-        if (fighter->x2034) {
-            fighter->x2038 -= damage_amount;
+        if (fp->x2034) {
+            fp->x2038 -= damage_amount;
         }
 
-        if (fighter->dmg.x1830_percent > 999.0f) {
-            fighter->dmg.x1830_percent = 999.0f;
+        if (fp->dmg.x1830_percent > 999.0f) {
+            fp->dmg.x1830_percent = 999.0f;
         }
-        Player_SetHPByIndex(fighter->xC_playerID, fighter->x221F_flag.bits.b4, fighter->dmg.x1830_percent);
-        func_8003EC9C(fighter->xC_playerID, fighter->x221F_flag.bits.b4, fighter->dmg.x1830_percent, damage_amount);
-        func_800C8C84(fighter->x0_fighter);
+        Player_SetHPByIndex(fp->xC_playerID, fp->x221F_flag.bits.b4, fp->dmg.x1830_percent);
+        func_8003EC9C(fp->xC_playerID, fp->x221F_flag.bits.b4, fp->dmg.x1830_percent, damage_amount);
+        func_800C8C84(fp->x0_fighter);
         
     }
 }
 
 ///https://decomp.me/scratch/9QvFG  
-void Fighter_8006CDA4(Fighter* fighter, s32 arg1, s32 arg2, s32 arg3) {
+void Fighter_8006CDA4(Fighter* fp, s32 arg1, s32 arg2, s32 arg3) {
     BOOL temp_bool;
     BOOL hold_item_bool = 0;
     Vec vec;
 
-    if (fighter->x1974_heldItem && !func_8026B2B4(fighter->x1974_heldItem)) {
+    if (fp->x1974_heldItem && !func_8026B2B4(fp->x1974_heldItem)) {
         hold_item_bool = 1;
     }
 
     
-    temp_bool = !((fighter->x2220_flag.bits.b3 || fighter->x2220_flag.bits.b4 || func_8008E984(fighter)));
+    temp_bool = !((fp->x2220_flag.bits.b3 || fp->x2220_flag.bits.b4 || func_8008E984(fp)));
     vec = vec3_803B7494;
 
 
-    if ((fighter->x10_action_state_index) != 0x145 && ((fighter->x10_action_state_index - 0x122) > 1U) &&  fighter->dmg.x1860_dealt != 0xAU  && !fighter->x2226_flag.bits.b2) {
+    if ((fp->x10_action_state_index) != 0x145 && ((fp->x10_action_state_index - 0x122) > 1U) &&  fp->dmg.x1860_dealt != 0xAU  && !fp->x2226_flag.bits.b2) {
         if (   ///// giant if condition
                 hold_item_bool && temp_bool && ((HSD_Randi(p_ftCommonData->x418) < arg1)
                 ||
-                ((((func_8026B30C(fighter->x1974_heldItem) == 3) && 
-                func_8026B594(fighter->x1974_heldItem))) && 
+                ((((func_8026B30C(fp->x1974_heldItem) == 3) && 
+                func_8026B594(fp->x1974_heldItem))) && 
                 !HSD_Randi(p_ftCommonData->x41C)))
             ) 
             {
-            if (fighter->x1978) {
-                func_8026ABD8(fighter->x1978, &vec, 1.0f);
+            if (fp->x1978) {
+                func_8026ABD8(fp->x1978, &vec, 1.0f);
             }
-            func_8026ABD8(fighter->x1974_heldItem, &vec, 1.0f);
+            func_8026ABD8(fp->x1974_heldItem, &vec, 1.0f);
         }
-        if (fighter->x197C) {
+        if (fp->x197C) {
             if (HSD_Randi(p_ftCommonData->x418) < arg1) {
-                func_8007F8E8(fighter->x0_fighter);
-                func_8026ABD8(fighter->x197C, &vec, 1.0f);
-                func_8007F9B4(fighter->x0_fighter);
+                func_8007F8E8(fp->x0_fighter);
+                func_8026ABD8(fp->x197C, &vec, 1.0f);
+                func_8007F9B4(fp->x0_fighter);
             }
         }
     }
 
 }
 
-void Fighter_8006CF5C(Fighter* fighter, s32 arg1) {
+void Fighter_8006CF5C(Fighter* fp, s32 arg1) {
 
-   if (!fighter->x2224_flag.bits.b2) {
-       fighter->dmg.x18F0 += arg1;
-       func_800BFFD0(fighter, 8, 0);
-       func_8007EBAC(fighter, 2, 0);
+   if (!fp->x2224_flag.bits.b2) {
+       fp->dmg.x18F0 += arg1;
+       func_800BFFD0(fp, 8, 0);
+       func_8007EBAC(fp, 2, 0);
    }
 }
 
 
 void Fighter_UnkSetFlag_8006CFBC(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    if (fighter->x2219_flag.bits.b7){
-        fighter->x221A_flag.bits.b1 = 1;
+    if (fp->x2219_flag.bits.b7){
+        fp->x221A_flag.bits.b1 = 1;
     }
 
 }
 
 void Fighter_8006CFE0(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    if (fighter->x2219_flag.bits.b7) {
-        if (!fighter->x221A_flag.bits.b2) {
-            if (!fighter->dmg.x1954){
+    if (fp->x2219_flag.bits.b7) {
+        if (!fp->x221A_flag.bits.b2) {
+            if (!fp->dmg.x1954){
                 Fighter_8006D10C(fighterObj);
             }
         }
-        fighter->x2219_flag.bits.b7 = 0;
+        fp->x2219_flag.bits.b7 = 0;
     }
 }
 
 void Fighter_UnkRecursiveFunc_8006D044(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    if (fighter->cb.x21D4_callback_EnterHitlag) {
-        fighter->cb.x21D4_callback_EnterHitlag(fighterObj);
+    if (fp->cb.x21D4_callback_EnterHitlag) {
+        fp->cb.x21D4_callback_EnterHitlag(fighterObj);
     }
 
-    fighter->x2219_flag.bits.b5 = 1;
+    fp->x2219_flag.bits.b5 = 1;
 
-    if (fighter->x1A5C && !fighter->x2219_flag.bits.b7) {
-        HSD_GObj* jobj = fighter->x1A5C;
+    if (fp->x1A5C && !fp->x2219_flag.bits.b7) {
+        HSD_GObj* jobj = fp->x1A5C;
 
-        (getFighter(fighter->x1A5C))->x2219_flag.bits.b7 = 1;
+        (getFighter(fp->x1A5C))->x2219_flag.bits.b7 = 1;
 
         Fighter_UnkRecursiveFunc_8006D044(jobj);
     }
 }
 
-static void Fighter_8006D10C_Inline2(Fighter* new_fighter) {
-    HSD_GObj* gobj = new_fighter->x1A5C;
-    if (gobj && !new_fighter->x2219_flag.bits.b7) {
+static void Fighter_8006D10C_Inline2(Fighter* new_fp) {
+    HSD_GObj* gobj = new_fp->x1A5C;
+    if (gobj && !new_fp->x2219_flag.bits.b7) {
         Fighter_8006CFE0(gobj);
     }
 }
 
 static void Fighter_8006D10C_Inline1(HSD_GObj* otherObj) {
-    Fighter* new_fighter = otherObj->user_data;
-    if (new_fighter->x2219_flag.bits.b7) {
-        if (!new_fighter->x221A_flag.bits.b2 && !new_fighter->dmg.x1954) {
-            if (new_fighter->cb.x21D8_callback_ExitHitlag) {
-                new_fighter->cb.x21D8_callback_ExitHitlag(otherObj);
+    Fighter* new_fp = otherObj->user_data;
+    if (new_fp->x2219_flag.bits.b7) {
+        if (!new_fp->x221A_flag.bits.b2 && !new_fp->dmg.x1954) {
+            if (new_fp->cb.x21D8_callback_ExitHitlag) {
+                new_fp->cb.x21D8_callback_ExitHitlag(otherObj);
             }
-            new_fighter->x2219_flag.bits.b5 = 0;
-            Fighter_8006D10C_Inline2(new_fighter);        
+            new_fp->x2219_flag.bits.b5 = 0;
+            Fighter_8006D10C_Inline2(new_fp);        
         }
-        new_fighter->x2219_flag.bits.b7 = 0;
+        new_fp->x2219_flag.bits.b7 = 0;
     }
 }
 
 void Fighter_8006D10C(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
 
-    if (fighter->cb.x21D8_callback_ExitHitlag) {
-        fighter->cb.x21D8_callback_ExitHitlag(fighterObj);
+    if (fp->cb.x21D8_callback_ExitHitlag) {
+        fp->cb.x21D8_callback_ExitHitlag(fighterObj);
     }
 
-    fighter->x2219_flag.bits.b5 = 0;
+    fp->x2219_flag.bits.b5 = 0;
 
-    if (fighter->x1A5C && !fighter->x2219_flag.bits.b7) {
-        Fighter_8006D10C_Inline1(fighter->x1A5C);
+    if (fp->x1A5C && !fp->x2219_flag.bits.b7) {
+        Fighter_8006D10C_Inline1(fp->x1A5C);
     }
 }
 
 void Fighter_UnkProcessShieldHit_8006D1EC(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
     BOOL bool1 = 0;
-    s32 action_state_index = fighter->x10_action_state_index;
+    s32 action_state_index = fp->x10_action_state_index;
     BOOL bool2 = 0;
     BOOL bool3 = 0;
     BOOL bool4 = 0;
     f32 forceAppliedOnHit;
 
-    if (!fighter->x221F_flag.bits.b3) {
+    if (!fp->x221F_flag.bits.b3) {
 
-        if (!fighter->x221A_flag.bits.b7) {
-            if (fighter->x1998_shieldHealth < p_ftCommonData->x260_startShieldHealth) {
-                fighter->x1998_shieldHealth += p_ftCommonData->x27C;
-                if (fighter->x1998_shieldHealth > p_ftCommonData->x260_startShieldHealth) {
-                    fighter->x1998_shieldHealth = p_ftCommonData->x260_startShieldHealth;
+        if (!fp->x221A_flag.bits.b7) {
+            if (fp->x1998_shieldHealth < p_ftCommonData->x260_startShieldHealth) {
+                fp->x1998_shieldHealth += p_ftCommonData->x27C;
+                if (fp->x1998_shieldHealth > p_ftCommonData->x260_startShieldHealth) {
+                    fp->x1998_shieldHealth = p_ftCommonData->x260_startShieldHealth;
                 }
             }
         }
 
-        if (fighter->x221A_flag.bits.b7) {
-            fighter->x1998_shieldHealth -= (p_ftCommonData->x284 * ((fighter->x19A0_shieldDamageTaken) * (1.0f - ((fighter->x199C_shieldLightshieldAmt * (p_ftCommonData->x2E0 - p_ftCommonData->x2DC)) + p_ftCommonData->x2DC)))) + p_ftCommonData->x288;
-            if (fighter->x1998_shieldHealth < 0.0f) {
+        if (fp->x221A_flag.bits.b7) {
+            fp->x1998_shieldHealth -= (p_ftCommonData->x284 * ((fp->x19A0_shieldDamageTaken) * (1.0f - ((fp->x199C_shieldLightshieldAmt * (p_ftCommonData->x2E0 - p_ftCommonData->x2DC)) + p_ftCommonData->x2DC)))) + p_ftCommonData->x288;
+            if (fp->x1998_shieldHealth < 0.0f) {
                 bool3 = 1;
-                fighter->x1998_shieldHealth = p_ftCommonData->x280_unkShieldHealth;
+                fp->x1998_shieldHealth = p_ftCommonData->x280_unkShieldHealth;
                 /// this function is called when shield is broken
-                func_8003E058(fighter->x19BC_shieldDamageTaken3, fighter->x221F_flag.bits.b6, fighter->xC_playerID, fighter->x221F_flag.bits.b4);
+                func_8003E058(fp->x19BC_shieldDamageTaken3, fp->x221F_flag.bits.b6, fp->xC_playerID, fp->x221F_flag.bits.b4);
             }
         }
 
-        if (fighter->dmg.x189C_unk_num_frames > 0.0f) {
-            fighter->dmg.x189C_unk_num_frames--;
-            if (fighter->dmg.x189C_unk_num_frames <= 0.0f && !fighter->dmg.x1850_forceApplied) {
-                fighter->dmg.x189C_unk_num_frames = 0.0f;
+        if (fp->dmg.x189C_unk_num_frames > 0.0f) {
+            fp->dmg.x189C_unk_num_frames--;
+            if (fp->dmg.x189C_unk_num_frames <= 0.0f && !fp->dmg.x1850_forceApplied) {
+                fp->dmg.x189C_unk_num_frames = 0.0f;
                 func_8007BE3C(fighterObj);
             }
         }
 
-        forceAppliedOnHit = fighter->dmg.x1850_forceApplied;
+        forceAppliedOnHit = fp->dmg.x1850_forceApplied;
         if (forceAppliedOnHit) {
-            s32 ground_or_air = fighter->xE0_ground_or_air;
+            s32 ground_or_air = fp->xE0_ground_or_air;
             BOOL damage_bool;
 
-            fighter->dmg.x189C_unk_num_frames = 0.0f;
-            Fighter_UnkTakeDamage_8006CC30(fighter, fighter->dmg.x1838_percentTemp);
-            func_8008D930(fighter);
-            func_800F5BA4(fighter);
+            fp->dmg.x189C_unk_num_frames = 0.0f;
+            Fighter_UnkTakeDamage_8006CC30(fp, fp->dmg.x1838_percentTemp);
+            func_8008D930(fp);
+            func_800F5BA4(fp);
 
-            if (fighter->cb.x21F0_callback) {
-                fighter->cb.x21F0_callback(fighterObj);
+            if (fp->cb.x21F0_callback) {
+                fp->cb.x21F0_callback(fighterObj);
             }
 
-            if (!fighter->x2229_b7) {
+            if (!fp->x2229_b7) {
 
-                switch (fighter->x1828) {
+                switch (fp->x1828) {
                     case 0:
                         func_8008EC90(fighterObj);
                         break;
@@ -2777,15 +2776,15 @@ void Fighter_UnkProcessShieldHit_8006D1EC(HSD_GObj* fighterObj) {
                         break;
                 }
 
-                damage_bool = fighter->dmg.x183C_applied;
+                damage_bool = fp->dmg.x183C_applied;
                 bool2 = 1;
-                func_80090594(fighter, fighter->dmg.x1860_dealt, damage_bool, action_state_index, ground_or_air, fighter->x1960_vibrateMult);
-                func_8007ED50(fighter, fighter->dmg.x1838_percentTemp);
+                func_80090594(fp, fp->dmg.x1860_dealt, damage_bool, action_state_index, ground_or_air, fp->x1960_vibrateMult);
+                func_8007ED50(fp, fp->dmg.x1838_percentTemp);
                 bool1 = damage_bool;
                 
             } else {
 
-                switch (fighter->x4_fighterKind) {
+                switch (fp->x4_fighterKind) {
                     case 0x1B:
                         func_8014FE58(fighterObj);
                         break;
@@ -2798,159 +2797,159 @@ void Fighter_UnkProcessShieldHit_8006D1EC(HSD_GObj* fighterObj) {
                 }
                 func_8008E9D0(fighterObj);
             }
-        } else if (fighter->dmg.x18a0) {
-            bool1 = fighter->dmg.x1840;
+        } else if (fp->dmg.x18a0) {
+            bool1 = fp->dmg.x1840;
             bool4 = 1;
-        } else if (fighter->x19A4) {
+        } else if (fp->x19A4) {
             if (bool3) {
                 func_80098B20(fighterObj);
-                func_80088148(fighter, 0x82, 0x7F, 0x40);
+                func_80088148(fp, 0x82, 0x7F, 0x40);
             } else {
-                if (fighter->cb.x21C4_callback_OnShieldHit) {
-                    fighter->cb.x21C4_callback_OnShieldHit(fighterObj);
+                if (fp->cb.x21C4_callback_OnShieldHit) {
+                    fp->cb.x21C4_callback_OnShieldHit(fighterObj);
                 }
             }
-            bool1 = fighter->x19A4;
-        } else if (fighter->dmg.x1918) {
-            if ((fighter->dmg.x191C) && (!fighter->x1A58_interactedFighter) && (!fighter->x1A60)) {
+            bool1 = fp->x19A4;
+        } else if (fp->dmg.x1918) {
+            if ((fp->dmg.x191C) && (!fp->x1A58_interactedFighter) && (!fp->x1A60)) {
                 func_8007DB58(fighterObj);
                 func_80099D9C(fighterObj);
             }
-            bool1 = fighter->dmg.x1918;
-        } else if (fighter->dmg.x1914) {
-            if (fighter->cb.x21C0_callback_OnGiveDamage) {
-                fighter->cb.x21C0_callback_OnGiveDamage(fighterObj);
+            bool1 = fp->dmg.x1918;
+        } else if (fp->dmg.x1914) {
+            if (fp->cb.x21C0_callback_OnGiveDamage) {
+                fp->cb.x21C0_callback_OnGiveDamage(fighterObj);
             }
-            bool1 = fighter->dmg.x1914;
-            if (fighter->x2073 == 0x46U) {
-                func_8007EBAC(fighter, 0xE, 0);
+            bool1 = fp->dmg.x1914;
+            if (fp->x2073 == 0x46U) {
+                func_8007EBAC(fp, 0xE, 0);
             } else {
-                func_8007EE0C(fighter, fighter->dmg.x1914);
+                func_8007EE0C(fp, fp->dmg.x1914);
             }
         } else {
-            if (fighter->dmg.x1924) {
-                bool1 = fighter->dmg.x1924;
-            } else if (fighter->ReflectAttr.x1A3C_damageOver) {
+            if (fp->dmg.x1924) {
+                bool1 = fp->dmg.x1924;
+            } else if (fp->ReflectAttr.x1A3C_damageOver) {
                 func_80098C9C(fighterObj);
-            } else if (fighter->ReflectAttr.x1A2C_reflectHitDirection) {
-                if (fighter->cb.x21C8_callback_OnReflectHit) {
-                    fighter->cb.x21C8_callback_OnReflectHit(fighterObj);
+            } else if (fp->ReflectAttr.x1A2C_reflectHitDirection) {
+                if (fp->cb.x21C8_callback_OnReflectHit) {
+                    fp->cb.x21C8_callback_OnReflectHit(fighterObj);
                 }
-            } else if (fighter->AbsorbAttr.x1A40_absorbHitDirection) {
-                if (ft_OnAbsorb[fighter->x4_fighterKind]) {
-                    ft_OnAbsorb[fighter->x4_fighterKind](fighterObj);
+            } else if (fp->AbsorbAttr.x1A40_absorbHitDirection) {
+                if (ft_OnAbsorb[fp->x4_fighterKind]) {
+                    ft_OnAbsorb[fp->x4_fighterKind](fighterObj);
                 }
-            } else if (fighter->x20AC) {
-                if (fighter->cb.x21F4_callback) {
-                    fighter->cb.x21F4_callback(fighterObj);
+            } else if (fp->x20AC) {
+                if (fp->cb.x21F4_callback) {
+                    fp->cb.x21F4_callback(fighterObj);
                 }
             }
         }
 
-        if(!forceAppliedOnHit && fighter->dmg.x1838_percentTemp) {
-            Fighter_UnkTakeDamage_8006CC30(fighter, fighter->dmg.x1838_percentTemp);
-            func_800F5C34(fighter);
-            func_800804FC(fighter);
+        if(!forceAppliedOnHit && fp->dmg.x1838_percentTemp) {
+            Fighter_UnkTakeDamage_8006CC30(fp, fp->dmg.x1838_percentTemp);
+            func_800F5C34(fp);
+            func_800804FC(fp);
         }
         func_800C8D00(fighterObj);
         
         if (bool1) {
-            fighter->dmg.x195c_hitlag_frames = func_8007DA74(bool1, action_state_index, fighter->x1960_vibrateMult);
-            if (fighter->dmg.x195c_hitlag_frames < fighter->x1964) {
-                fighter->dmg.x195c_hitlag_frames = fighter->x1964;
+            fp->dmg.x195c_hitlag_frames = func_8007DA74(bool1, action_state_index, fp->x1960_vibrateMult);
+            if (fp->dmg.x195c_hitlag_frames < fp->x1964) {
+                fp->dmg.x195c_hitlag_frames = fp->x1964;
             }
-            if (fighter->dmg.x195c_hitlag_frames > 0.0f) {
-                if (fighter->dmg.x195c_hitlag_frames > p_ftCommonData->x194_unkHitLagFrames) {
-                    fighter->dmg.x195c_hitlag_frames = p_ftCommonData->x194_unkHitLagFrames;
+            if (fp->dmg.x195c_hitlag_frames > 0.0f) {
+                if (fp->dmg.x195c_hitlag_frames > p_ftCommonData->x194_unkHitLagFrames) {
+                    fp->dmg.x195c_hitlag_frames = p_ftCommonData->x194_unkHitLagFrames;
                 }
-                fighter->x221A_flag.bits.b2 = 1;
+                fp->x221A_flag.bits.b2 = 1;
                 if (bool2) {
-                    fighter->x221A_flag.bits.b3 = 1;
+                    fp->x221A_flag.bits.b3 = 1;
                 }
                 if (bool4) {
-                    fighter->dmg.x189C_unk_num_frames = fighter->dmg.x195c_hitlag_frames;
+                    fp->dmg.x189C_unk_num_frames = fp->dmg.x195c_hitlag_frames;
                 }
-                if (!fighter->x2219_flag.bits.b5) {
+                if (!fp->x2219_flag.bits.b5) {
                     Fighter_UnkRecursiveFunc_8006D044(fighterObj);
                 }
             }
         } else {
-            func_80090718(fighter);
+            func_80090718(fp);
         }
 
-        if (fighter->x221A_flag.bits.b0 || fighter->dmg.x1958) {
-            if (!fighter->x2219_flag.bits.b5) {
+        if (fp->x221A_flag.bits.b0 || fp->dmg.x1958) {
+            if (!fp->x2219_flag.bits.b5) {
                 Fighter_UnkRecursiveFunc_8006D044(fighterObj);
             }
 
-            if (fighter->x221A_flag.bits.b0) {
-                fighter->x2219_flag.bits.b7 = 1;
-                fighter->x221A_flag.bits.b0 = 0;
+            if (fp->x221A_flag.bits.b0) {
+                fp->x2219_flag.bits.b7 = 1;
+                fp->x221A_flag.bits.b0 = 0;
             } else {
-                if (fighter->dmg.x1958 > fighter->dmg.x1954) {
-                    fighter->dmg.x1954 = fighter->dmg.x1958;
+                if (fp->dmg.x1958 > fp->dmg.x1954) {
+                    fp->dmg.x1954 = fp->dmg.x1958;
                 }
-                fighter->dmg.x1958 = 0.0f;
+                fp->dmg.x1958 = 0.0f;
             }
         }
 
 
-        if (fighter->dmg.x1928) {
-            float eval = (fighter->dmg.x1928 * p_ftCommonData->x3E0) + p_ftCommonData->x3E4;
-            fighter->xF4_ground_attacker_shield_kb_vel = (fighter->dmg.x192c < 0.0f) ? eval : -eval;
+        if (fp->dmg.x1928) {
+            float eval = (fp->dmg.x1928 * p_ftCommonData->x3E0) + p_ftCommonData->x3E4;
+            fp->xF4_ground_attacker_shield_kb_vel = (fp->dmg.x192c < 0.0f) ? eval : -eval;
             func_8007E2A4(fighterObj);
         }
 
-        fighter->dmg.x1838_percentTemp = 0.0f;
-        fighter->dmg.x183C_applied = 0;
-        fighter->x1828 = 0;
-        fighter->dmg.x1850_forceApplied = 0.0f;
-        fighter->dmg.x18a0 = 0.0f;
-        fighter->dmg.x1840 = 0;
-        fighter->dmg.x1914 = 0;
-        fighter->dmg.x1918 = 0;
-        fighter->dmg.x191C = 0.0f;
-        fighter->x20AC = NULL;
-        fighter->x221C_flag.bits.b5 = 0;
+        fp->dmg.x1838_percentTemp = 0.0f;
+        fp->dmg.x183C_applied = 0;
+        fp->x1828 = 0;
+        fp->dmg.x1850_forceApplied = 0.0f;
+        fp->dmg.x18a0 = 0.0f;
+        fp->dmg.x1840 = 0;
+        fp->dmg.x1914 = 0;
+        fp->dmg.x1918 = 0;
+        fp->dmg.x191C = 0.0f;
+        fp->x20AC = NULL;
+        fp->x221C_flag.bits.b5 = 0;
         
-        fighter->dmg.x1924 = 0;
-        fighter->dmg.x1928 = 0.0f;
-        fighter->x19A0_shieldDamageTaken = 0;
-        fighter->x19A4 = 0;
-        fighter->x19A8 = 0;
-        fighter->ReflectAttr.x1A3C_damageOver = 0;
-        fighter->ReflectAttr.x1A2C_reflectHitDirection = 0.0f;
-        fighter->AbsorbAttr.x1A40_absorbHitDirection = 0.0f;
-        fighter->AbsorbAttr.x1A44_damageTaken = 0;
-        fighter->AbsorbAttr.x1A48_hitsTaken = 0;
-        fighter->x1960_vibrateMult = 1.0f;
-        fighter->x1964 = 0.0f;
-        fighter->dmg.x1950 = 0;
+        fp->dmg.x1924 = 0;
+        fp->dmg.x1928 = 0.0f;
+        fp->x19A0_shieldDamageTaken = 0;
+        fp->x19A4 = 0;
+        fp->x19A8 = 0;
+        fp->ReflectAttr.x1A3C_damageOver = 0;
+        fp->ReflectAttr.x1A2C_reflectHitDirection = 0.0f;
+        fp->AbsorbAttr.x1A40_absorbHitDirection = 0.0f;
+        fp->AbsorbAttr.x1A44_damageTaken = 0;
+        fp->AbsorbAttr.x1A48_hitsTaken = 0;
+        fp->x1960_vibrateMult = 1.0f;
+        fp->x1964 = 0.0f;
+        fp->dmg.x1950 = 0;
 
-        if (!fighter->x2219_flag.bits.b6 || fighter->dmg.x18F4) {
+        if (!fp->x2219_flag.bits.b6 || fp->dmg.x18F4) {
             func_800C2FD8(fighterObj);
         }
-        func_800A0DA4(fighter);   
+        func_800A0DA4(fp);   
     }
 }
 
 void Fighter_8006D9AC(HSD_GObj* fighterObj) {
-    Fighter* fighter;
-    fighter  = fighterObj->user_data;
+    Fighter* fp;
+    fp  = fighterObj->user_data;
 
-    if (fighter->x221F_flag.bits.b3 || fighter->x2219_flag.bits.b5) return;
+    if (fp->x221F_flag.bits.b3 || fp->x2219_flag.bits.b5) return;
 
     func_8009E0A8(fighterObj);
 }
 
 
 void Fighter_UnkCallCameraCallback_8006D9EC(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    if (!fighter->x221F_flag.bits.b3) {
+    if (!fp->x221F_flag.bits.b3) {
         func_8008021C(fighterObj);
-        if (fighter->cb.x21AC_callback_Cam) {
-            fighter->cb.x21AC_callback_Cam(fighterObj);
+        if (fp->cb.x21AC_callback_Cam) {
+            fp->cb.x21AC_callback_Cam(fighterObj);
         }
     }
 
@@ -2958,12 +2957,12 @@ void Fighter_UnkCallCameraCallback_8006D9EC(HSD_GObj* fighterObj) {
 
 
 void Fighter_8006DA4C(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
+    Fighter* fp = fighterObj->user_data;
 
-    if (!fighter->x221F_flag.bits.b3) {
-        Player_80032828(fighter->xC_playerID, fighter->x221F_flag.bits.b4, &fighter->xB0_pos);
-        Player_SetFacingDirectionConditional(fighter->xC_playerID, fighter->x221F_flag.bits.b4, fighter->x2C_facing_direction);
-        func_8003FAA8(fighter->xC_playerID, fighter->x221F_flag.bits.b4, &fighter->xB0_pos, &fighter->xBC_prevPos);
+    if (!fp->x221F_flag.bits.b3) {
+        Player_80032828(fp->xC_playerID, fp->x221F_flag.bits.b4, &fp->xB0_pos);
+        Player_SetFacingDirectionConditional(fp->xC_playerID, fp->x221F_flag.bits.b4, fp->x2C_facing_direction);
+        func_8003FAA8(fp->xC_playerID, fp->x221F_flag.bits.b4, &fp->xB0_pos, &fp->xBC_prevPos);
     }
 }
 
@@ -2980,35 +2979,35 @@ inline HSD_ObjAllocData* sub_func(Fighter* uninitalized_fighter, Fighter* fighte
     return objAllocData;
 }
 
-void Fighter_Unload_8006DABC(Fighter* fighter) {
+void Fighter_Unload_8006DABC(Fighter* fp) {
     Fighter* uninitalized_fighter;
 
     HSD_ObjAllocData *objAllocData = &lbl_80458FD0;
-    objAllocData = sub_func(uninitalized_fighter, fighter);
+    objAllocData = sub_func(uninitalized_fighter, fp);
 
-    func_8007B8E8(fighter->x0_fighter);
-    func_80067688(&fighter->x60C);
-    func_8026B7F8(fighter->x0_fighter);
-    func_800290D4(fighter->x890_cameraBox);
-    func_8009E0D4(fighter);
-    func_800765AC(fighter->x0_fighter);
-    func_80088C5C(fighter->x0_fighter);
-    func_8000EE8C(&fighter->x20A4);
-    if (fighter->x20A0_accessory) {
-        HSD_JObjRemoveAll(fighter->x20A0_accessory);
+    func_8007B8E8(fp->x0_fighter);
+    func_80067688(&fp->x60C);
+    func_8026B7F8(fp->x0_fighter);
+    func_800290D4(fp->x890_cameraBox);
+    func_8009E0D4(fp);
+    func_800765AC(fp->x0_fighter);
+    func_80088C5C(fp->x0_fighter);
+    func_8000EE8C(&fp->x20A4);
+    if (fp->x20A0_accessory) {
+        HSD_JObjRemoveAll(fp->x20A0_accessory);
     }
-    HSD_JObjRemoveAll(fighter->x8AC_animSkeleton);
-    HSD_JObjUnref(fighter->x2184);
-    func_800859A8(fighter);
-    func_80366BD4(fighter->x588);
-    Player_80031FB0(fighter->xC_playerID, fighter->x221F_flag.bits.b4);
+    HSD_JObjRemoveAll(fp->x8AC_animSkeleton);
+    HSD_JObjUnref(fp->x2184);
+    func_800859A8(fp);
+    func_80366BD4(fp->x588);
+    Player_80031FB0(fp->xC_playerID, fp->x221F_flag.bits.b4);
     
-    HSD_ObjFree(&objAllocData[(0xDC / 40)], fighter->x59C);
-    HSD_ObjFree(&objAllocData[(0xDC / 40)], fighter->x5A0);
-    HSD_ObjFree(&objAllocData[(0x58 / 40)], fighter->x5E8_fighterBones);
-    HSD_ObjFree(&objAllocData[(0x84 / 40)], fighter->x5F0);
-    HSD_ObjFree(&objAllocData[(0xB0 / 40)], fighter->x2040);
-    HSD_ObjFree(&objAllocData[(0x2C / 40)], fighter->x2D8_specialAttributes2);
-    HSD_ObjFree(objAllocData, fighter);
+    HSD_ObjFree(&objAllocData[(0xDC / 40)], fp->x59C);
+    HSD_ObjFree(&objAllocData[(0xDC / 40)], fp->x5A0);
+    HSD_ObjFree(&objAllocData[(0x58 / 40)], fp->x5E8_fighterBones);
+    HSD_ObjFree(&objAllocData[(0x84 / 40)], fp->x5F0);
+    HSD_ObjFree(&objAllocData[(0xB0 / 40)], fp->x2040);
+    HSD_ObjFree(&objAllocData[(0x2C / 40)], fp->x2D8_specialAttributes2);
+    HSD_ObjFree(objAllocData, fp);
 
 }

--- a/src/melee/ft/fighter.h
+++ b/src/melee/ft/fighter.h
@@ -131,7 +131,7 @@ typedef enum CharacterKind
 #define FIGHTER_MODEL_FLAG_NOUPDATE 0x4000000
 #define FIGHTER_UNK_0x2227 0x8000000
 #define FIGHTER_HITSTUN_FLAG_NOUPDATE 0x10000000
-#define FIGHTER_ANIM_NOUPDATE 0x20000000 // Keeps current fighter animation?
+#define FIGHTER_ANIM_NOUPDATE 0x20000000 // Keeps current fp animation?
 #define FIGHTER_UNK_0x40000000 0x40000000 // Unused?
 #define FIGHTER_UNK_0x80000000 0x80000000 // Unused?
 
@@ -847,7 +847,7 @@ typedef struct ftHurt
 
 typedef struct _SmashAttr {
     s32 x2114_state;                        // 0x2114 0 = none, 1 = pre-charge, 2 = charging, 3 = release
-    f32 x2118_frames;                       // 0x2118 number of frames fighter has charged for
+    f32 x2118_frames;                       // 0x2118 number of frames fp has charged for
     f32 x211C_holdFrame;                    // 0x211c frame that charge begins/ends
     f32 x2120_damageMul;                    // 0x2120 damage multiplier
     f32 x2124_frameSpeedMul;                // 0x2124 speed multiplier?
@@ -926,7 +926,7 @@ struct S_TEMP4 {
 };
 
 // --------------------------------------------------------------------------------
-// UNION DEFS FOR FIGHTER STRUCTS. TODO: Maybe move these to per-fighter
+// UNION DEFS FOR FIGHTER STRUCTS. TODO: Maybe move these to per-fp
 // header includes or something.
 // --------------------------------------------------------------------------------
 struct SpecialAttrs_Mario {
@@ -1613,33 +1613,33 @@ typedef struct _Fighter {
     /* 0x2188 */ S32Pair x2188;
     // callback struct. Not all of them used by fighter.c, but I'm leaving them in for now.
     struct cb {
-        void (*x2190_callback_OnGrabFighter_Self)(HSD_GObj *fighter); // used
-        void (*x2194_callback)(HSD_GObj *fighter); // used
+        void (*x2190_callback_OnGrabFighter_Self)(HSD_GObj *fp); // used
+        void (*x2194_callback)(HSD_GObj *fp); // used
         void (*x2198_callback_OnGrabFighter_Victim)(HSD_GObj*, HSD_GObj*); // used
-        void (*x219C_callback_IASA)(HSD_GObj *fighter); // used
-        void (*x21A0_callback_Anim)(HSD_GObj *fighter);
-        void (*x21A4_callback_Phys)(HSD_GObj *fighter); // xused
-        void (*x21A8_callback_Coll)(HSD_GObj *fighter);
-        void (*x21AC_callback_Cam)(HSD_GObj *fighter);
-        void (*x21B0_callback_Accessory1)(HSD_GObj *fighter);
-        void (*x21B4_callback_Accessory2)(HSD_GObj *fighter); // used
-        void (*x21B8_callback_Accessory3)(HSD_GObj *fighter); // used
-        void (*x21BC_callback_Accessory4)(HSD_GObj *fighter);
-        void (*x21C0_callback_OnGiveDamage)(HSD_GObj *fighter);
-        void (*x21C4_callback_OnShieldHit)(HSD_GObj *fighter);
-        void (*x21C8_callback_OnReflectHit)(HSD_GObj *fighter);
-        void (*x21CC_callback)(HSD_GObj *fighter);
-        void (*x21D0_callback_EveryHitlag)(HSD_GObj *fighter); // xused
-        void (*x21D4_callback_EnterHitlag)(HSD_GObj *fighter);
-        void (*x21D8_callback_ExitHitlag)(HSD_GObj *fighter);
-        void (*x21DC_callback_OnTakeDamage)(HSD_GObj *fighter);
-        void (*x21E0_callback_OnDeath)(HSD_GObj *fighter); // used
-        void (*x21E4_callback_OnDeath2)(HSD_GObj *fighter); // used. internally Dead_Proc as evidenced by 800f5430
-        void (*x21E8_callback_OnDeath3)(HSD_GObj *fighter); // used
-        void (*x21EC_callback)(HSD_GObj *fighter);
-        void (*x21F0_callback)(HSD_GObj *fighter);
-        void (*x21F4_callback)(HSD_GObj *fighter);
-        void (*x21F8_callback)(HSD_GObj *fighter);
+        void (*x219C_callback_IASA)(HSD_GObj *fp); // used
+        void (*x21A0_callback_Anim)(HSD_GObj *fp);
+        void (*x21A4_callback_Phys)(HSD_GObj *fp); // xused
+        void (*x21A8_callback_Coll)(HSD_GObj *fp);
+        void (*x21AC_callback_Cam)(HSD_GObj *fp);
+        void (*x21B0_callback_Accessory1)(HSD_GObj *fp);
+        void (*x21B4_callback_Accessory2)(HSD_GObj *fp); // used
+        void (*x21B8_callback_Accessory3)(HSD_GObj *fp); // used
+        void (*x21BC_callback_Accessory4)(HSD_GObj *fp);
+        void (*x21C0_callback_OnGiveDamage)(HSD_GObj *fp);
+        void (*x21C4_callback_OnShieldHit)(HSD_GObj *fp);
+        void (*x21C8_callback_OnReflectHit)(HSD_GObj *fp);
+        void (*x21CC_callback)(HSD_GObj *fp);
+        void (*x21D0_callback_EveryHitlag)(HSD_GObj *fp); // xused
+        void (*x21D4_callback_EnterHitlag)(HSD_GObj *fp);
+        void (*x21D8_callback_ExitHitlag)(HSD_GObj *fp);
+        void (*x21DC_callback_OnTakeDamage)(HSD_GObj *fp);
+        void (*x21E0_callback_OnDeath)(HSD_GObj *fp); // used
+        void (*x21E4_callback_OnDeath2)(HSD_GObj *fp); // used. internally Dead_Proc as evidenced by 800f5430
+        void (*x21E8_callback_OnDeath3)(HSD_GObj *fp); // used
+        void (*x21EC_callback)(HSD_GObj *fp);
+        void (*x21F0_callback)(HSD_GObj *fp);
+        void (*x21F4_callback)(HSD_GObj *fp);
+        void (*x21F8_callback)(HSD_GObj *fp);
     } cb;
     /* 0x21FC */ u8 x21FC;
     u8 filler_x21FC[0x2200 - 0x21FD];
@@ -1970,7 +1970,7 @@ void Fighter_UpdateModelScale(HSD_GObj* fighterObj);
 void Fighter_UnkInitReset_80067C98(Fighter*);
 void Fighter_UnkProcessDeath_80068354(HSD_GObj* fighterObj);
 void Fighter_UnkUpdateCostumeJoint_800686E4(HSD_GObj* fighterObj);
-void Fighter_UnkUpdateVecFromBones_8006876C(Fighter* fighter);
+void Fighter_UnkUpdateVecFromBones_8006876C(Fighter* fp);
 void Fighter_ResetInputData_80068854(HSD_GObj* fighterObj);
 void Fighter_UnkInitLoad_80068914(HSD_GObj* fighterObj, struct S_TEMP1* argdata);
 u32 Fighter_NewSpawn_80068E40();
@@ -1990,10 +1990,10 @@ void Fighter_CallAcessoryCallbacks_8006C624(HSD_GObj* fighterObj);
 void Fighter_8006C80C(HSD_GObj* fighterObj);
 void Fighter_UnkProcessGrab_8006CA5C(HSD_GObj* fighterObj);
 void Fighter_8006CB94(HSD_GObj* fighterObj);
-void Fighter_UnkTakeDamage_8006CC30(Fighter* fighter, f32 damage_amount);
+void Fighter_UnkTakeDamage_8006CC30(Fighter* fp, f32 damage_amount);
 void Fighter_TakeDamage_8006CC7C(Fighter*, f32);
-void Fighter_8006CDA4(Fighter* fighter, s32 arg1, s32 arg2, s32 arg3);
-void Fighter_8006CF5C(Fighter* fighter, s32 arg1);
+void Fighter_8006CDA4(Fighter* fp, s32 arg1, s32 arg2, s32 arg3);
+void Fighter_8006CF5C(Fighter* fp, s32 arg1);
 void Fighter_UnkSetFlag_8006CFBC(HSD_GObj* fighterObj);
 void Fighter_8006CFE0(HSD_GObj* fighterObj);
 void Fighter_UnkRecursiveFunc_8006D044(HSD_GObj* fighterObj);
@@ -2002,31 +2002,31 @@ void Fighter_UnkProcessShieldHit_8006D1EC(HSD_GObj* fighterObj);
 void Fighter_8006D9AC(HSD_GObj* fighterObj);
 void Fighter_UnkCallCameraCallback_8006D9EC(HSD_GObj* fighterObj);
 void Fighter_8006DA4C(HSD_GObj* fighterObj);
-void Fighter_Unload_8006DABC(Fighter* fighter);
+void Fighter_Unload_8006DABC(Fighter* fp);
 
 
 ///// Shared Fighter Code
 
-#define PUSH_ATTRS(ft, attributeName)                                           \
+#define PUSH_ATTRS(fp, attributeName)                                           \
     do {                                                                    \
-        void* backup = (ft)->x2D8_specialAttributes2;                      \
-        attributeName *src = (attributeName*)(ft)->x10C_ftData->ext_attr;  \
-        void* *attr = &(ft)->x2D4_specialAttributes;                       \
-        *(attributeName *)(ft)->x2D8_specialAttributes2 = *src;            \
+        void* backup = (fp)->x2D8_specialAttributes2;                      \
+        attributeName *src = (attributeName*)(fp)->x10C_ftData->ext_attr;  \
+        void* *attr = &(fp)->x2D4_specialAttributes;                       \
+        *(attributeName *)(fp)->x2D8_specialAttributes2 = *src;            \
         *attr = backup;                                                      \
     } while(0)
 
 #define COPY_ATTRS(gobj, attributeName)                                          \
-    Fighter* ft = gobj->user_data;                                               \
-    attributeName* sA2 = (attributeName*)ft->x2D4_specialAttributes;             \
-    attributeName* ext_attr = (attributeName*)ft->x10C_ftData->ext_attr;         \
+    Fighter* fp = gobj->user_data;                                               \
+    attributeName* sA2 = (attributeName*)fp->x2D4_specialAttributes;             \
+    attributeName* ext_attr = (attributeName*)fp->x10C_ftData->ext_attr;         \
     *sA2 = *ext_attr;                                                            \
 
 #define SCALE_HEIGHT_ATTRS(num_attrs)                     \
     {                                                     \
         int i;                                            \
         for (i = 0; i < num_attrs; i++) {                 \
-            sA2->height_attributes[i] *= ft->x34_scale.y; \
+            sA2->height_attributes[i] *= fp->x34_scale.y; \
         }                                                 \
     }  \
 
@@ -2034,9 +2034,9 @@ void Fighter_Unload_8006DABC(Fighter* fighter);
 // Works but unused decided to go with inline instead 
 #define MACRO_ft_OnItemPickup(FTNAME, param1, param2)                             \
     void FTNAME##_OnItemPickup(HSD_GObj* fighterObj, BOOL bool) {                 \
-        Fighter *fighter = getFighter(fighterObj);                                \
-        if (!func_8026B2B4(fighter->x1974_heldItem)) {                            \
-            switch (func_8026B320(fighter->x1974_heldItem)) {                     \
+        Fighter *fp = getFighter(fighterObj);                                \
+        if (!func_8026B2B4(fp->x1974_heldItem)) {                            \
+            switch (func_8026B320(fp->x1974_heldItem)) {                     \
                 case 1:                                                           \
                     func_80070FB4(fighterObj, param1, 1);                         \
                     break;                                                        \
@@ -2058,9 +2058,9 @@ void Fighter_Unload_8006DABC(Fighter* fighter);
 
 /// used for all fighters except Kirby and Purin
 inline void Fighter_OnItemPickup(HSD_GObj* fighterObj, BOOL catchItemFlag, BOOL bool2, BOOL bool3) {
-    Fighter *fighter = getFighter(fighterObj);            
-    if (!func_8026B2B4(fighter->x1974_heldItem)) {        
-        switch (func_8026B320(fighter->x1974_heldItem)) { 
+    Fighter *fp = getFighter(fighterObj);            
+    if (!func_8026B2B4(fp->x1974_heldItem)) {        
+        switch (func_8026B320(fp->x1974_heldItem)) { 
             case 1:                                       
                 func_80070FB4(fighterObj, bool2, 1);     
                 break;                                    
@@ -2082,16 +2082,16 @@ inline void Fighter_OnItemPickup(HSD_GObj* fighterObj, BOOL catchItemFlag, BOOL 
 
 inline void Fighter_OnItemInvisible(HSD_GObj* gobj, BOOL bool)
 {
-    Fighter* ft = getFighter(gobj);
-    if (!func_8026B2B4(ft->x1974_heldItem)) {
+    Fighter* fp = getFighter(gobj);
+    if (!func_8026B2B4(fp->x1974_heldItem)) {
         func_80070CC4(gobj, bool);
     }
 }
 
 inline void Fighter_OnItemVisible(HSD_GObj* gobj, BOOL bool)
 {
-    Fighter* ft = getFighter(gobj);
-    if (!func_8026B2B4(ft->x1974_heldItem)) {
+    Fighter* fp = getFighter(gobj);
+    if (!func_8026B2B4(fp->x1974_heldItem)) {
         func_80070C48(gobj, bool);
     }
 }
@@ -2115,8 +2115,8 @@ inline void Fighter_OnKnockbackExit(HSD_GObj* gobj, s32 arg1) {
 }
 
 inline void Fighter_UnsetCmdVar0(HSD_GObj* fighterObj) {
-    Fighter* fighter = getFighter(fighterObj);
-    fighter->x2200_ftcmd_var0 = 0;
+    Fighter* fp = getFighter(fighterObj);
+    fp->x2200_ftcmd_var0 = 0;
 }
 
 #endif

--- a/src/melee/ft/ftbosslib.c
+++ b/src/melee/ft/ftbosslib.c
@@ -31,8 +31,8 @@ void func_8015BD24(s32 arg0, f32* arg1, f32 arg2, s32 arg3, s32 arg4, s32 arg5) 
 }
 
 void func_8015BDB4(HSD_GObj* arg0) {
-    Fighter *ft = arg0->user_data;
-    Gm_PKind kind = Player_GetPlayerSlotType(ft->xC_playerID);
+    Fighter *fp = arg0->user_data;
+    Gm_PKind kind = Player_GetPlayerSlotType(fp->xC_playerID);
     { // TODO: assert macro
         BOOL bad = (kind == Gm_PKind_Human || kind == Gm_PKind_Boss || kind == Gm_PKind_Cpu);
         if (!bad) {
@@ -68,12 +68,12 @@ static inline float my_lbvector_Len(Vec3 *vec)
 }
 
 void func_8015BE40(HSD_GObj* gobj, Point3d* arg1, f32* arg2, f32 arg3, f32 arg4) {
-    Fighter* ft;
+    Fighter* fp;
     Vec3 diff;
     f32 distance;
 
-    ft = gobj->user_data;
-    lbvector_Diff(arg1, &ft->xB0_pos, &diff); // third argument is result
+    fp = gobj->user_data;
+    lbvector_Diff(arg1, &fp->xB0_pos, &diff); // third argument is result
     distance = my_lbvector_Len(&diff);
     if (distance < arg3) {
         *arg2 = 0.0f;
@@ -84,20 +84,20 @@ void func_8015BE40(HSD_GObj* gobj, Point3d* arg1, f32* arg2, f32 arg3, f32 arg4)
         diff.y *= distance * arg4;
         diff.z *= distance * arg4;
     }
-    ft->x80_self_vel.x = diff.x;
-    ft->x80_self_vel.y = diff.y;
+    fp->x80_self_vel.x = diff.x;
+    fp->x80_self_vel.y = diff.y;
 }
 
 void func_8015BF74(HSD_GObj* arg0, f32 arg1) {
     Vec3 sp14;
-    Fighter* ft;
+    Fighter* fp;
     f32 temp_f1;
     f32 phi_f0;
     f32 phi_f1;
 
-    ft = arg0->user_data;
+    fp = arg0->user_data;
     func_8015C208(arg0, &sp14);
-    temp_f1 = sp14.x - ft->xB0_pos.x;
+    temp_f1 = sp14.x - fp->xB0_pos.x;
     phi_f0 = fabs_inline(temp_f1);
     if (phi_f0 > arg1) {
         if (temp_f1 > get_zero()) { //float reorder hack
@@ -105,22 +105,22 @@ void func_8015BF74(HSD_GObj* arg0, f32 arg1) {
         } else {
             phi_f1 = -arg1;
         }
-        ft->x80_self_vel.x += phi_f1;
+        fp->x80_self_vel.x += phi_f1;
     } else {
-        ft->x80_self_vel.x += temp_f1;
+        fp->x80_self_vel.x += temp_f1;
     }
 }
 
 void func_8015C010(HSD_GObj* arg0, f32 arg1) {
     Vec3 sp14;
-    Fighter* ft;
+    Fighter* fp;
     f32 temp_f1;
     f32 phi_f0;
     f32 phi_f0_2;
 
-    ft = arg0->user_data;
+    fp = arg0->user_data;
     func_8015C208(arg0, &sp14);
-    temp_f1 = sp14.x - ft->xB0_pos.x;
+    temp_f1 = sp14.x - fp->xB0_pos.x;
     phi_f0 = fabs_inline(temp_f1);
     if (phi_f0 > arg1) {
         if (temp_f1 > 0.0f) {
@@ -128,46 +128,46 @@ void func_8015C010(HSD_GObj* arg0, f32 arg1) {
         } else {
             phi_f0_2 = -arg1;
         }
-        ft->x80_self_vel.x = phi_f0_2;
+        fp->x80_self_vel.x = phi_f0_2;
     } else {
-        ft->x80_self_vel.x = temp_f1;
+        fp->x80_self_vel.x = temp_f1;
     }
 }
 
 void func_8015C09C(HSD_GObj* arg0, f32 arg1) {
     HSD_JObj* jobj = arg0->hsd_obj;
-    Fighter* ft = arg0->user_data;
+    Fighter* fp = arg0->user_data;
     Quaternion quat = {0};
     s32 unused[2];
 
-    ft->x2C_facing_direction = arg1;
-    quat.y = M_PI/2 * ft->x2C_facing_direction;
+    fp->x2C_facing_direction = arg1;
+    quat.y = M_PI/2 * fp->x2C_facing_direction;
     HSD_JObjSetRotation(jobj, &quat);
 }
 
 void func_8015C190(HSD_GObj* arg0) {
-    Fighter* ft;
+    Fighter* fp;
     s32 unused1;
     Vec3 sp10;
     s32 unused2;
 
-    ft = arg0->user_data;
+    fp = arg0->user_data;
     func_80053FF4(0, &sp10);
-    if (ft->xB0_pos.x > sp10.x) {
-        ft->xB0_pos.x = sp10.x;
-        ft->x80_self_vel.x = 0.0f;
+    if (fp->xB0_pos.x > sp10.x) {
+        fp->xB0_pos.x = sp10.x;
+        fp->x80_self_vel.x = 0.0f;
     }
     func_80054158(0, &sp10);
-    if (ft->xB0_pos.x < sp10.x) {
-        ft->xB0_pos.x = sp10.x;
-        ft->x80_self_vel.x = 0.0f;
+    if (fp->xB0_pos.x < sp10.x) {
+        fp->xB0_pos.x = sp10.x;
+        fp->x80_self_vel.x = 0.0f;
     }
 }
 
 void func_8015C208(HSD_GObj* arg0, Vec3* arg1) {
     s32 unused;
-    Fighter* ft = arg0->user_data;
-    HSD_GObj* gobj = func_8015C244(arg0, &ft->xB0_pos);
+    Fighter* fp = arg0->user_data;
+    HSD_GObj* gobj = func_8015C244(arg0, &fp->xB0_pos);
     func_80086644(gobj, arg1);
 }
 
@@ -285,37 +285,37 @@ s32 func_8015C530(u32 arg0) {
 }
 
 void func_8015C5F8(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     switch (HSD_Randi(4)) {
     case 0:
-        func_80088148(ft, 0x4E21A, 0x7F, 0x40); // SFX_PlayCharacterSFX
+        func_80088148(fp, 0x4E21A, 0x7F, 0x40); // SFX_PlayCharacterSFX
         return;
     case 1:
-        func_80088148(ft, 0x4E21B, 0x7F, 0x40); // SFX_PlayCharacterSFX
+        func_80088148(fp, 0x4E21B, 0x7F, 0x40); // SFX_PlayCharacterSFX
         return;
     case 2:
-        func_80088148(ft, 0x4E21C, 0x7F, 0x40); // SFX_PlayCharacterSFX
+        func_80088148(fp, 0x4E21C, 0x7F, 0x40); // SFX_PlayCharacterSFX
         return;
     case 3:
-        func_80088148(ft, 0x4E21D, 0x7F, 0x40); // SFX_PlayCharacterSFX
+        func_80088148(fp, 0x4E21D, 0x7F, 0x40); // SFX_PlayCharacterSFX
         return;
     }
 }
 
 MasterHandAttributes* func_8015C6BC(void) {
     HSD_GObj* gobj = func_8015C3E8(FTKIND_MASTERH);
-    Fighter* ft;
+    Fighter* fp;
     MasterHandAttributes* attr;
     s32 unused[4];
 
     if (!gobj) {
         return 0;
     }
-    ft = gobj->user_data;
-    if (!ft) {
+    fp = gobj->user_data;
+    if (!fp) {
         return 0;
     }
-    attr = ft->x10C_ftData->ext_attr;
+    attr = fp->x10C_ftData->ext_attr;
     if (!attr) {
         return 0;
     }

--- a/src/melee/ft/ftcamera.c
+++ b/src/melee/ft/ftcamera.c
@@ -15,15 +15,15 @@ void func_80076018(UnkFloat6_Camera* in, UnkFloat6_Camera* out, f32 mul) {
 }
 
 // Camera_CopyPlayerPositionToCameraBoxPosition
-void func_80076064(Fighter* ft) {
+void func_80076064(Fighter* fp) {
     CameraBox* camera_box;
     UnkFloat6_Camera* ftData_floats;
     UnkFloat6_Camera spC;
 
-    camera_box = ft->x890_cameraBox;
-    func_80076018(ft->x10C_ftData->x3C, &spC, ft->x34_scale.y);
+    camera_box = fp->x890_cameraBox;
+    func_80076018(fp->x10C_ftData->x3C, &spC, fp->x34_scale.y);
     camera_box->x8 = 0;
-    if (ft->x2C_facing_direction == 1.0f) {
+    if (fp->x2C_facing_direction == 1.0f) {
         camera_box->x40.x = spC.x0.z;
         camera_box->x40.y = spC.x0.y * Stage_GetCamFixedZoom();
         camera_box->x28 = 1.0f;
@@ -38,25 +38,25 @@ void func_80076064(Fighter* ft) {
     camera_box->x48.z = spC.xC.z;
     camera_box->x2C = camera_box->x40;
     camera_box->x34 = camera_box->x48;
-    camera_box->x10.x = ft->xB0_pos.x;
-    camera_box->x10.y = ft->xB0_pos.y + spC.x0.x;
-    camera_box->x10.z = ft->xB0_pos.z;
+    camera_box->x10.x = fp->xB0_pos.x;
+    camera_box->x10.y = fp->xB0_pos.y + spC.x0.x;
+    camera_box->x10.z = fp->xB0_pos.z;
     camera_box->x1C = camera_box->x10;
 }
 
 // Fighter_UpdateCameraBox
 // Camera_UpdatePlayerCameraBoxPosition
 void func_800761C8(HSD_GObj* gobj) {
-    Fighter* ft;
+    Fighter* fp;
     CameraBox* camera_box;
     UnkFloat6_Camera sp10;
     s32 unused;
 
-    ft = gobj->user_data;
-    camera_box = ft->x890_cameraBox;
-    ft->x2C_facing_direction + 1.0f; // lol
-    func_80076018(ft->x10C_ftData->x3C, &sp10, ft->x34_scale.y);
-    if (ft->x2C_facing_direction == 1.0f) {
+    fp = gobj->user_data;
+    camera_box = fp->x890_cameraBox;
+    fp->x2C_facing_direction + 1.0f; // lol
+    func_80076018(fp->x10C_ftData->x3C, &sp10, fp->x34_scale.y);
+    if (fp->x2C_facing_direction == 1.0f) {
         camera_box->x40.x = sp10.x0.z;
         camera_box->x40.y = sp10.x0.y * Stage_GetCamFixedZoom();
         camera_box->x28 = 1.0f;
@@ -66,26 +66,26 @@ void func_800761C8(HSD_GObj* gobj) {
         camera_box->x28 = -1.0f;
     }
     sp10.xC; //this line changes everything lol
-    camera_box->x10.x = ft->xB0_pos.x;
-    camera_box->x10.y = ft->xB0_pos.y + sp10.x0.x;
-    camera_box->x10.z = ft->xB0_pos.z;
+    camera_box->x10.x = fp->xB0_pos.x;
+    camera_box->x10.y = fp->xB0_pos.y + sp10.x0.x;
+    camera_box->x10.z = fp->xB0_pos.z;
     camera_box->xC_flag.bits.b0 = 0;
     func_800866DC(gobj, &camera_box->x1C); // Fighter_GetCameraBonePos
 }
 
 void func_800762F4(HSD_GObj* gobj) {
-    Fighter* ft = gobj->user_data;
-    func_800866DC(gobj, &ft->x890_cameraBox->x1C);
+    Fighter* fp = gobj->user_data;
+    func_800866DC(gobj, &fp->x890_cameraBox->x1C);
 }
 
 void func_80076320(HSD_GObj* gobj) {
     Vec3 center_pos;
-    Fighter* ft = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     CameraBox* camera_box;
     f32 temp_f1;
     f32 temp_f31;
 
-    camera_box = ft->x890_cameraBox;
+    camera_box = fp->x890_cameraBox;
     func_800761C8(gobj); // Fighter_UpdateCameraBox
     Stage_UnkSetVec3TCam_Offset(&center_pos);
 

--- a/src/melee/ft/ftcliffcommon.c
+++ b/src/melee/ft/ftcliffcommon.c
@@ -3,25 +3,25 @@
 #include <dolphin/types.h>
 
 BOOL func_80081298(HSD_GObj* gobj) {
-    Fighter* other_fighter;
+    Fighter* other_fp;
     HSD_GObj* other_gobj;
     s32 unused1, unused2;
 
-    Fighter* fighter = gobj->user_data;
-    if (fighter->input.x624_lstick_y <= -p_ftCommonData->x480) {
+    Fighter* fp = gobj->user_data;
+    if (fp->input.x624_lstick_y <= -p_ftCommonData->x480) {
         return FALSE;
     }
-    if (((fighter->x6F0_collData.x134_envFlags & 0x03000000) != 0)
-        && (((fighter->x2228_flag.bits.b2 & 1) == 0))) {
+    if (((fp->x6F0_collData.x134_envFlags & 0x03000000) != 0)
+        && (((fp->x2228_flag.bits.b2 & 1) == 0))) {
         other_gobj = func_80082E3C(gobj);
         if (other_gobj == NULL) {
-            func_80040048(fighter->xC_playerID, fighter->x221F_flag.bits.b4);
+            func_80040048(fp->xC_playerID, fp->x221F_flag.bits.b4);
             func_80081370(gobj);
             return TRUE;
         }
-        other_fighter = other_gobj->user_data;
-        func_8003FFDC(other_fighter->xC_playerID, other_fighter->x221F_flag.bits.b4, fighter->xC_playerID, fighter->x221F_flag.bits.b4, other_fighter->commonVars[0].cliffCommon.ledgeID);
-        fighter->x213C = other_fighter->commonVars[0].cliffCommon.ledgeID;
+        other_fp = other_gobj->user_data;
+        func_8003FFDC(other_fp->xC_playerID, other_fp->x221F_flag.bits.b4, fp->xC_playerID, fp->x221F_flag.bits.b4, other_fp->commonVars[0].cliffCommon.ledgeID);
+        fp->x213C = other_fp->commonVars[0].cliffCommon.ledgeID;
         return FALSE;
     }
     return FALSE;
@@ -37,45 +37,45 @@ void func_80081370(HSD_GObj* gobj) {
     f32 facingDirection;
     f32 ledgeDirection;
 
-    Fighter* fighter = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     UnkParameterStruct unkParam;
 
-    if ((fighter->x6F0_collData.x134_envFlags & 0x01000000) != 0) {
+    if ((fp->x6F0_collData.x134_envFlags & 0x01000000) != 0) {
         ledgeDirection = 1.0f;
     } else {
         ledgeDirection = -1.0f;
     }
-    facingDirection = fighter->x2C_facing_direction;
+    facingDirection = fp->x2C_facing_direction;
     if (facingDirection != ledgeDirection) {
-        fighter->x2C_facing_direction = -facingDirection;
+        fp->x2C_facing_direction = -facingDirection;
     }
-    func_8007D780(fighter);
-    func_8007D5D4(fighter);
+    func_8007D780(fp);
+    func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(gobj, 0xFC, 0, NULL, 0.0f, 1.0f, 0.0f);
     func_8006EBA4(gobj);
-    func_8007D5D4(fighter);
-    func_8007EFC0(fighter, p_ftCommonData->x5F0);
+    func_8007D5D4(fp);
+    func_8007EFC0(fp, p_ftCommonData->x5F0);
     func_8007E2FC(gobj);
-    fighter->x221D_flag.bits.b7 = 1;
-    if (fighter->x2C_facing_direction > 0.0f) {
-        fighter->commonVars[0].cliffCommon.ledgeID = fighter->x6F0_collData.x44;
+    fp->x221D_flag.bits.b7 = 1;
+    if (fp->x2C_facing_direction > 0.0f) {
+        fp->commonVars[0].cliffCommon.ledgeID = fp->x6F0_collData.x44;
     } else {
-        fighter->commonVars[0].cliffCommon.ledgeID = fighter->x6F0_collData.x40;
+        fp->commonVars[0].cliffCommon.ledgeID = fp->x6F0_collData.x40;
     }
     func_80081544(gobj);
-    func_800881D8(fighter, fighter->x10C_ftData->x4C_collisionData->x28, 0x7F, 0x40);
-    func_8007E2F4(fighter, 0x1FF);
-    func_8007EBAC(fighter, 0xC, 0);
+    func_800881D8(fp, fp->x10C_ftData->x4C_collisionData->x28, 0x7F, 0x40);
+    func_8007E2F4(fp, 0x1FF);
+    func_8007EBAC(fp, 0xC, 0);
 
-    if (fighter->x2C_facing_direction > 0.0f) {
-        func_80053ECC(fighter->commonVars[0].cliffCommon.ledgeID, unkParam.x10);
+    if (fp->x2C_facing_direction > 0.0f) {
+        func_80053ECC(fp->commonVars[0].cliffCommon.ledgeID, unkParam.x10);
     }
     else
     {
-        func_80053DA4(fighter->commonVars[0].cliffCommon.ledgeID, unkParam.x10);
+        func_80053DA4(fp->commonVars[0].cliffCommon.ledgeID, unkParam.x10);
     }
     efAsync_Spawn(gobj, (void*) ((u32) gobj->user_data + 0x60C), 2, 0x41C, 0, &unkParam.x10);
-    func_80088148(fighter, 4, 0x7F, 0x40);
+    func_80088148(fp, 4, 0x7F, 0x40);
 }
 
 void func_80081504(HSD_GObj* gobj)
@@ -93,40 +93,40 @@ void func_80081544(HSD_GObj* gobj) {
     f32 sp10[2];
     s32 dummy2[1];
 
-    Fighter* fighter = gobj->user_data;
-    if (func_80054ED8(fighter->commonVars[0].cliffCommon.ledgeID) != 0) {
-        if (fighter->x2C_facing_direction > 0.0f) {
-            func_80053ECC(fighter->commonVars[0].cliffCommon.ledgeID, sp10);
+    Fighter* fp = gobj->user_data;
+    if (func_80054ED8(fp->commonVars[0].cliffCommon.ledgeID) != 0) {
+        if (fp->x2C_facing_direction > 0.0f) {
+            func_80053ECC(fp->commonVars[0].cliffCommon.ledgeID, sp10);
         } else {
-            func_80053DA4(fighter->commonVars[0].cliffCommon.ledgeID, sp10);
+            func_80053DA4(fp->commonVars[0].cliffCommon.ledgeID, sp10);
         }
-        fighter->xB0_pos.x = (f32) ((fighter->x68C_transNPos.z * fighter->x2C_facing_direction) + sp10[0]);
-        fighter->xB0_pos.y = (f32) (sp10[1] + fighter->x68C_transNPos.y);
+        fp->xB0_pos.x = (f32) ((fp->x68C_transNPos.z * fp->x2C_facing_direction) + sp10[0]);
+        fp->xB0_pos.y = (f32) (sp10[1] + fp->x68C_transNPos.y);
         return;
     }
     func_800CC730(gobj);
 }
 
 void func_800815E4(HSD_GObj* gobj) {
-    Fighter* fighter;
+    Fighter* fp;
     s32 unused1, unused2;
     if (func_800821DC() != 0) {
         func_80082B1C(gobj);
         return;
     }
     if (func_8009EF68(gobj) != 0) {
-        fighter = gobj->user_data;
-        fighter->x2064_ledgeCooldown = p_ftCommonData->x498_ledgeCooldownTime;
+        fp = gobj->user_data;
+        fp->x2064_ledgeCooldown = p_ftCommonData->x498_ledgeCooldownTime;
     }
 }
 
 void func_80081644(HSD_GObj* gobj)
 {
-    Fighter* fighter = gobj->user_data;
+    Fighter* fp = gobj->user_data;
     func_800761C8();
-    if ((s32) fighter->xE0_ground_or_air == GA_Air)
+    if ((s32) fp->xE0_ground_or_air == GA_Air)
     {
-        func_8005811C(&fighter->x6F0_collData, fighter->commonVars[0].cliffCommon.ledgeID);
-        fighter->x890_cameraBox->xC_flag.bits.b0 = 1;
+        func_8005811C(&fp->x6F0_collData, fp->commonVars[0].cliffCommon.ledgeID);
+        fp->x890_cameraBox->xC_flag.bits.b0 = 1;
     }
 }

--- a/src/melee/ft/ftcoll.c
+++ b/src/melee/ft/ftcoll.c
@@ -71,7 +71,7 @@ void func_8007646C(HSD_GObj* attackItem, HSD_GObj* victim) // Combo Count Logic 
     HSD_GObj* itemOwner = func_8026BC78(attackItem);
     s32 attackID = func_8026BC84(attackItem);
 
-    if (func_80086960(itemOwner) != FALSE) // Check if item's owner is a fighter //
+    if (func_80086960(itemOwner) != FALSE) // Check if item's owner is a fp //
     {
         func_800763C0(itemOwner, victim, attackID);
     }
@@ -150,7 +150,7 @@ void func_800765AC(HSD_GObj* victim) // Clear victim pointer from attacker upon 
     Fighter* fp;
     HSD_GObj* gobj;
 
-    gobj = lbl_804D782C->x20_fighterGObj; // Get fighter GObj from global list of entities (?) //
+    gobj = lbl_804D782C->x20_fighterGObj; // Get fp GObj from global list of entities (?) //
     while (gobj != NULL)
     {
         fp = getFighter(gobj); 
@@ -158,7 +158,7 @@ void func_800765AC(HSD_GObj* victim) // Clear victim pointer from attacker upon 
         {
             fp->x2094 = NULL;
         }
-        gobj = gobj->next; // Repeat until there are no more fighter GObjs left //
+        gobj = gobj->next; // Repeat until there are no more fp GObjs left //
     }
 }
 

--- a/src/melee/ft/ftcommon.c
+++ b/src/melee/ft/ftcommon.c
@@ -142,17 +142,17 @@ void func_8007CC78(Fighter* fp, f32 max)
     }
 }
 
-void func_8007CCA0(Fighter* arg0, f32 arg1)
+void func_8007CCA0(Fighter* fp, f32 arg1)
 {
-    if (arg0->xF0_ground_kb_vel < 0) {
-        arg0->xF0_ground_kb_vel = arg0->xF0_ground_kb_vel + arg1;
-        if (arg0->xF0_ground_kb_vel > 0) {
-            arg0->xF0_ground_kb_vel = 0;
+    if (fp->xF0_ground_kb_vel < 0) {
+        fp->xF0_ground_kb_vel = fp->xF0_ground_kb_vel + arg1;
+        if (fp->xF0_ground_kb_vel > 0) {
+            fp->xF0_ground_kb_vel = 0;
         }
     } else {
-        arg0->xF0_ground_kb_vel = arg0->xF0_ground_kb_vel - arg1;
-        if (arg0->xF0_ground_kb_vel < 0) {
-            arg0->xF0_ground_kb_vel = 0;
+        fp->xF0_ground_kb_vel = fp->xF0_ground_kb_vel - arg1;
+        if (fp->xF0_ground_kb_vel < 0) {
+            fp->xF0_ground_kb_vel = 0;
         }
     }
 }
@@ -2076,14 +2076,14 @@ void func_80080484(Fighter* fp)
     }
 }
 
-void func_800804A0(Fighter* arg0, f32 arg8)
+void func_800804A0(Fighter* fp, f32 arg8)
 {
     f32 temp_f1;
     f32 phi_f31 = arg8;
-    if ((temp_f1 = func_80084A40(arg0)) < 1) {
+    if ((temp_f1 = func_80084A40(fp)) < 1) {
         phi_f31 *= temp_f1;
     }
-    arg0->xE8_ground_accel_2 = phi_f31;
+    fp->xE8_ground_accel_2 = phi_f31;
 }
 
 f32 func_800804EC(Fighter* fp)

--- a/src/melee/ft/ftlib.c
+++ b/src/melee/ft/ftlib.c
@@ -90,7 +90,7 @@ HSD_GObj* func_80086198(HSD_GObj* gobj)
     return result;
 }
 
-// get closest opposing fighter?
+// get closest opposing fp?
 HSD_GObj* func_8008627C(Vec3* v, HSD_GObj* gobj)
 {
     Vec3 cur_v;
@@ -135,7 +135,7 @@ HSD_GObj* func_8008627C(Vec3* v, HSD_GObj* gobj)
     return result;
 }
 
-// get closest opposing fighter, on given side (left/right)
+// get closest opposing fp, on given side (left/right)
 HSD_GObj* func_80086368(Vec3* v, HSD_GObj* gobj, f32 arg8)
 {
     Vec3 sp24;

--- a/src/melee/ft/ftwalkcommon.c
+++ b/src/melee/ft/ftwalkcommon.c
@@ -1,12 +1,12 @@
 #include <fighter.h>
 
 s32 ftWalkCommon_GetWalkType_800DFBF8(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    f32 ground_vel = fighter->xEC_ground_vel;
+    Fighter* fp = fighterObj->user_data;
+    f32 ground_vel = fp->xEC_ground_vel;
     f32 walking_velocity = fabs_inline(ground_vel);
-    if (walking_velocity >= (fighter->x2360_f32 * (p_ftCommonData->x2C * fighter->x110_attr.x118_WalkMaximumVelocity))) {
+    if (walking_velocity >= (fp->x2360_f32 * (p_ftCommonData->x2C * fp->x110_attr.x118_WalkMaximumVelocity))) {
         return 2;
-    } else if (walking_velocity >= (fighter->x2360_f32 * (p_ftCommonData->x28 * fighter->x110_attr.x118_WalkMaximumVelocity))) {
+    } else if (walking_velocity >= (fp->x2360_f32 * (p_ftCommonData->x28 * fp->x110_attr.x118_WalkMaximumVelocity))) {
         return 1;
     } else {
         return 0;
@@ -14,12 +14,12 @@ s32 ftWalkCommon_GetWalkType_800DFBF8(HSD_GObj* fighterObj) {
 }
 
 inline s32 ftWalkCommon_GetWalkType_800DFBF8_fake(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    f32 walking_velocity = fabs_inline(fighter->xEC_ground_vel);
-    f32 tempf = fighter->x2360_f32;
-    if (walking_velocity >= (tempf * (p_ftCommonData->x2C * fighter->x110_attr.x118_WalkMaximumVelocity))) {
+    Fighter* fp = fighterObj->user_data;
+    f32 walking_velocity = fabs_inline(fp->xEC_ground_vel);
+    f32 tempf = fp->x2360_f32;
+    if (walking_velocity >= (tempf * (p_ftCommonData->x2C * fp->x110_attr.x118_WalkMaximumVelocity))) {
         return 2;
-    } else if (walking_velocity >= (tempf * (p_ftCommonData->x28 * fighter->x110_attr.x118_WalkMaximumVelocity))) {
+    } else if (walking_velocity >= (tempf * (p_ftCommonData->x28 * fp->x110_attr.x118_WalkMaximumVelocity))) {
         return 1;
     } else {
         return 0;
@@ -27,8 +27,8 @@ inline s32 ftWalkCommon_GetWalkType_800DFBF8_fake(HSD_GObj* fighterObj) {
 }  
 
 s32 ftWalkCommon_800DFC70(HSD_GObj* fighterObj) {
-    Fighter* fighter = fighterObj->user_data;
-    if ((fighter->input.x620_lstick_x * fighter->x2C_facing_direction) >= p_ftCommonData->x24) {
+    Fighter* fp = fighterObj->user_data;
+    if ((fp->input.x620_lstick_x * fp->x2C_facing_direction) >= p_ftCommonData->x24) {
         return 1;
     }
     return 0;
@@ -39,48 +39,48 @@ void ftWalkCommon_800DFCA4(HSD_GObj *fighterObj, s32 arg1, s32 arg2, f32 arg8, f
     s32 unused[3];
     s32 new_action_state;
     s32 walking_state;
-    Fighter *fighter;
-    fighter = getFighterPlus(fighterObj);
-    fighter->x2360_f32 = argF;
+    Fighter *fp;
+    fp = getFighterPlus(fighterObj);
+    fp->x2360_f32 = argF;
     walking_state = ftWalkCommon_GetWalkType_800DFBF8_fake(fighterObj);
     new_action_state = arg1 + walking_state;
     Fighter_ActionStateChange_800693AC(fighterObj, new_action_state, arg2, 0, arg8, 1.0f, 0.0f);
     func_8006EBA4(fighterObj);
-    fighter->x2340_f32 = fighter->xEC_ground_vel;
-    fighter->x2344_stateVar2_s32 = arg1;
-    fighter->x2348_stateVar3_f32 = arg9;
-    fighter->x234C_stateVar4_f32 = argA;
-    fighter->x2350_stateVar5_f32 = argB;
-    fighter->x2354_stateVar6_f32 = argC;
-    fighter->x2358_stateVar7 = argD;
-    fighter->x235C_f32 = argE;
+    fp->x2340_f32 = fp->xEC_ground_vel;
+    fp->x2344_stateVar2_s32 = arg1;
+    fp->x2348_stateVar3_f32 = arg9;
+    fp->x234C_stateVar4_f32 = argA;
+    fp->x2350_stateVar5_f32 = argB;
+    fp->x2354_stateVar6_f32 = argC;
+    fp->x2358_stateVar7 = argD;
+    fp->x235C_f32 = argE;
 }
 
 void ftWalkCommon_800DFDDC(HSD_GObj* fighterObj) {
     f32 velocity_f2;
     f32 anim_rate;
     
-    Fighter* fighter = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
     
-    if (func_80084A40(fighter) < 1.0f) {
-        velocity_f2 = fighter->x2340_f32;
+    if (func_80084A40(fp) < 1.0f) {
+        velocity_f2 = fp->x2340_f32;
     } else {
-        velocity_f2 = fighter->xEC_ground_vel;
+        velocity_f2 = fp->xEC_ground_vel;
     }
-    if ((velocity_f2 * fighter->x2C_facing_direction) <= 0.0f) {
+    if ((velocity_f2 * fp->x2C_facing_direction) <= 0.0f) {
         anim_rate = 0.0f;
     } else {
 
         velocity_f2 = fabs_inline(velocity_f2);
-        switch (fighter->x10_action_state_index - fighter->x2344_stateVar2) {  
+        switch (fp->x10_action_state_index - fp->x2344_stateVar2) {  
             case 0:
-                anim_rate = velocity_f2 / fighter->x234C_pos.z;
+                anim_rate = velocity_f2 / fp->x234C_pos.z;
                 break;
             case 1:
-                anim_rate = velocity_f2 / fighter->x2358_stateVar7;
+                anim_rate = velocity_f2 / fp->x2358_stateVar7;
                 break;
             case 2:
-                anim_rate = velocity_f2 / fighter->x235C;
+                anim_rate = velocity_f2 / fp->x235C;
                 break;
         }
     }
@@ -90,13 +90,13 @@ void ftWalkCommon_800DFDDC(HSD_GObj* fighterObj) {
 void ftWalkCommon_800DFEC8(HSD_GObj* fighterObj, void (*arg_cb)(HSD_GObj*, f32)) {
     s32 action_state_sum;
     s32 action_state_base;
-    Fighter* fighter = getFighter(fighterObj);
+    Fighter* fp = getFighter(fighterObj);
     s32 walk_action_type = ftWalkCommon_GetWalkType_800DFBF8_fake(fighterObj);
 
 
-    action_state_base = fighter->x2344_stateVar2_s32;
+    action_state_base = fp->x2344_stateVar2_s32;
     action_state_sum = action_state_base + walk_action_type;
-    if (action_state_sum != fighter->x10_action_state_index) { 
+    if (action_state_sum != fp->x10_action_state_index) { 
         f32 float_result;
         f32 var_f31;
         f32 init_animFrame;
@@ -106,13 +106,13 @@ void ftWalkCommon_800DFEC8(HSD_GObj* fighterObj, void (*arg_cb)(HSD_GObj*, f32))
         
         switch (action_state_sum - action_state_base) {                   
             case 0:
-                var_f31 = fighter->x2348_stateVar3_f32;
+                var_f31 = fp->x2348_stateVar3_f32;
                 break;
             case 1:
-                var_f31 = fighter->x234C_stateVar4_f32;
+                var_f31 = fp->x234C_stateVar4_f32;
                 break;
             case 2:
-                var_f31 = fighter->x2350_stateVar5_f32;
+                var_f31 = fp->x2350_stateVar5_f32;
                 break;
             default:
                 OSReport("couldn't get walk frame\n");
@@ -120,43 +120,43 @@ void ftWalkCommon_800DFEC8(HSD_GObj* fighterObj, void (*arg_cb)(HSD_GObj*, f32))
                 break;
         }
         float_result = func_8006F484(fighterObj);
-        init_animFrame = fighter->x894_currentAnimFrame;
+        init_animFrame = fp->x894_currentAnimFrame;
         quotient = init_animFrame / float_result;
-        adjusted_animFrame = fighter->x894_currentAnimFrame - (float_result * quotient);
+        adjusted_animFrame = fp->x894_currentAnimFrame - (float_result * quotient);
         final_animFrame = var_f31 * (adjusted_animFrame / float_result);
         arg_cb(fighterObj, final_animFrame);
     }
 }
 
-inline f32 getFtWalkAcceleration(Fighter* fighter, f32 multiplier) {
-    if (fighter->input.x620_lstick_x > 0.0f) { 
-        return multiplier * fighter->x110_attr.x114_WalkAcceleration;
+inline f32 getFtWalkAcceleration(Fighter* fp, f32 multiplier) {
+    if (fp->input.x620_lstick_x > 0.0f) { 
+        return multiplier * fp->x110_attr.x114_WalkAcceleration;
     } else {
-        return multiplier * -fighter->x110_attr.x114_WalkAcceleration;
+        return multiplier * -fp->x110_attr.x114_WalkAcceleration;
     }
 } 
  
 void ftWalkCommon_800E0060(HSD_GObj* fighterObj) {
     s32 unused[5];
-    Fighter* fighter;
+    Fighter* fp;
     f32 temp_f0;
     f32 temp_f4;
     f32 ftx2360_f5;
     f32 velocity_f1; 
     f32 unused_float;
  
-    fighter = fighterObj->user_data;
-    unused_float = ftx2360_f5 = fighter->x2360_f32;
-    velocity_f1 = fighter->input.x620_lstick_x * fighter->x110_attr.x110_WalkInitialVelocity * ftx2360_f5;
-    velocity_f1 += getFtWalkAcceleration(fighter, ftx2360_f5); 
-    temp_f0 = (fighter->input.x620_lstick_x * fighter->x110_attr.x118_WalkMaximumVelocity) * ftx2360_f5;
+    fp = fighterObj->user_data;
+    unused_float = ftx2360_f5 = fp->x2360_f32;
+    velocity_f1 = fp->input.x620_lstick_x * fp->x110_attr.x110_WalkInitialVelocity * ftx2360_f5;
+    velocity_f1 += getFtWalkAcceleration(fp, ftx2360_f5); 
+    temp_f0 = (fp->input.x620_lstick_x * fp->x110_attr.x118_WalkMaximumVelocity) * ftx2360_f5;
     if (temp_f0) {
-        temp_f4 = fighter->xEC_ground_vel / temp_f0;
+        temp_f4 = fp->xEC_ground_vel / temp_f0;
         if (temp_f4 > 0.0f && temp_f4 < 1.0f) {
             velocity_f1 *= (1.0f - temp_f4) * p_ftCommonData->x30;
         }
     }
-    fighter->x2340_f32 = temp_f0 * p_ftCommonData->x440;
-    func_8007C98C(fighter, velocity_f1, temp_f0, fighter->x110_attr.x128_GroundFriction);
+    fp->x2340_f32 = temp_f0 * p_ftCommonData->x440;
+    func_8007C98C(fp, velocity_f1, temp_f0, fp->x110_attr.x128_GroundFriction);
     func_8007CB74(fighterObj);
 }

--- a/src/melee/ft/ftwalljump.c
+++ b/src/melee/ft/ftwalljump.c
@@ -12,7 +12,7 @@ extern ftCommonData* p_ftCommonData; // defined in fighter.s
 // @Returns: true if this function started a walljump
 BOOL func_8008169C(HSD_GObj* pPlayerEntityStruct/*r3*/)
 {
-    Fighter* pCharData_r31 = (Fighter*) pPlayerEntityStruct->user_data;
+    Fighter* fp_r31 = (Fighter*) pPlayerEntityStruct->user_data;
     CollData* pCollData_r6;
     s32 wallSideFlag_r0;
     f32 deltaX_f1;
@@ -23,10 +23,10 @@ BOOL func_8008169C(HSD_GObj* pPlayerEntityStruct/*r3*/)
     s32 dummy3[3];
 
 	// is a walljump character? is airborne?
-    if (pCharData_r31->x2224_flag.bits.b7)
+    if (fp_r31->x2224_flag.bits.b7)
     {
-        pCollData_r6 = &pCharData_r31->x6F0_collData;
-        if ((pCharData_r31->x6F0_collData.x134_envFlags & 0x800) || (pCollData_r6->x134_envFlags & 0x20))
+        pCollData_r6 = &fp_r31->x6F0_collData;
+        if ((fp_r31->x6F0_collData.x134_envFlags & 0x800) || (pCollData_r6->x134_envFlags & 0x20))
         {
             wallSideFlag_r0 = pCollData_r6->x134_envFlags & 0x800;
             wallSide_f31 = wallSideFlag_r0 ? -1.0f : 1.0f; // side of the collision?
@@ -34,9 +34,9 @@ BOOL func_8008169C(HSD_GObj* pPlayerEntityStruct/*r3*/)
 			// x210C_walljumpInputTimer = some walljump animation/input timer?
 			// is initialized in the else-block when the user does the right inputs.
 			// gets incremented here every frame.
-            if ((pCharData_r31->x210C_walljumpInputTimer < MAX_WALLJUMP_INPUT_FRAMES) && (wallSide_f31 == pCharData_r31->x2110_walljumpWallSide))
+            if ((fp_r31->x210C_walljumpInputTimer < MAX_WALLJUMP_INPUT_FRAMES) && (wallSide_f31 == fp_r31->x2110_walljumpWallSide))
             {
-                pCharData_r31->x210C_walljumpInputTimer++;
+                fp_r31->x210C_walljumpInputTimer++;
             }
             else
             {
@@ -46,9 +46,9 @@ BOOL func_8008169C(HSD_GObj* pPlayerEntityStruct/*r3*/)
                     ecb_sp18.x = pCollData_r6->xBC_ecbCurrCorrect_left.x;
                     ecb_sp18.y = pCollData_r6->xBC_ecbCurrCorrect_left.y;
                     ecb_sp18.z = 0.0f;
-                    ecb_sp18.x += pCharData_r31->xB0_pos.x;
-                    ecb_sp18.y += pCharData_r31->xB0_pos.y;
-                    ecb_sp18.z += pCharData_r31->xB0_pos.z;
+                    ecb_sp18.x += fp_r31->xB0_pos.x;
+                    ecb_sp18.y += fp_r31->xB0_pos.y;
+                    ecb_sp18.z += fp_r31->xB0_pos.z;
 					// compute distance to the wall?
                     if (!func_800567C0(pCollData_r6->x174_leftwall_index, &ecb_sp18, &wallPos_sp24))
                         wallPos_sp24.x = 0.0f;
@@ -59,44 +59,44 @@ BOOL func_8008169C(HSD_GObj* pPlayerEntityStruct/*r3*/)
                     ecb_sp18.x = pCollData_r6->xB4_ecbCurrCorrect_right.x;
                     ecb_sp18.y = pCollData_r6->xB4_ecbCurrCorrect_right.y;
                     ecb_sp18.z = 0.0f;
-                    ecb_sp18.x += pCharData_r31->xB0_pos.x;
-                    ecb_sp18.y += pCharData_r31->xB0_pos.y;
-                    ecb_sp18.z += pCharData_r31->xB0_pos.z;
+                    ecb_sp18.x += fp_r31->xB0_pos.x;
+                    ecb_sp18.y += fp_r31->xB0_pos.y;
+                    ecb_sp18.z += fp_r31->xB0_pos.z;
 					// compute distance to the wall?
                     if (!func_800567C0(pCollData_r6->x160_rightwall_index, &ecb_sp18, &wallPos_sp24))
                         wallPos_sp24.x = 0.0f;
                 }
 				// not sure what this computes, I guess it checks if we are close to the wall and move towards it with sufficent speed
-                deltaX_f1 = pCharData_r31->xC8_pos_delta.x - wallPos_sp24.x;
+                deltaX_f1 = fp_r31->xC8_pos_delta.x - wallPos_sp24.x;
                 deltaX_f1 = (deltaX_f1 < 0.0f) ? -deltaX_f1 : deltaX_f1;
-                if (deltaX_f1 > pCharData_r31->x110_attr.x258)
+                if (deltaX_f1 > fp_r31->x110_attr.x258)
                 {
 					// walljump input phase one completed, now start the walljump input timer
 					// and check for the control stick movement away from the wall in the next phase
-                    pCharData_r31->x2110_walljumpWallSide = wallSide_f31;
-                    pCharData_r31->x210C_walljumpInputTimer = 0U;
+                    fp_r31->x2110_walljumpWallSide = wallSide_f31;
+                    fp_r31->x210C_walljumpInputTimer = 0U;
                 }
             }
             if (
-                    (f32)pCharData_r31->x210C_walljumpInputTimer < p_ftcommon_r4->x768 && // walljump timer within limits?
+                    (f32)fp_r31->x210C_walljumpInputTimer < p_ftcommon_r4->x768 && // walljump timer within limits?
                     (
-                        (pCharData_r31->x2110_walljumpWallSide == -1.0f && pCharData_r31->input.x620_lstick_x >=  p_ftcommon_r4->x76C) || // left wall & control stick right?
-                        (pCharData_r31->x2110_walljumpWallSide ==  1.0f && pCharData_r31->input.x620_lstick_x <= -p_ftcommon_r4->x76C)    // right wal & control stick left?
+                        (fp_r31->x2110_walljumpWallSide == -1.0f && fp_r31->input.x620_lstick_x >=  p_ftcommon_r4->x76C) || // left wall & control stick right?
+                        (fp_r31->x2110_walljumpWallSide ==  1.0f && fp_r31->input.x620_lstick_x <= -p_ftcommon_r4->x76C)    // right wal & control stick left?
                     )
-                    && (f32)pCharData_r31->x670_timer_lstick_tilt_x < p_ftcommon_r4->x770 // control stick didn't stay too long in the tilt area?
+                    && (f32)fp_r31->x670_timer_lstick_tilt_x < p_ftcommon_r4->x770 // control stick didn't stay too long in the tilt area?
                 )
             {
 				// do a walljump!
-                func_800C1E64(pPlayerEntityStruct, 0xCB, p_ftcommon_r4->x774, pCharData_r31->x1969_walljumpUsed, pCharData_r31->x2110_walljumpWallSide);
-                pCharData_r31->x210C_walljumpInputTimer = MAX_WALLJUMP_INPUT_FRAMES;
-                if (pCharData_r31->x1969_walljumpUsed < 255)
-                    pCharData_r31->x1969_walljumpUsed++;
+                func_800C1E64(pPlayerEntityStruct, 0xCB, p_ftcommon_r4->x774, fp_r31->x1969_walljumpUsed, fp_r31->x2110_walljumpWallSide);
+                fp_r31->x210C_walljumpInputTimer = MAX_WALLJUMP_INPUT_FRAMES;
+                if (fp_r31->x1969_walljumpUsed < 255)
+                    fp_r31->x1969_walljumpUsed++;
                 return 1;
             }
         }
         else
         {
-            pCharData_r31->x210C_walljumpInputTimer = MAX_WALLJUMP_INPUT_FRAMES;
+            fp_r31->x210C_walljumpInputTimer = MAX_WALLJUMP_INPUT_FRAMES;
         }
     }
     return 0;

--- a/src/melee/it/item.h
+++ b/src/melee/it/item.h
@@ -72,7 +72,7 @@ struct ItemLogicTable
     s32 (*x2C_callback_OnAbsorb)(HSD_GObj* item);
     s32 (*x30_callback_OnShieldBounce)(HSD_GObj* item);
     s32 (*x34_callback_OnHitShield)(HSD_GObj* item);
-    void (*x38_callback_OnUnknown)(HSD_GObj* item, HSD_GObj* fighter);
+    void (*x38_callback_OnUnknown)(HSD_GObj* item, HSD_GObj* fp);
 };
 
 typedef struct _CameraBoxFlags
@@ -211,7 +211,7 @@ typedef struct ItemDynamicsDesc
 
 typedef struct ItemDynamics
 {
-    s32 x0_dynamics_num;            // 0x8 number of dynamic bonesets for this fighter
+    s32 x0_dynamics_num;            // 0x8 number of dynamic bonesets for this fp
     ItemDynamicsDesc* x4_dynamicsDesc; // 0x4 boneset data array (one for each boneset)
 }ItemDynamics;
 
@@ -464,7 +464,7 @@ typedef struct _Item
         f32 xCE4;                                       // 0xce4
         f32 xCE8;                                       // 0xce8
         HSD_GObj* xCEC_fighterGObj;                     // 0xcec
-        HSD_GObj* xCF0_itemGObj;                        // 0xcf0, is a fighter GObj, but is the owner of the fighter that hit the item (?)
+        HSD_GObj* xCF0_itemGObj;                        // 0xcf0, is a fp GObj, but is the owner of the fp that hit the item (?)
     } itdmg;
     HSD_GObj* xCF4_fighterGObjUnk;
     HSD_GObj* xCF8_detectGObj; // GObj that was detected by this item's inert hitbox
@@ -487,8 +487,8 @@ typedef struct _Item
         void (*xD28_callback_EnterHitlag)(HSD_GObj* item);                              // 0xd28, runs after applying hitlag in damage apply proc 8026a62c
         void (*xD2C_callback_ExitHitlag)(HSD_GObj* item);                               // 0xd2c, runs after exiting hitlag in hitlag update proc 8026a200
         s32 (*xD30_callback_JumpedOn)(HSD_GObj* item);                                 // 0xd30, runs when the item is "jumped on", 80269bac
-        void (*xD34_callback_Grab_ItemCB)(HSD_GObj* item);                       // 0xd34, when grabbing a fighter, run this function on self
-        void (*xD38_callback_Grab_VictimCB)(HSD_GObj* victim, HSD_GObj* item); // 0xd38, when grabbing a fighter, run this function on fighter
+        void (*xD34_callback_Grab_ItemCB)(HSD_GObj* item);                       // 0xd34, when grabbing a fp, run this function on self
+        void (*xD38_callback_Grab_VictimCB)(HSD_GObj* victim, HSD_GObj* item); // 0xd38, when grabbing a fp, run this function on fp
     } itcb;
     f32 xD3C_spinSpeed;
     f32 xD40;
@@ -618,7 +618,7 @@ typedef struct BobOmbRain
 
 typedef struct SpawnItem
 {
-    HSD_GObj* x0_parent_gobj;  // Primary owner of the item; usually a fighter GObj
+    HSD_GObj* x0_parent_gobj;  // Primary owner of the item; usually a fp GObj
     HSD_GObj* x4_parent_gobj2; // Secondary owner GObj of the item; e.g. Ness' PK Fire Pillar has this set to PK Fire Spark's item GObj
     s32 x8_item_id;            // 0x8, ID of the item to spawn
     s32 xC_hold_kind;          // Defines the behavior of the item, such as thrown and pickup. 0 = capsule
@@ -746,8 +746,8 @@ s32 func_8026B588(void);                                           // Get unknow
 BOOL func_8026B594(HSD_GObj* item_gobj);                           // Check if item can fire projectiles //
 HSD_GObj* func_8026B5E4(Vec3* vector, Vec3* vector2, HSD_GObj* item_gobj); // Unknown item camera check? //
 HSD_GObj* func_8026B634(Vec3* vector, Vec3* vector2, HSD_GObj* item_gobj); // Unknown item camera check 2? //
-f32 func_8026B684(Vec3* pos);                                      // Get facing direction of fighter (?) with argument 0 //
-f32 func_8026B6A8(Vec3* pos, s32 arg);                             // Get facing direction of fighter (?) with variable argument //
+f32 func_8026B684(Vec3* pos);                                      // Get facing direction of fp (?) with argument 0 //
+f32 func_8026B6A8(Vec3* pos, s32 arg);                             // Get facing direction of fp (?) with variable argument //
 BOOL func_8026B6C8(HSD_GObj* item_gobj);                           // Check if item is a stage item? //
 void func_8026B718(HSD_GObj* item_gobj, f32 hitlagFrames);         // Set item's hitlag frames //
 void func_8026B724(HSD_GObj* item_gobj);                           // Toggle bit 3 of 0xDC8 word ON //
@@ -768,10 +768,10 @@ void func_8026B9A8(HSD_GObj* item_gobj, s32 arg1, s32 arg2);       // Transfer i
 void func_8026BAE8(HSD_GObj* item_gobj, f32 scale_mul);            // Multiply item's scale //
 void func_8026BB20(HSD_GObj* item_gobj);                           // Clear JObj flags on item model //
 void func_8026BB44(HSD_GObj* item_gobj);                           // Set JObj flags on item model //
-void func_8026BB68(HSD_GObj* fighter_gobj, Vec3* pos);             // Adjust item's position to fighter bone //
+void func_8026BB68(HSD_GObj* fighter_gobj, Vec3* pos);             // Adjust item's position to fp bone //
 void func_8026BB88(HSD_GObj* item_gobj, Vec3* pos);                // Adjust item's position based on ECB? //
 void func_8026BBCC(HSD_GObj* item_gobj, Vec3* pos);                // Adjust item's ECB position? //
-void func_8026BC14(HSD_GObj* item_gobj);                           // Check if item owner is a fighter + decrement hitlag //
+void func_8026BC14(HSD_GObj* item_gobj);                           // Check if item owner is a fp + decrement hitlag //
 s32 func_8026BC68(HSD_GObj* item_gobj);                            // Return bit 0 of 0xDD0 //
 HSD_GObj* func_8026BC78(HSD_GObj* item_gobj);                      // Get item owner //
 BOOL func_8026BC84(HSD_GObj* item_gobj);                            // Get item attack kind //

--- a/src/melee/it/item2.c
+++ b/src/melee/it/item2.c
@@ -349,7 +349,7 @@ extern f32 func_800864A8(Vec3*, s32);
 
 // 0x8026B684 //
 // https://decomp.me/scratch/2wWfM //
-f32 func_8026B684(Vec3* pos) // Get facing direction of fighter (?) with argument 0 //
+f32 func_8026B684(Vec3* pos) // Get facing direction of fp (?) with argument 0 //
 {
     return func_800864A8(pos, 0);
 }
@@ -358,7 +358,7 @@ extern f32 func_800864A8(Vec3*, s32);
 
 // 0x8026B6A8 //
 // https://decomp.me/scratch/LJ42K //
-f32 func_8026B6A8(Vec3* pos, s32 arg) // Get facing direction of fighter (?) with variable argument //
+f32 func_8026B6A8(Vec3* pos, s32 arg) // Get facing direction of fp (?) with variable argument //
 {
     func_800864A8(pos, arg);
 }
@@ -783,7 +783,7 @@ extern void func_80086990(HSD_GObj*, Vec3*);
 
 // 0x8026BB68 //
 // https://decomp.me/scratch/U1sE9 //
-void func_8026BB68(HSD_GObj* fighter_gobj, Vec3* pos) // Adjust item's position to fighter bone //
+void func_8026BB68(HSD_GObj* fighter_gobj, Vec3* pos) // Adjust item's position to fp bone //
 {
     func_80086990(fighter_gobj, pos);
 }
@@ -824,7 +824,7 @@ extern void func_80086A4C(HSD_GObj*, f32);
 
 // 0x8026BC14 //
 // https://decomp.me/scratch/j3vB2 //
-void func_8026BC14(HSD_GObj* item_gobj) // Check if item owner is a fighter + decrement hitlag //
+void func_8026BC14(HSD_GObj* item_gobj) // Check if item owner is a fp + decrement hitlag //
 {
     Item* item_data;
 


### PR DESCRIPTION
There are some exceptions, like `uninitialized_fighter` and some very messy m2c temporary variables.