### PR TITLE
Use `.textContent` to get text from the `#ctx-text` element

### DIFF
--- a/tools/ctx_template.html
+++ b/tools/ctx_template.html
@@ -9,7 +9,7 @@
             var copyButton = document.getElementById('copy-button');
             copyButton.addEventListener('click', function() {{
                 var text = document.querySelector('#ctx-text')
-                    .innerText.trim();
+                    .textContent.trim();
                 navigator.clipboard.writeText(text).then(function() {{
                     console.log('Copied text to clipboard');
                 }}, function(err) {{


### PR DESCRIPTION
I was following along with the [getting started instructions](https://doldecomp.github.io/melee/getting_started.html#:~:text=Copy%20in%20the%20contents%20of%20this%20link%20into%20the%20%E2%80%9CContext%E2%80%9D%20section.%20More%20on%20that%20later.) and I noticed the [copy button](https://doldecomp.github.io/melee/ctx.html) for the target assembly wasn't working for me.

At first I thought the button was broken, but after looking into it some more I found out that it was because I did not have the text expanded. `innerText` returns an empty string when the text in collapsed because it is trying to emulate what the the user would be able to copy if they were to highlight the content with their mouse.

Using `.textContent` to get the text will always return the correct content to be copied.