### PR TITLE
Add Windows build job and improve speed of Ubuntu build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,6 @@ jobs:
       run:
         make WINDOWS=1 `
           AS=".\tools\mwcc_compiler\powerpc-eabi-as.exe" `
-          HOSTCC=gcc `
           -j "$env:NUMBER_OF_PROCESSORS" `
           ${{ matrix.makeflags }}
     - name: Calc progress

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
     container: devkitpro/devkitppc:20230110
     steps:
     - name: Install GCC
-      run: |
-        apt update
-        apt -y --no-install-recommends install \
-          build-essential libc6-dev
+      uses: awalsh128/cache-apt-pkgs-action@v1.2.4
+      with:
+        packages: build-essential libc6-dev
+        version: 1.0.0
     - name: Checkout Melee repo
       uses: actions/checkout@v3
     - name: Download WiBo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,47 +5,89 @@ on:
   pull_request:
 
 jobs:
-  build:
+  build-ubuntu:
     strategy:
       matrix:
         makeflags: ["GENERATE_MAP=1", "NON_MATCHING=1"]
-    runs-on: ubuntu-latest
-    container: devkitpro/devkitppc:latest
+    runs-on: ubuntu-22.04
+    container: devkitpro/devkitppc:20230110
     steps:
-    - name: Install devkitPro
+    - name: Install GCC
       run: |
-        sudo dpkg --add-architecture i386
-        sudo apt-get update
-        sudo apt-get -y install build-essential gcc-multilib g++-multilib libc6:i386
-        sudo chown $(whoami) "$GITHUB_WORKSPACE"
+        apt update
+        apt -y --no-install-recommends install \
+          build-essential libc6-dev
     - name: Checkout Melee repo
       uses: actions/checkout@v3
-    - name: Checkout WiBo repo
-      uses: actions/checkout@v3
-      with:
-        repository: decompals/WiBo
-        path: tools/WiBo
+    - name: Download WiBo
+      shell: bash
+      run: |
+        curl -L 'https://github.com/decompals/wibo/releases/download/0.4.1/wibo' \
+          -o tools/wibo
+        sha1sum -c <(echo "23f5eee8793f7bb93a1a5de4380d153bc360f7b0  tools/wibo")
+        chmod +x tools/wibo
     - name: Download compilers
       run: |
-        curl -L https://cdn.discordapp.com/attachments/727918646525165659/917185027656286218/GC_WII_COMPILERS.zip \
-          | bsdtar -xvf- -C tools --exclude Wii
+        curl -L 'https://cdn.discordapp.com/attachments/727909624342380615/1079286377230909440/MELEE_COMPILERS.zip' \
+          | bsdtar -xvf- -C tools
         mv tools/GC tools/mwcc_compiler
-        sha1sum -c tools/mwld_prepatch.sha1
-        python3 tools/mwld_patch.py
-        sha1sum -c tools/mwld_postpatch.sha1
-    - name: Build WiBo
-      working-directory: tools/WiBo
-      run: |
-        cmake -B build
-        cmake --build build
     - name: Build Melee
-      run: make -j$(nproc) ${{ matrix.makeflags }} WINE=./tools/WiBo/build/wibo
+      run: |
+        make \
+          WINE=./tools/wibo \
+          -j$(nproc) \
+          ${{ matrix.makeflags }}
     - name: Upload map
       if: matrix.makeflags == 'GENERATE_MAP=1'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: GALE01.map
         path: build/ssbm.us.1.2/GALE01.map
     - name: Calc progress
       if: matrix.makeflags == 'GENERATE_MAP=1'
-      run: python3 tools/calcprogress/calcprogress.py --dol build/ssbm.us.1.2/main.dol --map build/ssbm.us.1.2/GALE01.map --asm-obj-ext .s.o --old-map true >> $GITHUB_STEP_SUMMARY
+      run: |
+        python3 tools/calcprogress/calcprogress.py \
+        --dol build/ssbm.us.1.2/main.dol \
+        --map build/ssbm.us.1.2/GALE01.map \
+        --asm-obj-ext .s.o \
+        --old-map true \
+        >> $GITHUB_STEP_SUMMARY
+
+  build-windows:
+    strategy:
+      matrix:
+        makeflags: ["GENERATE_MAP=1", "NON_MATCHING=1"]
+    runs-on: windows-2022
+    steps:
+    - name: Checkout Melee repo
+      uses: actions/checkout@v3
+    - name: Download compilers
+      run: |
+        $uri = "https://cdn.discordapp.com/attachments/727909624342380615/1079286377230909440/MELEE_COMPILERS.zip"
+        $zip = New-TemporaryFile
+
+        Invoke-WebRequest -Uri $uri -OutFile $zip
+        $target = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "MELEE_COMPILERS")
+        Expand-Archive -LiteralPath $zip.FullName -DestinationPath $target.FullName
+
+        $path = Get-ChildItem -Path $target.FullName | Select-Object -ExpandProperty FullName
+        Copy-Item -Path $path -Destination "tools\mwcc_compiler" -Recurse
+
+        $zip | Remove-Item -Force
+        $target | Remove-Item -Recurse -Force
+    - name: Build Melee
+      run:
+        make WINDOWS=1 `
+          AS=".\tools\mwcc_compiler\powerpc-eabi-as.exe" `
+          HOSTCC=gcc `
+          -j "$env:NUMBER_OF_PROCESSORS" `
+          ${{ matrix.makeflags }}
+    - name: Calc progress
+      if: matrix.makeflags == 'GENERATE_MAP=1'
+      run: |
+        python3 tools/calcprogress/calcprogress.py `
+          --dol build/ssbm.us.1.2/main.dol `
+          --map build/ssbm.us.1.2/GALE01.map `
+          --asm-obj-ext .s.o `
+          --old-map true `
+          >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ endif
 # ELF creation makefile instructions
 $(ELF): $(O_FILES) $(LDSCRIPT)
 	@echo Linking ELF $@
-	$(QUIET) echo $(O_FILES) > build/o_files
+	$(file >build/o_files, $(O_FILES))
 	$(QUIET) $(LD) $(LDFLAGS) -o $@ -lcf $(LDSCRIPT) @build/o_files
 
 $(BUILD_DIR)/%.s.o: %.s

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ CC_EPI   = $(WINE) tools/mwcc_compiler/$(MWCC_EPI_VERSION)/$(MWCC_EPI_EXE)
 endif
 LD      := $(WINE) tools/mwcc_compiler/$(MWCC_LD_VERSION)/mwldeppc.exe
 ELF2DOL := tools/elf2dol
-HOSTCC  := cc
+HOSTCC  := gcc
 PYTHON  := python3
 FORMAT  := clang-format -i -style=file
 


### PR DESCRIPTION
1. Add Windows build
   * This build relies only on PowerShell, MinGW, Git for Windows, and Python 3; no more MSYS2 or devkitPro.
   * It mirrors the actions of the Ubuntu build except for uploading the map artifact.
2. Use a new compilers zip
   * Only contains binaries we actually use, including a pre-patched 1.1 linker, as well as `powerpc-eabi-as.exe` which is needed for the Windows build.
3. Improve speed of Ubuntu build
   * Download the `wibo` binary from their CI release instead of building it ourselves.
   * The sha1 of the 0.4.1 binary is hard-coded and was double-checked locally by me.
   * This lets us cut down on the packages installed.
4. Clean up the build script
   * Use version numbers everywhere instead of `latest` to avoid future breakages.
   * Prefer breaking up long lines for readability and git-friendliness.
5. Tweak Makefile to be able to run under Windows shells
   * Just need to use `make`'s `file` function.

---

Going to need to change the repo settings to require `build-ubuntu` and `build-windows` instead of `build`, under Branches > Branch protection rules > `master`.

---

Also need to allow `cache-apt-pkgs-action`. Settings > Actions > Allow specified actions and reusable workflows:
```
awalsh128/cache-apt-pkgs-action@*,
```