### PR TITLE
Implement dump (`-d`) flag in `build.sh`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ clean.bat
 # Other
 src/m2ctx.py
 expected/
+dump/
 *.log
 
 # Epilogue hack folder

--- a/build.sh
+++ b/build.sh
@@ -89,6 +89,7 @@ build() {
     fi
 
     if [ "$dump" = true ]; then
+        echo "Dumping main.dol to dump."
         rm -rf dump
         mkdir -p dump
         python "tools/parse_map.py"

--- a/build.sh
+++ b/build.sh
@@ -85,7 +85,6 @@ build() {
 
     if [ "$result" != 0 ]; then
         echo "Build failed at $(build_time)."
-        exit "$result"
     fi
 
     if [ "$dump" = true ]; then
@@ -96,7 +95,7 @@ build() {
         dadosod dol "build/ssbm.us.1.2/main.dol" -m "build/map.csv" -o "dump"
     fi
 
-    if [ "$expected" = true ]; then
+    if [ "$expected" = true ] && [ "$result" = 0 ]; then
         echo "Syncing build to expected."
         mkdir -p build expected/build
         rsync -a --delete build/ expected/build/
@@ -109,6 +108,7 @@ build() {
     fi
 
     echo "Build finished at $(build_time)."
+    exit "$result"
 }
 
 if [ "$log" = true ]; then


### PR DESCRIPTION
Dumps the dol back to `/dump` when the build is completed, if `-d` is passed. Requires `dadosod`, which you can install using:

```sh
cargo install --git https://github.com/InusualZ/dadosod
```

If you don't have `cargo`, you need to [install Rust](https://www.rust-lang.org/tools/install).

The `dump` folder is also synchronized to `expected`, when `-e` is passed.