### PR TITLE
Use `GET_FIGHTER` macro, pass 2

### DIFF
--- a/src/melee/ft/chara/ftCaptain/ftCaptain.c
+++ b/src/melee/ft/chara/ftCaptain/ftCaptain.c
@@ -98,7 +98,7 @@ Fighter_CostumeStrings lbl_803C773C[] = {
 // https://decomp.me/scratch/XZ1Jx
 void ftCaptain_OnDeath(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = (Fighter*) fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_80074A4C(fighter_gobj, 0, 0);
     fp->sa.captain.x2230_isSpecialSGFX = 0;
     fp->sa.captain.x222C_isSpecialSStartGFX = 0;
@@ -158,7 +158,7 @@ void ftCaptain_OnLoad(HSD_GObj* fighter_gobj)
     Fighter* fp;
     ftCaptainAttributes* sA2;
 
-    fp = (Fighter*) fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     fp->x2224_flag.bits.b7 = 1;
 
     PUSH_ATTRS(fp, ftCaptainAttributes);

--- a/src/melee/ft/chara/ftCaptain/ftCaptain_SpecialN.c
+++ b/src/melee/ft/chara/ftCaptain/ftCaptain_SpecialN.c
@@ -14,7 +14,7 @@
 void ftCaptain_SpecialN_CreateWindEffect(HSD_GObj* fighter_gobj)
 {
     s32 currentAnimFrame;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     s32 ftKind;
 
     currentAnimFrame = (s32) fp->x894_currentAnimFrame;
@@ -257,7 +257,7 @@ void ftCaptain_SpecialAirN_Phys(HSD_GObj* fighter_gobj)
 void ftCaptain_SpecialN_Coll(HSD_GObj* fighter_gobj)
 {
     if (func_800827A0(fighter_gobj) == false) {
-        Fighter* fp = fighter_gobj->user_data;
+        Fighter* fp = GET_FIGHTER(fighter_gobj);
         func_8007D5D4(fp);
         Fighter_ActionStateChange_800693AC(
             fighter_gobj, AS_CAPTAIN_SPECIALAIRN, FTCAPTAIN_SPECIALN_COLL_FLAG,
@@ -274,7 +274,7 @@ void ftCaptain_SpecialN_Coll(HSD_GObj* fighter_gobj)
 void ftCaptain_SpecialAirN_Coll(HSD_GObj* fighter_gobj)
 {
     if (func_80081D0C(fighter_gobj) != false) {
-        Fighter* fp = fighter_gobj->user_data;
+        Fighter* fp = GET_FIGHTER(fighter_gobj);
         func_8007D7FC(fp);
         Fighter_ActionStateChange_800693AC(
             fighter_gobj, AS_CAPTAIN_SPECIALN, FTCAPTAIN_SPECIALN_COLL_FLAG,

--- a/src/melee/ft/chara/ftCaptain/ftCaptain_SpecialS.c
+++ b/src/melee/ft/chara/ftCaptain/ftCaptain_SpecialS.c
@@ -114,7 +114,7 @@ void ftCaptain_SpecialAirS_StartAction(HSD_GObj* fighter_gobj)
 
 inline void ftCaptain_SpecialS_Switch0(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftCaptainAttributes* captainAttrs = getFtSpecialAttrsD(fp);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_CAPTAIN_SPECIALS,
@@ -160,7 +160,7 @@ void ftCaptain_SpecialS_OnDetect(HSD_GObj* fighter_gobj)
     HSD_GObj* detectGObj;
     s32 ASID;
     u16 entityClass;
-    s32 unused[6];
+    s32 unused[5];
 
     if ((u32) fp->x2200_ftcmd_var0 != 0U) {
         detectGObj = fp->x20AC;
@@ -239,7 +239,7 @@ void ftCaptain_SpecialSStart_Anim(HSD_GObj* fighter_gobj)
 // Raptor Boost / Gerudo Dragon Hit Animation callback
 void ftCaptain_SpecialS_Anim(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     s32 ftKind;
 
     if ((u32) fp->sa.captain.x2230_isSpecialSGFX == false) {
@@ -373,8 +373,13 @@ void ftCaptain_SpecialS_Phys(HSD_GObj* fighter_gobj)
 // Boost / Gerudo Dragon Start Physics callback
 void ftCaptain_SpecialAirSStart_Phys(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    ftCaptainAttributes* captainAttrs = captainAttrs = getFtSpecialAttrs(fp);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftCaptainAttributes* captainAttrs = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     func_80085134(fighter_gobj);
     if ((u32) fp->x2204_ftcmd_var1 == 1U) {
@@ -395,8 +400,13 @@ void ftCaptain_SpecialAirSStart_Phys(HSD_GObj* fighter_gobj)
 // Boost / Gerudo Dragon Hit Physics callback
 void ftCaptain_SpecialAirS_Phys(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    ftCaptainAttributes* captainAttrs = captainAttrs = getFtSpecialAttrs(fp);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftCaptainAttributes* captainAttrs = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     func_80085134(fighter_gobj);
     fp->captainVars[0].SpecialS.gravity -=
@@ -477,8 +487,8 @@ void ftCaptain_SpecialS_Coll(HSD_GObj* fighter_gobj)
 // Boost / Gerudo Dragon Start Collision callback
 void ftCaptain_SpecialAirSStart_Coll(HSD_GObj* fighter_gobj)
 {
-    ftCaptainAttributes* captainAttrs =
-        getFtSpecialAttrsD(fighter_gobj->user_data);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftCaptainAttributes* captainAttrs = fp->x2D4_specialAttributes;
 
     if (func_80081D0C(fighter_gobj) == true) {
         efLib_DestroyAll(fighter_gobj);

--- a/src/melee/ft/chara/ftCrazyHand/ftcrazyhand.c
+++ b/src/melee/ft/chara/ftCrazyHand/ftcrazyhand.c
@@ -130,7 +130,7 @@ void ftCrazyhand_OnLoad(HSD_GObj* fighter_gobj)
     void** items;
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     ftdata = fp->x10C_ftData;
     ftData_attr = ftdata->ext_attr;
     items = ftdata->x48_items;

--- a/src/melee/ft/chara/ftDonkey/ftdonkey1.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey1.c
@@ -19,9 +19,14 @@ bool ftDonkey_800DF938(HSD_GObj* fighter_gobj)
 
 void ftDonkey_800DF980(HSD_GObj* fighter_gobj)
 {
-    s32 unused[2]; /// getFighter inlines not working
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftDonkeyAttributes* donkey_attr;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[4];
+#endif
+
     if (fp->xE0_ground_or_air == GA_Air) {
         func_8007D7FC(fp);
     }

--- a/src/melee/ft/chara/ftDonkey/ftdonkey8.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey8.c
@@ -23,7 +23,7 @@ void ftDonkey_800E05C4(HSD_GObj* fighter_gobj)
 
 void ftDonkey_800E05E4(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs2CC(fp);
     fp->x2344_f32 = donkey_attr->cargo_hold.x28_LANDING_LAG;
     donkey_attr = getFtSpecialAttrs2CC(fp);
@@ -34,7 +34,7 @@ void ftDonkey_800E05E4(HSD_GObj* fighter_gobj)
 
 void ftDonkey_800E0648(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->x2344_f32 <= 0.0f)
         ftDonkey_800DF980(fighter_gobj);

--- a/src/melee/ft/chara/ftDonkey/ftdonkey9.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey9.c
@@ -46,14 +46,14 @@ bool ftDonkey_800E0750(HSD_GObj* fighter_gobj)
 
 void ftDonkey_800E07B0(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftDonkeyAttributes* donkey_attr = fp->x2CC;
     func_8008DCE0(fighter_gobj, donkey_attr->action_state + 9, 0.0f);
 }
 
 void ftDonkey_800E07E4(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8008F744(fighter_gobj);
     if (!fp->x221C_flag.bits.b6) {
         if (fp->xE0_ground_or_air == GA_Air) {

--- a/src/melee/ft/chara/ftDonkey/ftdonkey_SpecialHi.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey_SpecialHi.c
@@ -9,7 +9,7 @@
 
 void ftDonkey_SetCallbacks_SpecialHi(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     fp->cb.x21DC_callback_OnTakeDamage = &ftDonkey_8010D774;
     fp->cb.x21E4_callback_OnDeath2 = &ftDonkey_8010D774;
     fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
@@ -42,7 +42,7 @@ void ftDonkey_SpecialAirHi_StartAction(HSD_GObj* fighter_gobj)
 
     /// @todo Unused stack.
 #ifdef MUST_MATCH
-    u8 unused[16];
+    u8 unused[8];
 #endif
 
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x17E, 0, NULL, 0.0f, 1.0f,
@@ -103,7 +103,7 @@ void ftDonkey_8010FDA4(HSD_GObj* fighter_gobj)
 void ftDonkey_8010FDEC(HSD_GObj* fighter_gobj)
 {
     s32 unused[2]; /// get inline break the regalloc, this seems cleanest
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftDonkeyAttributes* donkey_attr = fp->x2D4_specialAttributes;
     f32 gravity_scalar;
 
@@ -120,8 +120,9 @@ void ftDonkey_8010FDEC(HSD_GObj* fighter_gobj)
 
 void ftDonkey_8010FE60(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = getFighter(fighter_gobj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftDonkeyAttributes* donkey_attr = fp->x2D4_specialAttributes;
+
     if (!func_80082708(fighter_gobj)) {
         func_8007D60C(fp);
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x17E, 0x0C4C5080,
@@ -135,9 +136,13 @@ void ftDonkey_8010FE60(HSD_GObj* fighter_gobj)
 
 void ftDonkey_8010FF14(HSD_GObj* fighter_gobj)
 {
-    s32 unused[2]; /// get inline break the regalloc, this seems cleanest
-    Fighter* fp = fighter_gobj->user_data;
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftDonkeyAttributes* donkey_attr = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     if (fp->x80_self_vel.y >= 0.0f) {
         if (func_80081D0C(fighter_gobj)) {

--- a/src/melee/ft/chara/ftDonkey/ftdonkey_SpecialLw.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey_SpecialLw.c
@@ -39,7 +39,7 @@ void ftDonkey_8010DD38(HSD_GObj* fighter_gobj)
 
 void ftDonkey_8010DD74(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     if (!ftAnim_IsFramesRemaining(fighter_gobj)) {
         if (fp->x2340_stateVar1) {
             fp->x2340_stateVar1 = 0;
@@ -52,7 +52,7 @@ void ftDonkey_8010DD74(HSD_GObj* fighter_gobj)
 
 void ftDonkey_8010DDDC(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     if (fp->input.x668 & 0x200) {
         fp->x2340_stateVar1 = 1;
     }

--- a/src/melee/ft/chara/ftDonkey/ftdonkey_SpecialN.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey_SpecialN.c
@@ -10,7 +10,7 @@
 
 void ftDonkey_SetCallbacks_SpecialN(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     fp->cb.x21DC_callback_OnTakeDamage = &ftDonkey_8010D774;
     fp->cb.x21E4_callback_OnDeath2 = &ftDonkey_8010D774;
     fp->cb.x21F0_callback = &ftDonkey_DestroyAllEffects;
@@ -20,7 +20,7 @@ void ftDonkey_SetCallbacks_SpecialN(HSD_GObj* fighter_gobj)
 
 void ftDonkey_UpdateDKVelocityAfterPunch(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp);
     fp->xEC_ground_vel =
         fp->facing_dir * (donkey_attr->SpecialN.x34_PUNCH_HORIZONTAL_VEL *
@@ -30,7 +30,13 @@ void ftDonkey_UpdateDKVelocityAfterPunch(HSD_GObj* fighter_gobj)
 void ftDonkey_SpecialN_StartAction(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp);
+    ftDonkeyAttributes* donkey_attr = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
+
     if (fp->sa.dk.x222C == donkey_attr->SpecialN.x2C_MAX_ARM_SWINGS) {
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x175, 0, NULL, 0.0f,
                                            1.0f, 0.0f);
@@ -60,7 +66,13 @@ void ftDonkey_SpecialN_StartAction(HSD_GObj* fighter_gobj)
 void ftDonkey_SpecialAirN_StartAction(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp);
+    ftDonkeyAttributes* donkey_attr = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
+
     if (fp->sa.dk.x222C == donkey_attr->SpecialN.x2C_MAX_ARM_SWINGS) {
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x17A, 0, NULL, 0.0f,
                                            1.0f, 0.0f);
@@ -129,8 +141,8 @@ void ftDonkey_8010E8E0(HSD_GObj* fighter_gobj)
 
 void ftDonkey_8010E930(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = getFighter(fighter_gobj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftDonkeyAttributes* donkey_attr = fp->x2D4_specialAttributes;
 
     if (fp->x2200_ftcmd_var0) {
         if (fp->x2348_stateVar3_s32 == 0) {
@@ -185,7 +197,11 @@ void ftDonkey_8010E930(HSD_GObj* fighter_gobj)
 void ftDonkey_8010EB0C(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
-    ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp);
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     if (fp->x2200_ftcmd_var0) {
         if (fp->x2348_stateVar3_s32 == 0)
@@ -355,7 +371,7 @@ void ftDonkey_8010F098(HSD_GObj* fighter_gobj)
     Fighter* fp = GET_FIGHTER(fighter_gobj);
     /// @todo Unused stack.
 #ifdef MUST_MATCH
-    u8 unused[16];
+    u8 unused[8];
 #endif
 
     if (!func_8009917C(fighter_gobj)) {
@@ -392,7 +408,7 @@ void ftDonkey_8010F1E8(HSD_GObj* fighter_gobj)
 
     /// @todo Unused stack.
 #ifdef MUST_MATCH
-    u8 unused[12];
+    u8 unused[4];
 #endif
 
     if ((fp->input.x668 & 0x200)) {
@@ -473,11 +489,6 @@ void ftDonkey_8010F468(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
 
-    /// @todo Unused stack.
-#ifdef MUST_MATCH
-    u8 unused[8];
-#endif
-
     if (!func_80082708(fighter_gobj)) {
         func_8007D5D4(fp);
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x176, 0x0C4C5080,
@@ -490,11 +501,6 @@ void ftDonkey_8010F468(HSD_GObj* fighter_gobj)
 void ftDonkey_8010F50C(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
-
-    /// @todo Unused stack.
-#ifdef MUST_MATCH
-    u8 unused[8];
-#endif
 
     if (!func_80082708(fighter_gobj)) {
         func_8007D5D4(fp);
@@ -509,11 +515,6 @@ void ftDonkey_8010F5B0(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
 
-    /// @todo Unused stack.
-#ifdef MUST_MATCH
-    u8 unused[8];
-#endif
-
     if (!func_80082708(fighter_gobj)) {
         func_8007D5D4(fp);
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x178, 0x0C4C5080,
@@ -526,11 +527,6 @@ void ftDonkey_8010F5B0(HSD_GObj* fighter_gobj)
 void ftDonkey_8010F654(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
-
-    /// @todo Unused stack.
-#ifdef MUST_MATCH
-    u8 unused[8];
-#endif
 
     if (func_800827A0(fighter_gobj) == 0) {
         func_8007D5D4(fp);
@@ -545,11 +541,6 @@ void ftDonkey_8010F6F8(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
 
-    /// @todo Unused stack.
-#ifdef MUST_MATCH
-    u8 unused[8];
-#endif
-
     if (func_800827A0(fighter_gobj) == 0) {
         func_8007D5D4(fp);
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x17A, 0x0C4D508E,
@@ -562,11 +553,6 @@ void ftDonkey_8010F6F8(HSD_GObj* fighter_gobj)
 void ftDonkey_8010F79C(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
-
-    /// @todo Unused stack.
-#ifdef MUST_MATCH
-    u8 unused[8];
-#endif
 
     if (func_80081D0C(fighter_gobj) == 1) {
         func_8007D7FC(fp);
@@ -581,11 +567,6 @@ void ftDonkey_8010F840(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
 
-    /// @todo Unused stack.
-#ifdef MUST_MATCH
-    u8 unused[8];
-#endif
-
     if (func_80081D0C(fighter_gobj) == 1) {
         func_8007D7FC(fp);
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x172, 0x0C4C5080,
@@ -598,11 +579,6 @@ void ftDonkey_8010F840(HSD_GObj* fighter_gobj)
 void ftDonkey_8010F8E4(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
-
-    /// @todo Unused stack.
-#ifdef MUST_MATCH
-    u8 unused[8];
-#endif
 
     if (func_80081D0C(fighter_gobj) == 1) {
         func_8007D7FC(fp);
@@ -617,11 +593,6 @@ void ftDonkey_8010F988(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
 
-    /// @todo Unused stack.
-#ifdef MUST_MATCH
-    u8 unused[8];
-#endif
-
     if (func_80081D0C(fighter_gobj)) {
         func_8007D7FC(fp);
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x174, 0x0C4D508E,
@@ -634,11 +605,6 @@ void ftDonkey_8010F988(HSD_GObj* fighter_gobj)
 void ftDonkey_8010FA2C(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
-
-    /// @todo Unused stack.
-#ifdef MUST_MATCH
-    u8 unused[8];
-#endif
 
     if (func_80081D0C(fighter_gobj)) {
         func_8007D7FC(fp);
@@ -656,7 +622,7 @@ void ftDonkey_DestroyAllEffects(HSD_GObj* fighter_gobj)
 
 void ftDonkey_DestroyAllEffectsPlus(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     fp->sa.dk.x222C = 0;
     efLib_DestroyAll(fighter_gobj);
 }

--- a/src/melee/ft/chara/ftDonkey/ftdonkey_SpecialS.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey_SpecialS.c
@@ -92,7 +92,7 @@ void ftDonkey_8010E428(HSD_GObj* fighter_gobj)
 
 void ftDonkey_8010E464(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x17C, 0x0C4C508A, NULL,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -104,7 +104,7 @@ void ftDonkey_8010E464(HSD_GObj* fighter_gobj)
 
 void ftDonkey_8010E4EC(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x17B, 0x0C4C508A, NULL,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);

--- a/src/melee/ft/chara/ftDonkey/ftdonkey_callbacks.c
+++ b/src/melee/ft/chara/ftDonkey/ftdonkey_callbacks.c
@@ -154,7 +154,7 @@ Fighter_CostumeStrings lbl_803CC020[] = {
 
 void ftDonkey_OnDeath(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     fp->sa.dk.x222C = 0;
     func_80074A4C(fighter_gobj, 0, 0);
 }
@@ -187,7 +187,7 @@ void ftDonkey_OnItemDrop(HSD_GObj* gobj, bool bool1)
 
 void func_8010D96C(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftDonkeyAttributes* attr = fp->x2D4_specialAttributes;
 
     if (fp->sa.dk.x222C == attr->SpecialN.x2C_MAX_ARM_SWINGS)
@@ -226,23 +226,27 @@ void ftDonkey_OnKnockbackExit(HSD_GObj* fighter_gobj)
 
 void ftDonkey_8010DB3C(HSD_GObj* fighter_gobj)
 {
-    s32 unused[2]; /// can't remove with get inlines
     bool bool1;
     Fighter* fp = fighter_gobj->user_data;
     ftDonkeyAttributes* donkey_attr = fp->x2D4_specialAttributes;
     CollData* colldata = &fp->x6F0_collData;
 
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
+
     if (fp->x2210_ThrowFlags.b3) {
-        fp->x2210_ThrowFlags.b3 = 0;
-        bool1 = 1;
+        fp->x2210_ThrowFlags.b3 = false;
+        bool1 = true;
     } else {
-        bool1 = 0;
+        bool1 = false;
     }
 
-    if ((bool1) && ((colldata->x134_envFlags & 0x18000))) {
+    if (bool1 && FLAGS_ANY(colldata->x134_envFlags, 0x18000)) {
         Vec3 vec_list[4];
 
-        s32 i;
+        int i;
         for (i = 0; i < 4; i++) {
             f32 temp_f5 = (donkey_attr->SpecialLw.x68 * i) -
                           (donkey_attr->SpecialLw.x68 * 1.5f);

--- a/src/melee/ft/chara/ftFox/ftFox_AppealS.c
+++ b/src/melee/ft/chara/ftFox/ftFox_AppealS.c
@@ -36,7 +36,7 @@ static inline bool ftFox_CheckAppealSCount(void)
 
 bool ftFox_AppealS_CheckInput(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     s32 ftKind = fp->x4_fighterKind;
 
     if (((ftKind == FTKIND_FOX) || (ftKind == FTKIND_FALCO)) &&
@@ -79,7 +79,7 @@ void ftFox_AppealS_Action(HSD_GObj* fighter_gobj)
     s32 facingDir;
     s32 actionDir;
     s32 animCount;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     fp->foxVars[0].AppealS.animCount = 0;
     facingDir = ftFox_AppealS_GetLR(1.0f, fp->facing_dir);
@@ -100,14 +100,17 @@ static void ftFox_AppealS_OnTakeDamage(HSD_GObj*);
 
 void ftFox_AppealS_Anim(HSD_GObj* fighter_gobj)
 {
-    s32 ftKind;
-    s32 flag;
-    s32 var1;
-    s32 var2;
-    Fighter* fp = fighter_gobj->user_data;
+    FighterKind ftKind;
+    bool flag;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
-    if (fp->x2210_ThrowFlags.b3 != 0) {
-        fp->x2210_ThrowFlags.b3 = 0;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[4];
+#endif
+
+    if (fp->x2210_ThrowFlags.b3) {
+        fp->x2210_ThrowFlags.b3 = false;
         flag = true;
     } else {
         flag = false;
@@ -162,7 +165,7 @@ void ftFox_AppealS_Coll(HSD_GObj* fighter_gobj)
 
 static void ftFox_AppealS_OnTakeDamage(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     func_801E2AF4();
     fp->cb.x21E0_callback_OnDeath = NULL;

--- a/src/melee/ft/chara/ftFox/ftFox_SpecialHi.c
+++ b/src/melee/ft/chara/ftFox/ftFox_SpecialHi.c
@@ -17,7 +17,7 @@
 
 void ftFox_SpecialHi_CreateLaunchGFX(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->x2219_flag.bits.b0 == false) {
         ef_Spawn(0x48C, fighter_gobj,
@@ -33,7 +33,7 @@ void ftFox_SpecialHi_CreateLaunchGFX(HSD_GObj* fighter_gobj)
 
 void ftFox_SpecialHi_CreateChargeGFX(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->x2219_flag.bits.b0 == false) {
         ef_Spawn(0x48B, fighter_gobj,
@@ -135,9 +135,14 @@ void ftFox_SpecialHiHold_Phys(HSD_GObj* fighter_gobj)
 
 void ftFox_SpecialHiHoldAir_Phys(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    ftFoxAttributes* foxAttrs = getFtSpecialAttrs(fp);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftFoxAttributes* foxAttrs = fp->x2D4_specialAttributes;
     attr* ftAttrs = &fp->x110_attr;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     if (fp->foxVars[0].SpecialHi.gravityDelay != 0) {
         fp->foxVars[0].SpecialHi.gravityDelay -= 1;
@@ -479,7 +484,7 @@ void ftFox_SpecialAirHi_Action(HSD_GObj* fighter_gobj)
 {
     ftFoxAttributes* foxAttrs;
     attr* ftAttrs;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftFoxAttributes* tempAttrs;
     f32 stick_x;
     f32 stick_y;
@@ -609,7 +614,10 @@ void ftFox_SpecialHiLanding_Coll(HSD_GObj* fighter_gobj)
 // Collision callback
 void ftFox_SpecialHiFall_Coll(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     if (EnvColl_CheckGroundAndLedge(fighter_gobj, CLIFFCATCH_BOTH) != false) {
         ftFox_SpecialHiFall_Action(fighter_gobj);
@@ -624,7 +632,7 @@ void ftFox_SpecialHiFall_Coll(HSD_GObj* fighter_gobj)
 // Action State handler
 void ftFox_SpecialHiFall_Action(HSD_GObj* fighter_gobj)
 {
-    func_8007D7FC(fighter_gobj->user_data);
+    func_8007D7FC(GET_FIGHTER(fighter_gobj));
     Fighter_ActionStateChange_800693AC(
         fighter_gobj, AS_FOX_SPECIALHI_LANDING,
         (FIGHTER_COLANIM_NOUPDATE | FIGHTER_CMD_UPDATE), NULL, 13.0f, 1.0f,
@@ -637,7 +645,7 @@ void ftFox_SpecialHiFall_Action(HSD_GObj* fighter_gobj)
 // Firefox/Firebird End Action State handler
 void ftFox_SpecialHiFall_AirToGround(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     func_8007DB24(fighter_gobj);
     if ((s32) fp->xE0_ground_or_air == GA_Air) {
@@ -653,7 +661,7 @@ void ftFox_SpecialHiFall_AirToGround(HSD_GObj* fighter_gobj)
 // Rebound Collision thing
 void ftFox_SpecialHiLanding_GroundToAir(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     func_8007DB24(fighter_gobj);
 
@@ -671,9 +679,14 @@ void ftFox_SpecialHiBound_Anim(HSD_GObj* fighter_gobj)
     Fighter* fp;
     ftFoxAttributes* foxAttrs;
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[4];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     ftAttrs = &fp->x110_attr;
-    foxAttrs = getFtSpecialAttrs(fp);
+    foxAttrs = fp->x2D4_specialAttributes;
 
     if (((u32) fp->x2200_ftcmd_var0 != 0U) &&
         ((s32) fp->xE0_ground_or_air == GA_Air))
@@ -723,7 +736,7 @@ void ftFox_SpecialHiBound_Phys(HSD_GObj* fighter_gobj)
 // Collision callback
 void ftFox_SpecialHiBound_Coll(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     s32 cliffCatchDir;
 
     if ((s32) fp->xE0_ground_or_air == GA_Air) {
@@ -751,18 +764,18 @@ void ftFox_SpecialHiBound_Coll(HSD_GObj* fighter_gobj)
 
 inline void ftFox_SpecialHiBound_SetVars(HSD_GObj* fighter_gobj)
 {
-    vf32 sp1C; // I have a feeling this is a Vec3 struct however
-    Fighter* fp = fp = GET_FIGHTER(fighter_gobj);
+    vf32 f; // I have a feeling this is a Vec3 struct however
+    Fighter* fp = fp = fighter_gobj->user_data;
     CollData* collData = collData = getFtColl(fp);
 
     if (fp->x6F0_collData.x134_envFlags & 0x18000) {
-        sp1C = -atan2f(collData->x14C_ground.normal.x,
-                       collData->x14C_ground.normal.y);
+        f = -atan2f(collData->x14C_ground.normal.x,
+                    collData->x14C_ground.normal.y);
     } else {
-        sp1C = 0.0f;
+        f = 0.0f;
     }
-    ef_Spawn(0x406, fighter_gobj, &fp->xB0_pos, &sp1C);
-    fp->x2219_flag.bits.b0 = 1;
+    ef_Spawn(0x406, fighter_gobj, &fp->xB0_pos, &f);
+    fp->x2219_flag.bits.b0 = true;
     fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
     fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
 }
@@ -772,7 +785,7 @@ inline void ftFox_SpecialHiBound_SetVars(HSD_GObj* fighter_gobj)
 // Action State handler
 void ftFox_SpecialHiBound_Action(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftFoxAttributes* foxAttrs = fp->x2D4_specialAttributes;
 
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_FOX_SPECIALHI_BOUND, 0,

--- a/src/melee/ft/chara/ftFox/ftFox_SpecialN.c
+++ b/src/melee/ft/chara/ftFox/ftFox_SpecialN.c
@@ -67,7 +67,7 @@ s32 ftFox_GetBlasterAction(HSD_GObj* fighter_gobj)
     s32 ASID = 9;
 
     if (fighter_gobj != NULL) {
-        Fighter* fp = fighter_gobj->user_data;
+        Fighter* fp = GET_FIGHTER(fighter_gobj);
         if (fp != NULL) {
             s32 currASID = fp->action_id;
             switch (currASID) {
@@ -96,7 +96,7 @@ s32 ftFox_GetBlasterAction(HSD_GObj* fighter_gobj)
 bool ftFox_CheckBlasterAction(HSD_GObj* fighter_gobj)
 {
     if (fighter_gobj != NULL) {
-        Fighter* fp = fighter_gobj->user_data;
+        Fighter* fp = GET_FIGHTER(fighter_gobj);
         s32 ASID = fp->action_id;
         switch (ASID) {
         case AS_FOX_SPECIALN_START:
@@ -129,7 +129,7 @@ inline void ftFox_SpecialN_SetNULL(HSD_GObj* fighter_gobj)
 // https://decomp.me/scratch/4v8j4 // Clear Blaster GObj pointer and callbacks
 void ftFox_ClearBlaster(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->sa.fox.x222C_blasterGObj != NULL) {
         fp->sa.fox.x222C_blasterGObj = NULL;
@@ -141,7 +141,7 @@ void ftFox_ClearBlaster(HSD_GObj* fighter_gobj)
 // https://decomp.me/scratch/WglAb // Remove Blaster item
 void ftFox_RemoveBlaster(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     HSD_GObj* blasterGObj;
 
     if (fp->sa.fox.x222C_blasterGObj != NULL) {
@@ -362,7 +362,7 @@ void ftFox_SpecialNLoop_Anim(HSD_GObj* fighter_gobj)
         ftFoxAttributes* foxAttrs;
         Fighter* fp;
         f64 launchAngle;
-        s32 ftKind;
+        FighterKind ftKind;
 
 #ifdef MUST_MATCH
         fp = fp = GET_FIGHTER(fighter_gobj);
@@ -592,7 +592,7 @@ void ftFox_SpecialAirNEnd_Anim(HSD_GObj* fighter_gobj)
 // callback
 void ftFox_SpecialNStart_IASA(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (((u32) fp->x2200_ftcmd_var0 != 0U) && (fp->input.x668 & HSD_BUTTON_B)) {
         fp->foxVars[0].SpecialN.isBlasterLoop = true;
@@ -604,7 +604,7 @@ void ftFox_SpecialNStart_IASA(HSD_GObj* fighter_gobj)
 // callback
 void ftFox_SpecialNLoop_IASA(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (((u32) fp->x2200_ftcmd_var0 != 0U) && (fp->input.x668 & HSD_BUTTON_B)) {
         fp->foxVars[0].SpecialN.isBlasterLoop = true;
@@ -622,7 +622,7 @@ void ftFox_SpecialNEnd_IASA(HSD_GObj* fighter_gobj)
 // callback
 void ftFox_SpecialAirNStart_IASA(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (((u32) fp->x2200_ftcmd_var0 != 0U) && (fp->input.x668 & HSD_BUTTON_B)) {
         fp->foxVars[0].SpecialN.isBlasterLoop = true;
@@ -634,7 +634,7 @@ void ftFox_SpecialAirNStart_IASA(HSD_GObj* fighter_gobj)
 // callback
 void ftFox_SpecialAirNLoop_IASA(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (((u32) fp->x2200_ftcmd_var0 != 0U) && (fp->input.x668 & HSD_BUTTON_B)) {
         fp->foxVars[0].SpecialN.isBlasterLoop = true;

--- a/src/melee/ft/chara/ftFox/ftFox_SpecialS.c
+++ b/src/melee/ft/chara/ftFox/ftFox_SpecialS.c
@@ -43,7 +43,7 @@ bool ftFox_SpecialS_CheckGhostRemove(HSD_GObj* fighter_gobj)
 // https://decomp.me/scratch/jUfwc // Return 0x2208 from Fighter Struct
 u32 ftFox_SpecialS_GetCmdVar2(HSD_GObj* fighter_gobj)
 {
-    return ((Fighter*) fighter_gobj->user_data)->x2208_ftcmd_var2;
+    return (GET_FIGHTER(fighter_gobj))->x2208_ftcmd_var2;
 }
 
 // 0x800E9EAC
@@ -51,7 +51,7 @@ u32 ftFox_SpecialS_GetCmdVar2(HSD_GObj* fighter_gobj)
 void ftFox_SpecialS_CopyGhostPosIndexed(HSD_GObj* fighter_gobj, s32 index,
                                         Vec3* ghostPos)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     *ghostPos = fp->foxVars[0].SpecialS.ghostEffectPos[index];
 }
@@ -150,7 +150,7 @@ void ftFox_SpecialAirSStart_IASA(HSD_GObj* fighter_gobj)
 // Start Physics callback
 void ftFox_SpecialSStart_Phys(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->foxVars[0].SpecialS.gravityDelay != 0) {
         fp->foxVars[0].SpecialS.gravityDelay--;
@@ -163,9 +163,14 @@ void ftFox_SpecialSStart_Phys(HSD_GObj* fighter_gobj)
 // Start Physics callback
 void ftFox_SpecialAirSStart_Phys(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fp = fighter_gobj->user_data;
-    ftFoxAttributes* foxAttrs = getFtSpecialAttrs(fp);
+    Fighter* fp = fp = GET_FIGHTER(fighter_gobj);
+    ftFoxAttributes* foxAttrs = fp->x2D4_specialAttributes;
     attr* ftAttrs = &fp->x110_attr;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     if (fp->foxVars[0].SpecialS.gravityDelay != 0) {
         fp->foxVars[0].SpecialS.gravityDelay--;
@@ -214,7 +219,7 @@ void ftFox_SpecialAirSStart_Coll(HSD_GObj* fighter_gobj)
 // Illusion/Phantasm Start Action State handler
 void ftFox_SpecialSStart_GroundToAir(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     func_8007D60C(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_FOX_SPECIALAIRS_START,
@@ -227,7 +232,7 @@ void ftFox_SpecialSStart_GroundToAir(HSD_GObj* fighter_gobj)
 // Illusion/Phantasm Start Action State handler
 void ftFox_SpecialAirSStart_AirToGround(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_FOX_SPECIALS_START,
@@ -287,7 +292,7 @@ void ftFox_SpecialAirS_Anim(HSD_GObj* fighter_gobj)
 // Dash IASA callback
 void ftFox_SpecialS_IASA(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if ((fp->input.x668 & HSD_BUTTON_B) != false) {
         if ((s32) fp->xE0_ground_or_air == GA_Air) {
@@ -303,7 +308,7 @@ void ftFox_SpecialS_IASA(HSD_GObj* fighter_gobj)
 // Dash IASA callback
 void ftFox_SpecialAirS_IASA(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if ((fp->input.x668 & HSD_BUTTON_B) != false) {
         if ((s32) fp->xE0_ground_or_air == GA_Air) {
@@ -318,7 +323,7 @@ static inline void ftFox_SpecialS_SetPhys(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
 
     fp->foxVars[0].SpecialS.ghostEffectPos[3] =
         fp->foxVars[0].SpecialS.ghostEffectPos[2];
@@ -394,7 +399,7 @@ void ftFox_SpecialAirS_Coll(HSD_GObj* fighter_gobj)
 // Illusion/Phantasm Dash Action State handler
 void ftFox_SpecialS_GroundToAir(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     func_8007D60C(fp);
     Fighter_ActionStateChange_800693AC(
@@ -409,7 +414,7 @@ void ftFox_SpecialS_GroundToAir(HSD_GObj* fighter_gobj)
 // Illusion/Phantasm Dash Action State handler
 void ftFox_SpecialAirS_AirToGround(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(
@@ -509,7 +514,12 @@ void ftFox_SpecialAirSEnd_IASA(HSD_GObj* fighter_gobj)
 void ftFox_SpecialSEnd_Phys(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = getFighter(fighter_gobj);
-    ftFoxAttributes* foxAttrs = getFtSpecialAttrs(fp);
+    ftFoxAttributes* foxAttrs = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     if (fp->foxVars[0].SpecialS.gravityDelay != 0) {
         fp->foxVars[0].SpecialS.gravityDelay--;
@@ -525,8 +535,13 @@ void ftFox_SpecialSEnd_Phys(HSD_GObj* fighter_gobj)
 void ftFox_SpecialAirSEnd_Phys(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = fp = GET_FIGHTER(fighter_gobj);
-    ftFoxAttributes* foxAttrs = getFtSpecialAttrs(fp);
-    attr* ftAttrs = getFtAttrs(fp);
+    ftFoxAttributes* foxAttrs = fp->x2D4_specialAttributes;
+    attr* ftAttrs = &fp->x110_attr;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     if (fp->foxVars[0].SpecialS.gravityDelay != 0) {
         fp->foxVars[0].SpecialS.gravityDelay--;
@@ -542,7 +557,10 @@ void ftFox_SpecialAirSEnd_Phys(HSD_GObj* fighter_gobj)
 // End Collision callback
 void ftFox_SpecialSEnd_Coll(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     if (func_800827A0(fighter_gobj) == false) {
         func_800CC730(fighter_gobj);
@@ -554,9 +572,15 @@ void ftFox_SpecialSEnd_Coll(HSD_GObj* fighter_gobj)
 // Collision callback
 void ftFox_SpecialAirSEnd_Coll(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    ftFoxAttributes* foxAttrs = getFtSpecialAttrs(fp);
-    s32 cliffCatchDir;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftFoxAttributes* foxAttrs = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[4];
+#endif
+
+    int cliffCatchDir;
 
     if (fp->facing_dir < 0.0f) {
         cliffCatchDir = -1;
@@ -573,7 +597,7 @@ void ftFox_SpecialAirSEnd_Coll(HSD_GObj* fighter_gobj)
 
 inline void ftFox_SpecialSEnd_SetVars(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftFoxAttributes* foxAttrs = getFtSpecialAttrs(fp);
     fp->foxVars[0].SpecialS.gravityDelay =
         foxAttrs->x44_FOX_ILLUSION_FALL_ACCEL;
@@ -585,8 +609,8 @@ inline void ftFox_SpecialSEnd_SetVars(HSD_GObj* fighter_gobj)
 // State handler
 void ftFox_SpecialSEnd_Action(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    ftFoxAttributes* foxAttrs = getFtSpecialAttrs(fp);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftFoxAttributes* foxAttrs = fp->x2D4_specialAttributes;
 
     fp->xEC_ground_vel =
         foxAttrs->x34_FOX_ILLUSION_GROUND_END_VEL_X * fp->facing_dir;
@@ -601,8 +625,8 @@ void ftFox_SpecialSEnd_Action(HSD_GObj* fighter_gobj)
 // https://decomp.me/scratch/QFxa9
 void ftFox_SpecialAirSEnd_Action(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    ftFoxAttributes* foxAttrs = getFtSpecialAttrs(fp);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftFoxAttributes* foxAttrs = fp->x2D4_specialAttributes;
 
     fp->x80_self_vel.x =
         foxAttrs->x3C_FOX_ILLUSION_AIR_END_VEL_X * fp->facing_dir;

--- a/src/melee/ft/chara/ftGameWatch/ftGameWatch_AttackAir.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGameWatch_AttackAir.c
@@ -12,13 +12,12 @@ static void ftGameWatch_AttackAir_ExitItemHitlag(HSD_GObj*);
 void ftGameWatch_ItemParachuteSetup(HSD_GObj* fighter_gobj)
 {
     Vec3 sp10;
-    HSD_GObj* parachuteGObj;
-    Fighter* fp = getFighter(fighter_gobj);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->sa.gaw.x2258_parachuteGObj != NULL) {
         ftGameWatch_ItemParachuteOnLand(fighter_gobj);
     } else {
-        func_8000B1CC(fp->x5E8_fighterBones[0x1].x0_jobj, NULL, &sp10);
+        func_8000B1CC(fp->x5E8_fighterBones[1].x0_jobj, NULL, &sp10);
         fp->sa.gaw.x2258_parachuteGObj =
             func_802C6C38(fighter_gobj, &sp10, 1, fp->facing_dir);
         if (fp->sa.gaw.x2258_parachuteGObj != NULL) {
@@ -306,28 +305,28 @@ bool ftGameWatch_ItemCheckSparkyRemove(HSD_GObj* fighter_gobj)
     return true;
 }
 
-static void ftGameWatch_AttackAirB_Action(HSD_GObj*, s32);
-static void ftGameWatch_AttackAirHi_Action(HSD_GObj*, s32);
+static void ftGameWatch_AttackAirB_Action(HSD_GObj*);
+static void ftGameWatch_AttackAirHi_Action(HSD_GObj*);
 
 // 0x8014B64C
 // https://decomp.me/scratch/Ads9W // Decide Mr. Game & Watch's Aerial Attack
 // Action State
 void ftGameWatch_AttackAir_DecideAction(HSD_GObj* fighter_gobj)
 {
-    s32 ASID = func_8008CE68(fighter_gobj->user_data);
+    enum_t ASID = func_8008CE68(GET_FIGHTER(fighter_gobj));
 
     switch (ASID) {
     case ASID_ATTACKAIRN:
-        ftGameWatch_AttackAirN_Action(fighter_gobj, ASID);
+        ftGameWatch_AttackAirN_Action(fighter_gobj);
         return;
     case ASID_ATTACKAIRF:
         func_8008CFAC(fighter_gobj, ASID);
         return;
     case ASID_ATTACKAIRB:
-        ftGameWatch_AttackAirB_Action(fighter_gobj, ASID);
+        ftGameWatch_AttackAirB_Action(fighter_gobj);
         return;
     case ASID_ATTACKAIRHI:
-        ftGameWatch_AttackAirHi_Action(fighter_gobj, ASID);
+        ftGameWatch_AttackAirHi_Action(fighter_gobj);
         return;
     case ASID_ATTACKAIRLW:
         func_8008CFAC(fighter_gobj, ASID);
@@ -338,9 +337,9 @@ void ftGameWatch_AttackAir_DecideAction(HSD_GObj* fighter_gobj)
 // 0x8014B6E4
 // https://decomp.me/scratch/iunEP // Mr. Game & Watch's Neutral Aerial Action
 // State handler
-void ftGameWatch_AttackAirN_Action(HSD_GObj* fighter_gobj, s32 ASID)
+void ftGameWatch_AttackAirN_Action(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     func_8008CFAC(fighter_gobj, AS_GAMEWATCH_ATTACKAIRN);
     fp->cb.x21BC_callback_Accessory4 = ftGameWatch_ItemParachuteSetup;
@@ -411,9 +410,9 @@ void ftGameWatch_LandingAirN_Action(HSD_GObj* fighter_gobj)
 // 0x8014B840
 // https://decomp.me/scratch/iunEP // Mr. Game & Watch's Back Aerial Action
 // State handler
-static void ftGameWatch_AttackAirB_Action(HSD_GObj* fighter_gobj, s32 ASID)
+static void ftGameWatch_AttackAirB_Action(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     func_8008CFAC(fighter_gobj, AS_GAMEWATCH_ATTACKAIRB);
     fp->cb.x21BC_callback_Accessory4 = ftGameWatch_ItemTurtleSetup;
@@ -481,9 +480,9 @@ void ftGameWatch_LandingAirB_Action(HSD_GObj* fighter_gobj)
 // 0x8014B99C
 // https://decomp.me/scratch/iunEP // Mr. Game & Watch's Up Aerial Action State
 // handler
-static void ftGameWatch_AttackAirHi_Action(HSD_GObj* fighter_gobj, s32 ASID)
+static void ftGameWatch_AttackAirHi_Action(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     func_8008CFAC(fighter_gobj, AS_GAMEWATCH_ATTACKAIRHI);
     fp->cb.x21BC_callback_Accessory4 = ftGameWatch_ItemSparkySetup;

--- a/src/melee/ft/chara/ftGameWatch/ftGameWatch_SpecialHi.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGameWatch_SpecialHi.c
@@ -16,12 +16,11 @@ static void ftGameWatch_ItemRescueExitHitlag(HSD_GObj* fighter_gobj);
 void ftGameWatch_ItemRescueSetup(HSD_GObj* fighter_gobj)
 {
     Vec3 sp10;
-    f32 temp;
     Fighter* fp;
     HSD_GObj* rescueGObj;
 
-    fp = fighter_gobj->user_data;
-    if ((u32) fp->sa.gaw.x226C_rescueGObj == 0) {
+    fp = GET_FIGHTER(fighter_gobj);
+    if (fp->sa.gaw.x226C_rescueGObj == NULL) {
         func_8000B1CC(fp->x5E8_fighterBones[0].x0_jobj, NULL, &sp10);
         sp10.y = -((2.5f * Fighter_GetModelScale(fp)) - sp10.y);
         rescueGObj = func_802C8038(fighter_gobj, &sp10, 0,
@@ -42,7 +41,7 @@ void ftGameWatch_ItemRescueSetup(HSD_GObj* fighter_gobj)
 // Fire Rescue
 bool ftGameWatch_ItemCheckRescueRemove(HSD_GObj* fighter_gobj)
 {
-    s32 ASID = ((Fighter*) fighter_gobj->user_data)->action_id;
+    enum_t ASID = GET_FIGHTER(fighter_gobj)->action_id;
 
     switch (ASID) {
     case AS_GAMEWATCH_SPECIALHI:
@@ -56,7 +55,7 @@ bool ftGameWatch_ItemCheckRescueRemove(HSD_GObj* fighter_gobj)
 // 0x8014DFE4 - Set Fire Rescue GObj pointer and callbacks to NULL
 void ftGameWatch_ItemRescueSetNULL(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     fp->sa.gaw.x226C_rescueGObj = NULL;
     fp->cb.x21E4_callback_OnDeath2 = NULL;
@@ -66,9 +65,7 @@ void ftGameWatch_ItemRescueSetNULL(HSD_GObj* fighter_gobj)
 // 0x8014DFFC - Remove Fire Rescue item
 void ftGameWatch_ItemRescueRemove(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    HSD_GObj* rescueGObj;
-    HSD_GObj* rescueGObj2;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->sa.gaw.x226C_rescueGObj != NULL) {
         func_802C8158(fp->sa.gaw.x226C_rescueGObj);
@@ -79,7 +76,7 @@ void ftGameWatch_ItemRescueRemove(HSD_GObj* fighter_gobj)
 // 0x8014E04C - Apply hitlag to Fire Rescue item
 static void ftGameWatch_ItemRescueEnterHitlag(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->sa.gaw.x226C_rescueGObj != NULL) {
         func_802C81C8(fp->sa.gaw.x226C_rescueGObj);
@@ -89,7 +86,7 @@ static void ftGameWatch_ItemRescueEnterHitlag(HSD_GObj* fighter_gobj)
 // 0x8014E06C - Remove hitlag for Fire Rescue item
 static void ftGameWatch_ItemRescueExitHitlag(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->sa.gaw.x226C_rescueGObj != NULL) {
         func_802C81E8(fp->sa.gaw.x226C_rescueGObj);
@@ -98,7 +95,7 @@ static void ftGameWatch_ItemRescueExitHitlag(HSD_GObj* fighter_gobj)
 
 static inline void ftGameWatch_SpecialHi_SetVars(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     fp->x220C_ftcmd_var3 = 0;
     fp->x2208_ftcmd_var2 = 0;
     fp->x2204_ftcmd_var1 = 0;
@@ -111,14 +108,12 @@ static inline void ftGameWatch_SpecialHi_SetVars(HSD_GObj* fighter_gobj)
 // Action State handler
 void ftGameWatch_SpecialHi_StartAction(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    HSD_GObj* rescueGObj;
-    void (*cb_Accessory4)(HSD_GObj*);
-    s32 sfx;
-    s8 pan;
-    s8 volume;
-    f32 temp;
-    f32 vel;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[16];
+#endif
 
     fp->x74_anim_vel.y = 0.0f;
     fp->x80_self_vel.y = 0.0f;
@@ -133,16 +128,12 @@ void ftGameWatch_SpecialHi_StartAction(HSD_GObj* fighter_gobj)
 // 0x8014E158 - Mr. Game & Watch's aerial Fire Rescue Action State handler
 void ftGameWatch_SpecialAirHi_StartAction(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    HSD_GObj* rescueGObj;
-    void (*cb_Accessory4)(HSD_GObj*);
-    s32 var;
-    s32 var2;
-    s32 sfx;
-    s8 pan;
-    s8 volume;
-    f32 temp;
-    f32 vel;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[24];
+#endif
 
     func_8007D60C(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_GAMEWATCH_SPECIALAIRHI,
@@ -167,7 +158,7 @@ void ftGameWatch_SpecialAirHi_Anim(HSD_GObj* fighter_gobj)
     ftGameWatchAttributes* gawAttrs;
     f32 temp;
 
-    gawAttrs = ((Fighter*) fighter_gobj->user_data)->x2D4_specialAttributes;
+    gawAttrs = (GET_FIGHTER(fighter_gobj))->x2D4_specialAttributes;
     if (!ftAnim_IsFramesRemaining(fighter_gobj)) {
         if (0.0f == gawAttrs->x60_GAMEWATCH_RESCUE_LANDING) {
             func_800CC730(fighter_gobj);
@@ -189,10 +180,9 @@ void ftGameWatch_SpecialHi_IASA(HSD_GObj* fighter_gobj)
 // callback
 void ftGameWatch_SpecialAirHi_IASA(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftGameWatchAttributes* gawAttrs = fp->x2D4_specialAttributes;
     f32 stick_x;
-    f32 stick_range_min;
     f32 temp;
     f32 angle;
     f32 facing_dir;
@@ -243,11 +233,16 @@ void ftGameWatch_SpecialAirHi_Coll(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
     ftGameWatchAttributes* gawAttrs;
-    f32 animFrame;
-    s32 ledgeGrabDir;
+    int ledgeGrabDir;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     fp = GET_FIGHTER(fighter_gobj);
-    gawAttrs = getFtSpecialAttrs(fp);
+    gawAttrs = fp->x2D4_specialAttributes;
+
     if (fp->x894_currentAnimFrame > 4.0f) {
         if (fp->x80_self_vel.y >= 0.0f) {
             if (func_80081D0C(fighter_gobj) != false) {

--- a/src/melee/ft/chara/ftGameWatch/ftGameWatch_SpecialLw.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGameWatch_SpecialLw.c
@@ -40,7 +40,7 @@ void ftGameWatch_ItemPanicSetup(HSD_GObj* fighter_gobj)
 // https://decomp.me/scratch/Cdp6X // Set Oil Panic flags + clear pointers
 void ftGameWatch_ItemPanicSetFlag(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     ftGameWatch_ItemPanicExitHitlag(fighter_gobj);
     fp->sa.gaw.x2268_panicGObj = NULL;
@@ -52,9 +52,7 @@ void ftGameWatch_ItemPanicSetFlag(HSD_GObj* fighter_gobj)
 // https://decomp.me/scratch/UDMIR // Remove Oil Panic item
 void ftGameWatch_ItemPanicRemove(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    HSD_GObj* panicGObj;
-    HSD_GObj* panicGObj2;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->sa.gaw.x2268_panicGObj != NULL) {
         func_802C7E94(fp->sa.gaw.x2268_panicGObj);
@@ -65,7 +63,7 @@ void ftGameWatch_ItemPanicRemove(HSD_GObj* fighter_gobj)
 // 0x8014CD38 - Apply hitlag to Oil Panic item
 void ftGameWatch_ItemPanicEnterHitlag(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->sa.gaw.x2268_panicGObj != NULL)
         func_802C7EE0(fp->sa.gaw.x2268_panicGObj);
@@ -74,7 +72,7 @@ void ftGameWatch_ItemPanicEnterHitlag(HSD_GObj* fighter_gobj)
 // 0x8014CD68 - Remove hitlag for Oil Panic item
 void ftGameWatch_ItemPanicExitHitlag(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->sa.gaw.x2268_panicGObj != NULL)
         func_802C7F00(fp->sa.gaw.x2268_panicGObj);
@@ -86,7 +84,7 @@ void ftGameWatch_ItemPanicExitHitlag(HSD_GObj* fighter_gobj)
 bool ftGameWatch_ItemCheckPanicRemove(HSD_GObj* fighter_gobj)
 {
     /// @todo @c enum
-    enum_t asid = ((Fighter*) fighter_gobj->user_data)->action_id;
+    enum_t asid = (GET_FIGHTER(fighter_gobj))->action_id;
 
     if ((asid >= AS_GAMEWATCH_SPECIALLW_SHOOT) &&
         (asid <= AS_GAMEWATCH_SPECIALAIRLW_SHOOT))
@@ -102,12 +100,11 @@ bool ftGameWatch_ItemCheckPanicRemove(HSD_GObj* fighter_gobj)
 // models
 void ftGameWatch_SpecialLw_UpdateBucketModel(HSD_GObj* fighter_gobj)
 {
-    s32 modelState;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     func_80074B0C(fighter_gobj, 5, 2);
-    modelState = fp->sa.gaw.x2238_panicCharge;
-    switch (modelState) {
+
+    switch (fp->sa.gaw.x2238_panicCharge) {
     case GAMEWATCH_PANIC_EMPTY:
         func_80074B0C(fighter_gobj, 6, -1);
         func_80074B0C(fighter_gobj, 7, -1);
@@ -182,7 +179,7 @@ static inline void ftGameWatch_SpecialLw_UpdateVars(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
     u32 ftcmd_var = fp->x2200_ftcmd_var0;
-    ftGameWatchAttributes* gawAttrs = getFtSpecialAttrs(fp);
+    ftGameWatchAttributes* gawAttrs = fp->x2D4_specialAttributes;
     if (ftcmd_var == 1U) {
         fp->x2200_ftcmd_var0 = 2U;
         ftColl_CreateAbsorbHit(fighter_gobj,
@@ -201,7 +198,12 @@ static inline void ftGameWatch_SpecialLw_UpdateVars(HSD_GObj* fighter_gobj)
 void ftGameWatch_SpecialLw_Anim(HSD_GObj* fighter_gobj)
 {
     /// @todo Shared @c inline with #ftGameWatch_SpecialAirLw_Anim.
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     if ((38.0f == fp->x894_currentAnimFrame) &&
         ((s32) fp->gameWatchVars[0].SpecialLw.isRelease == false))
@@ -220,7 +222,12 @@ void ftGameWatch_SpecialLw_Anim(HSD_GObj* fighter_gobj)
 // Animation callback
 void ftGameWatch_SpecialAirLw_Anim(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     if ((38.0f == fp->x894_currentAnimFrame) &&
         ((s32) fp->gameWatchVars[0].SpecialLw.isRelease == false))
@@ -246,7 +253,7 @@ void ftGameWatch_SpecialLw_IASA(HSD_GObj* fighter_gobj)
     s32 turnFrames;
     ftGameWatchAttributes* gawAttrs;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     turnFrames = fp->gameWatchVars[0].SpecialLw.turnFrames;
     gawAttrs = getFtSpecialAttrs(fp);
     if (turnFrames > 0) {
@@ -281,7 +288,7 @@ void ftGameWatch_SpecialAirLw_IASA(HSD_GObj* fighter_gobj)
     s32 turnFrames;
     ftGameWatchAttributes* gawAttrs;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     turnFrames = fp->gameWatchVars[0].SpecialLw.turnFrames;
     gawAttrs = getFtSpecialAttrs(fp);
     if (turnFrames > 0) {
@@ -319,7 +326,7 @@ void ftGameWatch_SpecialLw_Phys(HSD_GObj* fighter_gobj)
 // Physics callback
 void ftGameWatch_SpecialAirLw_Phys(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftGameWatchAttributes* gawAttrs = fp->x2D4_specialAttributes;
     f32 fall_accel;
     f32 momentum_mul;
@@ -352,7 +359,7 @@ static inline void ftGameWatch_SpecialLw_UpdateVarsColl(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
     u32 ftcmd_var = fp->x2200_ftcmd_var0;
-    ftGameWatchAttributes* gawAttrs = getFtSpecialAttrs(fp);
+    ftGameWatchAttributes* gawAttrs = fp->x2D4_specialAttributes;
     if (ftcmd_var == 2U) {
         ftColl_CreateAbsorbHit(fighter_gobj,
                                &gawAttrs->x80_GAMEWATCH_PANIC_ABSORPTION);
@@ -368,7 +375,12 @@ static inline void ftGameWatch_SpecialLw_UpdateVarsColl(HSD_GObj* fighter_gobj)
 // https://decomp.me/scratch/I9dd1
 void ftGameWatch_SpecialLw_GroundToAir(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_GAMEWATCH_SPECIALAIRLW,
@@ -381,7 +393,12 @@ void ftGameWatch_SpecialLw_GroundToAir(HSD_GObj* fighter_gobj)
 // https://decomp.me/scratch/xk6So
 void ftGameWatch_SpecialAirLw_AirToGround(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_GAMEWATCH_SPECIALLW,
@@ -540,7 +557,7 @@ void ftGameWatch_SpecialAirLwCatch_AirToGround(HSD_GObj* fighter_gobj)
 // Panic Fill
 void ftGameWatch_AbsorbThink_DecideAction(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     /// @todo @c enum
     enum_t asid;
@@ -564,7 +581,7 @@ void ftGameWatch_AbsorbThink_DecideAction(HSD_GObj* fighter_gobj)
 static inline void
 ftGameWatch_SpecialLwShoot_ApplyDamage(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     int i;
 
     for (i = 0; i < 4; i++)

--- a/src/melee/ft/chara/ftGameWatch/ftGameWatch_SpecialS.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGameWatch_SpecialS.c
@@ -15,8 +15,7 @@ void ftGameWatch_ItemJudgementSetup(HSD_GObj* fighter_gobj)
 {
     Vec3 sp20;
     Vec3 sp14;
-    Fighter* fp = fighter_gobj->user_data;
-    HSD_GObj* judgementGObj;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (GET_FIGHTER(fighter_gobj)->x2204_ftcmd_var1 != 0U) {
         fp->x2204_ftcmd_var1 = 0;
@@ -49,7 +48,7 @@ void ftGameWatch_ItemJudgementSetup(HSD_GObj* fighter_gobj)
 // https://decomp.me/scratch/KIUEJ // Set Judgement flags + clear pointers
 void ftGameWatch_ItemJudgementSetFlag(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     ftGameWatch_ItemJudgementExitHitlag(fighter_gobj);
     fp->sa.gaw.x2264_judgementGObj = NULL;
@@ -62,8 +61,6 @@ void ftGameWatch_ItemJudgementSetFlag(HSD_GObj* fighter_gobj)
 void ftGameWatch_ItemJudgementRemove(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
-    Fighter* fp2;
-    HSD_GObj* judgementGObj;
 
     if (fp->sa.gaw.x2264_judgementGObj != NULL) {
         func_802C7A84(fp->sa.gaw.x2264_judgementGObj);
@@ -168,7 +165,7 @@ void ftGameWatch_SpecialS_StartAction(HSD_GObj* fighter_gobj)
 // https://decomp.me/scratch/IzXqX
 void ftGameWatch_SpecialAirS_StartAction(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftGameWatchAttributes* gawAttrs = fp->x2D4_specialAttributes;
     s32 asid;
 
@@ -229,7 +226,7 @@ void ftGameWatch_SpecialS_Phys(HSD_GObj* fighter_gobj)
 // Physics callback
 void ftGameWatch_SpecialAirS_Phys(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     u32 ftcmd_var = fp->x2200_ftcmd_var0;
     ftGameWatchAttributes* gawAttrs = fp->x2D4_specialAttributes;
     f32 ftGameWatchPhys[4];
@@ -289,7 +286,7 @@ static inline void ftGameWatch_SpecialS_SetCall(HSD_GObj* fighter_gobj)
 // Acion State handler
 static void ftGameWatch_SpecialS_GroundToAir(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     s32 ASID;
 
     func_8007D5D4(fp);
@@ -307,7 +304,7 @@ static void ftGameWatch_SpecialS_GroundToAir(HSD_GObj* fighter_gobj)
 // 0x8014CB44 - Mr. Game & Watch's air -> ground Judgement Action State Handler
 static void ftGameWatch_SpecialAirS_AirToGround(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     s32 ASID;
 
     fp->sa.gaw.x2234 = 0;

--- a/src/melee/ft/chara/ftGameWatch/ftgamewatch.c
+++ b/src/melee/ft/chara/ftGameWatch/ftgamewatch.c
@@ -151,7 +151,7 @@ Fighter_CostumeStrings lbl_803D29C8[] = {
 
 void ftGameWatch_OnDeath(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_80074A4C(fighter_gobj, 0U, 0);
     func_80074A4C(fighter_gobj, 1U, -1);
     func_80074A4C(fighter_gobj, 2U, 0);
@@ -183,7 +183,7 @@ void ftGameWatch_OnDeath(HSD_GObj* fighter_gobj)
 
 void ftGameWatch_OnLoad(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     void** items = fp->x10C_ftData->x48_items;
 
     fp->x2222_flag.bits.b6 = 0;

--- a/src/melee/ft/chara/ftGameWatch/ftgamewatch.h
+++ b/src/melee/ft/chara/ftGameWatch/ftgamewatch.h
@@ -231,7 +231,7 @@ void ftGameWatch_AttackAir_DecideAction(HSD_GObj* fighter_gobj);
 
 // Aerial Attacks (AttackAir) //
 
-void ftGameWatch_AttackAirN_Action(HSD_GObj* fighter_gobj, s32 ASID);
+void ftGameWatch_AttackAirN_Action(HSD_GObj* fighter_gobj);
 void ftGameWatch_AttackAirN_Anim(HSD_GObj* fighter_gobj);
 void ftGameWatch_AttackAirN_IASA(HSD_GObj* fighter_gobj);
 void ftGameWatch_AttackAirN_Phys(HSD_GObj* fighter_gobj);

--- a/src/melee/ft/chara/ftGigaKoopa/ftgigakoopa.c
+++ b/src/melee/ft/chara/ftGigaKoopa/ftgigakoopa.c
@@ -78,7 +78,7 @@ Fighter_CostumeStrings lbl_803D3988[] = {
 void ftGKoopa_OnDeath(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftKoopaAttributes* koopaAttr = fp->x2D4_specialAttributes;
 
     func_80074A4C(fighter_gobj, 0, 0);

--- a/src/melee/ft/chara/ftIceClimber/fticeclimber1.c
+++ b/src/melee/ft/chara/ftIceClimber/fticeclimber1.c
@@ -122,7 +122,7 @@ void ftIceClimber_OnLoadForNana(Fighter* fp)
 void ftIceClimber_OnLoad(HSD_GObj* fighter_gobj)
 {
     s32 unused;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     void** item_list = fp->x10C_ftData->x48_items;
     fp->x2222_flag.bits.b5 = 1;
 
@@ -139,13 +139,12 @@ void ftIceClimber_OnLoad(HSD_GObj* fighter_gobj)
 
 void ftIceClimber_OnDeath(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    ftIceClimberAttributes* attr = fp->x2D4_specialAttributes;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_80074A4C(fighter_gobj, 0U, 0);
     func_80074A4C(fighter_gobj, 1U, 0);
     fp->sa.nana.x2234 = 0;
     fp->sa.nana.x222C = 0;
-    fp->sa.nana.x2230.bits.b0 = 0;
+    fp->sa.nana.x2230.bits.b0 = false;
     fp->sa.nana.x2238 = 0;
     fp->sa.nana.x224C = 0;
     fp->sa.nana.x2250 = 0.0f;

--- a/src/melee/ft/chara/ftIceClimber/fticeclimber2_nana.c
+++ b/src/melee/ft/chara/ftIceClimber/fticeclimber2_nana.c
@@ -106,9 +106,13 @@ extern f32 lbl_804D9898;
 
 void ftNana_OnLoad(HSD_GObj* fighter_gobj)
 {
-    s32 unused[4];
-    Fighter* fp = fighter_gobj->user_data;
-    fp->x2222_flag.bits.b4 = 1;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
+
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    fp->x2222_flag.bits.b4 = true;
     ftIceClimber_OnLoadForNana(fp);
 
     {
@@ -120,7 +124,7 @@ void ftNana_OnLoad(HSD_GObj* fighter_gobj)
 void ftNana_OnDeath(HSD_GObj* fighter_gobj)
 {
     s32 unused;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftIceClimberAttributes* attr = fp->x2D4_specialAttributes;
     fp->dmg.x18B0 = attr->xC8;
     func_80074A4C(fighter_gobj, 0U, 0);

--- a/src/melee/ft/chara/ftKirby/ftkirby.c
+++ b/src/melee/ft/chara/ftKirby/ftkirby.c
@@ -1070,7 +1070,7 @@ void func_800EE528(void)
 
 void ftKirby_OnDeath(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_80074A4C(fighter_gobj, 0, 0);
     func_80074A4C(fighter_gobj, 1, 0);
     fp->sa.kirby.x222C = 0;
@@ -1089,7 +1089,7 @@ void ftKirby_OnDeath(HSD_GObj* fighter_gobj)
 
 void ftKirby_OnLoad(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     void** item_list = fp->x10C_ftData->x48_items;
 
     PUSH_ATTRS(fp, ftKirbyAttributes);
@@ -1105,7 +1105,7 @@ void ftKirby_OnLoad(HSD_GObj* fighter_gobj)
 
 void ftKirby_800EE74C(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_800F5524(fighter_gobj);
     func_800F22D4(fighter_gobj);
     func_800F5318(fighter_gobj);
@@ -1117,7 +1117,7 @@ void ftKirby_800EE74C(HSD_GObj* fighter_gobj)
 
 void ftKirby_800EE7B8(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_800F5524(fighter_gobj);
     func_800F22D4(fighter_gobj);
     func_800F5318(fighter_gobj);

--- a/src/melee/ft/chara/ftLink/ftlink.c
+++ b/src/melee/ft/chara/ftLink/ftlink.c
@@ -94,7 +94,7 @@ Vec3 const lbl_803B7520[3] = { 0 };
 
 bool func_800EAD64(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->sa.link.x2234)
         return true;
@@ -104,7 +104,7 @@ bool func_800EAD64(HSD_GObj* fighter_gobj)
 
 void ftLink_OnDeath(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     func_80074A4C(fighter_gobj, 0, 0);
     func_80074A4C(fighter_gobj, 1, 0);
@@ -126,7 +126,7 @@ void ftLink_OnLoadForCLink(Fighter* fp)
 
 void ftLink_OnLoad(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftLinkAttributes* link_attr = fp->x10C_ftData->ext_attr;
     void** item_list = fp->x10C_ftData->x48_items;
     link_attr->x54 = func_8001E8F8(func_80085E50(fp, 0x48U));
@@ -218,7 +218,7 @@ void ftLink_800EB334(HSD_GObj* fighter_gobj)
 {
     f32 new_ground_vel;
 
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftLinkAttributes* link_attr = fp->x10C_ftData->ext_attr;
 
     f32 resultf = func_80092ED8(fp->x19A4, link_attr, link_attr->xD8);

--- a/src/melee/ft/chara/ftLuigi/ftLuigi_SpecialHi.c
+++ b/src/melee/ft/chara/ftLuigi/ftLuigi_SpecialHi.c
@@ -24,7 +24,7 @@ void ftLuigi_SpecialHi_StartAction(HSD_GObj* fighter_gobj)
 // State handler
 void ftLuigi_SpecialAirHi_StartAction(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftLuigiAttributes* luigiAttrs = fp->x2D4_specialAttributes;
     f32 vel;
     f32 mul;
@@ -90,7 +90,7 @@ void ftLuigi_SpecialHi_IASA(HSD_GObj* fighter_gobj)
     f32 stick_angle;
     bool flag;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     stick_x = fp->input.x620_lstick_x;
     luigiAttrs = fp->x2D4_specialAttributes;
     stick_range = stickGetDir(fp->input.x620_lstick_x, 0.0f);
@@ -161,7 +161,7 @@ void ftLuigi_SpecialAirHi_IASA(HSD_GObj* fighter_gobj)
     f32 range4;
     bool flag;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     stick_x = fp->input.x620_lstick_x;
     luigiAttrs = fp->x2D4_specialAttributes;
     stick_range = stickGetDir(fp->input.x620_lstick_x, 0.0f);
@@ -259,7 +259,7 @@ void ftLuigi_SpecialHi_CheckLanding(HSD_GObj* fighter_gobj)
 // Collision callback
 void ftLuigi_SpecialHi_Coll(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if ((s32) fp->xE0_ground_or_air == GA_Air) {
         if (((u32) fp->x2200_ftcmd_var0 == 0U) || (fp->x80_self_vel.y >= 0.0f))
@@ -279,7 +279,7 @@ void ftLuigi_SpecialHi_Coll(HSD_GObj* fighter_gobj)
 // callback
 void ftLuigi_SpecialAirHi_Coll(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if ((s32) fp->xE0_ground_or_air == GA_Air) {
         if (((u32) fp->x2200_ftcmd_var0 == 0U) || (fp->x80_self_vel.y >= 0.0f))

--- a/src/melee/ft/chara/ftLuigi/ftLuigi_SpecialLw.c
+++ b/src/melee/ft/chara/ftLuigi/ftLuigi_SpecialLw.c
@@ -11,13 +11,13 @@
 // https://decomp.me/scratch/TTyNT // Luigi Cyclone Rotation Update
 void ftLuigi_SpecialLw_UpdateRot(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007592C(fp, 0, 0.0f);
 }
 
 static inline void ftLuigi_SpecialLw_SetVars(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftLuigiAttributes* luigiAttrs = fp->x2D4_specialAttributes;
     fp->x2200_ftcmd_var0 = 0;
     fp->x2204_ftcmd_var1 = 0;
@@ -29,14 +29,14 @@ static inline void ftLuigi_SpecialLw_SetVars(HSD_GObj* fighter_gobj)
 
 static inline void ftLuigi_SpecialLw_SetCall(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     fp->cb.x21DC_callback_OnTakeDamage = ftLuigi_SpecialLw_UpdateRot;
     fp->cb.x21E4_callback_OnDeath2 = ftLuigi_SpecialLw_UpdateRot;
 }
 
 static inline void ftLuigi_SpecialLw_SetGFX(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     HSD_JObj* hsd_obj = fighter_gobj->hsd_obj;
     ef_Spawn(0x509, fighter_gobj, hsd_obj);
     fp->x2219_flag.bits.b0 = 1;
@@ -51,8 +51,12 @@ void ftLuigi_SpecialLw_StartAction(HSD_GObj* fighter_gobj)
     Fighter* fp;
     ftLuigiAttributes* luigiAttrs;
     Fighter* temp_fp;
-    Fighter* var[7];
     Fighter* fp2;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[20];
+#endif
 
     temp_fp = (fp = GET_FIGHTER(fighter_gobj));
     luigiAttrs = temp_fp->x2D4_specialAttributes;
@@ -79,9 +83,13 @@ void ftLuigi_SpecialAirLw_StartAction(HSD_GObj* fighter_gobj)
     Fighter* fp;
     ftLuigiAttributes* luigiAttrs;
     Fighter* temp_fp;
-    Fighter* var[7];
     Fighter* fp2;
     f32 cycloneVar;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[16];
+#endif
 
     temp_fp = (fp = GET_FIGHTER(fighter_gobj));
     luigiAttrs = temp_fp->x2D4_specialAttributes;
@@ -128,7 +136,7 @@ void ftLuigi_SpecialLw_Anim(HSD_GObj* fighter_gobj)
 // https://decomp.me/scratch/gssxH // Luigi's aerial Cyclone Animation callback
 void ftLuigi_SpecialAirLw_Anim(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     Fighter* temp_fp;
     ftLuigiAttributes* luigiAttrs = fp->x2D4_specialAttributes;
     s32 cycloneLanding;
@@ -184,7 +192,7 @@ void ftLuigi_SpecialLw_Phys(HSD_GObj* fighter_gobj)
     f32 var2;
     f32 var3;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     luigiAttrs = getFtSpecialAttrs(fp);
     var2 = luigiAttrs->x74_LUIGI_CYCLONE_MOMENTUM_X_GROUND;
     if ((u32) fp->x2200_ftcmd_var0 != 0U) {
@@ -217,7 +225,7 @@ void ftLuigi_SpecialAirLw_Phys(HSD_GObj* fighter_gobj)
     f32 unused;
     f32 vel;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     luigiAttrs = fp->x2D4_specialAttributes;
     if (((s32) fp->sa.luigi.x222C_cycloneCharge == false) &&
         ((u32) fp->x2208_ftcmd_var2 != 0U) &&
@@ -290,7 +298,7 @@ void ftLuigi_SpecialLw_Coll(HSD_GObj* fighter_gobj)
 
 static inline void ftLuigi_SpecialAirLw_AirToGround(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftLuigiAttributes* luigiAttrs = fp->x2D4_specialAttributes;
     fp->x2208_ftcmd_var2 = 0;
     func_8007D7FC(fp);
@@ -308,8 +316,12 @@ static inline void ftLuigi_SpecialAirLw_AirToGround(HSD_GObj* fighter_gobj)
 // https://decomp.me/scratch/fdQ4f // Luigi's aerial Cyclone Collision callback
 void ftLuigi_SpecialAirLw_Coll(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    s32 var[8];
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[24];
+#endif
 
     if (func_800824A0(fighter_gobj, &ftLuigi_SpecialLw_CollisionBox) != false) {
         ftLuigi_SpecialAirLw_AirToGround(fighter_gobj);

--- a/src/melee/ft/chara/ftLuigi/ftLuigi_SpecialN.c
+++ b/src/melee/ft/chara/ftLuigi/ftLuigi_SpecialN.c
@@ -115,8 +115,7 @@ void ftLuigi_SpecialAirN_Coll(HSD_GObj* fighter_gobj)
 void ftLuigi_SpecialN_FireSpawn(HSD_GObj* fighter_gobj)
 {
     Vec3 sp10;
-    Fighter* fp = fighter_gobj->user_data;
-    s32 unused;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     bool flag;
 
     if (fp->x2210_ThrowFlags.b0 != 0) {

--- a/src/melee/ft/chara/ftLuigi/ftLuigi_SpecialS.c
+++ b/src/melee/ft/chara/ftLuigi/ftLuigi_SpecialS.c
@@ -49,7 +49,7 @@ void ftLuigi_SpecialS_SetVars(HSD_GObj* fighter_gobj)
 void ftLuigi_SpecialS_StartAction(HSD_GObj* fighter_gobj)
 {
     /// @todo Shared @c inline with #ftLuigi_SpecialAirS_StartAction.
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftLuigiAttributes* luigiAttrs = fp->x2D4_specialAttributes;
     HSD_GObjEvent callback;
     s32 asid;
@@ -66,7 +66,7 @@ void ftLuigi_SpecialS_StartAction(HSD_GObj* fighter_gobj)
 // handler
 void ftLuigi_SpecialAirS_StartAction(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftLuigiAttributes* luigiAttrs = fp->x2D4_specialAttributes;
     HSD_GObjEvent callback;
     s32 asid;
@@ -137,7 +137,7 @@ void ftLuigi_SpecialSStart_Phys(HSD_GObj* fighter_gobj)
 // callback
 void ftLuigi_SpecialAirSStart_Phys(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftLuigiAttributes* luigiAttrs = fp->x2D4_specialAttributes;
     attr* ftAttr = &fp->x110_attr;
     s32 var;
@@ -196,7 +196,7 @@ void ftLuigi_SpecialAirSStart_AirToGround(HSD_GObj* fighter_gobj)
 void ftLuigi_SpecialSHold_Anim(HSD_GObj* fighter_gobj)
 {
     /// @todo Shared @c inline with #ftLuigi_SpecialAirSHold_Anim.
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftLuigiAttributes* luigiAttrs = fp->x2D4_specialAttributes;
     HSD_GObjEvent callback;
     s32 stateVar;
@@ -218,7 +218,7 @@ void ftLuigi_SpecialSHold_Anim(HSD_GObj* fighter_gobj)
 // Animation callback
 void ftLuigi_SpecialAirSHold_Anim(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftLuigiAttributes* luigiAttrs = fp->x2D4_specialAttributes;
     HSD_GObjEvent callback;
     s32 stateVar;
@@ -706,7 +706,7 @@ void ftLuigi_SpecialAirSFly_Coll(HSD_GObj* fighter_gobj)
     CollData* collData;
     s32 envFlags;
 
-    temp_fp = fighter_gobj->user_data;
+    temp_fp = GET_FIGHTER(fighter_gobj);
     fp = temp_fp;
     collData = &temp_fp->x6F0_collData;
 
@@ -799,7 +799,7 @@ void ftLuigi_SpecialSEnd_Phys(HSD_GObj* fighter_gobj)
 // callback
 void ftLuigi_SpecialAirSEnd_Phys(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftLuigiAttributes* luigiAttrs = fp->x2D4_specialAttributes;
     f32 gravity;
     f32 decel;
@@ -832,7 +832,7 @@ void ftLuigi_SpecialAirSEnd_Coll(HSD_GObj* fighter_gobj)
 // Action State handler
 void ftLuigi_SpecialSEnd_Action(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftLuigiAttributes* luigiAttrs = fp->x2D4_specialAttributes;
 
     fp->x2200_ftcmd_var0 = 0;
@@ -846,7 +846,7 @@ void ftLuigi_SpecialSEnd_Action(HSD_GObj* fighter_gobj)
 // Action State handler
 void ftLuigi_SpecialAirSEnd_Action(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftLuigiAttributes* luigiAttrs = fp->x2D4_specialAttributes;
 
     fp->x2200_ftcmd_var0 = 0;

--- a/src/melee/ft/chara/ftLuigi/ftluigi.c
+++ b/src/melee/ft/chara/ftLuigi/ftluigi.c
@@ -103,14 +103,14 @@ Fighter_CostumeStrings lbl_803D0AB4[] = {
 
 void ftLuigi_OnDeath(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_80074A4C(fighter_gobj, 0, false);
     fp->sa.luigi.x2234 = 0;
 }
 
 void ftLuigi_OnLoad(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     void** item_list = fp->x10C_ftData->x48_items;
 
     PUSH_ATTRS(fp, ftLuigiAttributes);

--- a/src/melee/ft/chara/ftMewtwo/ftMewtwo_SpecialHi.c
+++ b/src/melee/ft/chara/ftMewtwo/ftMewtwo_SpecialHi.c
@@ -282,7 +282,7 @@ void ftMewtwo_SpecialHi_Coll(HSD_GObj* fighter_gobj)
 
 bool ftMewtwo_SpecialHi_CheckTimer(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftMewtwoAttributes* mewtwoAttrs = fp->x2D4_specialAttributes;
 
     if ((f32) fp->mewtwoVars[0].SpecialHi.unk4 >=

--- a/src/melee/ft/chara/ftMewtwo/ftMewtwo_SpecialN.c
+++ b/src/melee/ft/chara/ftMewtwo/ftMewtwo_SpecialN.c
@@ -299,8 +299,11 @@ void ftMewtwo_SpecialN_PlayChargeSFX(HSD_GObj* fighter_gobj)
     ftMewtwoAttributes* mewtwoAttrs = fp->x2D4_specialAttributes;
     static u32 shadowBallSFX[4] = { 0x30DB9, 0x30DBC, 0x30DBF, 0x30DC2 };
     f32 chargeLevel;
-    f32 localVar;
-    f32 var2;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     if ((u32) fp->x2208_ftcmd_var2 != 0U) {
         if (fp->sa.mewtwo.x2234_shadowBallCharge != 0) {
@@ -491,13 +494,11 @@ void ftMewtwo_SpecialNStart_Anim(HSD_GObj* fighter_gobj)
 inline void ftMewtwo_SpecialN_CreateHeldShadow(HSD_GObj* fighter_gobj,
                                                Vec3* pos1, Vec3* pos2)
 {
-    Fighter* fp = fp = getFighter(fighter_gobj);
+    Fighter* fp = getFighter(fighter_gobj);
 
     if (((u32) fp->x220C_ftcmd_var3 == 1U) &&
         (fp->sa.mewtwo.x2230_shadowHeldGObj == NULL))
     {
-        Vec3 sp2C;
-        Vec3 sp20;
         HSD_GObj* shadowHeldGObj;
 
         pos1->z = 2.0f;
@@ -528,7 +529,7 @@ void ftMewtwo_SpecialNLoop_Anim(HSD_GObj* fighter_gobj)
     Vec3 sp1C;
     const Vec3 shadowBallPos = { 0.0f, 7.0f, 0.0f };
 
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftMewtwoAttributes* mewtwoAttrs = fp->x2D4_specialAttributes;
 
     sp34 = shadowBallPos;
@@ -681,7 +682,7 @@ void ftMewtwo_SpecialAirNLoop_Anim(HSD_GObj* fighter_gobj)
     Vec3 sp1C;
     const Vec3 shadowBallPos = { 0.0f, 7.0f, 0.0f };
 
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftMewtwoAttributes* mewtwoAttrs = fp->x2D4_specialAttributes;
 
     sp34 = shadowBallPos;
@@ -873,7 +874,11 @@ void ftMewtwo_SpecialAirNLoop_IASA(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = getFighter(fighter_gobj);
     u32 recentInput;
-    u32 unused[8];
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[32];
+#endif
 
     recentInput = fp->input.x668;
     if (((recentInput & HSD_BUTTON_A) != false) &&

--- a/src/melee/ft/chara/ftMewtwo/ftmewtwo.c
+++ b/src/melee/ft/chara/ftMewtwo/ftmewtwo.c
@@ -113,9 +113,9 @@ void ftMewtwo_OnDeath(HSD_GObj* gobj)
 
 void ftMewtwo_OnLoad(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    ftMewtwoAttributes* attr = fp->x10C_ftData->ext_attr;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     void** item_list = fp->x10C_ftData->x48_items;
+
     PUSH_ATTRS(fp, ftMewtwoAttributes);
 
     {

--- a/src/melee/ft/chara/ftNess/ftNess_AttackS4.c
+++ b/src/melee/ft/chara/ftNess/ftNess_AttackS4.c
@@ -10,7 +10,7 @@
 void ftNess_AttackS4_OnReflect(
     HSD_GObj* fighter_gobj) // Ness's F-Smash OnReflect callback
 {
-    func_80088148(fighter_gobj->user_data, 0xE0U, 0x7FU, 0x40U);
+    func_80088148(GET_FIGHTER(fighter_gobj), 0xE0U, 0x7FU, 0x40U);
 };
 
 // 0x80114C24
@@ -54,7 +54,7 @@ bool ftNess_CheckNessBatRemove(
     HSD_GObj*
         fighter_gobj) // Check if Ness is in F-Smash + has Baseball Bat item
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->action_id != AS_NESS_ATTACKS4) {
         return true;
@@ -71,7 +71,7 @@ bool ftNess_CheckNessBatRemove(
 // https://decomp.me/scratch/mpl3X
 void ftNess_ItemNessBatRemove(HSD_GObj* fighter_gobj) // Remove Baseball Bat
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->sa.ness.x2248_baseballBatGObj != NULL) {
         func_802AD6B8(fp->sa.ness.x2248_baseballBatGObj);
@@ -84,7 +84,7 @@ void ftNess_ItemNessBatRemove(HSD_GObj* fighter_gobj) // Remove Baseball Bat
 void ftNess_ItemNessBatSetNULL(
     HSD_GObj* fighter_gobj) // Clear Baseball Bat GObj pointer
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->sa.ness.x2248_baseballBatGObj != NULL) {
         fp->sa.ness.x2248_baseballBatGObj = NULL;

--- a/src/melee/ft/chara/ftNess/ftNess_SpecialLw.c
+++ b/src/melee/ft/chara/ftNess/ftNess_SpecialLw.c
@@ -16,11 +16,15 @@ void ftNess_SpecialLwStart_Action(
     HSD_GObj* fighter_gobj) // Ness's grounded PSI Magnet Start Action State
                             // handler //
 {
-    s32 filler[7];
     ftNessAttributes* ness_attr;
     Fighter* temp_fp;
 
-    temp_fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[20];
+#endif
+
+    temp_fp = GET_FIGHTER(fighter_gobj);
     ness_attr = temp_fp->x2D4_specialAttributes;
     temp_fp->nessVars[0].SpecialLw.releaseLag =
         (s32) ness_attr->x74_PSI_MAGNET_RELEASE_LAG;
@@ -39,11 +43,15 @@ void ftNess_SpecialAirLwStart_Action(
     HSD_GObj*
         fighter_gobj) // Ness's aerial PSI Magnet Start Action State handler //
 {
-    s32 filler[7];
     Fighter* temp_fp;
     ftNessAttributes* ness_attr;
 
-    temp_fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[20];
+#endif
+
+    temp_fp = GET_FIGHTER(fighter_gobj);
     ness_attr = temp_fp->x2D4_specialAttributes;
     temp_fp->nessVars[0].SpecialLw.releaseLag =
         (s32) ness_attr->x74_PSI_MAGNET_RELEASE_LAG;
@@ -66,16 +74,15 @@ void ftNess_SpecialLwStart_Anim(
 {
     Fighter* fp;
     Fighter* fighter_data2;
-    s32 unused[2];
 
-    fighter_data2 = fighter_gobj->user_data;
+    fighter_data2 = GET_FIGHTER(fighter_gobj);
 
-    if ((fighter_data2->input.x65C_heldInputs & HSD_BUTTON_B) == false) {
+    if (FLAGS_NONE(fighter_data2->input.x65C_heldInputs, HSD_BUTTON_B)) {
         fighter_data2->nessVars[0].SpecialLw.isRelease = 1;
     }
 
     if (!ftAnim_IsFramesRemaining(fighter_gobj)) {
-        fp = fighter_gobj->user_data;
+        fp = GET_FIGHTER(fighter_gobj);
 
         if (fp->x2219_flag.bits.b0 == 0) {
             efAsync_Spawn(fighter_gobj, &fp->x60C, 0U, 0x4F0U,
@@ -101,16 +108,20 @@ void ftNess_SpecialAirLwStart_Anim(
 {
     Fighter* fighter_data2;
     Fighter* fp;
-    s32 unused[4];
 
-    fighter_data2 = fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
+
+    fighter_data2 = fp = GET_FIGHTER(fighter_gobj);
 
     if ((fighter_data2->input.x65C_heldInputs & HSD_BUTTON_B) == false) {
         fighter_data2->nessVars[0].SpecialLw.isRelease = 1;
     }
 
     if (!ftAnim_IsFramesRemaining(fighter_gobj)) {
-        fp = fighter_gobj->user_data;
+        fp = GET_FIGHTER(fighter_gobj);
 
         if (fp->x2219_flag.bits.b0 == 0) {
             efAsync_Spawn(fighter_gobj, &fp->x60C, 0U, 0x4F0U,
@@ -163,7 +174,7 @@ void ftNess_SpecialAirLwStart_Phys(
     attr* attr;
     ftNessAttributes* ness_attr;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     attr = &fp->x110_attr;
     ness_attr = fp->x2D4_specialAttributes;
     gravityDelay = fp->nessVars[0].SpecialLw.gravityDelay;
@@ -208,7 +219,7 @@ void ftNess_SpecialLwStart_GroundToAir(
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_NESS_SPECIALAIRLW_START,
                                        FTNESS_SPECIALLW_COLL_FLAG, NULL,
@@ -223,7 +234,7 @@ void ftNess_SpecialAirLwStart_AirToGround(
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_NESS_SPECIALLW_START,
                                        FTNESS_SPECIALLW_COLL_FLAG, NULL,
@@ -237,12 +248,10 @@ void ftNess_SpecialLwHold_Anim(
     HSD_GObj*
         fighter_gobj) // Ness's grounded PSI Magnet Hold Animation callback //
 {
-    s32 unused[2];
-    s32 timer_var;
     Fighter* temp_r31;
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     if ((fp->input.x65C_heldInputs & HSD_BUTTON_B) == false) {
         fp->nessVars[0].SpecialLw.isRelease = 1;
     }
@@ -259,7 +268,7 @@ void ftNess_SpecialLwHold_Anim(
             ftNess_SpecialAirLwEnd_Action(fighter_gobj);
         }
     }
-    temp_r31 = fighter_gobj->user_data;
+    temp_r31 = GET_FIGHTER(fighter_gobj);
 
     temp_r31->x2350_stateVar5--;
 
@@ -275,12 +284,15 @@ void ftNess_SpecialAirLwHold_Anim(
     HSD_GObj*
         fighter_gobj) // Ness's aerial PSI Magnet Hold Animation callback //
 {
-    s32 unused[4];
-    s32 timer_var;
     Fighter* temp_r31;
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     if ((fp->input.x65C_heldInputs & HSD_BUTTON_B) == false) {
         fp->nessVars[0].SpecialLw.isRelease = 1;
     }
@@ -298,7 +310,7 @@ void ftNess_SpecialAirLwHold_Anim(
             ftNess_SpecialAirLwEnd_Action(fighter_gobj);
         }
     }
-    temp_r31 = fighter_gobj->user_data;
+    temp_r31 = GET_FIGHTER(fighter_gobj);
 
     temp_r31->x2350_stateVar5 = (s32) (temp_r31->x2350_stateVar5 - 1);
 
@@ -343,7 +355,7 @@ void ftNess_SpecialAirLwHold_Phys(
     ftNessAttributes* ness_attr;
     attr* attr;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     ness_attr = fp->x2D4_specialAttributes;
     attr = &fp->x110_attr;
 
@@ -386,16 +398,20 @@ void ftNess_SpecialLwHold_GroundToAir(
     HSD_GObj* fighter_gobj) // Ness's ground->air PSI Magnet Hold Action State
                             // handler //
 {
-    s32 filler[6];
     Fighter* fp;
     ftNessAttributes* ness_attr;
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[16];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_NESS_SPECIALAIRLW_HOLD,
                                        FTNESS_SPECIALLW_COLL_FLAG, NULL,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     ness_attr = fp->x2D4_specialAttributes;
     ftColl_CreateAbsorbHit(fighter_gobj, &ness_attr->x98_PSI_MAGNET_ABSORPTION);
 }
@@ -406,17 +422,21 @@ void ftNess_SpecialAirLwHold_AirToGround(
     HSD_GObj* fighter_gobj) // Ness's air->ground PSI Magnet Hold Action State
                             // handler //
 {
-    s32 filler[6];
     Fighter* fp;
     ftNessAttributes* ness_attr;
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[16];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_NESS_SPECIALLW_HOLD,
                                        FTNESS_SPECIALLW_COLL_FLAG, NULL,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
     func_8007D468(fp);
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     ness_attr = fp->x2D4_specialAttributes;
     ftColl_CreateAbsorbHit(fighter_gobj, &ness_attr->x98_PSI_MAGNET_ABSORPTION);
 }
@@ -427,14 +447,18 @@ void ftNess_SpecialLwHold_Action(
     HSD_GObj*
         fighter_gobj) // Ness's grounded PSI Magnet Hold Action State handler //
 {
-    s32 filler[4];
     Fighter* fp;
     ftNessAttributes* ness_attr;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_NESS_SPECIALLW_HOLD,
                                        FIGHTER_GFX_PRESERVE, NULL, 0.0f, 1.0f,
                                        0.0f);
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     ness_attr = fp->x2D4_specialAttributes;
     ftColl_CreateAbsorbHit(fighter_gobj, &ness_attr->x98_PSI_MAGNET_ABSORPTION);
 }
@@ -445,14 +469,18 @@ void ftNess_SpecialAirLwHold_Action(
     HSD_GObj*
         fighter_gobj) // Ness's aerial PSI Magnet Hold Action State handler //
 {
-    s32 filler[4];
     Fighter* fp;
     ftNessAttributes* ness_attr;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_NESS_SPECIALAIRLW_HOLD,
                                        FIGHTER_GFX_PRESERVE, NULL, 0.0f, 1.0f,
                                        0.0f);
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     ness_attr = fp->x2D4_specialAttributes;
     ftColl_CreateAbsorbHit(fighter_gobj, &ness_attr->x98_PSI_MAGNET_ABSORPTION);
 }
@@ -568,7 +596,7 @@ void ftNess_SpecialAirLwTurn_Phys(
     ftNessAttributes* ness_attr;
     attr* attr;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     ness_attr = fp->x2D4_specialAttributes;
     attr = &fp->x110_attr;
 
@@ -614,7 +642,7 @@ void ftNess_SpecialLwTurn_GroundToAir(
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_NESS_SPECIALAIRLW_TURN,
                                        FTNESS_SPECIALLW_COLL_FLAG, NULL,
@@ -629,7 +657,7 @@ void ftNess_SpecialAirLwTurn_AirToGround(
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_NESS_SPECIALLW_TURN,
                                        FTNESS_SPECIALLW_COLL_FLAG, NULL,
@@ -677,7 +705,7 @@ bool ftNess_SpecialLwHold_GroundOrAir(
 
 inline void MagnetStateVarCalc(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     fp->x2350_stateVar5 = fp->x2350_stateVar5 - 1;
     if ((s32) fp->x2350_stateVar5 <= 0) {
         func_80088478(fp, 0x334A1, 0x7F, 0x40);
@@ -690,22 +718,23 @@ inline void MagnetStateVarCalc(HSD_GObj* fighter_gobj)
 void ftNess_SpecialLwHit_Anim(
     HSD_GObj* arg0) // Ness's grounded PSI Magnet Absorb Animation callback //
 {
-    s32 unused[10];
-    f32 temp_f1;
-    f32 temp_f1_2;
-
     Fighter* temp_r30;
     Fighter* temp_r3_2;
     Fighter* temp_r4;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[44];
+#endif
+
     s32 phi_r0;
 
     Fighter* temp_e1;
     Fighter* temp_e2;
     ftNessAttributes* attr;
-    Fighter* temp_r31;
 
     temp_r4 = arg0->user_data;
-    if ((temp_r4->input.x65C_heldInputs & HSD_BUTTON_B) == false) {
+    if (FLAGS_NONE(temp_r4->input.x65C_heldInputs, HSD_BUTTON_B)) {
         temp_r4->nessVars[0].SpecialLw.isRelease = 1;
     }
 
@@ -879,16 +908,20 @@ void ftNess_SpecialLwHit_GroundToAir(
     HSD_GObj* fighter_gobj) // Ness's ground->air PSI Magnet Absorb Action State
                             // handler //
 {
-    s32 filler[6];
     Fighter* fp;
     ftNessAttributes* ness_attr;
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[16];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_NESS_SPECIALAIRLW_HIT,
                                        FTNESS_SPECIALLW_COLL_FLAG, NULL,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     ness_attr = fp->x2D4_specialAttributes;
     ftColl_CreateAbsorbHit(fighter_gobj, &ness_attr->x98_PSI_MAGNET_ABSORPTION);
 }
@@ -899,17 +932,21 @@ void ftNess_SpecialAirLwHit_AirToGround(
     HSD_GObj* fighter_gobj) // Ness's air->ground PSI Magnet Absorb Action State
                             // handler //
 {
-    s32 filler[6];
     Fighter* fp;
     ftNessAttributes* ness_attr;
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[16];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_NESS_SPECIALLW_HIT,
                                        FTNESS_SPECIALLW_COLL_FLAG, NULL,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
     func_8007D468(fp);
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     ness_attr = fp->x2D4_specialAttributes;
     ftColl_CreateAbsorbHit(fighter_gobj, &ness_attr->x98_PSI_MAGNET_ABSORPTION);
 }
@@ -1067,7 +1104,7 @@ void ftNess_SpecialLwEnd_GroundToAir(
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_NESS_SPECIALAIRLW_END,
                                        FTNESS_SPECIALLW_END_FLAG, NULL,
@@ -1082,7 +1119,7 @@ void ftNess_SpecialAirLwEnd_AirToGround(
 {
     Fighter* temp_r31;
 
-    temp_r31 = fighter_gobj->user_data;
+    temp_r31 = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(temp_r31);
     Fighter_ActionStateChange_800693AC(
         fighter_gobj, AS_NESS_SPECIALLW_END, FTNESS_SPECIALLW_END_FLAG, NULL,

--- a/src/melee/ft/chara/ftNess/ftNess_SpecialN.c
+++ b/src/melee/ft/chara/ftNess/ftNess_SpecialN.c
@@ -17,7 +17,7 @@ bool ftNess_CheckSpecialNHold(
     s32 ASID;
 
     if (fighter_gobj != NULL) {
-        fp = fighter_gobj->user_data;
+        fp = GET_FIGHTER(fighter_gobj);
         if (fp != NULL) {
             if (fp->sa.ness.x2240_flashGObj != NULL) {
                 ASID = fp->action_id;
@@ -41,7 +41,7 @@ void ftNess_SpecialNSetNULL(
     Fighter* fp;
 
     if (fighter_gobj != NULL) {
-        fp = fighter_gobj->user_data;
+        fp = GET_FIGHTER(fighter_gobj);
         if (fp != NULL) {
             if (fp->sa.ness.x2240_flashGObj != NULL) {
                 fp->sa.ness.x2240_flashGObj = NULL;
@@ -62,7 +62,7 @@ void ftNess_ItemPKFlushSetNULL(
     Fighter* fp;
 
     if (fighter_gobj != NULL) {
-        fp = fighter_gobj->user_data;
+        fp = GET_FIGHTER(fighter_gobj);
         if (fp != NULL) {
             if (fp->sa.ness.x2240_flashGObj != NULL) {
                 func_802AAA50(fp->sa.ness.x2240_flashGObj);
@@ -114,7 +114,7 @@ void ftNess_SpecialNStart_Action(
     fp->x2204_ftcmd_var1 = 0;
     fp->x2200_ftcmd_var0 = 0;
 
-    temp_fp = fighter_gobj->user_data;
+    temp_fp = GET_FIGHTER(fighter_gobj);
     ness_attr = getFtSpecialAttrs(temp_fp);
 
     temp_fp->nessVars[0].SpecialN.flashTimerLoop1 =
@@ -157,7 +157,7 @@ void ftNess_SpecialAirNStart_Action(
     fp->x2200_ftcmd_var0 = 0;
     fp->x80_self_vel.y = 0.0f;
 
-    temp_fp = fighter_gobj->user_data;
+    temp_fp = GET_FIGHTER(fighter_gobj);
     ness_attr = getFtSpecialAttrs(temp_fp);
 
     temp_fp->nessVars[0].SpecialN.flashTimerLoop1 =
@@ -224,7 +224,7 @@ void ftNess_SpecialNHold_Anim(
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     if (fp->nessVars[0].SpecialN.flashTimerLoop1 != 0) {
         fp->nessVars[0].SpecialN.flashTimerLoop1--;
     }
@@ -343,7 +343,7 @@ void ftNess_SpecialAirNStart_Anim(
 void ftNess_SpecialAirNHold_Anim(
     HSD_GObj* fighter_gobj) // Ness's aerial PK Flash Charge Animation callback
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->nessVars[0].SpecialN.flashTimerLoop1 != 0) {
         fp->nessVars[0].SpecialN.flashTimerLoop1--;
@@ -387,7 +387,7 @@ void ftNess_SpecialAirNHold_Anim(
 void ftNess_SpecialAirNEnd_Anim(
     HSD_GObj* fighter_gobj) // Ness's aerial PK Flash Release Animation callback
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftNessAttributes* ness_attr = getFtSpecialAttrs(fp);
     f32 landingLag;
 
@@ -425,7 +425,7 @@ void ftNess_SpecialNHold_IASA(
     Fighter* fp;
     s32 phi_r0;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     fp->nessVars[0].SpecialN.flashTimerMin--;
     if ((s32) fp->nessVars[0].SpecialN.flashTimerMin <= 0) {
         fp->nessVars[0].SpecialN.flashTimerMin = 0;
@@ -437,7 +437,7 @@ void ftNess_SpecialNHold_IASA(
         ((fp->input.x65C_heldInputs & HSD_BUTTON_B) == false) &&
         (fighter_gobj != NULL))
     {
-        fp = fighter_gobj->user_data;
+        fp = GET_FIGHTER(fighter_gobj);
         if (fp != NULL) {
             if (fp->sa.ness.x2240_flashGObj != NULL) {
                 fp->sa.ness.x2240_flashGObj = NULL;
@@ -471,7 +471,7 @@ void ftNess_SpecialAirNHold_IASA(
     Fighter* fp;
     s32 phi_r0;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     fp->nessVars[0].SpecialN.flashTimerMin =
         (s32) (fp->nessVars[0].SpecialN.flashTimerMin - 1);
     if ((s32) fp->nessVars[0].SpecialN.flashTimerMin <= 0) {
@@ -484,7 +484,7 @@ void ftNess_SpecialAirNHold_IASA(
         ((fp->input.x65C_heldInputs & HSD_BUTTON_B) == false) &&
         (fighter_gobj != NULL))
     {
-        fp = fighter_gobj->user_data;
+        fp = GET_FIGHTER(fighter_gobj);
         if (fp != NULL) {
             if (fp->sa.ness.x2240_flashGObj != NULL) {
                 fp->sa.ness.x2240_flashGObj = NULL;
@@ -505,7 +505,7 @@ void ftNess_SpecialAirNEnd_IASA(
 inline void GravityDelay(HSD_GObj* fighter_gobj) // Inline to set remaining
                                                  // frames of gravity delay
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->nessVars[0].SpecialN.gravityDelay != 0) {
         fp->nessVars[0].SpecialN.gravityDelay--;

--- a/src/melee/ft/chara/ftNess/ftNess_SpecialS.c
+++ b/src/melee/ft/chara/ftNess/ftNess_SpecialS.c
@@ -72,7 +72,7 @@ void ftNess_SpecialS_StartAction(
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     fp->x2210_ThrowFlags.flags = 0; // Set projectile summon flag to 0 //
     fp->x2200_ftcmd_var0 = 0; // Set ftcmd flag0 to 0; unused in PK Fire? //
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_NESS_SPECIALS, 0, NULL,
@@ -89,7 +89,7 @@ void ftNess_SpecialAirS_Action(
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     fp->x2210_ThrowFlags.flags = 0; // Set projectile summon flag to 0 //
     fp->x2200_ftcmd_var0 = 0; // Set ftcmd flag0 to 0; unused in PK Fire? //
     Fighter_ActionStateChange_800693AC(fighter_gobj, AS_NESS_SPECIALAIRS, 0,

--- a/src/melee/ft/chara/ftPikachu/ftpikachu.h
+++ b/src/melee/ft/chara/ftPikachu/ftpikachu.h
@@ -163,7 +163,7 @@ void ftPikachu_ActionChange_80126A2C(HSD_GObj* fighter_gobj);
 void ftPikachu_ActionChange_80126AA4(HSD_GObj* fighter_gobj);
 void ftPikachu_80126C0C(HSD_GObj* fighter_gobj);
 void ftPikachu_80126E1C(HSD_GObj* fighter_gobj);
-s32 ftPikachu_80127064(HSD_GObj* fighter_gobj);
+bool ftPikachu_80127064(HSD_GObj* fighter_gobj);
 void ftPikachu_80127198(HSD_GObj* fighter_gobj);
 void ftPikachu_80127228(HSD_GObj* fighter_gobj);
 void ftPikachu_801272E0(HSD_GObj* fighter_gobj);

--- a/src/melee/ft/chara/ftPikachu/ftpikachu1.c
+++ b/src/melee/ft/chara/ftPikachu/ftpikachu1.c
@@ -106,7 +106,7 @@ void ftPikachu_OnLoadForPichu(Fighter* fp)
 
 void ftPikachu_OnLoad(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     void** item_list = fp->x10C_ftData->x48_items;
 
     PUSH_ATTRS(fp, ftPikachuAttributes);

--- a/src/melee/ft/chara/ftPikachu/ftpikachu2.c
+++ b/src/melee/ft/chara/ftPikachu/ftpikachu2.c
@@ -11,7 +11,7 @@
 
 void ftPikachu_SpecialN_StartAction(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x155, 0, 0, 0.0f, 1.0f,
                                        0.0f);
     fp->x220C_ftcmd_var3 = 0;
@@ -23,7 +23,7 @@ void ftPikachu_SpecialN_StartAction(HSD_GObj* fighter_gobj)
 
 void ftPikachu_SpecialAirN_StartAction(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x156, 0, 0, 0.0f, 1.0f,
                                        0.0f);
     fp->x220C_ftcmd_var3 = 0;
@@ -36,9 +36,13 @@ void ftPikachu_SpecialAirN_StartAction(HSD_GObj* fighter_gobj)
 void ftPikachu_80124908(HSD_GObj* fighter_gobj)
 {
     Vec3 sp14;
-    s32 stack_buffer[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[4];
+#endif
 
     if (fp->x2200_ftcmd_var0 == 1) {
         fp->x2200_ftcmd_var0 = 0;
@@ -69,9 +73,13 @@ void ftPikachu_80124908(HSD_GObj* fighter_gobj)
 void ftPikachu_80124A20(HSD_GObj* fighter_gobj)
 {
     Vec3 sp14;
-    s32 stack_buffer[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[4];
+#endif
 
     if (fp->x2200_ftcmd_var0 == 1) {
         fp->x2200_ftcmd_var0 = 0;
@@ -121,7 +129,7 @@ void ftPikachu_ActionChange_80124BB4(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
     if (!func_80082708(fighter_gobj)) {
-        fp = fighter_gobj->user_data;
+        fp = GET_FIGHTER(fighter_gobj);
         func_8007D5D4(fp);
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x156, 0xc4c5082, 0,
                                            fp->x894_currentAnimFrame, 1.0f,
@@ -133,7 +141,7 @@ void ftPikachu_ActionChange_80124C20(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
     if (func_80081D0C(fighter_gobj) == 1) {
-        fp = fighter_gobj->user_data;
+        fp = GET_FIGHTER(fighter_gobj);
         func_8007D7FC(fp);
         fp->x80_self_vel.y = 0.0f;
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x155, 0xc4c5082, 0,
@@ -144,7 +152,7 @@ void ftPikachu_ActionChange_80124C20(HSD_GObj* fighter_gobj)
 
 void ftPikachu_EfSpawn_80124C90(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     HSD_GObj* tempObj;
     HSD_GObj* tempObj2;
@@ -163,7 +171,7 @@ void ftPikachu_EfSpawn_80124C90(HSD_GObj* fighter_gobj)
 
 void ftPikachu_EfSpawn_80124D2C(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     HSD_GObj* tempObj;
     HSD_GObj* tempObj2;
@@ -183,7 +191,7 @@ void ftPikachu_EfSpawn_80124D2C(HSD_GObj* fighter_gobj)
 void ftPikachu_80124DC8(HSD_GObj* fighter_gobj)
 {
     u8 fighter_x673_byte;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
     f32 pika_attr_1C;
 

--- a/src/melee/ft/chara/ftPikachu/ftpikachu3.c
+++ b/src/melee/ft/chara/ftPikachu/ftpikachu3.c
@@ -8,7 +8,7 @@
 void ftPikachu_SpecialS_StartAction(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
     fp->cb.x21EC_callback = ftPikachu_80124DC8;
@@ -22,7 +22,7 @@ void ftPikachu_SpecialS_StartAction(HSD_GObj* fighter_gobj)
 void ftPikachu_SpecialAirS_StartAction(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
     fp->cb.x21EC_callback = ftPikachu_80124DC8;
@@ -36,7 +36,7 @@ void ftPikachu_SpecialAirS_StartAction(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ZeroVelocity_80124F24(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     fp->x80_self_vel.x = 0.0f;
     if (fp->x80_self_vel.y >= 0.0f) {
         fp->x80_self_vel.y = 0.0f;
@@ -65,7 +65,7 @@ void ftPikachu_Stub_80124FE0(HSD_GObj* arg0) {}
 void ftPikachu_80124FE4(HSD_GObj* fighter_gobj)
 {
     s32 unused;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
     f32 pika_attr_x34 = pika_attr->x34;
     func_8007C930(fp, pika_attr_x34);
@@ -75,7 +75,7 @@ void ftPikachu_80124FE4(HSD_GObj* fighter_gobj)
 void ftPikachu_80125024(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
     struct attr* attr = &fp->x110_attr;
 
@@ -101,7 +101,7 @@ void ftPikachu_801250C0(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_801250FC(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x15C, 0xc4c5284, 0,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -109,7 +109,7 @@ void ftPikachu_ActionChange_801250FC(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_8012515C(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x157, 0xc4c5284, 0,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -118,7 +118,7 @@ void ftPikachu_ActionChange_8012515C(HSD_GObj* fighter_gobj)
 void ftPikachu_801251BC(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
     if (!ftAnim_IsFramesRemaining(fighter_gobj)) {
         func_8007DB24(fighter_gobj);
@@ -133,7 +133,7 @@ void ftPikachu_801251BC(HSD_GObj* fighter_gobj)
 void ftPikachu_8012525C(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
     if (!ftAnim_IsFramesRemaining(fighter_gobj)) {
@@ -150,7 +150,7 @@ void ftPikachu_8012525C(HSD_GObj* fighter_gobj)
 
 void ftPikachu_801252FC(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     if (!(fp->input.x65C_heldInputs & 0x200)) {
         ftPikachu_ActionChange_80125834(fighter_gobj);
     }
@@ -158,7 +158,7 @@ void ftPikachu_801252FC(HSD_GObj* fighter_gobj)
 
 void ftPikachu_8012532C(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     if (!(fp->input.x65C_heldInputs & 0x200)) {
         ftPikachu_ActionChange_801258A0(fighter_gobj);
     }
@@ -190,7 +190,7 @@ void ftPikachu_801253D8(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_80125414(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x15D, 0xC4C5286, 0,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -198,7 +198,7 @@ void ftPikachu_ActionChange_80125414(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_80125474(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x158, 0xC4C5286, 0,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -210,7 +210,7 @@ void ftPikachu_ActionChange_801254D4(HSD_GObj* fighter_gobj)
     Fighter* fp;
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x158, 0x200, 0, 0.0f,
                                        1.0f, 0.0f);
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     fp->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_80124C90;
 }
 
@@ -220,14 +220,14 @@ void ftPikachu_ActionChange_80125528(HSD_GObj* fighter_gobj)
     Fighter* fp;
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x15D, 0x200, 0, 0.0f,
                                        1.0f, 0.0f);
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     fp->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_80124C90;
 }
 
 void ftPikachu_8012557C(HSD_GObj* fighter_gobj)
 {
     s32 unused[4];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
     if (fp->x914[0].tangiblity == Invincible) {
@@ -245,7 +245,7 @@ void ftPikachu_8012557C(HSD_GObj* fighter_gobj)
 void ftPikachu_8012561C(HSD_GObj* fighter_gobj)
 {
     s32 unused[4];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
     if (fp->x914[0].tangiblity == Invincible) {
@@ -289,7 +289,7 @@ void ftPikachu_80125738(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_80125774(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x160, 0xC4C5086, 0,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -297,7 +297,7 @@ void ftPikachu_ActionChange_80125774(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_801257D4(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x15B, 0xC4C5086, 0,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -309,7 +309,7 @@ void ftPikachu_ActionChange_80125834(HSD_GObj* fighter_gobj)
     Fighter* fp;
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x15B, 0, 0, 0.0f, 1.0f,
                                        0.0f);
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     fp->x2200_ftcmd_var0 = 0;
     func_8007DB24(fighter_gobj);
     fp->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_80124D2C;
@@ -321,7 +321,7 @@ void ftPikachu_ActionChange_801258A0(HSD_GObj* fighter_gobj)
     Fighter* fp;
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x160, 0, 0, 0.0f, 1.0f,
                                        0.0f);
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     fp->x2200_ftcmd_var0 = 0;
     func_8007DB24(fighter_gobj);
     fp->cb.x21BC_callback_Accessory4 = &ftPikachu_EfSpawn_80124D2C;
@@ -345,7 +345,7 @@ void ftPikachu_Stub_80125954(HSD_GObj* arg0) {}
 void ftPikachu_80125958(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
     if (fp->x2200_ftcmd_var0) {
@@ -363,7 +363,7 @@ void ftPikachu_Stub_801259D4(HSD_GObj* arg0) {}
 
 void ftPikachu_801259D8(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     CollData* collData = &fp->x6F0_collData;
 
     if (func_80081D0C(fighter_gobj)) {
@@ -379,7 +379,7 @@ void ftPikachu_801259D8(HSD_GObj* fighter_gobj)
 void ftPikachu_ActionChange_80125A54(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
     fp->x2200_ftcmd_var0 = 0;
@@ -418,7 +418,7 @@ void ftPikachu_Stub_80125BB0(HSD_GObj* arg0) {}
 void ftPikachu_80125BB4(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
     func_8007C930(fp, pika_attr->x54);
     func_8007CB74(fighter_gobj);
@@ -427,7 +427,7 @@ void ftPikachu_80125BB4(HSD_GObj* fighter_gobj)
 void ftPikachu_80125BF4(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
     func_8007D494(fp, pika_attr->x58, fp->x110_attr.x170_TerminalVelocity);
     func_8007CE94(fp, pika_attr->x54);
@@ -442,7 +442,7 @@ void ftPikachu_80125C44(HSD_GObj* fighter_gobj)
 
 void ftPikachu_80125C80(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     if (func_80081D0C(fighter_gobj)) {
         func_8007D7FC(fp);
         ftPikachu_ActionChange_80125CD0(fighter_gobj);
@@ -452,7 +452,7 @@ void ftPikachu_80125C80(HSD_GObj* fighter_gobj)
 void ftPikachu_ActionChange_80125CD0(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
     fp->x2200_ftcmd_var0 = 0;
@@ -465,7 +465,7 @@ void ftPikachu_ActionChange_80125CD0(HSD_GObj* fighter_gobj)
 void ftPikachu_ActionChange_80125D28(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
     fp->x2200_ftcmd_var0 = 0;

--- a/src/melee/ft/chara/ftPikachu/ftpikachu4.c
+++ b/src/melee/ft/chara/ftPikachu/ftpikachu4.c
@@ -17,7 +17,7 @@
 // points velocity toward facing direction
 void ftPikachu_UpdateVel_80125D80(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     fp->xEC_ground_vel = fp->facing_dir * fabs_inline(fp->xEC_ground_vel);
     fp->x80_self_vel.x = fp->facing_dir * fabs_inline(fp->x80_self_vel.x);
     fp->x234C_pos.y = fp->facing_dir * fabs_inline(fp->x234C_pos.y);
@@ -27,7 +27,7 @@ void ftPikachu_SpecialHi_StartAction(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
     ftPikachuAttributes* pika_attr;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     pika_attr = fp->x2D4_specialAttributes;
     fp->x2200_ftcmd_var0 = 0;
     fp->x2340_stateVar1 = pika_attr->x5C;
@@ -45,7 +45,7 @@ void ftPikachu_SpecialAirHi_StartAction(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
     ftPikachuAttributes* pika_attr;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     pika_attr = fp->x2D4_specialAttributes;
     fp->x2200_ftcmd_var0 = 0;
     fp->x2340_stateVar1 = pika_attr->x5C;
@@ -85,7 +85,7 @@ void ftPikachu_80125F58(HSD_GObj* fighter_gobj)
 void ftPikachu_80125F78(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
     struct attr* attr = &fp->x110_attr;
     if (fp->x2340_stateVar1) {
@@ -106,7 +106,7 @@ void ftPikachu_80125FD8(HSD_GObj* fighter_gobj)
 void ftPikachu_80126014(HSD_GObj* fighter_gobj)
 {
     s32 unused;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (EnvColl_CheckGroundAndLedge(fighter_gobj,
                                     fp->facing_dir < 0.0f ? -1 : 1))
@@ -121,7 +121,7 @@ void ftPikachu_80126014(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_80126084(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D60C(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x164, 0xC4C5084, 0,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -129,7 +129,7 @@ void ftPikachu_ActionChange_80126084(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_801260E4(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x161, 0xC4C5084, 0,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -139,14 +139,18 @@ void ftPikachu_80126144(HSD_GObj* fighter_gobj)
 {
     Vec3 vec;
     Vec3 vec2;
-    s32 unused[5];
 
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     fp->x2344_stateVar2_s32--;
     if (fp->x2344_stateVar2_s32 <= 0) {
         ftPikachu_ActionChangeUpdateVel_801274AC(fighter_gobj);
-        fp = fighter_gobj->user_data;
+        fp = GET_FIGHTER(fighter_gobj);
         if (fp->x4_fighterKind != FTKIND_PICHU) {
             func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 2)].x0_jobj,
                           0, &vec);
@@ -156,7 +160,7 @@ void ftPikachu_80126144(HSD_GObj* fighter_gobj)
             fp->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
         }
     } else {
-        fp = fighter_gobj->user_data;
+        fp = GET_FIGHTER(fighter_gobj);
         if (fp->x4_fighterKind != FTKIND_PICHU) {
             f32 tempf;
             func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 2)].x0_jobj,
@@ -177,14 +181,18 @@ void ftPikachu_801262B4(HSD_GObj* fighter_gobj)
 {
     Vec3 vec;
     Vec3 vec2;
-    s32 unused[5];
 
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     fp->x2344_stateVar2_s32--;
     if (fp->x2344_stateVar2_s32 <= 0) {
         ftPikachu_ActionChangeUpdateVel_80127534(fighter_gobj);
-        fp = fighter_gobj->user_data;
+        fp = GET_FIGHTER(fighter_gobj);
         if (fp->x4_fighterKind != FTKIND_PICHU) {
             func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 2)].x0_jobj,
                           0, &vec);
@@ -194,7 +202,7 @@ void ftPikachu_801262B4(HSD_GObj* fighter_gobj)
             fp->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;
         }
     } else {
-        fp = fighter_gobj->user_data;
+        fp = GET_FIGHTER(fighter_gobj);
         if (fp->x4_fighterKind != FTKIND_PICHU) {
             f32 tempf;
             func_8000B1CC(fp->x5E8_fighterBones[func_8007500C(fp, 2)].x0_jobj,
@@ -219,10 +227,9 @@ void ftPikachu_8012642C(HSD_GObj* fighter_gobj)
 {
     Vec3 scale;
     Vec3 velocity_vec;
-    s32 unused;
 
     HSD_JObj* jobj;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
     f32 half_pi = (f32) M_PI_2;
@@ -270,16 +277,20 @@ void ftPikachu_801265F4(HSD_GObj* fighter_gobj)
 void ftPikachu_80126614(HSD_GObj* fighter_gobj)
 {
     Vec3 scale;
-    s32 unused[7];
 
     Fighter* fighter2;
 
     HSD_JObj* jobj;
 
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     CollData* collData = &fp->x6F0_collData;
 
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[20];
+#endif
 
     /// @todo Eliminate cast (by changing type of field)
     if (!func_80082888(fighter_gobj,
@@ -298,7 +309,7 @@ void ftPikachu_80126614(HSD_GObj* fighter_gobj)
 
     { /// could be an inline?
         CollData* collData;
-        fighter2 = fighter_gobj->user_data;
+        fighter2 = GET_FIGHTER(fighter_gobj);
         collData = &fighter2->x6F0_collData;
         pika_attr = fighter2->x2D4_specialAttributes;
         if (collData->x134_envFlags & 0x18000) {
@@ -334,11 +345,15 @@ bool ftPikachu_GetBool(HSD_GObj* fighter_gobj)
 
 void ftPikachu_801267C8(HSD_GObj* fighter_gobj)
 {
-    s32 unused[5];
     bool bool0;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
     CollData* collData = &fp->x6F0_collData;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[12];
+#endif
 
     fp->x2358_stateVar7_s32++;
     if (EnvColl_CheckGroundAndLedge(fighter_gobj,
@@ -393,12 +408,17 @@ void ftPikachu_801267C8(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_80126A2C(HSD_GObj* fighter_gobj)
 {
-    s32 unused[2];
     Fighter* fp = fighter_gobj->user_data;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
+
     func_8007D60C(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x165, 0xC4C508A, 0,
                                        fp->x894_currentAnimFrame, 0.0f, 0.0f);
-    fp->x2223_flag.bits.b4 = 1;
+    fp->x2223_flag.bits.b4 = true;
     ftPikachu_8012642C(fighter_gobj);
 }
 
@@ -409,7 +429,6 @@ void ftPikachu_ActionChange_80126A2C(HSD_GObj* fighter_gobj)
 void ftPikachu_ActionChange_80126AA4(HSD_GObj* fighter_gobj)
 {
     Vec3 scale;
-    s32 unused[6];
 
     CollData* collData;
     ftPikachuAttributes* pika_attr;
@@ -419,13 +438,18 @@ void ftPikachu_ActionChange_80126AA4(HSD_GObj* fighter_gobj)
 
     HSD_JObj* jobj;
 
-    fighter2 = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[16];
+#endif
+
+    fighter2 = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fighter2);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x162, 0xC4C508A, 0,
                                        fighter2->x894_currentAnimFrame, 0.0f,
                                        0.0f);
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     collData = &fp->x6F0_collData;
     pika_attr = fp->x2D4_specialAttributes;
     if (fp->x6F0_collData.x134_envFlags & 0x18000) {
@@ -442,9 +466,10 @@ void ftPikachu_ActionChange_80126AA4(HSD_GObj* fighter_gobj)
     HSD_JObjSetScale(jobj, &scale);
 }
 
+/// @todo What.
 static inline float get_max_and_fill_stack(void)
 {
-    float stack[9];
+    float stack[7];
     stack[0] = MAX_STICK_MAG;
     return MAX_STICK_MAG;
 }
@@ -452,20 +477,18 @@ static inline float get_max_and_fill_stack(void)
 // grounded up b zip
 void ftPikachu_80126C0C(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     CollData* collData = &fp->x6F0_collData;
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
     // distance formula
-    f32 stick_mag = sqrtf((fp->input.x620_lstick_x * fp->input.x620_lstick_x) +
-                          (fp->input.x624_lstick_y * fp->input.x624_lstick_y));
+    f32 stick_mag = sqrtf(fp->input.x620_lstick_x * fp->input.x620_lstick_x +
+                          fp->input.x624_lstick_y * fp->input.x624_lstick_y);
 
     // cap stick magnitude to MAX_STICK_MAG
-    if (stick_mag > MAX_STICK_MAG) {
+    if (stick_mag > MAX_STICK_MAG)
         stick_mag = get_max_and_fill_stack();
-        ;
-    }
 
     if (!(stick_mag < pika_attr->x8C)) {
         Vec3 lstick_direction;
@@ -485,7 +508,7 @@ void ftPikachu_80126C0C(HSD_GObj* fighter_gobj)
             fp->x234C_pos.y = lstick_direction.x;
             fp->x234C_pos.z = lstick_direction.y;
 
-            fighter2 = fighter_gobj->user_data;
+            fighter2 = GET_FIGHTER(fighter_gobj);
 
             // set zip duration
             fighter2->x2344_stateVar2_s32 =
@@ -529,7 +552,7 @@ void ftPikachu_80126E1C(HSD_GObj* fighter_gobj)
     f32 final_stick_mag;
 
     Fighter* fighter2;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
@@ -541,9 +564,8 @@ void ftPikachu_80126E1C(HSD_GObj* fighter_gobj)
     final_stick_mag = temp_stick_mag;
 
     // cap stick magnitude to MAX_STICK_MAG
-    if (temp_stick_mag > MAX_STICK_MAG) {
+    if (temp_stick_mag > MAX_STICK_MAG)
         final_stick_mag = get_max_and_fill_stack();
-    }
 
     if ((final_stick_mag > pika_attr->x8C)) {
         if (fabs_inline(fp->input.x620_lstick_x) > 0.001f) {
@@ -570,7 +592,7 @@ void ftPikachu_80126E1C(HSD_GObj* fighter_gobj)
         fp->x234C_pos.z = MAX_STICK_MAG;
     }
 
-    fighter2 = fighter_gobj->user_data;
+    fighter2 = GET_FIGHTER(fighter_gobj);
 
     // set zip duration
     fighter2->x2344_stateVar2_s32 =
@@ -607,7 +629,7 @@ void ftPikachu_80126E1C(HSD_GObj* fighter_gobj)
     fp->cb.x21F8_callback = &ftPikachu_UpdateVel_80125D80;
 }
 
-static inline s32 return_and_fill_stack(void)
+static inline bool return_and_fill_stack(void)
 {
     float stack[1];
     stack[0] = MAX_STICK_MAG;
@@ -615,13 +637,9 @@ static inline s32 return_and_fill_stack(void)
 }
 
 // seems to check whether to perform a second up b zip
-s32 ftPikachu_80127064(HSD_GObj* fighter_gobj)
+bool ftPikachu_80127064(HSD_GObj* fighter_gobj)
 {
-    Vec3 vec1;
-    Vec3 vec2;
-
     Fighter* fp = fighter_gobj->user_data;
-
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
     // distance formula
@@ -630,12 +648,17 @@ s32 ftPikachu_80127064(HSD_GObj* fighter_gobj)
 
     // if stick_mag is less than the threshold, push the max stick magnitude
     // onto the stack and return 0
-    if (stick_mag < pika_attr->x8C) {
+    if (stick_mag < pika_attr->x8C)
         return return_and_fill_stack();
-    }
 
     if (!fp->x2348_stateVar3_s32) {
+        Vec3 vec1, vec2;
         f32 tempf;
+
+        /// @todo Unused stack.
+#ifdef MUST_MATCH
+        u8 unused[4];
+#endif
 
         // push current stick to temporary vector
         vec1.x = fp->input.x620_lstick_x;
@@ -651,17 +674,18 @@ s32 ftPikachu_80127064(HSD_GObj* fighter_gobj)
         tempf = lbvector_AngleXY(&vec2, &vec1);
 
         // if the angular difference > the minimum difference, return 1
-        if (tempf > (DEG_TO_RAD * (pika_attr->xA8))) {
-            return 1;
-        }
-        return 0;
+        if (tempf > (DEG_TO_RAD * (pika_attr->xA8)))
+            return true;
+
+        return false;
     }
-    return 0;
+
+    return false;
 }
 
 void ftPikachu_80127198(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     if ((u32) fp->x2200_ftcmd_var0 == 1U) {
         if (ftPikachu_80127064(fighter_gobj)) {
             fp->x2200_ftcmd_var0 = 0;
@@ -680,7 +704,7 @@ void ftPikachu_80127198(HSD_GObj* fighter_gobj)
 void ftPikachu_80127228(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
     if (fp->x2200_ftcmd_var0 == 1) {
         if (ftPikachu_80127064(fighter_gobj)) {
@@ -703,7 +727,7 @@ void ftPikachu_Stub_801272DC(HSD_GObj* arg0) {}
 
 void ftPikachu_801272E0(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     if (fp->x2200_ftcmd_var0) {
         func_80084F3C(fighter_gobj);
     }
@@ -712,7 +736,7 @@ void ftPikachu_801272E0(HSD_GObj* fighter_gobj)
 void ftPikachu_80127310(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
     if (fp->x2200_ftcmd_var0) {
         func_8007D4B8(fp);
@@ -725,8 +749,7 @@ void ftPikachu_80127310(HSD_GObj* fighter_gobj)
 
 void ftPikachu_8012738C(HSD_GObj* fighter_gobj)
 {
-    s32 unused[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
 
     /// @todo Eliminate cast (by changing type of field)
@@ -739,9 +762,14 @@ void ftPikachu_8012738C(HSD_GObj* fighter_gobj)
 
 void ftPikachu_801273D4(HSD_GObj* fighter_gobj)
 {
-    s32 unused[2];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
+
     if (func_8008239C(fighter_gobj, fp->facing_dir,
                       pika_attr->height_attributes))
     {
@@ -755,7 +783,7 @@ void ftPikachu_801273D4(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_8012744C(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D60C(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x166, 0xC4C508A, 0,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -765,7 +793,7 @@ void ftPikachu_ActionChangeUpdateVel_801274AC(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
     ftPikachuAttributes* pika_attr;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     pika_attr = fp->x2D4_specialAttributes;
     fp->x235C = fp->x80_self_vel.x;
     fp->x2360_f32 = fp->x80_self_vel.y;
@@ -784,7 +812,7 @@ void ftPikachu_ActionChangeUpdateVel_80127534(HSD_GObj* fighter_gobj)
 {
     s32 unused[2];
     ftPikachuAttributes* pika_attr;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     pika_attr = fp->x2D4_specialAttributes;
     fp->x235C = fp->x80_self_vel.x;
     fp->x2360_f32 = fp->x80_self_vel.y;

--- a/src/melee/ft/chara/ftPikachu/ftpikachu5.c
+++ b/src/melee/ft/chara/ftPikachu/ftpikachu5.c
@@ -10,7 +10,7 @@
 
 bool ftPikachu_CheckProperty_801275CC(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     s32 value = fp->x2071_b0_3;
 
@@ -35,14 +35,14 @@ bool ftPikachu_CheckProperty_801275CC(HSD_GObj* fighter_gobj)
 
 void ftPikachu_80127608(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_80030E44(2, &fp->xB0_pos);
     func_8007EBAC(fp, 0xB, 0);
 }
 
 void ftPikachu_SetState_8012764C(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     fp->x2344_stateVar2 = 3;
 }
 
@@ -87,7 +87,7 @@ bool ftPikachu_8012765C(HSD_GObj* fighter_gobj)
 
 void ftPikachu_SetState_8012779C(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     fp->x2344_stateVar2 = 0;
 }
 
@@ -132,7 +132,7 @@ void ftPikachu_EfSpawn_801277AC(HSD_GObj* fighter_gobj)
 
 void ftPikachu_SpecialLw_StartAction(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     fp->x2200_ftcmd_var0 = 0;
     *((u32*) (&fp->x2210_ThrowFlags)) = 0;
     fp->x2344_stateVar2 = 1;
@@ -144,7 +144,7 @@ void ftPikachu_SpecialLw_StartAction(HSD_GObj* fighter_gobj)
 
 void ftPikachu_SpecialAirLw_StartAction(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     fp->x2200_ftcmd_var0 = 0;
     *((u32*) (&fp->x2210_ThrowFlags)) = 0;
     fp->x2344_stateVar2 = 1;
@@ -156,7 +156,7 @@ void ftPikachu_SpecialAirLw_StartAction(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_8012798C(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x167, 0xC4C5086, 0,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -164,7 +164,7 @@ void ftPikachu_ActionChange_8012798C(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_801279EC(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x16B, 0xC4C5086, 0,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -173,7 +173,7 @@ void ftPikachu_ActionChange_801279EC(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_80127A54(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x168, 0xC4C588E, 0,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -183,7 +183,7 @@ void ftPikachu_ActionChange_80127A54(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_80127ACC(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x16C, 0xC4C588E, 0,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -194,7 +194,7 @@ void ftPikachu_ActionChange_80127ACC(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_80127B4C(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x169, 0xC4C508E, 0,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -202,7 +202,7 @@ void ftPikachu_ActionChange_80127B4C(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_80127BAC(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x16D, 0xC4C508E, 0,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -211,7 +211,7 @@ void ftPikachu_ActionChange_80127BAC(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_80127C14(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x16A, 0xC4C5086, 0,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -219,7 +219,7 @@ void ftPikachu_ActionChange_80127C14(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_80127C74(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x16E, 0xC4C5086, 0,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
@@ -228,14 +228,17 @@ void ftPikachu_ActionChange_80127C74(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_80127CDC(HSD_GObj* fighter_gobj)
 {
-    s32 unused[4];
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     if (!ftAnim_IsFramesRemaining(fighter_gobj)) {
         Fighter* fighter_copy;
-        Fighter* fp = fighter_gobj->user_data;
+        Fighter* fp = GET_FIGHTER(fighter_gobj);
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x168, 0x800, 0, 0.0f,
                                            1.0f, 0.0f);
-        fighter_copy = fighter_gobj->user_data;
+        fighter_copy = GET_FIGHTER(fighter_gobj);
         *((u32*) (&fighter_copy->x2210_ThrowFlags)) = 0;
         fighter_copy->cb.x21DC_callback_OnTakeDamage =
             &ftPikachu_SetState_8012779C;
@@ -245,14 +248,17 @@ void ftPikachu_ActionChange_80127CDC(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_80127D60(HSD_GObj* fighter_gobj)
 {
-    s32 unused[4];
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     if (!ftAnim_IsFramesRemaining(fighter_gobj)) {
         Fighter* fighter_copy;
-        Fighter* fp = fighter_gobj->user_data;
+        Fighter* fp = GET_FIGHTER(fighter_gobj);
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x16C, 0x800, 0, 0.0f,
                                            1.0f, 0.0f);
-        fighter_copy = fighter_gobj->user_data;
+        fighter_copy = GET_FIGHTER(fighter_gobj);
         *((u32*) (&fighter_copy->x2210_ThrowFlags)) = 0;
         fighter_copy->cb.x21DC_callback_OnTakeDamage =
             &ftPikachu_SetState_8012779C;
@@ -262,8 +268,12 @@ void ftPikachu_ActionChange_80127D60(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_80127DE4(HSD_GObj* fighter_gobj)
 {
-    s32 unused[4];
-    Fighter* fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
+
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     if ((fp->x2344_stateVar2_s32 == 3) || fp->x2200_ftcmd_var0) {
         fp->cb.x21DC_callback_OnTakeDamage = 0;
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x16A, 0, 0, 0.0f,
@@ -271,12 +281,12 @@ void ftPikachu_ActionChange_80127DE4(HSD_GObj* fighter_gobj)
         return;
     }
     if (ftPikachu_8012765C(fighter_gobj)) {
-        Fighter* fighter_copy = fighter_gobj->user_data;
+        Fighter* fighter_copy = GET_FIGHTER(fighter_gobj);
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x169, 0, 0, 0.0f,
                                            1.0f, 0.0f);
         fighter_copy->x2200_ftcmd_var0 = 0;
         fighter_copy->cb.x21DC_callback_OnTakeDamage = 0;
-        fp = fighter_gobj->user_data;
+        fp = GET_FIGHTER(fighter_gobj);
         efAsync_Spawn(fighter_gobj, &fp->x60C, 0, 0x4C0,
                       fighter_copy->x5E8_fighterBones[0].x0_jobj);
     }
@@ -284,8 +294,12 @@ void ftPikachu_ActionChange_80127DE4(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_80127EC0(HSD_GObj* fighter_gobj)
 {
-    s32 unused[8];
-    Fighter* fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[24];
+#endif
+
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     if ((fp->x2344_stateVar2_s32 == 3) || fp->x2200_ftcmd_var0) {
         fp->cb.x21DC_callback_OnTakeDamage = 0;
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x16E, 0, 0, 0.0f,
@@ -293,14 +307,14 @@ void ftPikachu_ActionChange_80127EC0(HSD_GObj* fighter_gobj)
         return;
     }
     if (ftPikachu_8012765C(fighter_gobj)) {
-        Fighter* fighter_copy = fighter_gobj->user_data;
+        Fighter* fighter_copy = GET_FIGHTER(fighter_gobj);
         ftPikachuAttributes* pika_attr = fighter_copy->x2D4_specialAttributes;
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x16D, 0, 0, 0.0f,
                                            1.0f, 0.0f);
         fighter_copy->x2200_ftcmd_var0 = 0;
         fighter_copy->cb.x21DC_callback_OnTakeDamage = 0;
         fighter_copy->x80_self_vel.y = (f32) pika_attr->xB4;
-        fp = fighter_gobj->user_data;
+        fp = GET_FIGHTER(fighter_gobj);
         efAsync_Spawn(fighter_gobj, &fp->x60C, 0, 0x4C0,
                       fighter_copy->x5E8_fighterBones[0].x0_jobj);
     }
@@ -308,7 +322,7 @@ void ftPikachu_ActionChange_80127EC0(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_80127FB0(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     if (fp->x2200_ftcmd_var0) {
         fp->cb.x21DC_callback_OnTakeDamage = 0;
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x16A, 0, 0, 0.0f,
@@ -318,7 +332,7 @@ void ftPikachu_ActionChange_80127FB0(HSD_GObj* fighter_gobj)
 
 void ftPikachu_ActionChange_80128000(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     if (fp->x2200_ftcmd_var0) {
         fp->cb.x21DC_callback_OnTakeDamage = 0;
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x16E, 0, 0, 0.0f,
@@ -366,7 +380,7 @@ void ftPikachu_80128148(HSD_GObj* fighter_gobj)
 void ftPikachu_80128168(HSD_GObj* fighter_gobj)
 {
     s32 unused;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftPikachuAttributes* pika_attr = fp->x2D4_specialAttributes;
     f32 pika_B8 = pika_attr->xB8;
     f32 terminal_velocity = fp->x110_attr.x170_TerminalVelocity;

--- a/src/melee/ft/chara/ftPurin/ftpurin.c
+++ b/src/melee/ft/chara/ftPurin/ftpurin.c
@@ -163,7 +163,7 @@ void func_8013C360(HSD_GObj* fighter_gobj)
     s32 unused;
 
     HSD_Joint** joint_list = lbl_8045A1E0;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (lbl_803D05B4[fp->x619_costume_id]) {
         void** item_list = fp->x10C_ftData->x48_items;
@@ -195,10 +195,9 @@ void func_8013C360(HSD_GObj* fighter_gobj)
 
 void func_8013C494(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    HSD_JObj* jobj = fp->sa.purin.x223C;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
-    if (jobj) {
+    if (fp->sa.purin.x223C != NULL) {
         HSD_JObjRemoveAll(fp->sa.purin.x223C);
         fp->sa.purin.x223C = NULL;
         HSD_ObjFree(&lbl_80459080, fp->sa.purin.x2244);
@@ -210,7 +209,7 @@ void func_8013C4F0(HSD_GObj* fighter_gobj, s32 arg1, Mtx vmtx)
 {
     s32 unused[2];
 
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->sa.purin.x223C && fp->x2225_flag.bits.b2) {
         Mtx* mtx;
@@ -241,7 +240,7 @@ void func_8013C614(Fighter* fp, s32 arg1, s32 arg2)
 
 void* func_8013C664(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->sa.purin.x223C)
         return fp->sa.purin.x223C;
@@ -251,7 +250,7 @@ void* func_8013C664(HSD_GObj* fighter_gobj)
 
 void ftPurin_OnLoad(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     PUSH_ATTRS(fp, ftPurinAttributes);
     fp->x2222_flag.bits.b1 = 1;
     fp->x2D0 = fp->x2D4_specialAttributes;

--- a/src/melee/ft/chara/ftSamus/ftsamus1.c
+++ b/src/melee/ft/chara/ftSamus/ftsamus1.c
@@ -77,7 +77,7 @@ Fighter_CostumeStrings lbl_803CE678[] = {
 
 void ftSamus_OnDeath(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_80074A4C(fighter_gobj, 0, 0);
     fp->sa.samus.x222C = 0;
     fp->sa.samus.x2230 = 0;
@@ -89,7 +89,7 @@ void ftSamus_OnDeath(HSD_GObj* fighter_gobj)
 
 void ftSamus_OnLoad(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     void** item_list = fp->x10C_ftData->x48_items;
 
     fp->x2224_flag.bits.b7 = 1;

--- a/src/melee/ft/chara/ftSamus/ftsamus2.c
+++ b/src/melee/ft/chara/ftSamus/ftsamus2.c
@@ -8,9 +8,15 @@
 
 void ftSamus_80128944(HSD_GObj* fighter_gobj, f32 farg1, f32 farg2)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    ftSamusAttributes* attr = getFtSpecialAttrs(fp);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftSamusAttributes* attr = fp->x2D4_specialAttributes;
     f32 float_result = ftSamus_80128AC8(fighter_gobj, farg1, farg2);
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
+
     if (!func_8007B868(fighter_gobj)) {
         switch (fp->x2071_b0_3) {
         case 0:
@@ -29,19 +35,20 @@ void ftSamus_80128944(HSD_GObj* fighter_gobj, f32 farg1, f32 farg2)
     }
 }
 
-s32 ftSamus_80128A1C(HSD_GObj* fighter_gobj, s32 arg1, f32 farg1)
+bool ftSamus_80128A1C(HSD_GObj* fighter_gobj, s32 arg1, f32 farg1)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
-    s32 i;
+    int i;
 
     for (i = 0; i < fp->x119E_hurtboxNum; i++) {
         if (func_80008248(arg1, &fp->x11A0_fighterHurtbox[i], func_8007F804(fp),
                           farg1, fp->x34_scale.y, fp->xB0_pos.z))
         {
-            return 1;
+            return true;
         }
     }
-    return 0;
+
+    return false;
 }
 
 f32 ftSamus_80128AC8(HSD_GObj* fighter_gobj, f32 farg1, f32 farg2)
@@ -95,7 +102,7 @@ void ftSamus_80128B1C(HSD_GObj* fighter_gobj, f32 angle, f32 arg9, f32 argA)
 
 void ftSamus_80128C04(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     if ((fp->x2200_ftcmd_var0) && (!fp->x2340_stateVar1)) {
         ftSamus_8012AEBC(fighter_gobj);
         fp->x2340_stateVar1 = 1;
@@ -111,7 +118,7 @@ void ftSamus_80128C04(HSD_GObj* fighter_gobj)
 
 void ftSamus_80128CA0(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     if ((fp->x2200_ftcmd_var0) && (!fp->x2340_stateVar1)) {
         ftSamus_8012AEBC(fighter_gobj);
         fp->x2340_stateVar1 = 1;
@@ -196,9 +203,15 @@ void ftSamus_80128E88(HSD_GObj* fighter_gobj)
 
 void ftSamus_80128EF8(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
     struct attr* ftAttr = &fp->x110_attr;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
+
     func_8007D4B8(fp);
     func_8007D344(fp, 0.0f,
                   ftAttr->x154_GroundToAirJumpMomentumMultiplier *
@@ -263,11 +276,17 @@ void ftSamus_801290A4(HSD_GObj* fighter_gobj)
                                        fp->x89C_frameSpeedMul, 0.0f);
 }
 
-s32 ftSamus_80129100(HSD_GObj* fighter_gobj, s32* arg1, s32* arg2)
+int ftSamus_80129100(HSD_GObj* fighter_gobj, s32* arg1, s32* arg2)
 {
-    if (fighter_gobj) {
-        Fighter* fp = fighter_gobj->user_data;
-        ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    if (fighter_gobj != NULL) {
+        Fighter* fp = GET_FIGHTER(fighter_gobj);
+        ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
+
+        /// @todo Unused stack.
+#ifdef MUST_MATCH
+        u8 unused[4];
+#endif
+
         if (!fp->sa.samus.x222C)
             return -1;
 
@@ -275,6 +294,7 @@ s32 ftSamus_80129100(HSD_GObj* fighter_gobj, s32* arg1, s32* arg2)
         *arg2 = samus_attr->x18;
         return 0;
     }
+
     return -1;
 }
 

--- a/src/melee/ft/chara/ftSamus/ftsamus2.h
+++ b/src/melee/ft/chara/ftSamus/ftsamus2.h
@@ -15,10 +15,10 @@ void ftSamus_80128E88(HSD_GObj* fighter_gobj);
 void ftSamus_80128EF8(HSD_GObj* fighter_gobj);
 void ftSamus_80128F60(HSD_GObj* fighter_gobj);
 void ftSamus_80128FD4(HSD_GObj* fighter_gobj);
-s32 ftSamus_80129100(HSD_GObj* fighter_gobj, s32* arg1, s32* arg2);
+int ftSamus_80129100(HSD_GObj* fighter_gobj, s32* arg1, s32* arg2);
 s32 ftSamus_80129158(HSD_GObj* fighter_gobj);
 s32 ftSamus_801291A8(HSD_GObj* fighter_gobj);
-s32 ftSamus_80128A1C(HSD_GObj* fighter_gobj, s32 arg1, f32 farg1);
+bool ftSamus_80128A1C(HSD_GObj* fighter_gobj, s32 arg1, f32 farg1);
 void ftSamus_80128C04(HSD_GObj* fighter_gobj);
 
 #endif

--- a/src/melee/ft/chara/ftSamus/ftsamus3.c
+++ b/src/melee/ft/chara/ftSamus/ftsamus3.c
@@ -269,11 +269,8 @@ void ftSamus_801299D0(HSD_GObj* fighter_gobj)
 
 void ftSamus_80129A14(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    /// @todo Unused stack.
-#ifdef MUST_MATCH
-    u8 unused[8];
-#endif
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+
     ftSamus_801292E4(fighter_gobj);
     fp->x2340_stateVar1 = 1;
     if (!ftAnim_IsFramesRemaining(fighter_gobj)) {
@@ -301,7 +298,7 @@ void ftSamus_80129B18(HSD_GObj* fighter_gobj) {}
 
 void ftSamus_80129B1C(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     HSD_GObj* fighterObj2;
     /// @todo Unused stack.
 #ifdef MUST_MATCH
@@ -440,7 +437,7 @@ void ftSamus_80129FE8(HSD_GObj* fighter_gobj)
 
 s32 ftSamus_8012A068(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     return fp->sa.samus.x2238;
 }
 

--- a/src/melee/ft/chara/ftSamus/ftsamus4.c
+++ b/src/melee/ft/chara/ftSamus/ftsamus4.c
@@ -6,7 +6,7 @@
 
 void ftSamus_ClearThrowFlagsUnk(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     fp->x2210_ThrowFlags.flags = 0;
     fp->cb.x21BC_callback_Accessory4 = &ftSamus_8012A074;
 }

--- a/src/melee/ft/chara/ftSamus/ftsamus5.c
+++ b/src/melee/ft/chara/ftSamus/ftsamus5.c
@@ -58,17 +58,18 @@ void ftSamus_SpecialAirHi_StartAction(HSD_GObj* fighter_gobj)
 
 void ftSamus_DestroyAllUnsetx2444(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     efLib_DestroyAll(fighter_gobj);
     fp->sa.samus.x2244 = 0;
 }
 
 void ftSamus_8012A81C(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftSamusAttributes* samus_attr;
     ftSamusAttributes* samus_attr2;
-    samus_attr = samus_attr2 = getFtSpecialAttrs(fp);
+    samus_attr = samus_attr2 = fp->x2D4_specialAttributes;
+
     if (!ftAnim_IsFramesRemaining(fighter_gobj)) {
         Fighter* fighter2 = fp;
         ftSamus_DestroyAllUnsetx2444(fighter_gobj);
@@ -83,10 +84,10 @@ void ftSamus_8012A81C(HSD_GObj* fighter_gobj)
 
 void ftSamus_8012A8C4(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftSamusAttributes* samus_attr;
     ftSamusAttributes* samus_attr2;
-    samus_attr = samus_attr2 = getFtSpecialAttrs(fp);
+    samus_attr = samus_attr2 = fp->x2D4_specialAttributes;
 
     if (!ftAnim_IsFramesRemaining(fighter_gobj)) {
         Fighter* fighter2 = fp;
@@ -104,8 +105,14 @@ void ftSamus_8012A96C(HSD_GObj* fighter_gobj)
 {
     f32 mag;
     f32 lstick_x;
-    Fighter* fp = fighter_gobj->user_data;
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[4];
+#endif
+
     if ((!fp->x2204_ftcmd_var1) && (!fp->x2340_stateVar1)) {
         if ((lstick_x = fp->input.x620_lstick_x) < 0.0f) {
             mag = -lstick_x;
@@ -129,8 +136,14 @@ void ftSamus_8012AA3C(HSD_GObj* fighter_gobj)
 {
     f32 mag;
     f32 lstick_x;
-    Fighter* fp = fighter_gobj->user_data;
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
+
     if ((!fp->x2204_ftcmd_var1) && (!fp->x2340_stateVar1)) {
         if ((lstick_x = fp->input.x620_lstick_x) < 0.0f) {
             mag = -lstick_x;
@@ -171,8 +184,14 @@ void ftSamus_8012AB0C(HSD_GObj* fighter_gobj)
 
 void ftSamus_8012ABB4(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
+
     func_80084DB0(fighter_gobj);
     func_8007D344(fp, 0.0f, samus_attr->x3C, samus_attr->x40);
 }
@@ -180,10 +199,15 @@ void ftSamus_8012ABB4(HSD_GObj* fighter_gobj)
 void ftSamus_8012AC00(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = getFighter(fighter_gobj);
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     if (fp->xE0_ground_or_air == GA_Air) {
-        s32 direction;
+        int direction;
 
         if (fp->x80_self_vel.y >= 0.0f) {
             func_80081D0C(fighter_gobj);
@@ -210,11 +234,16 @@ void ftSamus_8012AC00(HSD_GObj* fighter_gobj)
 
 void ftSamus_8012ACF8(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = getFighter(fighter_gobj);
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[4];
+#endif
 
     if (fp->xE0_ground_or_air == GA_Air) {
-        s32 direction;
+        int direction;
 
         if (fp->x80_self_vel.y >= 0.0f) {
             func_80081D0C(fighter_gobj);

--- a/src/melee/ft/chara/ftSamus/ftsamus6.c
+++ b/src/melee/ft/chara/ftSamus/ftsamus6.c
@@ -40,7 +40,7 @@ void ftSamus_8012ADF0(HSD_GObj* fighter_gobj)
 void ftSamus_8012AEBC(HSD_GObj* fighter_gobj)
 {
     struct UNK_SAMUS_S2 unk_struct;
-    Fighter* fp = getFighter(fighter_gobj);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007B0C0(fighter_gobj, 2);
 
     unk_struct.intvec.x = 2;
@@ -113,6 +113,7 @@ void ftSamus_SpecialAirLw_StartAction(HSD_GObj* fighter_gobj)
 inline void checkStateVar1(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = fighter_gobj->user_data;
+
     if ((fp->x2200_ftcmd_var0) && (!fp->x2340_stateVar1)) {
         ftSamus_8012AEBC(fighter_gobj);
         fp->x2340_stateVar1 = 1;
@@ -306,12 +307,11 @@ void ftSamus_8012B264(HSD_GObj* fighter_gobj)
         func_800CC730(fighter_gobj);
     }
 }
-
 #endif
 
 void ftSamus_8012B358(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
     if ((fp->x2208_ftcmd_var2) && (fp->input.x624_lstick_y < samus_attr->x80)) {
         fp->x2208_ftcmd_var2 = 0;
@@ -339,10 +339,14 @@ void ftSamus_8012B3A8(HSD_GObj* fighter_gobj)
 
 void ftSamus_8012B41C(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
     attr* ft_attr = &fp->x110_attr;
 
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
     func_8007D4B8(fp);
     func_8007D3A8(fp, 0.0f,
                   ft_attr->x174_AerialDriftStickMult * samus_attr->x68,
@@ -351,8 +355,13 @@ void ftSamus_8012B41C(HSD_GObj* fighter_gobj)
 
 void ftSamus_8012B488(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     if (fp->x2200_ftcmd_var0) {
         /// @todo Remove cast
@@ -368,8 +377,13 @@ void ftSamus_8012B488(HSD_GObj* fighter_gobj)
 
 void ftSamus_8012B4FC(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
-    ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    ftSamusAttributes* samus_attr = fp->x2D4_specialAttributes;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
 
     if (fp->x2200_ftcmd_var0) {
         /// @todo Remove cast
@@ -402,7 +416,7 @@ void ftSamus_8012B570(HSD_GObj* fighter_gobj)
 
 void ftSamus_8012B5F0(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftSamusAttributes* samus_attr = getFtSpecialAttrs(fp);
     fp->x80_self_vel.y = samus_attr->x54;
     func_8007D5D4(fp);

--- a/src/melee/ft/chara/ftSeak/ftseak1.c
+++ b/src/melee/ft/chara/ftSeak/ftseak1.c
@@ -95,7 +95,7 @@ Fighter_CostumeStrings lbl_803CC558[] = {
 
 void ftSeak_OnDeath(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     fp->sa.seak.x222C = 0;
     fp->sa.seak.x2230 = 0;
     fp->sa.seak.x2234 = 0;
@@ -105,7 +105,7 @@ void ftSeak_OnDeath(HSD_GObj* fighter_gobj)
 
 void ftSeak_OnLoad(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     void** item_list = fp->x10C_ftData->x48_items;
 
     fp->x2224_flag.bits.b7 = 1;
@@ -129,7 +129,7 @@ void ftSeak_80110198(HSD_GObj* fighter_gobj)
 
 void ftSeak_801101CC(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     if (fp->sa.seak.x222C == 6) {
         func_800BFFD0(fp, 0x56, 0);
     }
@@ -170,10 +170,15 @@ void ftSeak_OnKnockbackExit(HSD_GObj* fighter_gobj)
     Fighter_OnKnockbackExit(fighter_gobj, 1);
 }
 
+/// @todo Commented code.
+#if false
+
 // 8011412C - 80114160
 // https://decomp.me/scratch/b1oIZ
-// void lbl_8011412C(HSD_GObj* fighter_gobj) {
-//     Fighter* fp = fighter_gobj->user_data;
-//     fp->cb.x21BC_callback_Accessory4 = 0;
-//     func_8007EFC8(fighter_gobj, &ftZelda_8013B4D8);
-// }
+void lbl_8011412C(HSD_GObj* fighter_gobj) {
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
+    fp->cb.x21BC_callback_Accessory4 = 0;
+    func_8007EFC8(fighter_gobj, &ftZelda_8013B4D8);
+}
+
+#endif

--- a/src/melee/ft/chara/ftYoshi/ftyoshi1.c
+++ b/src/melee/ft/chara/ftYoshi/ftyoshi1.c
@@ -152,9 +152,12 @@ void func_8012B804(Fighter* fp, struct S_UNK_YOSHI1* unk_struct_arg,
 
 void func_8012B8A4(HSD_GObj* fighter_gobj)
 {
-    s32 unused[4];
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     ftYoshiAttributes* attr = fp->x2D4_specialAttributes;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[8];
+#endif
     f32 tempf = attr->xC * (1.0f - (fp->x1998_shieldHealth /
                                     p_ftCommonData->x260_startShieldHealth));
     func_8012B804(fp, (struct S_UNK_YOSHI1*) fp->x5B8, tempf);
@@ -163,7 +166,7 @@ void func_8012B8A4(HSD_GObj* fighter_gobj)
 
 void func_8012B918(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     func_8012B804(fp, (struct S_UNK_YOSHI1*) fp->x5B8, 0.0f);
     func_8012B804(fp, (struct S_UNK_YOSHI1*) fp->x5BC, 0.0f);
@@ -171,7 +174,7 @@ void func_8012B918(HSD_GObj* fighter_gobj)
 
 void ftYoshi_OnDeath(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_80074A4C(fighter_gobj, 0, 0);
     fp->sa.yoshi.x2238 = 0;
 }
@@ -187,7 +190,7 @@ void ftYoshi_OnLoad(HSD_GObj* fighter_gobj)
     struct S_UNK_YOSHI1* temp_r27;
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     temp = temp_r27 = (struct S_UNK_YOSHI1*) fp->x5B8;
     ft = fp->x10C_ftData;
     temp_r28 = (struct S_UNK_YOSHI1*) fp->x5BC;
@@ -314,28 +317,20 @@ asm unk_t func_8012BDA0(void)
 }
 #pragma pop
 
-#else
-
-unk_t func_8012BDA0(void)
-{
-    NOT_IMPLEMENTED;
-}
-
 #endif
 
 void func_8012BE3C(HSD_GObj* fighter_gobj) {
     s32* x1CC;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     s32 bone_idx;
     Fighter* fp2;
     HSD_JObj* jobj;
-    u32 unused[2];
     func_80074B0C(fighter_gobj, 0, 0);
     func_8007B0C0(fighter_gobj, 0);
 
     x1CC = &fp->x110_attr.x1CC;
     bone_idx = func_8007500C(fp, 4);
-    fp2 = fighter_gobj->user_data;
+    fp2 = GET_FIGHTER(fighter_gobj);
     jobj = fp->x5E8_fighterBones[bone_idx].x0_jobj;
     efAsync_Spawn(fighter_gobj, &fp2->x60C, 4U, 0x4CF, jobj, x1CC);
 }
@@ -446,13 +441,6 @@ lbl_8012BFF0:
 } // clang-format on
 #pragma pop
 
-#else
-
-unk_t func_8012BECC(void)
-{
-    NOT_IMPLEMENTED;
-}
-
 #endif
 
 /** @fn func_8012C850
@@ -467,7 +455,7 @@ void func_8012C850(HSD_GObj* fighter_gobj)
     ftCommonData* temp_r5;
     Fighter* fp;
 
-    fp = getFighter(fighter_gobj);
+    fp = GET_FIGHTER(fighter_gobj);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x159, 0x10, NULL,
                                        fp->x894_currentAnimFrame, 1.0f, 0.0f);
     fp->x672_input_timer_counter = 0xFE;

--- a/src/melee/ft/chara/ftZelda/ftzelda1.c
+++ b/src/melee/ft/chara/ftZelda/ftzelda1.c
@@ -81,7 +81,7 @@ Fighter_CostumeStrings lbl_803CFEB0[] = {
 
 void ftZelda_OnDeath(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_80074A4C(fighter_gobj, 0, 0);
     func_80074A4C(fighter_gobj, 1, 0);
     fp->sa.zelda.x222C = 0;
@@ -89,7 +89,7 @@ void ftZelda_OnDeath(HSD_GObj* fighter_gobj)
 
 void ftZelda_OnLoad(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     void** item_list = fp->x10C_ftData->x48_items;
 
     PUSH_ATTRS(fp, ftZeldaAttributes);

--- a/src/melee/ft/chara/ftZelda/ftzelda2.c
+++ b/src/melee/ft/chara/ftZelda/ftzelda2.c
@@ -187,7 +187,7 @@ void ftZelda_80139A54(HSD_GObj* fighter_gobj)
     Fighter* fp;
     ftZeldaAttributes* attributes;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     attributes = fp->x2D4_specialAttributes;
     attrs[0] = attributes->x40;
     attrs[1] = attributes->x44;
@@ -208,11 +208,10 @@ void ftZelda_80139A98(HSD_GObj* fighter_gobj)
 // https://decomp.me/scratch/btfXC
 void ftZelda_80139AD4(HSD_GObj* fighter_gobj)
 {
-    s32 result;
     f32 facingDirection;
     s32 ledgeGrabDir;
 
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     facingDirection = fp->facing_dir;
 
     if (facingDirection < 0) { // lbl_804D9BA4
@@ -232,7 +231,7 @@ void ftZelda_80139AD4(HSD_GObj* fighter_gobj)
 // https://decomp.me/scratch/XI2m5
 void ftZelda_80139B44(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D60C(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x160, 0x0C4C508E, NULL,
                                        fp->x894_currentAnimFrame, 1.0,
@@ -244,7 +243,7 @@ void ftZelda_80139B44(HSD_GObj* fighter_gobj)
 // https://decomp.me/scratch/KOA33
 void ftZelda_80139BB0(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x15D, 0x0C4C508E, NULL,
                                        fp->x894_currentAnimFrame, 1.0,
@@ -304,7 +303,7 @@ void ftZelda_80139CC0(HSD_GObj* fighter_gobj)
     s32 envFlags;
     CollData* collData;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     collData = &fp->x6F0_collData;
 
     if (func_80082708(fighter_gobj) == 0) {
@@ -348,13 +347,17 @@ void ftZelda_80139D60(HSD_GObj* fighter_gobj)
 {
     s32 ledgeGrabDir;
     bool returnVar;
-    f32 angle1, angle2, angle3;
-    Fighter* fp;                   // r31
-    ftZeldaAttributes* attributes; // r30
-    CollData* collData;            // r29
+    Fighter* fp;
+    ftZeldaAttributes* attributes;
+    CollData* collData;
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[4];
+#endif
 
     // Get the character, collision data, and character attributes
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     collData = &fp->x6F0_collData;
     attributes = fp->x2D4_specialAttributes;
     fp->x234C_stateVar4_s32++;
@@ -418,22 +421,16 @@ void ftZelda_80139F6C(HSD_GObj* fighter_gobj)
     fp->x221E_flag.bits.b0 = 1;
 }
 
-// AS_ZeldaUpBGround
-// 80139FE8 - 8013A058 (0x70 bytes)
-// https://decomp.me/scratch/Jcxch
 void ftZelda_80139FE8(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp;
-    f32 temp_f2;
-
-    fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     func_8007D7FC(fp);
 
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x15E, 0x0C4C508E, NULL,
                                        fp->x894_currentAnimFrame, 0.0f, 0.0f);
 
-    fp->x221E_flag.bits.b0 = 1;
+    fp->x221E_flag.bits.b0 = true;
 }
 
 // AS_ZeldaUpBTravelGround
@@ -450,17 +447,19 @@ void ftZelda_8013A058(HSD_GObj* fighter_gobj)
     ftZeldaAttributes* attributes; // r31
     f32 temp_f0;
     f32 temp_f1;
-    f32 temp_f1_5;
     f32 temp_f2;
     f32 var_f31;
     f32 var_f4;
     f32 temp_f5;
     f32 temp_f6;
-    f64 guess;
     CollData* collData;
-    f32 unused[3];
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[16];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     attributes = fp->x2D4_specialAttributes;
     collData = &fp->x6F0_collData;
     temp_f2 = fp->input.x620_lstick_x;
@@ -517,7 +516,7 @@ void ftZelda_8013A058(HSD_GObj* fighter_gobj)
                 func_8006EBA4(fighter_gobj);
                 ftAnim_SetAnimRate(fighter_gobj, 0);
 
-                fp = fighter_gobj->user_data;
+                fp = GET_FIGHTER(fighter_gobj);
                 attributes = fp->x2D4_specialAttributes;
                 fp->x2340_stateVar1 = attributes->x48;
                 fp->x1968_jumpsUsed = fp->x110_attr.x168_MaxJumps;
@@ -548,12 +547,17 @@ void ftZelda_8013A244(HSD_GObj* fighter_gobj)
     f32 var_f30;
     f32 var_f31;
     f32 temp_f0;
-    f32 unused[5];
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[12];
+#endif
+
     f64 _half;
     f64 _three;
     f64 guess;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     temp_f2 = fp->input.x620_lstick_x;
     temp_f1 = fp->input.x624_lstick_y;
     attributes = fp->x2D4_specialAttributes;
@@ -611,7 +615,7 @@ void ftZelda_8013A244(HSD_GObj* fighter_gobj)
     func_8006EBA4(fighter_gobj);
     ftAnim_SetAnimRate(fighter_gobj, 0);
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     attributes = fp->x2D4_specialAttributes;
     fp->x2340_stateVar1 = attributes->x48;
     fp->x1968_jumpsUsed = fp->x110_attr.x168_MaxJumps;
@@ -641,7 +645,7 @@ void ftZelda_8013A484(HSD_GObj* fighter_gobj)
     f32 attr1, attr2;              // f1, f2
     u32 unused;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     attributes = fp->x2D4_specialAttributes;
 
     if (!ftAnim_IsFramesRemaining(fighter_gobj)) {
@@ -676,7 +680,7 @@ void ftZelda_8013A50C(HSD_GObj* fighter_gobj)
     ftZeldaAttributes* attributes; // r30
     u32 unused[2];
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     attributes = fp->x2D4_specialAttributes;
 
     if (fp->x2200_ftcmd_var0 != 0) {
@@ -710,7 +714,7 @@ void ftZelda_8013A5C4(HSD_GObj* fighter_gobj)
     bool result;
     s32 unused[2];
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     attributes = fp->x2D4_specialAttributes;
 
     if (fp->facing_dir < 0) {
@@ -736,7 +740,7 @@ void ftZelda_8013A648(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     func_8007D60C(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x162, 0x0C4C508A, NULL,
                                        fp->x894_currentAnimFrame, 1.0, 0);
@@ -748,20 +752,19 @@ void ftZelda_8013A648(HSD_GObj* fighter_gobj)
 void ftZelda_8013A6A8(HSD_GObj* fighter_gobj)
 {
     f32 temp_f0;
-    Fighter* fp;                   // r31
-    ftZeldaAttributes* attributes; // r30
+    Fighter* fp;
+    ftZeldaAttributes* attributes;
     Fighter* fighter2;
-    s32 unused[3];
 
     temp_f0 = 0;
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     attributes = fp->x2D4_specialAttributes;
 
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x15F, 0, NULL, temp_f0,
                                        1.0f, temp_f0);
     func_8006EBA4(fighter_gobj);
 
-    fighter2 = fighter_gobj->user_data;
+    fighter2 = GET_FIGHTER(fighter_gobj);
     fighter2->x2350_stateVar5_f32 = fighter2->x80_self_vel.x;
     fighter2->x2354_stateVar6_f32 = fighter2->x80_self_vel.y;
     fighter2->x2358_stateVar7 = fighter2->xEC_ground_vel;
@@ -773,26 +776,22 @@ void ftZelda_8013A6A8(HSD_GObj* fighter_gobj)
     fp->xEC_ground_vel = fp->x2358_stateVar7 * attributes->x64;
 }
 
-// AS_ZeldaUpBEndAir?
-// 8013A764 - 8013A830 (0xCC bytes)
-// https://decomp.me/scratch/8Fjwf
 void ftZelda_8013A764(HSD_GObj* fighter_gobj)
 {
     f32 temp_f0;
     Fighter* fp;                   // r31
     ftZeldaAttributes* attributes; // r30
     Fighter* fighter2;             // r5
-    f32 unused[3];
 
     temp_f0 = 0;
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     attributes = fp->x2D4_specialAttributes;
 
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x162, 0, NULL, temp_f0,
                                        1.0, temp_f0);
     func_8006EBA4(fighter_gobj);
 
-    fighter2 = fighter_gobj->user_data;
+    fighter2 = GET_FIGHTER(fighter_gobj);
     fighter2->x2350_stateVar5_f32 = fighter2->x80_self_vel.x;
     fighter2->x2354_stateVar6_f32 = fighter2->x80_self_vel.y;
     fighter2->x2358_stateVar7 = fighter2->xEC_ground_vel;

--- a/src/melee/ft/chara/ftZelda/ftzelda3.c
+++ b/src/melee/ft/chara/ftZelda/ftzelda3.c
@@ -11,7 +11,7 @@ void ftZelda_8013A830(HSD_GObj* fighter_gobj)
 {
     Fighter* fp; // r31
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     if (fp->x2219_flag.bits.b0 == 0) {
         ef_Spawn(0x4F4, fighter_gobj, fp->x5E8_fighterBones[1].x0_jobj);
         fp->x2219_flag.bits.b0 = 1;
@@ -25,7 +25,7 @@ void ftZelda_8013A8AC(HSD_GObj* fighter_gobj)
 {
     Fighter* fp; // r31
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     if (fp->x2219_flag.bits.b0 == 0) {
         ef_Spawn(0x4F5, fighter_gobj, fp->x5E8_fighterBones[1].x0_jobj);
         fp->x2219_flag.bits.b0 = 1;
@@ -87,9 +87,13 @@ void ftZelda_8013AA38(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
     ftZeldaAttributes* attributes;
-    s32 unused[5];
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[12];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     attributes = fp->x2D4_specialAttributes;
 
     if (fp->x2200_ftcmd_var0 == 1) {
@@ -111,9 +115,13 @@ void ftZelda_8013AACC(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
     ftZeldaAttributes* attributes;
-    s32 unused[5];
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[12];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     attributes = fp->x2D4_specialAttributes;
 
     if (fp->x2200_ftcmd_var0 == 1U) {
@@ -158,7 +166,7 @@ void ftZelda_8013AB9C(HSD_GObj* fighter_gobj)
     f32 arg2, arg3;
     s32 unused[2];
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     stateVar1 = fp->x2340_stateVar1;
     fighterAttr = &fp->x110_attr;
     charAttr = fp->x2D4_specialAttributes;
@@ -198,14 +206,18 @@ void ftZelda_8013AC88(HSD_GObj* fighter_gobj)
     ftZeldaAttributes* attributes;
     Fighter* fp;
     Fighter* fighter2;
-    s32 unused[5];
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[12];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x156, 0x0C4C508E, NULL,
                                        fp->x894_currentAnimFrame, 1.0, 0);
 
-    fighter2 = fighter_gobj->user_data;
+    fighter2 = GET_FIGHTER(fighter_gobj);
     attributes = fighter2->x2D4_specialAttributes;
 
     if (fighter2->x2200_ftcmd_var0 == 2U) {
@@ -220,14 +232,18 @@ void ftZelda_8013AD1C(HSD_GObj* fighter_gobj)
     ftZeldaAttributes* attributes;
     Fighter* fp;
     Fighter* fighter2;
-    s32 unused[5];
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[12];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x155, 0x0C4C508E, NULL,
                                        fp->x894_currentAnimFrame, 1.0, 0);
 
-    fighter2 = fighter_gobj->user_data;
+    fighter2 = GET_FIGHTER(fighter_gobj);
     attributes = fighter2->x2D4_specialAttributes;
 
     if (fighter2->x2200_ftcmd_var0 == 2U) {

--- a/src/melee/ft/chara/ftZelda/ftzelda4.c
+++ b/src/melee/ft/chara/ftZelda/ftzelda4.c
@@ -17,7 +17,7 @@ void ftZelda_8013ADB4(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     if (!fp->x2219_flag.bits.b0) {
         ef_Spawn(0x4FC, fighter_gobj, fp->x5E8_fighterBones[0x68].x0_jobj);
         fp->x2219_flag.bits.b0 = 1;
@@ -34,7 +34,7 @@ void ftZelda_8013AE30(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     if (!fp->x2219_flag.bits.b0) {
         ef_Spawn(0x4FD, fighter_gobj, fp->x5E8_fighterBones[4].x0_jobj);
         fp->x2219_flag.bits.b0 = 1;
@@ -52,7 +52,7 @@ void ftZelda_8013AEAC(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     fp->cb.x21BC_callback_Accessory4 = 0;
 
     func_8007EFC8(fighter_gobj, func_80114758);
@@ -114,7 +114,7 @@ void ftZelda_8013B068(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     if (!ftAnim_IsFramesRemaining(fighter_gobj)) {
         fp->cb.x21BC_callback_Accessory4 = &ftZelda_8013AEAC;
     }
@@ -126,7 +126,7 @@ void ftZelda_8013B0A8(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     if (!ftAnim_IsFramesRemaining(fighter_gobj)) {
         fp->cb.x21BC_callback_Accessory4 = &ftZelda_8013AEAC;
     }
@@ -153,9 +153,13 @@ void ftZelda_8013B110(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
     ftZeldaAttributes* attributes;
-    f32 unused[3];
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[4];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     attributes = fp->x2D4_specialAttributes;
 
     func_8007D494(fp, attributes->x78, attributes->x7C);
@@ -186,7 +190,7 @@ void ftZelda_8013B1CC(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x165, 0x0C4C508E, NULL,
                                        fp->x894_currentAnimFrame, 1.0, 0);
@@ -198,7 +202,7 @@ void ftZelda_8013B238(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x163, 0x0C4C508E, NULL,
                                        fp->x894_currentAnimFrame, 1.0, 0);
@@ -242,9 +246,13 @@ void ftZelda_8013B344(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
     ftZeldaAttributes* attributes;
-    f32 unused[3];
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[4];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     attributes = fp->x2D4_specialAttributes;
 
     func_8007D494(fp, attributes->x78, attributes->x7C);
@@ -275,7 +283,7 @@ void ftZelda_8013B400(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     func_8007D5D4(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x166, 0x0C4C508E, NULL,
                                        fp->x894_currentAnimFrame, 1.0, 0);
@@ -288,7 +296,7 @@ void ftZelda_8013B46C(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     func_8007D7FC(fp);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x164, 0x0C4C508E, NULL,
                                        fp->x894_currentAnimFrame, 1.0, 0);
@@ -326,7 +334,7 @@ s32 ftZelda_8013B540(HSD_GObj* fighter_gobj)
     s32 actionStateIndex;
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     actionStateIndex = fp->action_id;
 
     if (((actionStateIndex == 0x158) || (actionStateIndex == 0x15B)) &&
@@ -345,7 +353,7 @@ s32 ftZelda_8013B574(HSD_GObj* fighter_gobj)
     s32 temp_r0;
     Fighter* fp; // r3
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->sa.zelda.x222C != 0) {
         switch (fp->action_id) {
@@ -368,7 +376,7 @@ void ftZelda_8013B5C4(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     if (fp->sa.zelda.x222C != 0) {
         fp->sa.zelda.x222C = 0;
     }
@@ -381,7 +389,7 @@ void ftZelda_8013B5C4(HSD_GObj* fighter_gobj)
 // https://decomp.me/scratch/8QoCa
 void ftZelda_8013B5EC(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->sa.zelda.x222C != NULL) {
         func_802C3D44(fp->sa.zelda.x222C);

--- a/src/melee/ft/chara/ftZelda/ftzelda5.c
+++ b/src/melee/ft/chara/ftZelda/ftzelda5.c
@@ -17,17 +17,21 @@ void ftZelda_SpecialS_StartAction(HSD_GObj* fighter_gobj)
     Fighter* fp; // r31
     ftZeldaAttributes* attributes;
     Fighter* fighter2;
-    s32 unused[7];
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[20];
+#endif
 
     temp_f1 = 0;
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x157, 0, NULL, temp_f1,
                                        1.0, temp_f1);
     fp->x220C_ftcmd_var3 = 0;
     fp->x2208_ftcmd_var2 = 0;
     fp->x2204_ftcmd_var1 = 0;
     fp->x2200_ftcmd_var0 = 0;
-    fighter2 = fighter_gobj->user_data;
+    fighter2 = GET_FIGHTER(fighter_gobj);
     attributes = fighter2->x2D4_specialAttributes;
     fighter2->x2340_stateVar1 = attributes->x10;
     fighter2->x2344_stateVar2_s32 = attributes->x14;
@@ -47,10 +51,14 @@ void ftZelda_SpecialAirS_StartAction(HSD_GObj* fighter_gobj)
     Fighter* fp;
     ftZeldaAttributes* attributes;
     Fighter* fighter2;
-    s32 unused[7];
+
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[20];
+#endif
 
     temp_f1 = 0;
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     Fighter_ActionStateChange_800693AC(fighter_gobj, 0x15A, 0, NULL, temp_f1,
                                        1.0, temp_f1);
     fp->x220C_ftcmd_var3 = 0;
@@ -58,7 +66,7 @@ void ftZelda_SpecialAirS_StartAction(HSD_GObj* fighter_gobj)
     fp->x2204_ftcmd_var1 = 0;
     fp->x2200_ftcmd_var0 = 0;
     fp->x80_self_vel.y = 0.0F;
-    fighter2 = fighter_gobj->user_data;
+    fighter2 = GET_FIGHTER(fighter_gobj);
     attributes = fighter2->x2D4_specialAttributes;
     fighter2->x2340_stateVar1 = attributes->x10;
     fighter2->x2344_stateVar2_s32 = attributes->x14;
@@ -80,9 +88,13 @@ void ftZelda_8013B780(HSD_GObj* fighter_gobj)
     HSD_GObj* temp_r3;
     ftZeldaAttributes* attributes; // r31
     Fighter* fp;                   // r30
-    f32 unused[6];
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[20];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     attributes = fp->x2D4_specialAttributes;
 
     if (fp->x2200_ftcmd_var0 == 1U && fp->sa.zelda.x222C == 0U) {
@@ -123,9 +135,13 @@ void ftZelda_8013B89C(HSD_GObj* fighter_gobj)
     f32 temp_f2;
     HSD_GObj* temp_r3;
     HSD_GObj* temp_r3_u32;
-    f32 unused[5];
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[16];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     attributes = fp->x2D4_specialAttributes;
 
     if ((fp->x2200_ftcmd_var0 == 1U) && (fp->sa.zelda.x222C == 0U)) {
@@ -205,13 +221,16 @@ void ftZelda_8013BA8C(HSD_GObj* fighter_gobj)
     Vec3 sp24;
     f32 temp_f1;
     f32 temp_f2;
-    s32 temp_cr0_eq;
     HSD_GObj* temp_r3;
-    ftZeldaAttributes* attributes; // r31
-    Fighter* fp;                   // r30
-    s32 unused[5];
+    ftZeldaAttributes* attributes;
+    Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[20];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     attributes = fp->x2D4_specialAttributes;
     if (fp->x2200_ftcmd_var0 == 1U && fp->sa.zelda.x222C == 0U) {
         fp->x2200_ftcmd_var0 = 0U;
@@ -250,9 +269,13 @@ void ftZelda_8013BBA8(HSD_GObj* fighter_gobj)
     HSD_GObj* temp_r3;
     ftZeldaAttributes* attributes; // r31
     Fighter* fp;                   // r30
-    s32 unused[5];
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[16];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     attributes = fp->x2D4_specialAttributes;
 
     if (fp->x2200_ftcmd_var0 == 1U && fp->sa.zelda.x222C == 0U) {
@@ -348,7 +371,7 @@ void ftZelda_8013BDD4(HSD_GObj* fighter_gobj)
     s32 var_r0;
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     fp->x234C_stateVar4_s32 -= 1;
 
     if (fp->x234C_stateVar4_s32 <= 0) {
@@ -365,14 +388,9 @@ void ftZelda_8013BDD4(HSD_GObj* fighter_gobj)
     }
 }
 
-void ftZelda_8013BE50(HSD_GObj* fighter_gobj)
-{
-    return;
-}
-void ftZelda_8013BE54(HSD_GObj* fighter_gobj)
-{
-    return;
-}
+void ftZelda_8013BE50(HSD_GObj* fighter_gobj) {}
+
+void ftZelda_8013BE54(HSD_GObj* fighter_gobj) {}
 
 // 8013BE58 - 8013BED4 (0x7C bytes)
 // https://decomp.me/scratch/Zxkmg
@@ -382,7 +400,7 @@ void ftZelda_8013BE58(HSD_GObj* fighter_gobj)
     s32 var_r0;
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     fp->x234C_stateVar4_s32 -= 1;
 
     if (fp->x234C_stateVar4_s32 <= 0) {
@@ -442,9 +460,13 @@ void ftZelda_8013BF50(HSD_GObj* fighter_gobj)
     ftZeldaAttributes* charAttr;
     attr* fighterAttr;
     f32 aerialFriction;
-    f32 unused[3];
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[4];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     temp_r3 = fp->x2348_stateVar3;
     charAttr = fp->x2D4_specialAttributes;
 
@@ -468,9 +490,13 @@ void ftZelda_8013BFB0(HSD_GObj* fighter_gobj)
     ftZeldaAttributes* charAttr;
     attr* fighterAttr;
     f32 aerialFriction;
-    f32 unused[3];
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[4];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     temp_r3 = fp->x2348_stateVar3;
     charAttr = fp->x2D4_specialAttributes;
 
@@ -494,9 +520,13 @@ void ftZelda_8013C010(HSD_GObj* fighter_gobj)
     ftZeldaAttributes* charAttr;
     attr* fighterAttr;
     f32 aerialFriction;
-    f32 unused[3];
 
-    fp = fighter_gobj->user_data;
+    /// @todo Unused stack.
+#ifdef MUST_MATCH
+    u8 unused[4];
+#endif
+
+    fp = GET_FIGHTER(fighter_gobj);
     temp_r3 = fp->x2348_stateVar3;
     charAttr = fp->x2D4_specialAttributes;
 
@@ -517,7 +547,7 @@ void ftZelda_8013C070(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     if (func_80082708(fighter_gobj) == 0) {
         func_8007D5D4(fp);
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x15A, 0x0C4C5082,
@@ -532,7 +562,7 @@ void ftZelda_8013C0DC(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     if (func_80082708(fighter_gobj) == 0) {
         func_8007D5D4(fp);
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x15B, 0x0C4C5080,
@@ -546,7 +576,7 @@ void ftZelda_8013C148(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     if (func_80082708(fighter_gobj) == 0) {
         func_8007D5D4(fp);
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x15C, 0x0C4C5080,
@@ -560,7 +590,7 @@ void ftZelda_8013C1B4(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     if (func_80081D0C(fighter_gobj) != 0) {
         func_8007D7FC(fp);
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x157, 0x0C4C5082,
@@ -574,7 +604,7 @@ void ftZelda_8013C220(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     if (func_80081D0C(fighter_gobj) != 0) {
         func_8007D7FC(fp);
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x158, 0x0C4C5080,
@@ -588,7 +618,7 @@ void ftZelda_8013C28C(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     if (func_80081D0C(fighter_gobj) != 0) {
         func_8007D7FC(fp);
         Fighter_ActionStateChange_800693AC(fighter_gobj, 0x159, 0x0C4C5080,

--- a/src/melee/ft/fighter.c
+++ b/src/melee/ft/fighter.c
@@ -1412,7 +1412,7 @@ void Fighter_ActionStateChange_800693AC(HSD_GObj* fighter_gobj,
 
 void Fighter_8006A1BC(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (!fp->x221F_flag.bits.b3) {
         if (fp->dmg.x1954 > 0.0f) {
@@ -1726,7 +1726,7 @@ void Fighter_8006A360(HSD_GObj* fighter_gobj)
 
 void Fighter_8006ABA0(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     if (!fp->x221F_flag.bits.b3 && func_800A2040(fp)) {
         func_800B3900(fighter_gobj);
     }
@@ -1735,7 +1735,7 @@ void Fighter_8006ABA0(HSD_GObj* fighter_gobj)
 // https://decomp.me/scratch/A7CgG
 void Fighter_UnkIncrementCounters_8006ABEC(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (func_800CAE80(fighter_gobj)) {
         fp->x68A = fp->x685;
@@ -2527,14 +2527,14 @@ void Fighter_8006C27C(HSD_GObj* fighter_gobj)
 
 void Fighter_8006C5F4(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     if (!fp->x221F_flag.bits.b3)
         func_80089B08(fighter_gobj);
 }
 
 void Fighter_CallAcessoryCallbacks_8006C624(HSD_GObj* fighter_gobj)
 {
-    Fighter* fighter_r31 = fighter_gobj->user_data;
+    Fighter* fighter_r31 = GET_FIGHTER(fighter_gobj);
     s32 bit = fighter_r31->x221F_flag.bits.b3;
 
     if (!bit) {
@@ -2601,7 +2601,7 @@ void Fighter_8006C80C(HSD_GObj* fighter_gobj)
 
 void Fighter_UnkProcessGrab_8006CA5C(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (!fp->x221F_flag.bits.b3 && !func_8016B1C4()) {
         func_8007BA0C(fighter_gobj);
@@ -2636,7 +2636,7 @@ void Fighter_UnkProcessGrab_8006CA5C(HSD_GObj* fighter_gobj)
 
 void Fighter_8006CB94(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     f32 func_8007BBCC_float_output;
 
     if (!fp->x221F_flag.bits.b3 && !fp->x2219_flag.bits.b1) {
@@ -2735,7 +2735,7 @@ void Fighter_8006CF5C(Fighter* fp, s32 arg1)
 
 void Fighter_UnkSetFlag_8006CFBC(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->x2219_flag.bits.b7) {
         fp->x221A_flag.bits.b1 = 1;
@@ -2744,7 +2744,7 @@ void Fighter_UnkSetFlag_8006CFBC(HSD_GObj* fighter_gobj)
 
 void Fighter_8006CFE0(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->x2219_flag.bits.b7) {
         if (!fp->x221A_flag.bits.b2) {
@@ -2815,7 +2815,7 @@ void Fighter_8006D10C(HSD_GObj* fighter_gobj)
 
 void Fighter_UnkProcessShieldHit_8006D1EC(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     bool bool1 = 0;
     s32 action_state_index = fp->action_id;
     bool bool2 = 0;
@@ -3066,7 +3066,7 @@ void Fighter_UnkProcessShieldHit_8006D1EC(HSD_GObj* fighter_gobj)
 void Fighter_8006D9AC(HSD_GObj* fighter_gobj)
 {
     Fighter* fp;
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
 
     if (fp->x221F_flag.bits.b3 || fp->x2219_flag.bits.b5)
         return;
@@ -3076,7 +3076,7 @@ void Fighter_8006D9AC(HSD_GObj* fighter_gobj)
 
 void Fighter_UnkCallCameraCallback_8006D9EC(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (!fp->x221F_flag.bits.b3) {
         func_8008021C(fighter_gobj);
@@ -3088,7 +3088,7 @@ void Fighter_UnkCallCameraCallback_8006D9EC(HSD_GObj* fighter_gobj)
 
 void Fighter_8006DA4C(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if (!fp->x221F_flag.bits.b3) {
         Player_80032828(fp->xC_playerID, fp->x221F_flag.bits.b4, &fp->xB0_pos);

--- a/src/melee/ft/ft_unknown_006.c
+++ b/src/melee/ft/ft_unknown_006.c
@@ -106,7 +106,7 @@ s32 func_800879F8(HSD_GObj* fighter_gobj)
 s32 func_80087A18(HSD_GObj* fighter_gobj)
 {
     s32 var1;
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if ((fp->x2226_flag.bits.b4) &&
         ((var1 = func_800C06B4(fp), ((var1 == 0x7B) != 0)) || (var1 == 0x80)) &&
@@ -165,7 +165,7 @@ void func_80087AC0(HSD_GObj* fighter_gobj, s32 arg1)
 
 s32 func_80087AEC(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if ((fp->x34_scale.y != fp->x34_scale.x) ||
         ((fp->x2226_flag.bits.b4) || (fp->x2223_flag.bits.b7) ||
@@ -232,7 +232,7 @@ s32 func_80087C1C(void)
     for (fighter_gobj = lbl_804D782C->x20_fighters; fighter_gobj != 0;
          fighter_gobj = fighter_gobj->next)
     {
-        ftKind = ((Fighter*) fighter_gobj->user_data)->x4_fighterKind;
+        ftKind = (GET_FIGHTER(fighter_gobj))->x4_fighterKind;
         if (ftKind < 27) {
             result = result | 1 << ftKind;
         }

--- a/src/melee/ft/ft_unknown_006.h
+++ b/src/melee/ft/ft_unknown_006.h
@@ -242,7 +242,7 @@ void func_800D6C60(HSD_GObj*, HSD_GObjEvent callback);
 void func_800D6E70(HSD_GObj* fighter_gobj);
 void func_800D6E34(HSD_GObj* fighter_gobj);
 s32 func_8008CE68(Fighter*);
-void func_8008CFAC(HSD_GObj*, s32);
+void func_8008CFAC(HSD_GObj*, enum_t);
 void func_800D638C(HSD_GObj*);
 bool func_8008A9F8(HSD_GObj*);
 bool func_8008B658(HSD_GObj*);

--- a/src/melee/ft/ftcoll.c
+++ b/src/melee/ft/ftcoll.c
@@ -131,7 +131,7 @@ void func_80076528(
     u16 temp_r3;
     Fighter* fp;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     temp_r3 = fp->x2092;
     if (temp_r3 != 0) {
         fp->x2092 = (u16) (temp_r3 - 1);

--- a/src/melee/ft/ftlib.c
+++ b/src/melee/ft/ftlib.c
@@ -763,7 +763,7 @@ bool func_80087284(HSD_GObj* gobj)
     }
 }
 
-s32 func_800872A4(HSD_GObj* gobj)
+FighterKind func_800872A4(HSD_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
     return fp->x4_fighterKind;

--- a/src/melee/ft/ftlib.h
+++ b/src/melee/ft/ftlib.h
@@ -72,10 +72,7 @@ s32 func_80087120(HSD_GObj*);
 void func_80087140(HSD_GObj*);
 void func_800871A8(HSD_GObj*, HSD_GObj*);
 bool func_80087284(HSD_GObj*);
-
-/// @todo Returns #FighterKind
-s32 func_800872A4(HSD_GObj*);
-
+FighterKind func_800872A4(HSD_GObj*);
 void* func_800872B0(HSD_GObj*);
 bool func_800872BC(HSD_GObj*);
 s32 func_80087300(HSD_GObj*);

--- a/src/melee/ft/ftwalkcommon.c
+++ b/src/melee/ft/ftwalkcommon.c
@@ -7,7 +7,7 @@
 
 s32 ftWalkCommon_GetWalkType_800DFBF8(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     f32 ground_vel = fp->xEC_ground_vel;
     f32 walking_velocity = fabs_inline(ground_vel);
     if (walking_velocity >=
@@ -27,7 +27,7 @@ s32 ftWalkCommon_GetWalkType_800DFBF8(HSD_GObj* fighter_gobj)
 
 static inline s32 ftWalkCommon_GetWalkType_800DFBF8_fake(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
     f32 walking_velocity = fabs_inline(fp->xEC_ground_vel);
     f32 tempf = fp->x2360_f32;
     if (walking_velocity >= (tempf * (p_ftCommonData->x2C *
@@ -46,7 +46,7 @@ static inline s32 ftWalkCommon_GetWalkType_800DFBF8_fake(HSD_GObj* fighter_gobj)
 
 bool ftWalkCommon_800DFC70(HSD_GObj* fighter_gobj)
 {
-    Fighter* fp = fighter_gobj->user_data;
+    Fighter* fp = GET_FIGHTER(fighter_gobj);
 
     if ((fp->input.x620_lstick_x * fp->facing_dir) >= p_ftCommonData->x24) {
         return true;
@@ -178,7 +178,7 @@ void ftWalkCommon_800E0060(HSD_GObj* fighter_gobj)
     f32 velocity_f1;
     f32 unused_float;
 
-    fp = fighter_gobj->user_data;
+    fp = GET_FIGHTER(fighter_gobj);
     unused_float = ftx2360_f5 = fp->x2360_f32;
     velocity_f1 = fp->input.x620_lstick_x *
                   fp->x110_attr.x110_WalkInitialVelocity * ftx2360_f5;


### PR DESCRIPTION
Depends on #711 ([diff](https://github.com/ribbanya/melee/compare/pr-getfighter-1...pr-getfighter-2)).

Replaces all easily matching instances of `gobj->user_data` with `GET_FIGHTER(gobj)`. Not at parity with #614 yet.