### PR TITLE
rename unknown dsp func from pik1 map

### DIFF
--- a/src/dolphin/dsp/dsp.c
+++ b/src/dolphin/dsp/dsp.c
@@ -80,9 +80,7 @@ DSPTaskInfo* DSPAddTask(DSPTaskInfo* task)
     return task;
 }
 
-// Unknown DSP command
-// Similar to DSPReset, DSPHalt
-void DSPSomething(void)
+void DSPCancelTask(void)
 {
     bool enabled = OSDisableInterrupts();
     __DSPRegs[5] = (__DSPRegs[5] & ~0xA8) | 2;
@@ -102,7 +100,7 @@ void* DSPAssertTask(DSPTaskInfo* task)
         __DSP_rude_task = task;
         __DSP_rude_task_pending = 1;
         if (__DSP_curr_task->state == 1) {
-            DSPSomething();
+            DSPCancelTask();
         }
         OSRestoreInterrupts(enabled);
         return task;

--- a/src/dolphin/dsp/dsp.h
+++ b/src/dolphin/dsp/dsp.h
@@ -48,7 +48,7 @@ void __DSP_remove_task(DSPTaskInfo* task);
 DSPTaskInfo* DSPAddTask(DSPTaskInfo* task);
 void __DSP_exec_task(DSPTaskInfo*, DSPTaskInfo*);
 
-void DSPSomething(void);
+void DSPCancelTask(void);
 void* DSPAssertTask(DSPTaskInfo* task);
 
 #endif


### PR DESCRIPTION
reasonably certain this is what it is based on Pikmin 1's map, which has the same functions, albeit UNUSED