### PR TITLE
Fix SetScaleHack by making HSD_JObjSetMtxDirty a macro.

### DIFF
--- a/include/sysdolphin/baselib/jobj.h
+++ b/include/sysdolphin/baselib/jobj.h
@@ -145,6 +145,7 @@ void HSD_JObjAnimAll(HSD_JObj *); // asm/sysdolphin/baselib/jobj.s
 
 #pragma push
 #pragma always_inline on
+
 inline struct _HSD_RObj* HSD_JObjGetRObj(HSD_JObj* jobj)
 {
     assert_line(405, jobj);
@@ -169,11 +170,12 @@ inline void HSD_JObjSetupMatrix(HSD_JObj* jobj)
     }
 }
 
-inline void HSD_JObjSetMtxDirty(HSD_JObj* jobj) 
-{
-    if (jobj != NULL && !HSD_JObjMtxIsDirty(jobj)) {
-        HSD_JObjSetMtxDirtySub(jobj);
-    }
+// Why does this seem to be a define while the others are inline functions?
+#define HSD_JObjSetMtxDirty(jobj)                       \
+{                                                       \
+    if (jobj != NULL && !HSD_JObjMtxIsDirty(jobj)) {    \
+        HSD_JObjSetMtxDirtySub(jobj);                   \
+    }                                                   \
 }
 
 inline void HSD_JObjSetRotation(HSD_JObj* jobj, Quaternion* quat)

--- a/include/sysdolphin/baselib/jobj.h
+++ b/include/sysdolphin/baselib/jobj.h
@@ -143,9 +143,6 @@ HSD_JObj *HSD_JObjLoadJoint(HSD_Joint *);
 void HSD_JObjAddAnimAll(HSD_JObj *, HSD_AnimJoint *, HSD_MatAnimJoint *, HSD_ShapeAnimJoint *);
 void HSD_JObjAnimAll(HSD_JObj *); // asm/sysdolphin/baselib/jobj.s
 
-#pragma push
-#pragma always_inline on
-
 inline struct _HSD_RObj* HSD_JObjGetRObj(HSD_JObj* jobj)
 {
     assert_line(405, jobj);
@@ -250,7 +247,5 @@ inline void HSD_JObjCopyMtx(HSD_JObj* jobj, Mtx mtx)
     assert_line(1171, mtx);
     PSMTXCopy(mtx, jobj->mtx); 
 }
-
-#pragma pop
 
 #endif

--- a/src/melee/ft/fighter.c
+++ b/src/melee/ft/fighter.c
@@ -86,29 +86,7 @@ inline HSD_JObj *getHSDJObj(HSD_GObj* hsd_gobj) {
     HSD_JObj *hsd_jobj = hsd_gobj->hsd_obj;
     return (void *)hsd_jobj;
 }
-
-// WORKAROUND
-// bleeeehhhh. HSD_JObjSetScale does not have a correct inline depth due to
-// inline auto preferring 3 levels of depth. TODO: Determine if the Setup MTX
-// inline is fake, and correct the inline to adjust if so.
-inline void HSD_JObjSetScale_Hack(HSD_JObj* jobj, Vec* scale)
-{
-    ((jobj) ? ((void) 0) : __assert("jobj.h", 760, "jobj")) ;
-    ((scale) ? ((void) 0) : __assert("jobj.h", 761, "scale")) ;
-    jobj->scale = *scale;
-    if (!(jobj->flags & 0x2000000)) {
-#if 0
-        // this is what it should call
-        HSD_JObjSetMtxDirty(jobj);
-#else
-        // this is the code manually inlined...
-        if (jobj != ((void*)0) && !HSD_JObjMtxIsDirty(jobj)) {
-            HSD_JObjSetMtxDirtySub(jobj);
-        }
-#endif
-    }
-}
-// ---------------------------------------------
+// --------------------------------------------
 
 void Fighter_800679B0()
 { 
@@ -197,7 +175,7 @@ void Fighter_UpdateModelScale(HSD_GObj* fighterObj)
     Vec scale;
 
     Fighter_InitScale(fp, &scale, modelScale_f1);
-    HSD_JObjSetScale_Hack(jobj, &scale);
+    HSD_JObjSetScale(jobj, &scale);
 }
 
 void Fighter_UnkInitReset_80067C98(Fighter* fp) {


### PR DESCRIPTION
This affects at least two functions, also affects HSD_JObjSetFlagsAll since the manual inlining was required to fix the function. The solution may be that this function is a defined macro instead of an inline, which is rather odd, but it's the only thing that fixes both hacks/functions.