### PR TITLE
Create `build.sh`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ clean.bat
 src/m2ctx.py
 ctx.c
 ctx_includes.h
+expected/
 
 # Epilogue hack folder
 epilogue/

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ endif
 
 GENERATE_MAP ?= 0
 NON_MATCHING ?= 0
+EPILOGUE_PROCESS ?= 1
 
 VERBOSE ?= 0
 MAX_ERRORS ?= 0     # 0 = no maximum
@@ -20,9 +21,6 @@ endif
 #-------------------------------------------------------------------------------
 
 TARGET := ssbm.us.1.2
-
-# Overkill epilogue fixup strategy. Set to 1 if necessary.
-EPILOGUE_PROCESS := 1
 
 BUILD_DIR := build/$(TARGET)
 VANILLA_DIR := $(BUILD_DIR)/vanilla

--- a/build.sh
+++ b/build.sh
@@ -1,18 +1,18 @@
 HERE=$(dirname "$(readlink -f $0)")
 clean=false
-rebuild=false
+rebuild_pattern=
 expected=false
 generate_map=0
 non_matching=0
 frank=0
 clear=false
 
-usage="$(basename "$0") [-cremnfxh]
+usage="$(basename "$0") [-cemnfxh] [-r pattern]
 
 where
     -h  help: show this message
     -c  clean: ""make clean"" before running make
-    -r  rebuild: delete *.o files; -c takes priority
+    -r  rebuild: delete *.o files matching the given pattern; -c takes priority
     -e  expected: after a successful make run, sync ./build to ./expected/build
                   (requires ""pacman -S rsync"")
     -f  frank: pass EPILOGUE_PROCESS=1 to make
@@ -20,18 +20,22 @@ where
     -n  non-matching: pass NON_MATCHING=1 to make
     -x  clear: clear the console before executing this script"
 
-while getopts ":cremnfxh" arg; do
+while getopts ":cr:emnfxh" arg; do
     case $arg in
     h) echo "$usage"
        exit
        ;;
     c) clean=true ;;
-    r) rebuild=true ;;
+    r) rebuild_pattern=$OPTARG ;;
     e) expected=true ;;
     m) generate_map=1 ;;
     n) non_matching=1 ;;
     f) frank=1 ;;
     x) clear=true ;;
+    :) printf "missing argument for -%s\n" "$OPTARG" >&2
+       echo "$usage" >&2
+       exit 1
+       ;;
     \?) printf "illegal option: -%s\n" "$OPTARG" >&2
         echo "$usage" >&2
         exit 1
@@ -47,9 +51,10 @@ pushd $HERE
 if [ "$clean" = true ]; then
     echo "Cleaning."
     make clean
-elif [ "$rebuild" = true ]; then
-    echo "Deleting object files."
-    find build/ -name '*.o' -delete
+elif [ "$rebuild_pattern" ]; then
+    rebuild_pattern="*/${rebuild_pattern}*.o"
+    echo "Deleting files matching pattern $rebuild_pattern"
+    find ./build -iwholename $rebuild_pattern -delete
 fi
 
 echo "Running make with NON_MATCHING=$non_matching GENERATE_MAP=$generate_map EPILOGUE_PROCESS=$frank"

--- a/build.sh
+++ b/build.sh
@@ -44,17 +44,17 @@ pushd $HERE
 if [ "$clean" = true ]; then
     echo "Cleaning."
     make clean
-elif [ $rebuild = true ]; then
+elif [ "$rebuild" = true ]; then
     echo "Deleting object files."
     find build/ -name '*.o' -delete
 fi
 
 echo "Running make with NON_MATCHING=$non_matching and GENERATE_MAP=$generate_map"
-make non_matching=$non_matching generate_map=$generate_map
+make NON_MATCHING=$non_matching GENERATE_MAP=$generate_map
 result=$?
 
 if [ "$expected" = true ]; then
-    if [ $result != 0 ]; then
+    if [ "$result" != 0 ]; then
         echo >&2 "Make failed. Not syncing to expected."
     else
         echo "Syncing build to expected."

--- a/build.sh
+++ b/build.sh
@@ -4,9 +4,10 @@ rebuild=false
 expected=false
 generate_map=0
 non_matching=0
+frank=0
 clear=false
 
-usage="$(basename "$0") [-cremnxh]
+usage="$(basename "$0") [-cremnfxh]
 
 where
     -h  help: show this message
@@ -14,11 +15,12 @@ where
     -r  rebuild: delete *.o files; -c takes priority
     -e  expected: after a successful make run, sync ./build to ./expected/build
                   (requires ""pacman -S rsync"")
+    -f  frank: pass EPILOGUE_PROCESS=1 to make
     -m  map: pass GENERATE_MAP=1 to make
     -n  non-matching: pass NON_MATCHING=1 to make
     -x  clear: clear the console before executing this script"
 
-while getopts ":cremnxh" arg; do
+while getopts ":cremnfxh" arg; do
     case $arg in
     h) echo "$usage"
        exit
@@ -28,6 +30,7 @@ while getopts ":cremnxh" arg; do
     e) expected=true ;;
     m) generate_map=1 ;;
     n) non_matching=1 ;;
+    f) frank=1 ;;
     x) clear=true ;;
     \?) printf "illegal option: -%s\n" "$OPTARG" >&2
         echo "$usage" >&2
@@ -51,6 +54,7 @@ fi
 
 echo "Running make with NON_MATCHING=$non_matching and GENERATE_MAP=$generate_map"
 make NON_MATCHING=$non_matching GENERATE_MAP=$generate_map
+make NON_MATCHING=$non_matching GENERATE_MAP=$generate_map EPILOGUE_PROCESS=$frank
 result=$?
 
 if [ "$expected" = true ]; then

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,64 @@
+HERE=$(dirname "$(readlink -f $0)")
+clean=false
+rebuild=false
+expected=false
+generate_map=0
+non_matching=0
+clear=false
+
+usage="$(basename "$0") [-cremnxh]
+
+where
+    -h  help: show this message
+    -c  clean: ""make clean"" before running make
+    -r  rebuild: delete *.o files; -c takes priority
+    -e  expected: after a successful make run, sync ./build to ./expected/build
+                  (requires ""pacman -S rsync"")
+    -m  map: pass GENERATE_MAP=1 to make
+    -n  non-matching: pass NON_MATCHING=1 to make
+    -x  clear: clear the console before executing this script"
+
+while getopts ":cremnxh" arg; do
+    case $arg in
+    h) echo "$usage"
+       exit
+       ;;
+    c) clean=true ;;
+    r) rebuild=true ;;
+    e) expected=true ;;
+    m) generate_map=1 ;;
+    n) non_matching=1 ;;
+    x) clear=true ;;
+    \?) printf "illegal option: -%s\n" "$OPTARG" >&2
+        echo "$usage" >&2
+        exit 1
+        ;;
+    esac
+done
+
+if [ $clear = true ]; then
+    clear
+fi
+
+pushd $HERE
+if [ "$clean" = true ]; then
+    echo "Cleaning."
+    make clean
+elif [ $rebuild = true ]; then
+    echo "Deleting object files."
+    find build/ -name '*.o' -delete
+fi
+
+echo "Running make with NON_MATCHING=$non_matching and GENERATE_MAP=$generate_map"
+make non_matching=$non_matching generate_map=$generate_map
+result=$?
+
+if [ "$expected" = true ]; then
+    if [ $result != 0 ]; then
+        echo >&2 "Make failed. Not syncing to expected."
+    else
+        echo "Syncing build to expected."
+        rsync -a --delete build/ expected/build/
+    fi
+fi
+popd

--- a/build.sh
+++ b/build.sh
@@ -52,8 +52,7 @@ elif [ "$rebuild" = true ]; then
     find build/ -name '*.o' -delete
 fi
 
-echo "Running make with NON_MATCHING=$non_matching and GENERATE_MAP=$generate_map"
-make NON_MATCHING=$non_matching GENERATE_MAP=$generate_map
+echo "Running make with NON_MATCHING=$non_matching GENERATE_MAP=$generate_map EPILOGUE_PROCESS=$frank"
 make NON_MATCHING=$non_matching GENERATE_MAP=$generate_map EPILOGUE_PROCESS=$frank
 result=$?
 


### PR DESCRIPTION
Creates a script to run `make` with flags for quick operations.

Usage:
```
build.sh [-cemnfxh] [-r pattern]

where
    -h  help: show this message
    -c  clean: make clean before running make
    -r  rebuild: delete *.o files matching the given pattern; -c takes priority
    -e  expected: after a successful make run, sync ./build to ./expected/build
                  (requires pacman -S rsync)
    -f  frank: pass EPILOGUE_PROCESS=1 to make
    -m  map: pass GENERATE_MAP=1 to make
    -n  non-matching: pass NON_MATCHING=1 to make
    -x  clear: clear the console before executing this script
```