### PR TITLE
Add `replacerules` snippets

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,53 @@
+{
+    "replacerules.rules": {
+        "Remove asm addresses": {
+            "find": "/\\*.*?\\*/\\s*",
+            "replace": "\t"
+        },
+        "Normalize non-global labels": {
+            "find": "(?<!\\.global )(lbl|func)_[\\dA-F]{8}",
+            "replace": "$1_XXXXXXXX"
+        },
+        "Normalize relative labels": {
+            "find": "\"?@\\d+\"?",
+            "replace": "lbl_XXXXXXXX"
+        },
+        "Remove asm comments": {
+            "find": "^#.*$\n"
+        },
+        "Replace gx": {
+            "find": "\\bgx\\b",
+            "replace": "__GXContexts"
+        },
+        "Replace asm comments with C": {
+            "find": "^#\\s*(.*?)\\s*$",
+            "replace": "// $1"
+        },
+        "Wrap asm in C": {
+            "find": "(?<=\n\n)(?:^(\\/\\/.*?)$\n)?(?:^\\.global \\w+$\n)?(\\w+):$\n([\\s\\S]*?)\n\n",
+            "replace": "$1\n#pragma push\nasm unk_t $2()\n{ // clang-format off\n    nofralloc\n$3\n} // clang-format on\n#pragma pop\n\n"
+        },
+        "Remove @ directives": {
+            "find": "@sda21",
+            "replace": ""
+        }
+    },
+    "replacerules.rulesets": {
+        "Normalize asm for comparison": {
+            "rules": [
+                "Remove asm addresses",
+                "Normalize non-global labels",
+                "Normalize relative labels",
+                "Remove asm comments",
+                "Replace gx"
+            ]
+        },
+        "Embed asm in C": {
+            "rules": [
+                "Replace asm comments with C",
+                "Wrap asm in C",
+                "Remove @ directives"
+            ]
+        }
+    },
+}


### PR DESCRIPTION
Requires the "[Replace Rules](https://marketplace.visualstudio.com/items?itemName=bhughes339.replacerules)" extension for VS Code.

The primary usage is to highlight a block of asm functions, use the `replacerules.runRuleset` command, and select "Embed asm in C" to convert them to inline asm.