### PR TITLE
Standardize ground/air constants to `GroundOrAir` enum

### DIFF
--- a/include/common_structs.h
+++ b/include/common_structs.h
@@ -26,12 +26,6 @@
 #define MPCOLL_RIGHTWALL 0x3F
 #define MPCOLL_CEIL 0x6000
 
-
-// STATE FLAGS //
-
-#define GROUND 0
-#define AIR 1 // Used by fighters and items //
-
 typedef struct _Vec2 { float x, y; } Vec2;
 
 struct DemoMotionSymbols
@@ -131,5 +125,10 @@ struct r13_ColAnimStruct
     u8 x6_unk;
     u8 x7_unk;
 };
+
+typedef enum GroundOrAir {
+    GA_Ground,
+    GA_Air,
+} GroundOrAir;
 
 #endif

--- a/src/melee/ft/chara/ftNess/ftNess_AttackHi4.c
+++ b/src/melee/ft/chara/ftNess/ftNess_AttackHi4.c
@@ -770,7 +770,7 @@ void ftNess_AttackHi4_Coll(HSD_GObj* fighter_gobj)   // Ness's Up Smash Collisio
 
     func_80084104(fighter_gobj);
 
-    if (((s32)fp->xE0_ground_or_air == AIR) && ((yoyo_GObj = GetFighterData_x222C(fighter_gobj)) != NULL))
+    if (((s32)fp->xE0_ground_or_air == GA_Air) && ((yoyo_GObj = GetFighterData_x222C(fighter_gobj)) != NULL))
     {
         func_802BE958(yoyo_GObj);
 
@@ -864,7 +864,7 @@ void ftNess_AttackHi4_Charge_Coll(HSD_GObj* fighter_gobj)   // Ness's Up Smash C
 
     fp = getFighter(fighter_gobj);
     func_80084104(fighter_gobj);
-    if (((s32)fp->xE0_ground_or_air == AIR) && ((yoyo_GObj = GetFighterData_x222C(fighter_gobj)) != NULL))
+    if (((s32)fp->xE0_ground_or_air == GA_Air) && ((yoyo_GObj = GetFighterData_x222C(fighter_gobj)) != NULL))
 
     {
         func_802BE958(yoyo_GObj);
@@ -995,7 +995,7 @@ void ftNess_AttackHi4_Release_Coll(HSD_GObj* fighter_gobj)   // Ness's Up Smash 
     fp = getFighter(fighter_gobj);
     func_80084104(fighter_gobj);
 
-    if (((s32)fp->xE0_ground_or_air == AIR) && ((yoyo_GObj = GetFighterData_x222C(fighter_gobj)) != NULL)) 
+    if (((s32)fp->xE0_ground_or_air == GA_Air) && ((yoyo_GObj = GetFighterData_x222C(fighter_gobj)) != NULL)) 
     {
         func_802BE958(yoyo_GObj);
         fighter_data2 = getFighter(fighter_gobj);

--- a/src/melee/ft/chara/ftNess/ftNess_SpecialLw.c
+++ b/src/melee/ft/chara/ftNess/ftNess_SpecialLw.c
@@ -66,7 +66,7 @@ void ftNess_SpecialLwStart_Anim(HSD_GObj* fighter_gobj) // Ness's grounded PSI M
         fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
         fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
         fighter_data2->x2350_stateVar5 = 0;
-        if ((s32)fighter_data2->xE0_ground_or_air == GROUND)
+        if ((s32)fighter_data2->xE0_ground_or_air == GA_Ground)
         {
             ftNess_SpecialLwHold_Action(fighter_gobj);
             return;
@@ -102,7 +102,7 @@ void ftNess_SpecialAirLwStart_Anim(HSD_GObj* fighter_gobj) // Ness's aerial PSI 
         fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
         fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
         fighter_data2->x2350_stateVar5 = 0;
-        if ((s32)fighter_data2->xE0_ground_or_air == GROUND)
+        if ((s32)fighter_data2->xE0_ground_or_air == GA_Ground)
         {
             ftNess_SpecialLwHold_Action(fighter_gobj);
             return;
@@ -223,7 +223,7 @@ void ftNess_SpecialLwHold_Anim(HSD_GObj* fighter_gobj) // Ness's grounded PSI Ma
     }
     if (((s32)fp->nessVars[0].SpecialLw.releaseLag <= 0) && ((s32)fp->nessVars[0].SpecialLw.isRelease != 0))
     {
-        if ((s32)fp->xE0_ground_or_air == GROUND)
+        if ((s32)fp->xE0_ground_or_air == GA_Ground)
         {
             ftNess_SpecialLwEnd_Action(fighter_gobj);
         }
@@ -264,7 +264,7 @@ void ftNess_SpecialAirLwHold_Anim(HSD_GObj* fighter_gobj) // Ness's aerial PSI M
     }
     if (((s32)fp->nessVars[0].SpecialLw.releaseLag <= 0) && ((s32)fp->nessVars[0].SpecialLw.isRelease != 0))
     {
-        if ((s32)fp->xE0_ground_or_air == GROUND)
+        if ((s32)fp->xE0_ground_or_air == GA_Ground)
         {
             ftNess_SpecialLwEnd_Action(fighter_gobj);
         }
@@ -657,7 +657,7 @@ void ftNess_SpecialLwHit_Anim(HSD_GObj* arg0) // Ness's grounded PSI Magnet Abso
         temp_r3_2 = arg0->user_data;
         if (((s32)temp_r3_2->nessVars[0].SpecialLw.releaseLag <= 0) && ((s32)temp_r3_2->nessVars[0].SpecialLw.isRelease != 0))
         {
-            if ((s32)temp_r3_2->xE0_ground_or_air == GROUND)
+            if ((s32)temp_r3_2->xE0_ground_or_air == GA_Ground)
             {
                 ftNess_SpecialLwEnd_Action(arg0);
             }
@@ -669,7 +669,7 @@ void ftNess_SpecialLwHit_Anim(HSD_GObj* arg0) // Ness's grounded PSI Magnet Abso
         }
         else
         {
-            if ((s32)temp_r3_2->xE0_ground_or_air == GROUND)
+            if ((s32)temp_r3_2->xE0_ground_or_air == GA_Ground)
             {
                 Fighter_ActionStateChange_800693AC(arg0, AS_NESS_SPECIALLW_HOLD, FIGHTER_GFX_PRESERVE, NULL, 0.0f, 1.0f, 0.0f);
 
@@ -872,7 +872,7 @@ void ftNess_AbsorbThink_DecideAction(HSD_GObj* gobj) // Ness's PSI Magnet OnAbso
 
     if (((temp_r0 != AS_NESS_SPECIALLW_HIT) && (temp_r0 != AS_NESS_SPECIALAIRLW_HIT)) || !(temp_r31->x894_currentAnimFrame <= temp_r30->x7C_PSI_MAGNET_UNK2))
     {
-        if ((s32)temp_r31->xE0_ground_or_air == GROUND)
+        if ((s32)temp_r31->xE0_ground_or_air == GA_Ground)
         {
             phi_r4 = AS_NESS_SPECIALLW_HIT;
         }

--- a/src/melee/ft/chara/ftNess/ftNess_SpecialS.c
+++ b/src/melee/ft/chara/ftNess/ftNess_SpecialS.c
@@ -37,7 +37,7 @@ void ftNess_ItemPKFireSpawn(HSD_GObj* fighter_gobj) //* Ness's PK Fire spawn fun
         ItemBonePos.y += ness_attr->x34_PKFIRE_SPAWN_Y;
         ItemBonePos.z = 0.0f;
 
-        if (fp->xE0_ground_or_air == AIR)
+        if (fp->xE0_ground_or_air == GA_Air)
         {
             PKFireLaunch = ness_attr->x20_PKFIRE_AERIAL_LAUNCH_TRAJECTORY;
             PKFireVel = ness_attr->x24_PKFIRE_AERIAL_VELOCITY;

--- a/src/melee/ft/fighter.h
+++ b/src/melee/ft/fighter.h
@@ -968,12 +968,6 @@ typedef struct _S32Pair {
     s32 x, y;
 } S32Pair;
 
-// Ground/air state for Fighter.xE0_ground_or_air
-enum {
-    GA_Ground = 0,
-    GA_Air = 1,
-};
-
 typedef struct {
     HSD_Joint* joint;
     u8 padding[0x10];
@@ -1294,7 +1288,7 @@ typedef struct _Fighter {
     Vec3 xBC_prevPos;                                     // 0xBC
     Vec3 xC8_pos_delta;                                        // 0xC8
     Vec3 xD4_unk_vel;                                        // 0xD4
-    s32 xE0_ground_or_air;                                         // 0xE0
+    GroundOrAir xE0_ground_or_air;                                         // 0xE0
     f32 xE4_ground_accel_1; // 0xE4
     f32 xE8_ground_accel_2;   // 0xE8
     f32 xEC_ground_vel;                                    // 0xEC

--- a/src/melee/ft/ftcoll.c
+++ b/src/melee/ft/ftcoll.c
@@ -134,7 +134,7 @@ void func_80076528(HSD_GObj* fighter_gobj) // Combo count something + adjust Top
     if (temp_r3 != 0)
     {
         fp->x2092 = (u16)(temp_r3 - 1);
-        if ((fp->x1A58_interactedFighter == NULL) && (fp->xE0_ground_or_air == GROUND))
+        if ((fp->x1A58_interactedFighter == NULL) && (fp->xE0_ground_or_air == GA_Ground))
         {
             comboCount_Push(fp);
         }

--- a/src/melee/it/item.c
+++ b/src/melee/it/item.c
@@ -1268,7 +1268,7 @@ block_returnGObj:
 // https://decomp.me/scratch/YyUEI //
 void func_80268B18(SpawnItem* spawnItem) // Item spawn prefunction - spawn airborne //
 {
-    spawnItem->x48_ground_or_air = AIR;
+    spawnItem->x48_ground_or_air = GA_Air;
     spawnItem->x10 = 0;
     func_802674AC(spawnItem);
     func_8026862C(spawnItem);
@@ -1278,7 +1278,7 @@ void func_80268B18(SpawnItem* spawnItem) // Item spawn prefunction - spawn airbo
 // https://decomp.me/scratch/cN7Fn //
 void func_80268B5C(SpawnItem* spawnItem) // Item spawn prefunction - spawn grounded //
 {
-    spawnItem->x48_ground_or_air = GROUND;
+    spawnItem->x48_ground_or_air = GA_Ground;
     spawnItem->x10 = 0;
     func_802674AC(spawnItem);
     func_8026862C(spawnItem);
@@ -1288,7 +1288,7 @@ void func_80268B5C(SpawnItem* spawnItem) // Item spawn prefunction - spawn groun
 // https://decomp.me/scratch/V7AgZ //
 void func_80268B9C(SpawnItem* spawnItem) // Item spawn prefunction - spawn grounded and toggle unknown true //
 {
-    spawnItem->x48_ground_or_air = GROUND;
+    spawnItem->x48_ground_or_air = GA_Ground;
     spawnItem->x10 = 1;
     func_802674AC(spawnItem);
     func_8026862C(spawnItem);

--- a/src/melee/it/item.h
+++ b/src/melee/it/item.h
@@ -667,7 +667,7 @@ typedef struct SpawnItem
     UnkFlagStruct x45_flag;
     UnkFlagStruct x46_flag;
     UnkFlagStruct x47_flag;
-    s32 x48_ground_or_air;          // 0x0 = stationary, 0x1 = air (?)
+    GroundOrAir x48_ground_or_air;          // 0x0 = stationary, 0x1 = air (?)
 
 } SpawnItem;
 


### PR DESCRIPTION
Resolves #520.