### PR TITLE
Create `functions.sh`

### DIFF
--- a/tools/functions.sh
+++ b/tools/functions.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+function replace_symbol {
+    local find=${1//\//\\\/}
+    local find=${find//[.]/\\.}
+    local replace=${2//\//\\\/}
+    echo "$find -> $replace"
+    find asm src include -type f -regex 'Makefile\|.*\.\(c\|h\|s\|mk\)$' -exec sed -i "s/\b$find\b/$replace/g" {} +
+}
+
+function reverse_symbol {
+    replace_symbol "$2" "$1"
+}
+
+function rename_module_symbols_asm {
+    sed -rn 's/^(func|lbl)_([0-9A-F]{8})\b:$/\1_\2/pg' "$1" | while read line
+    do
+        new_line="$2_${line#*_}"
+        replace_symbol "$line" "$new_line"
+    done
+}
+
+function rename_module_symbols_c {
+    sed -rn 's/^(static )?(inline )?(asm )?\w+\**\s+(func|lbl)_([0-9A-F]{8})\(.*\);?$/\4_\5/p' "$1" | while read line
+    do
+        new_line="$2_${line#*_}"
+        replace_symbol "$line" "$new_line"
+    done
+}
+
+function get_guard {
+    local guard=$(echo "$1" | sed -e 's~/\|\.~_~g' -e 's/^src_//' -e 's/\w/\U\0/g')
+    echo "$guard"
+}
+
+function get_include_guard {
+    local guard=$(get_guard $1)
+    echo "#ifndef $guard
+#define $guard"
+}
+
+function rename_header {
+    local old_guard=$(get_guard $1)
+    local new_guard=$(get_guard $2)
+    local find=$(realpath --relative-to="src" $1)
+    local replace=$(realpath --relative-to="src" $2)
+    mv "$1" "$2"
+    sed -Ei -e "s@#(ifndef|define) [A-Z0-9_]+\$@#\1 $new_guard@" "$2"
+    replace_symbol "$find" "$replace"
+}
+
+function gen_header {
+    local out_base="$(basename $1)"
+    local out_base="${out_base%.*}"
+    local out_path="$(dirname $1)/$out_base.h"
+    local guard=$(get_include_guard $out_path)
+    local text="$guard
+
+#include <dolphin/types.h>
+
+#endif"
+
+    if [[ -f "$out_path" ]]; then
+        printf '%s\n\n%s\n' "$text" "$(cat $out_path)" >$out_path
+    else
+        echo "$text" >$out_path
+    fi
+}
+
+function convert_hex {
+    perl -Mbigint -lpi -e 's{\b0x[\da-f]{1,7}U?\b}{hex($&)}gie' "$1"
+}
+
+alias qd='qalc -p 10'
+alias qx='qalc -p 16'
+
+export WINEDEBUG=-all


### PR DESCRIPTION
Can be `source`d to gain access to several utility functions that I use frequently when working with the code. Generates include guards, renames symbols, and can replace the prefix of all symbols within a source file.

If anyone has any other functions they find useful, feel free to add them to this file.