### PR TITLE
Support skipping the `SHA1` check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ endif
 GENERATE_MAP ?= 0
 NON_MATCHING ?= 0
 EPILOGUE_PROCESS ?= 1
+SKIP_CHECK ?= 0
 
 VERBOSE ?= 0
 MAX_ERRORS ?= 0     # 0 = no maximum
@@ -117,6 +118,8 @@ HOSTCFLAGS := -Wall -O3 -s
 default: $(DOL)
 ifeq ($(NON_MATCHING),1)
 	@echo "Skipping checksum for non-matching build."
+else ifeq ($(SKIP_CHECK),1)
+	@echo "Skipping checksum for this build."
 else
 	$(QUIET) $(SHA1SUM) -c $(TARGET).sha1
 endif

--- a/build.sh
+++ b/build.sh
@@ -4,11 +4,12 @@ rebuild_pattern=
 expected=false
 generate_map=0
 non_matching=0
+skip_check=0
 frank=0
 clear=false
 log=false
 
-usage="$(basename "$0") [-cemnfxh] [-r pattern]
+usage="$(basename "$0") [-hcefmnsxl] [-r pattern]
 
 where
     -h  help: show this message
@@ -19,10 +20,11 @@ where
     -f  frank: pass EPILOGUE_PROCESS=1 to make
     -m  map: pass GENERATE_MAP=1 to make
     -n  non-matching: pass NON_MATCHING=1 to make
+    -s  skip check: pass SKIP_CHECK=1 to make
     -x  clear: clear the console before executing this script
     -l  log: tee output to build.log"
 
-while getopts ":cr:emnfxhl" arg; do
+while getopts ":hcemnsfxlr:" arg; do
     case $arg in
     h)
         echo "$usage"
@@ -33,6 +35,7 @@ while getopts ":cr:emnfxhl" arg; do
     e) expected=true ;;
     m) generate_map=1 ;;
     n) non_matching=1 ;;
+    s) skip_check=1 ;;
     f) frank=1 ;;
     x) clear=true ;;
     l) log=true ;;
@@ -71,8 +74,9 @@ build() {
         find ./build -iwholename $rebuild_pattern -delete
     fi
 
-    echo "Running make with NON_MATCHING=$non_matching GENERATE_MAP=$generate_map EPILOGUE_PROCESS=$frank"
-    make NON_MATCHING=$non_matching GENERATE_MAP=$generate_map EPILOGUE_PROCESS=$frank
+    make_flags="NON_MATCHING=$non_matching GENERATE_MAP=$generate_map EPILOGUE_PROCESS=$frank SKIP_CHECK=$skip_check"
+    echo "Running make with $make_flags"
+    make $make_flags
     result=$?
 
     if [ "$expected" = true ]; then


### PR DESCRIPTION
In `Makefile` and `build.sh`. The check is still enabled by default.