### PR TITLE
Create `gen.sh`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
+# Generated
 *.m2c
+ctx.c
+ctx_includes.h
+*.s.c
 
 # .DS_Store
 .DS_Store
@@ -23,8 +27,6 @@ clean.bat
 
 # Other
 src/m2ctx.py
-ctx.c
-ctx_includes.h
 expected/
 *.log
 

--- a/build.sh
+++ b/build.sh
@@ -80,6 +80,7 @@ build() {
             echo >&2 "Make failed. Not syncing to expected."
         else
             echo "Syncing build to expected."
+            mkdir -p build expected/build
             rsync -a --delete build/ expected/build/
         fi
     fi

--- a/gen.sh
+++ b/gen.sh
@@ -1,0 +1,95 @@
+HERE=$(dirname "$(readlink -f $0)")
+ctx_includes="ctx_includes.h"
+ctx=ctx.c
+includes=false
+pattern=
+clear=false
+log=false
+generate=false
+
+usage="$(basename "$0") [-hicgxl] [-p pattern]
+
+where
+    -h  help: show this message
+    -i  includes: regenerate $ctx_includes
+    -c  context: regenerate $ctx
+    -g  generate: run m2c and output each asm file to ./src/<original path>/<filename>.s.c
+    -p  pattern: restrict generation paths to a given pattern
+    -x  clear: clear the console before executing this script
+    -l  log: tee output to gen.log"
+
+while getopts ":hgicp:xl" arg; do
+    case $arg in
+    h)
+        echo "$usage"
+        exit
+        ;;
+    g) generate=true ;;
+    i) includes=true ;;
+    c) context=true ;;
+    p) pattern=$OPTARG ;;
+    x) clear=true ;;
+    l) log=true ;;
+    :)
+        printf "missing argument for -%s\n" "$OPTARG" >&2
+        echo "$usage" >&2
+        exit 1
+        ;;
+    \?)
+        printf "illegal option: -%s\n" "$OPTARG" >&2
+        echo "$usage" >&2
+        exit 1
+        ;;
+    esac
+done
+
+if [ "$clear" = true ]; then
+    clear
+fi
+
+pushd "$HERE"
+
+go() {
+    out_path="$(echo "$1" | sed 's/asm/src/').c"
+    mkdir -p $(dirname "$out_path")
+    echo "Generating code from $1 to $out_path"
+    (
+        echo "#include <$ctx_includes>"$'\n'
+        python tools/m2c/m2c.py -t ppc-mwcc-c --valid-syntax --context "./src/$ctx" "$1"
+    ) |
+        cat >"$out_path"
+}
+
+gen() {
+    if [ "$includes" = true ]; then
+        echo "Generating $ctx_includes."
+
+        find include/ src/ -type f -name "*.h" |
+            (
+                sed -r -e "/include\/$ctx_includes/d" -e 's/((include|src)\/)?(.*)/#include <\3>/'
+                cat ./tools/m2c/m2c_macros.h
+            ) |
+            cat >"include/$ctx_includes"
+    fi
+
+    if [ "$context" = true ]; then
+        result=$(python tools/m2ctx/m2ctx.py "include/$ctx_includes")
+        if [ $? != 0 ]; then
+            exit $?
+        fi
+        echo "$result" | cat >"src/$ctx"
+    fi
+
+    if [ "$generate" = true ]; then
+        pattern="*/${pattern}*.s"
+        find ./asm -iwholename "$pattern" -print0 | while IFS= read -r -d '' file; do go "$file"; done
+    fi
+}
+
+if [ "$log" = true ]; then
+    gen | tee -a gen.log
+else
+    gen
+fi
+
+popd

--- a/src/dolphin/gx/GXInit/GXInit_001.h
+++ b/src/dolphin/gx/GXInit/GXInit_001.h
@@ -10,9 +10,6 @@
 /* 004DADE8 */ extern const s32 lbl_804DE208;
 /* 004DADE4 */ extern const s32 lbl_804DE204;
 /* 004DADE0 */ extern const s32 lbl_804DE200;
-/* 004A42A8 */ extern const GXContext *__GXContext;
 /* 00337B20 */ extern void __GXInitGX();
-/* 0033733C */ extern void __GXDefaultTlutRegionCallback();
-/* 003372C0 */ extern void *__GXDefaultTexRegionCallback(GXTexRegionCallback);
 
 #endif

--- a/src/dolphin/gx/__GX_unknown_001.h
+++ b/src/dolphin/gx/__GX_unknown_001.h
@@ -16,8 +16,6 @@
 /* 0033C980 */ extern void __GXFlushTextureState(GXContext *, s32, u8 *);
 /* 0033C980 */ extern void __GXFlushTextureState(GXContext *, s32, u8 *);
 /* 0033C0F8 */ extern void __GXSetTmemConfig(s32);
-/* 0033BEAC */ extern GXTexRegionCallback GXSetTlutRegionCallback(GXTexRegionCallback);
-/* 0033BE98 */ extern GXTexRegionCallback GXSetTexRegionCallback(GXTexRegionCallback);
 /* 0033BE50 */ extern void GXInvalidateTexAll(GXContext *, s32, u8 *);
 /* 0033BE08 */ extern void GXInitTlutObj(s32 *, s32, s32);
 /* 0033BCE8 */ extern void GXInitTexCacheRegion(unk_t, s8, u32, s32, u32, s32, s32);

--- a/src/melee/mp/mpcoll.h
+++ b/src/melee/mp/mpcoll.h
@@ -1,5 +1,4 @@
 #ifndef _mpcoll_h_
-#include "global.h"
-#include "types.h"
-#include "melee/ft/fighter.h"
+#include <dolphin/types.h>
+#include <melee/ft/fighter.h>
 #endif

--- a/tools/m2ctx/m2ctx.py
+++ b/tools/m2ctx/m2ctx.py
@@ -67,9 +67,7 @@ def main():
 
     output = import_c_file(args.c_file)
 
-    with open(root / "ctx.c", "w", encoding="utf8") as f:
-        f.write(output)
-
+    print(output)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Generates complete C files from asm files using M2C. Run `./gen.sh -h` for help.

Examples:
```sh
# Generate include/ctx_includes.h, then src/ctx.c, then generate .s.c files for ALL asm files
./gen.sh -cig

# Same as above, but tee output to gen.log
./gen.sh -cigl

# Same but only generate with paths matching "gx"
./gen.sh -cigl -p gx

# Or only within the ft directory
./gen.sh -cigl -p ft/

# Or only a specific file
./gen.sh -cigl -p code_8007C114
```

The generated C files are output to a path corresponding to the original `asm` file, but in the `src` directory instead. Their extension is `.s.c`, which is ignored by git.