### PR TITLE
Use AT_ADDRESS macro for fixed-address declarations

### DIFF
--- a/include/dolphin/dsp/dsp.h
+++ b/include/dolphin/dsp/dsp.h
@@ -8,11 +8,7 @@
 #include <dolphin/os/OSInterrupt.h>
 
 #define HW_REG(reg, type) *(volatile type *)(uintptr_t)(reg)
-volatile u16 __DSPRegs[]
-#ifndef M2CTX
-    : 0xCC005000
-#endif
-    ;
+extern volatile u16 __DSPRegs[] AT_ADDRESS(0xCC005000);
 
 typedef void (*DSPCallback)(void *task);
 

--- a/include/dolphin/os/OSContext.h
+++ b/include/dolphin/os/OSContext.h
@@ -22,17 +22,8 @@ typedef struct OSContext {
     f64 psfs[32];                  // at 0x1C8
 } OSContext;
 
-OSContext* OS_CURRENT_CONTEXT
-#ifndef M2CTX
-    : 0x800000D4;
-#endif
-;
-
-OSContext* OS_CURRENT_FPU_CONTEXT
-#ifndef M2CTX
-    : 0x800000D8
-#endif
-    ;
+extern OSContext* OS_CURRENT_CONTEXT AT_ADDRESS(0x800000D4);
+extern OSContext* OS_CURRENT_FPU_CONTEXT AT_ADDRESS(0x800000D8);
 
 void OSSaveFPUContext(OSContext*);
 void OSSetCurrentContext(OSContext*);

--- a/include/dolphin/os/OSThread.h
+++ b/include/dolphin/os/OSThread.h
@@ -62,16 +62,8 @@ typedef struct OSThread {
 
 typedef void (*OSSwitchThreadCallback)(OSThread*, OSThread*);
 
-OSThreadQueue OS_THREAD_QUEUE
-#ifndef M2CTX
-    : 0x800000DC
-#endif
-    ;
-OSThread* OS_CURRENT_THREAD
-#ifndef M2CTX
-    : 0x800000E4
-#endif
-    ;
+extern OSThreadQueue OS_THREAD_QUEUE AT_ADDRESS(0x800000DC);
+extern OSThread* OS_CURRENT_THREAD AT_ADDRESS(0x800000E4);
 
 STRUCT_PLACEHOLDER(OSThread, 1)
 STRUCT_PLACEHOLDER(OSThread, 2)

--- a/include/dolphin/types.h
+++ b/include/dolphin/types.h
@@ -61,6 +61,14 @@ typedef struct _ ## module ## _Unk ## number module ## _Unk ## number;
 #endif
 #endif
 
+#if defined(PERMUTER)
+#define AT_ADDRESS(x) = FIXEDADDR(x)
+#elif defined(__MWERKS__)
+#define AT_ADDRESS(x) : (x)
+#else
+#define AT_ADDRESS(x)
+#endif
+
 #pragma region "macros.inc"
 #define qr0 0
 #define qr1 1

--- a/src/dolphin/card/CARDFormat.c
+++ b/src/dolphin/card/CARDFormat.c
@@ -3,7 +3,7 @@
 #include <dolphin/os/OSFont.h>
 #include <dolphin/os/OSRtc.h>
 
-vu16 __VIRegs[59] : 0xCC002000;
+extern vu16 __VIRegs[59] AT_ADDRESS(0xCC002000);
 
 void FormatCallback(s32 chan, s32 result)
 {

--- a/src/dolphin/card/CARDMount.c
+++ b/src/dolphin/card/CARDMount.c
@@ -2,7 +2,7 @@
 
 #include <dolphin/os/OSRtc.h>
 
-u8 GameChoice : 0x800030E3;
+u8 GameChoice AT_ADDRESS(0x800030E3);
 void __CARDExiHandler(s32 chan, OSContext* context);
 
 u16 __CARDVendorID = 0xFFFF;

--- a/src/dolphin/dvd/dvd.c
+++ b/src/dolphin/dvd/dvd.c
@@ -43,7 +43,7 @@ extern volatile struct _IO {
     u32 unk4;
     u32 x8[6];
     u32 error;
-} IO : 0xCC006000;
+} IO AT_ADDRESS(0xCC006000);
 
 static struct {
     u32 bootFilePosition;

--- a/src/dolphin/gx/__types.h
+++ b/src/dolphin/gx/__types.h
@@ -120,11 +120,7 @@ extern volatile union {
     unk_t ptr;
     f32 f32;
 
-} WGPIPE
-#ifndef M2CTX
-    : 0xCC008000
-#endif
-    ;
+} WGPIPE AT_ADDRESS(0xCC008000);
 
 typedef struct
 {

--- a/src/dolphin/os/OS.c
+++ b/src/dolphin/os/OS.c
@@ -28,8 +28,8 @@ u32 OSGetConsoleType(void)
 
 extern u32 OSGetResetCode(void);
 
-extern u32 BOOT_REGION_START : 0x812FDFF0;
-extern u32 BOOT_REGION_END : 0x812FDFEC;
+extern u32 BOOT_REGION_START AT_ADDRESS(0x812FDFF0);
+extern u32 BOOT_REGION_END AT_ADDRESS(0x812FDFEC);
 
 void ClearArena(void)
 {
@@ -685,7 +685,7 @@ asm void __OSPSInit(void)
 } // clang-format on
 #pragma pop
 
-extern volatile u32 __DIRegs[0x10] : 0xCC006000;
+extern volatile u32 __DIRegs[0x10] AT_ADDRESS(0xCC006000);
 
 #define DI_CONFIG_IDX 0x9
 #define DI_CONFIG_CONFIG_MASK 0x000000FF

--- a/src/dolphin/os/OSInterrupt.c
+++ b/src/dolphin/os/OSInterrupt.c
@@ -67,10 +67,10 @@ extern unk_t __OSSetExceptionHandler();
 extern volatile struct {
     u32 x0;
     u32 intr;
-} OS_PI : 0xCC003000;
+} OS_PI AT_ADDRESS(0xCC003000);
 
-extern volatile u32 OS_INTR_OLD : 0x800000C4;
-extern volatile u32 OS_INTR_CUR : 0x800000C8;
+extern volatile u32 OS_INTR_OLD AT_ADDRESS(0x800000C4);
+extern volatile u32 OS_INTR_CUR AT_ADDRESS(0x800000C8);
 
 #pragma peephole off
 

--- a/src/dolphin/os/OSMemory.c
+++ b/src/dolphin/os/OSMemory.c
@@ -3,9 +3,9 @@
 #include <dolphin/os/OSMemory.h>
 #include <dolphin/os/OSReset.h>
 
-extern volatile u32 Mem_Size : 0x80000028;
-extern volatile u32 Simulated_Mem : 0x800000F0;
-extern volatile u16 __MEMRegs[64] : 0xCC004000;
+extern volatile u32 Mem_Size AT_ADDRESS(0x80000028);
+extern volatile u32 Simulated_Mem AT_ADDRESS(0x800000F0);
+extern volatile u16 __MEMRegs[64] AT_ADDRESS(0xCC004000);
 extern OSErrorHandler __OSErrorTable[];
 
 static BOOL OnReset(BOOL);

--- a/src/dolphin/os/OSReset.c
+++ b/src/dolphin/os/OSReset.c
@@ -88,7 +88,7 @@ typedef struct Unk2 {
     u16 _2;
 } Unk2;
 
-volatile Unk2 DAT_cc002000 : 0xcc002000;
+extern volatile Unk2 DAT_cc002000 AT_ADDRESS(0xCC002000);
 
 typedef struct OSSram {
     u16 checkSum;
@@ -104,7 +104,7 @@ typedef struct OSSram {
 
 extern OSSram* __OSLockSram(void);
 
-OSThreadQueue __OSActiveThreadQueue : 0x800000DC;
+extern OSThreadQueue __OSActiveThreadQueue AT_ADDRESS(0x800000DC);
 
 BOOL __OSCallResetFunctions(u32 arg0)
 {
@@ -190,12 +190,12 @@ void OSResetSystem(int reset, u32 resetCode, BOOL forceMenu)
     __PADDisableRecalibration(disableRecalibration);
 }
 
-volatile u8 DAT_800030e2 : 0x800030e2;
+extern volatile u8 DAT_800030e2 AT_ADDRESS(0x800030E2);
 typedef struct Unk {
     u8 pad[0x24];
     u32 resetCode;
 } Unk;
-volatile Unk DAT_cc003000 : 0xcc003000;
+extern volatile Unk DAT_cc003000 AT_ADDRESS(0xCC003000);
 
 u32 OSGetResetCode(void)
 {

--- a/src/dolphin/os/OSResetSW.c
+++ b/src/dolphin/os/OSResetSW.c
@@ -4,8 +4,8 @@
 
 typedef void (*OSResetCallback)(void);
 
-extern u8 GameChoice : 0x800030E3;
-extern vu32 __PIRegs[12] : 0xCC003000;
+extern u8 GameChoice AT_ADDRESS(0x800030E3);
+extern vu32 __PIRegs[12] AT_ADDRESS(0xCC003000);
 
 static OSResetCallback ResetCallback;
 static BOOL Down;

--- a/src/dolphin/os/OSSerial.c
+++ b/src/dolphin/os/OSSerial.c
@@ -911,7 +911,7 @@ lbl_8034A0AC:
 
 extern volatile struct {
     u32 command, x4, x8;
-} SIRegs[] : 0xCC006400;
+} SIRegs[] AT_ADDRESS(0xCC006400);
 
 void SISetCommand(s32 index, s32 value)
 {

--- a/src/dolphin/os/OSTime.c
+++ b/src/dolphin/os/OSTime.c
@@ -15,7 +15,7 @@ asm OSTick OSGetTick(void)
     mftb r3, 0x10c
 }
 
-extern volatile OSTime OS_SYSTEM_TIME : 0x800030D8;
+extern volatile OSTime OS_SYSTEM_TIME AT_ADDRESS(0x800030D8);
 
 OSTime __OSGetSystemTime(void)
 {


### PR DESCRIPTION
This macro expands to an appropriate expression depending on the compiler, so these fixed-address declarations can still be used with decomp-permuter and non-MWCC compilers.