### PR TITLE
Use custom container for GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         makeflags: ["GENERATE_MAP=1", "NON_MATCHING=1"]
     runs-on: ubuntu-latest
-    container: ribbanya/melee:latest
+    container: ribbanya/melee:20230219
     steps:
     - name: Checkout Melee repo
       uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,36 +10,14 @@ jobs:
       matrix:
         makeflags: ["GENERATE_MAP=1", "NON_MATCHING=1"]
     runs-on: ubuntu-latest
-    container: devkitpro/devkitppc:latest
+    container: ribbanya/melee:latest
     steps:
-    - name: Install devkitPro
-      run: |
-        sudo dpkg --add-architecture i386
-        sudo apt-get update
-        sudo apt-get -y install build-essential gcc-multilib g++-multilib libc6:i386
-        sudo chown $(whoami) "$GITHUB_WORKSPACE"
     - name: Checkout Melee repo
       uses: actions/checkout@v3
-    - name: Checkout WiBo repo
-      uses: actions/checkout@v3
-      with:
-        repository: decompals/WiBo
-        path: tools/WiBo
-    - name: Download compilers
-      run: |
-        curl -L https://cdn.discordapp.com/attachments/727918646525165659/917185027656286218/GC_WII_COMPILERS.zip \
-          | bsdtar -xvf- -C tools --exclude Wii
-        mv tools/GC tools/mwcc_compiler
-        sha1sum -c tools/mwld_prepatch.sha1
-        python3 tools/mwld_patch.py
-        sha1sum -c tools/mwld_postpatch.sha1
-    - name: Build WiBo
-      working-directory: tools/WiBo
-      run: |
-        cmake -B build
-        cmake --build build
     - name: Build Melee
-      run: make -j$(nproc) ${{ matrix.makeflags }} WINE=./tools/WiBo/build/wibo
+      run: |
+        ln -s /usr/local/bin/mwcc_compiler tools/
+        make -j$(nproc) ${{ matrix.makeflags }} WINE=$WINE
     - name: Upload map
       if: matrix.makeflags == 'GENERATE_MAP=1'
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         make -j$(nproc) ${{ matrix.makeflags }} WINE=$WINE
     - name: Upload map
       if: matrix.makeflags == 'GENERATE_MAP=1'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: GALE01.map
         path: build/ssbm.us.1.2/GALE01.map

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    container: ribbanya/melee:latest
+    container: ribbanya/melee:20230219
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,47 +23,31 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    container: ribbanya/melee:latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          submodules: "true"
-
       - name: Checkout Doxygen Awesome repo
         uses: actions/checkout@v3
         with:
           repository: jothepro/doxygen-awesome-css
           path: tools/doxygen-awesome-css
-
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: doxygen graphviz
-          version: 1.0
-
-      - name: Create build directory
-        run: mkdir -p build/doxygen
-
       - name: Generate Doxygen documentation
-        run: doxygen Doxyfile
+        run: |
+          mkdir -p build/doxygen
+          doxygen Doxyfile
+          touch build/doxygen/html/.nojekyll
         shell: bash
-
-      - name: Create .nojekyll (ensures pages with underscores work on gh pages)
-        run: touch build/doxygen/html/.nojekyll
-        shell: bash
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-      - run: pip install -r requirements.txt
-      - run: python tools/m2ctx/m2ctx.py -pqr
-      - run: cp build/ctx.html build/doxygen/html
-
+      - name: Generate context
+        run: |
+          . /usr/local/share/venv/bin/activate
+          pip3 install -r requirements.txt --no-cache-dir
+          python3 tools/m2ctx/m2ctx.py -pqr
+          cp build/ctx.html build/doxygen/html
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v1.0.5
         with:
           path: build/doxygen/html
-
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,86 +1,79 @@
-FROM devkitpro/devkitppc:latest AS buster
-
+FROM devkitpro/devkitppc:20230110 AS buster
 ENV DEBIAN_FRONTEND noninteractive
 ENV LC_ALL C
 RUN printf '%s;\n' \
-    'APT::Cmd::Disable-Script-Warning "true"'\
+    'APT::Cmd::Disable-Script-Warning "true"' \
     'APT::Get::Assume-Yes "true"' \
-    >> /etc/apt/apt.conf.d/99disable-scripts
-RUN sudo apt update
+    >> /etc/apt/apt.conf.d/99disable-scripts && \
+    sudo apt update && \
+    sudo apt autoremove
 
 FROM buster AS bullseye
 RUN printf '%s\n' \
     'deb http://http.us.debian.org/debian bullseye main contrib non-free' \
     'deb-src http://http.us.debian.org/debian bullseye main contrib non-free' \
-    > /etc/apt/sources.list
-RUN sudo apt update
-RUN sudo apt dist-upgrade
-RUN sudo apt autoremove
+    > /etc/apt/sources.list && \
+    sudo apt update && \
+    sudo apt dist-upgrade && \
+    sudo apt autoremove
 
 FROM bullseye AS bookworm
 RUN printf '%s\n' \
     'deb http://http.us.debian.org/debian bookworm main contrib non-free' \
     'deb-src http://http.us.debian.org/debian bookworm main contrib non-free' \
-    > /etc/apt/sources.list
-RUN sudo apt update
-RUN sudo apt dist-upgrade
-RUN sudo apt autoremove
+    > /etc/apt/sources.list && \
+    sudo apt update && \
+    sudo apt dist-upgrade && \
+    sudo apt autoremove
 
-FROM bookworm AS sid
-RUN printf '%s\n' \
-    'deb http://http.us.debian.org/debian sid main contrib non-free' \
-    'deb-src http://http.us.debian.org/debian sid main contrib non-free' \
-    > /etc/apt/sources.list
-RUN sudo apt update
-RUN sudo apt dist-upgrade
-RUN sudo apt autoremove
-
-FROM sid AS install-packages
-RUN sudo dpkg --add-architecture i386
-RUN sudo apt update
-RUN sudo apt install \
+FROM bookworm AS install-packages
+RUN sudo dpkg --add-architecture i386 && \
+    sudo apt update && \
+    sudo apt install \
     build-essential \
     ninja-build \
     gcc-multilib \
     g++-multilib \
     libc6:i386 \
     lsb-release \
-    python3-full
+    neofetch \
+    python3-full \
+    nodejs \
+    npm
 
 FROM install-packages AS setup-wibo
-WORKDIR /tmp
-RUN git clone https://github.com/decompals/wibo.git --depth=1
-WORKDIR /tmp/wibo
-RUN cmake -B build
-RUN cmake --build build
-RUN chmod +x build/wibo
-RUN cp build/wibo /usr/local/bin
+RUN mkdir -p /tmp/wibo && \
+    cd /tmp/wibo && \
+    git clone https://github.com/decompals/wibo.git --depth=1 -- . && \
+    cmake -B build && \
+    cmake --build build && \
+    chmod +x build/wibo && \
+    cp build/wibo /usr/local/bin && \
+    cd / && \
+    rm -rf /tmp/*
 ENV WINE /usr/local/bin/wibo
-WORKDIR /
-RUN rm -rf /tmp/*
 
 FROM setup-wibo AS setup-melee
-RUN mkdir -p /usr/local/src/melee
+RUN git clone https://github.com/doldecomp/melee.git --depth=1 -- /usr/local/src/melee
 WORKDIR /usr/local/src/melee
-RUN git clone https://github.com/doldecomp/melee.git --depth=1 .
 ENV PATH="/usr/local/src/melee/tools:${PATH}"
 
 FROM setup-melee AS setup-mwcc
 RUN curl -L \
     'https://cdn.discordapp.com/attachments/727918646525165659/917185027656286218/GC_WII_COMPILERS.zip' | \
     bsdtar -xvf- -C tools --exclude Wii && \
-    mv tools/GC tools/mwcc_compiler
-RUN sha1sum -c tools/mwld_prepatch.sha1 && \
+    mv tools/GC tools/mwcc_compiler && \
+    sha1sum -c tools/mwld_prepatch.sha1 && \
     python3 tools/mwld_patch.py && \
     sha1sum -c tools/mwld_postpatch.sha1 && \
-    cp -a tools/mwcc_compiler /usr/local/bin/
-RUN printf "%s\n" \
-    '#!/bin/sh'\
+    cp -a tools/mwcc_compiler /usr/local/bin/ && \
+    printf "%s\n" \
+    '#!/bin/sh' \
     '$WINE /usr/local/bin/mwcc_compiler/1.2.5e/mwcceppc.exe "$@"' \
-    > /usr/local/bin/mwcceppc
-RUN chmod +x /usr/local/bin/mwcceppc
+    > /usr/local/bin/mwcceppc && \
+    chmod +x /usr/local/bin/mwcceppc
 
 FROM setup-mwcc AS setup-venv
-RUN python3 -m venv /usr/local/share/venv
-RUN . /usr/local/share/venv/bin/activate && \
+RUN python3 -m venv /usr/local/share/venv && \
+    . /usr/local/share/venv/bin/activate && \
     pip3 install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,85 @@
+FROM devkitpro/devkitppc:latest AS buster
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL C
+RUN printf '%s;\n' \
+    'APT::Cmd::Disable-Script-Warning "true"'\
+    'APT::Get::Assume-Yes "true"' \
+    >> /etc/apt/apt.conf.d/99disable-scripts
+RUN sudo apt update
+
+FROM buster AS bullseye
+RUN printf '%s\n' \
+    'deb http://http.us.debian.org/debian bullseye main contrib non-free' \
+    'deb-src http://http.us.debian.org/debian bullseye main contrib non-free' \
+    > /etc/apt/sources.list
+RUN sudo apt update
+RUN sudo apt dist-upgrade
+RUN sudo apt autoremove
+
+FROM bullseye AS bookworm
+RUN printf '%s\n' \
+    'deb http://http.us.debian.org/debian bookworm main contrib non-free' \
+    'deb-src http://http.us.debian.org/debian bookworm main contrib non-free' \
+    > /etc/apt/sources.list
+RUN sudo apt update
+RUN sudo apt dist-upgrade
+RUN sudo apt autoremove
+
+FROM bookworm AS sid
+RUN printf '%s\n' \
+    'deb http://http.us.debian.org/debian sid main contrib non-free' \
+    'deb-src http://http.us.debian.org/debian sid main contrib non-free' \
+    > /etc/apt/sources.list
+RUN sudo apt update
+RUN sudo apt dist-upgrade
+RUN sudo apt autoremove
+
+FROM sid AS setup-devkitpro
+RUN sudo dpkg --add-architecture i386
+RUN sudo apt update
+RUN sudo apt install \
+    build-essential \
+    gcc-multilib \
+    g++-multilib \
+    libc6:i386 \
+    lsb-release
+
+FROM setup-devkitpro AS setup-wibo
+WORKDIR /tmp
+RUN git clone https://github.com/decompals/wibo.git --depth=1
+WORKDIR /tmp/wibo
+RUN cmake -B build
+RUN cmake --build build
+RUN chmod +x build/wibo
+RUN cp build/wibo /usr/local/bin
+ENV WINE /usr/local/bin/wibo
+
+FROM setup-wibo AS setup-mwcc
+WORKDIR /tmp
+RUN git clone https://github.com/doldecomp/melee.git --depth=1
+WORKDIR /tmp/melee
+RUN curl -L \
+    'https://cdn.discordapp.com/attachments/727918646525165659/917185027656286218/GC_WII_COMPILERS.zip' \
+    | bsdtar -xvf- -C tools --exclude Wii
+RUN mv tools/GC tools/mwcc_compiler
+RUN sha1sum -c tools/mwld_prepatch.sha1
+RUN python3 tools/mwld_patch.py
+RUN sha1sum -c tools/mwld_postpatch.sha1
+RUN cp -a tools/mwcc_compiler /usr/local/bin/
+RUN printf "%s\n" \
+    '#!/bin/sh'\
+    '$WINE /usr/local/bin/mwcc_compiler/1.2.5e/mwcceppc.exe "$@"' \
+    >/usr/local/bin/mwcceppc
+RUN chmod +x /usr/local/bin/mwcceppc
+
+FROM setup-mwcc AS setup-devenv
+RUN sudo apt install \
+    python3-full
+RUN python3 -m venv /usr/local/share/venv
+RUN . /usr/local/share/venv/bin/activate; \
+    pip3 install -r requirements.txt
+RUN mkdir -p /usr/local/src/melee
+ENV PATH="/src/melee/tools:${PATH}"
+RUN rm -rf /tmp/*
+WORKDIR /usr/local/src


### PR DESCRIPTION
* Upgrade devkitpro's old Debian release (`buster`) to Testing (`bookworm`)
* The main reason for the above is to support Python 3.11
* Compile wibo and put it in `PATH` on the container
* Download and patch `mwcc` on the container, no need to download it on build
* Set up Python 3.11 `venv` with our packages
* Greatly simplify our workflows

The container lives at [ribbanya/melee](https://hub.docker.com/repository/docker/ribbanya/melee/general) but if doldecomp owners want to make their own that's cool with me.