### PR TITLE
Create `compile_flags.txt` and `.vimrc`

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,0 +1,15 @@
+set tabstop=4
+set softtabstop=4
+set shiftwidth=4
+set noexpandtab
+
+set colorcolumn=100
+highlight ColorColumn ctermbg=darkgray
+
+augroup project
+  autocmd!
+  autocmd BufRead,BufNewFile *.h,*.c set filetype=c | set syntax=c.doxygen
+augroup END
+
+let &path.="src,"
+

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,0 +1,10 @@
+-xc
+-std=c99
+-nostdinc
+-Isrc
+-Iinclude
+-Wall
+-Wextra
+-Wno-unknown-pragmas
+-Wno-unused-variable
+-Wno-typedef-redefinition


### PR DESCRIPTION
`compile_flags.txt` tells `clangd` how to process the source files. This is a placeholder until I figure out how to get `clangd` to run `mwcc` directly, which I believe is possible.

`.vimrc` turns on syntax highlighting for C (instead of C++) and turns on doxygen highlighting. Also shows a visual indicator on column 100. Can be activated in Vim or NeoVim with `source .vimrc`, or by creating an autocmd to do so for you.