### PR TITLE
Improve README instructions

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -88,7 +88,7 @@ The easiest way to get set up is with [scoop](https://scoop.sh/). You will also 
     make -j$(nproc) GENERATE_MAP=1
     ```
 
-You can refer to [`setup.sh`](/.github/packages/build-linux/setup.sh) and [`entrypoint.sh`](/.github/packages/build-linux/entrypoint.sh) to see how our CI builds on Ubuntu.
+You can refer to our [`Dockerfile`](/.github/packages/build-linux/Dockerfile) to see how our CI builds on Ubuntu.
 
 ## Containers
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -3,12 +3,9 @@
 
 This repo contains a WIP decompilation of Super Smash Bros Melee (US).
 
-```diff
-- INFORMATION! -
-
-The DOL this repository builds can be shifted! Meaning you are able to now
-add and remove code as you see fit, for modding or research purposes.
-```
+> **Note**
+>
+> The DOL this repository builds can be shifted! Meaning you are able to now add and remove code as you see fit, for modding or research purposes.
 
 It builds the following DOL:
 v1.02 - main.dol: `sha1: 08e0bf20134dfcb260699671004527b2d6bb1a45`

--- a/.github/README.md
+++ b/.github/README.md
@@ -15,7 +15,7 @@ v1.02 - main.dol: `sha1: 08e0bf20134dfcb260699671004527b2d6bb1a45`
 
 ## Windows
 
-The easiest way to get set up is with [scoop](https://scoop.sh/). You will also need our [compilers](https://cdn.discordapp.com/attachments/727909624342380615/1079286377230909440/MELEE_COMPILERS.zip).
+The easiest way to get set up is with [scoop](https://scoop.sh/). You will also need our compilers (linked below).
 
 1. Open a PowerShell window (`Win+X`). You do not need admin privileges.
 1. Install `scoop`, `git`, `python`, and `mingw`. You can skip these if you already have `git`, `python` (3.9+), `bash`, `gcc`, and `make` in your `PATH`.

--- a/.github/README.md
+++ b/.github/README.md
@@ -110,7 +110,11 @@ docker run --rm \
 
 # Contributing
 
-If you're new to decomp or getting started, check out our [Getting Started guide](https://doldecomp.github.io/melee/getting_started.html)! Once you're in a place that you're ready to open a PR, check out our [Contributing guidelines](CONTRIBUTING.md).
+Contributions are welcome! If you're new to decomp, check out our [Getting Started guide](https://doldecomp.github.io/melee/getting_started.html). Before [opening a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request), please read our [contributing guidelines](CONTRIBUTING.md).
+
+We're also happy to answer any questions in the `#melee` channel on Discord.
+
+[![Gamecube/Wii Decompilation Discord](https://discordapp.com/api/guilds/727908905392275526/widget.png?style=banner2)](https://discord.gg/hKx3FJJgrV)
 
 # FAQ
 ## What can be done after decompiling Melee?
@@ -128,14 +132,3 @@ So creating mods would be a lot easier as C code is much easier to consume than 
 Considering we don't have the source for the compiler, this is kind of "anything goes" territory. Unfortunately [register allocation is an NP-hard problem](https://en.wikipedia.org/wiki/Register_allocation?oldformat=true) which means there are all types of heuristics you can use to select registers, some of which can be confused by things as silly as variable names.
 
 One option is to attempt to automatically [permute the source code](https://github.com/simonlindholm/decomp-permuter) to get the correct register allocation.
-
-### How do I set up the source permuter?
-
-TODO
-
-
-## Contributions
-[Contributions and PRs](https://github.com/doldecomp/melee/compare) are welcome. Please read the [contributing guidelines](CONTRIBUTING.md).
-
-[![Gamecube/Wii Decompilation Discord](https://discordapp.com/api/guilds/727908905392275526/widget.png?style=banner2)](https://discord.gg/hKx3FJJgrV)
-

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,5 +1,9 @@
 # Super Smash Bros Melee
-[![build-melee](https://github.com/doldecomp/melee/actions/workflows/build-melee.yml/badge.svg)](https://github.com/doldecomp/melee/actions/workflows/build-melee.yml) [![publish-packages](https://github.com/doldecomp/melee/actions/workflows/publish-packages.yml/badge.svg)](https://github.com/doldecomp/melee/actions/workflows/publish-packages.yml) [![publish-pages](https://github.com/doldecomp/melee/actions/workflows/publish-pages.yml/badge.svg)](https://github.com/doldecomp/melee/actions/workflows/publish-pages.yml)
+[![build-melee](https://github.com/doldecomp/melee/actions/workflows/build-melee.yml/badge.svg)](https://github.com/doldecomp/melee/actions/workflows/build-melee.yml)
+[![publish-packages](https://github.com/doldecomp/melee/actions/workflows/publish-packages.yml/badge.svg)](https://github.com/doldecomp/melee/actions/workflows/publish-packages.yml)
+[![publish-pages](https://github.com/doldecomp/melee/actions/workflows/publish-pages.yml/badge.svg)](https://github.com/doldecomp/melee/actions/workflows/publish-pages.yml)
+
+[![](https://dcbadge.vercel.app/api/server/hKx3FJJgrV)](https://discord.gg/hKx3FJJgrV)
 
 This repo contains a WIP decompilation of Super Smash Bros Melee (US).
 
@@ -136,4 +140,3 @@ TODO
 Gamecube/Wii Decompilation Discord: https://discord.gg/hKx3FJJgrV
 
 Contributions and PRs are welcome.
-

--- a/.github/README.md
+++ b/.github/README.md
@@ -8,6 +8,7 @@ This repo contains a WIP decompilation of Super Smash Bros Melee (US).
 > The DOL this repository builds can be shifted! Meaning you are able to now add and remove code as you see fit, for modding or research purposes.
 
 It builds the following DOL:
+
 v1.02 - main.dol: `sha1: 08e0bf20134dfcb260699671004527b2d6bb1a45`
 
 # Building

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,4 +1,5 @@
 # Super Smash Bros Melee
+[![build-melee](https://github.com/doldecomp/melee/actions/workflows/build-melee.yml/badge.svg)](https://github.com/doldecomp/melee/actions/workflows/build-melee.yml) [![publish-packages](https://github.com/doldecomp/melee/actions/workflows/publish-packages.yml/badge.svg)](https://github.com/doldecomp/melee/actions/workflows/publish-packages.yml) [![publish-pages](https://github.com/doldecomp/melee/actions/workflows/publish-pages.yml/badge.svg)](https://github.com/doldecomp/melee/actions/workflows/publish-pages.yml)
 
 This repo contains a WIP decompilation of Super Smash Bros Melee (US).
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -110,7 +110,7 @@ docker run --rm \
 
 # Contributing
 
-Contributions are welcome! If you're new to decomp, check out our [Getting Started guide](https://doldecomp.github.io/melee/getting_started.html). Before [opening a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request), please read our [contributing guidelines](CONTRIBUTING.md).
+Contributions are welcome! If you're new to decomp, check out our [Getting Started guide](https://doldecomp.github.io/melee/getting_started.html). Before [opening a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request), please read our [contributing guidelines](CONTRIBUTING.md). If you're new to Git and don't know how to create a pull request, we encourage you to [create an issue](https://github.com/doldecomp/melee/issues/new) with your decomp.me link and a maintainer will add your code to the repository.
 
 We're also happy to answer any questions in the `#melee` channel on Discord.
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -135,7 +135,7 @@ TODO
 
 
 ## Contributions
+[Contributions and PRs](https://github.com/doldecomp/melee/compare) are welcome. Please read the [contributing guidelines](CONTRIBUTING.md).
 
-Gamecube/Wii Decompilation Discord: https://discord.gg/hKx3FJJgrV
+[![Gamecube/Wii Decompilation Discord](https://discordapp.com/api/guilds/727908905392275526/widget.png?style=banner2)](https://discord.gg/hKx3FJJgrV)
 
-Contributions and PRs are welcome.

--- a/.github/README.md
+++ b/.github/README.md
@@ -91,16 +91,17 @@ You can refer to our [`Dockerfile`](/.github/packages/build-linux/Dockerfile) to
 
 ## Containers
 
-We offer containerized [Linux](https://github.com/doldecomp/melee/pkgs/container/melee%2Fbuild-linux) and [Windows](https://github.com/doldecomp/melee/pkgs/container/melee%2Fbuild-windows) build environments, which you can run through `podman` or `docker` on any supported platform, including macOS.
-```sh
-cd melee
+We offer containerized [Linux](https://github.com/doldecomp/melee/pkgs/container/melee%2Fbuild-linux) and [Windows](https://github.com/doldecomp/melee/pkgs/container/melee%2Fbuild-windows) build environments, which you can run through [`podman`](https://podman.io/getting-started/) or [`docker`](https://www.docker.com/get-started/) on any supported platform, including macOS.
 
-# This will overwrite ./build but you can specify any path to map to /output
-build_target="$PWD/build"
+```sh
+melee_path="$PWD"
+make_flags='GENERATE_MAP=1'
+build_target="$melee_path/build"
+
 docker run --rm \
-  --volume "$PWD:/input:ro" \
+  --volume "$melee_path:/input:ro" \
   --volume "$build_target:/output" \
-  --env MAKE_FLAGS="GENERATE_MAP=1" \
+  --env MAKE_FLAGS="$make_flags" \
   ghcr.io/doldecomp/melee/build-linux:latest
 ```
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,9 +1,8 @@
 # Super Smash Bros Melee
+[![GC/Wii Decompilation](https://discordapp.com/api/guilds/727908905392275526/widget.png?style=shield)](https://discord.gg/hKx3FJJgrV)
 [![build-melee](https://github.com/doldecomp/melee/actions/workflows/build-melee.yml/badge.svg)](https://github.com/doldecomp/melee/actions/workflows/build-melee.yml)
 [![publish-packages](https://github.com/doldecomp/melee/actions/workflows/publish-packages.yml/badge.svg)](https://github.com/doldecomp/melee/actions/workflows/publish-packages.yml)
 [![publish-pages](https://github.com/doldecomp/melee/actions/workflows/publish-pages.yml/badge.svg)](https://github.com/doldecomp/melee/actions/workflows/publish-pages.yml)
-
-[![](https://dcbadge.vercel.app/api/server/hKx3FJJgrV)](https://discord.gg/hKx3FJJgrV)
 
 This repo contains a WIP decompilation of Super Smash Bros Melee (US).
 


### PR DESCRIPTION
* Windows
   * Tested on a fresh Windows 10 Home installation. You can just copy-paste the instructions into PowerShell and it works.
* Linux
    * Cleaned up the instructions a bit, updated the compilers zip.
* Containers
    * Added a section about running from a Docker image, tested locally.