### PR TITLE
Improve editorconfig workflow QoL

### DIFF
--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -1,4 +1,4 @@
-name: "Checking EditorConfig"
+name: "Check EditorConfig"
 
 permissions: read-all
 
@@ -8,17 +8,17 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
-    if: "github.repository_owner == 'doldecomp' && !contains(github.event.pull_request.title, '[skip editorconfig]')"
+    runs-on: ubuntu-22.04
+    if: "!contains(github.event.pull_request.title, '[skip editorconfig]')"
     steps:
     - name: Get list of changed files from PR
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh api \
-          repos/doldecomp/melee/pulls/${{github.event.number}}/files --paginate \
+          repos/${{github.repository_owner}}/melee/pulls/${{github.event.number}}/files --paginate \
           | jq '.[] | select(.status != "removed") | .filename' \
-          | grep -vE "^\"tools/m2c/.*?\"" \
+          | grep -vE '^"(dump|build|expected|tools/(m2c|calcprogress))/.*?"$' \
           > "$HOME/changed_files"
     - name: print list of changed files
       run: |
@@ -26,15 +26,19 @@ jobs:
     - uses: actions/checkout@v3
       with:
         # pull_request_target checks out the base branch by default
-        ref: refs/pull/${{ github.event.pull_request.number }}/merge
+        ref: ${{github.head_ref}}
     - uses: cachix/install-nix-action@v18
       with:
         # nixpkgs commit is pinned so that it doesn't break
         # editorconfig-checker 2.4.0
         nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/c473cc8714710179df205b153f4e9fa007107ff9.tar.gz
-    - name: Checking EditorConfig
+    - name: Check EditorConfig
       run: |
-        cat "$HOME/changed_files" | nix-shell -p editorconfig-checker --run 'xargs -r editorconfig-checker -disable-indent-size'
+        cat "$HOME/changed_files" | nix-shell -p editorconfig-checker --run 'xargs -r editorconfig-checker -v -disable-indent-size'
+
+        printf "These files were changed and checked by EditorConfig:\n\n%s" \
+          "$(cat "$HOME/changed_files" | sed -e 's/"/`/g' -e 's/^/* /')" \
+          >> "$GITHUB_STEP_SUMMARY"
     - if: ${{ failure() }}
       run: |
         echo "::error :: Hey! It looks like your changes don't follow our editorconfig settings. Read https://editorconfig.org/#download to configure your editor so you never see this error again."

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -16,7 +16,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh api \
-          repos/${{github.repository_owner}}/melee/pulls/${{github.event.number}}/files --paginate \
+          repos/${{github.repository}}/pulls/${{github.event.number}}/files --paginate \
           | jq '.[] | select(.status != "removed") | .filename' \
           | grep -vE '^"(dump|build|expected|tools/(m2c|calcprogress))/.*?"$' \
           > "$HOME/changed_files"


### PR DESCRIPTION
Apparently I can't reopen #747. Anyway:

* Use fixed Ubuntu version
* Remove hardcoded references to `doldecomp`
  * Now works on PRs to any repo
* Update `grep` exclude filter
* Run `editorconfig-checker` in verbose mode
* Add markdown step summary

Successful [run](https://github.com/ribbanya/melee/actions/runs/4299967378).