### PR TITLE
Rename fighter motion flags

### DIFF
--- a/src/melee/ft/chara/ftCLink/forward.h
+++ b/src/melee/ft/chara/ftCLink/forward.h
@@ -5,7 +5,6 @@
 #include "ft/forward.h"
 
 static MotionFlags const ftCl_MF_Zair ATTRIBUTE_USED =
-    FtStateChange_PreserveFastFall | FtStateChange_SkipUpdateModel |
-    FtStateChange_SkipUpdateAnimVel | FtStateChange_Unk_6;
+    Ft_MF_KeepFastFall | Ft_MF_SkipModel | Ft_MF_SkipAnimVel | Ft_MF_Unk06;
 
 #endif

--- a/src/melee/ft/chara/ftCLink/ftCl_Init.c
+++ b/src/melee/ft/chara/ftCLink/ftCl_Init.c
@@ -216,7 +216,7 @@ MotionState ftCl_Init_MotionStateTable[] = {
     },
     {
         312,
-        FtStateChange_FreezeState,
+        Ft_MF_FreezeState,
         FtMoveId_Default << 24,
         ftCo_Zair_Anim,
         ftCo_Zair_IASA,

--- a/src/melee/ft/chara/ftCaptain/forward.h
+++ b/src/melee/ft/chara/ftCaptain/forward.h
@@ -8,35 +8,34 @@ typedef struct ftCaptain_DatAttrs ftCaptain_DatAttrs;
 typedef union ftCaptain_MotionVars ftCaptain_MotionVars;
 
 static MotionFlags const ftCa_MF_Special ATTRIBUTE_USED =
-    ftCo_MF_Special | FtStateChange_PreserveSfx;
+    ftCo_MF_Special | Ft_MF_KeepSfx;
 
 static MotionFlags const ftCa_MF_SpecialN ATTRIBUTE_USED =
-    ftCa_MF_Special | FtStateChange_PreserveFastFall;
+    ftCa_MF_Special | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftCa_MF_SpecialAirN ATTRIBUTE_USED =
-    ftCa_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftCa_MF_SpecialN | Ft_MF_SkipParasol;
 
 static MotionFlags const ftCa_MF_SpecialS ATTRIBUTE_USED =
-    ftCa_MF_Special | FtStateChange_PreserveGfx;
+    ftCa_MF_Special | Ft_MF_KeepGfx;
 
 static MotionFlags const ftCa_MF_SpecialAirSStart ATTRIBUTE_USED =
-    ftCa_MF_SpecialS | FtStateChange_SkipUpdateParasol;
+    ftCa_MF_SpecialS | Ft_MF_SkipParasol;
 
 static MotionFlags const ftCa_MF_SpecialAirS ATTRIBUTE_USED =
-    ftCa_MF_SpecialS | FtStateChange_SkipUpdateParasol;
+    ftCa_MF_SpecialS | Ft_MF_SkipParasol;
 
 static MotionFlags const ftCa_MF_SpecialHi ATTRIBUTE_USED =
-    ftCo_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx;
+    ftCo_MF_Special | Ft_MF_KeepFastFall | Ft_MF_KeepGfx;
 
 static MotionFlags const ftCa_MF_SpecialAirHi ATTRIBUTE_USED =
-    ftCa_MF_SpecialHi | FtStateChange_SkipUpdateParasol;
+    ftCa_MF_SpecialHi | Ft_MF_SkipParasol;
 
 static MotionFlags const ftCa_MF_SpecialLw ATTRIBUTE_USED =
-    ftCa_MF_Special | FtStateChange_PreserveColAnimHitStatus;
+    ftCa_MF_Special | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftCa_MF_SpecialLwRebound ATTRIBUTE_USED =
-    ftCa_MF_SpecialLw | FtStateChange_SkipUpdateParasol;
+    ftCa_MF_SpecialLw | Ft_MF_SkipParasol;
 
 typedef enum ftCaptain_MotionState {
     ftCa_MS_Swing42_Sword = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftCaptain/ftCa_SpecialN.c
+++ b/src/melee/ft/chara/ftCaptain/ftCa_SpecialN.c
@@ -201,11 +201,9 @@ void ftCa_SpecialAirN_Phys(HSD_GObj* gobj)
 
 /// @todo Share with #ftCa_Init_MotionStateTable
 static u32 const transition_flags =
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateMatAnim |
-    FtStateChange_SkipUpdateRumble | FtStateChange_UpdateCmd |
-    FtStateChange_SkipUpdateColAnim | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis |
-    FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27;
+    Ft_MF_KeepGfx | Ft_MF_SkipMatAnim | Ft_MF_SkipRumble | Ft_MF_UpdateCmd |
+    Ft_MF_SkipColAnim | Ft_MF_SkipItemVis | Ft_MF_Unk19 |
+    Ft_MF_SkipModelPartVis | Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 void ftCa_SpecialN_Coll(HSD_GObj* gobj)
 {

--- a/src/melee/ft/chara/ftCaptain/ftCa_SpecialS.c
+++ b/src/melee/ft/chara/ftCaptain/ftCa_SpecialS.c
@@ -114,11 +114,9 @@ void ftCa_SpecialAirS_Enter(HSD_GObj* gobj)
 }
 
 static u32 const transition_flags =
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateMatAnim |
-    FtStateChange_UpdateCmd | FtStateChange_SkipUpdateColAnim |
-    FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_19 |
-    FtStateChange_SkipUpdateModelPartVis | FtStateChange_SkipUpdateModelFlag |
-    FtStateChange_Unk_27;
+    Ft_MF_KeepGfx | Ft_MF_SkipMatAnim | Ft_MF_UpdateCmd | Ft_MF_SkipColAnim |
+    Ft_MF_SkipItemVis | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |
+    Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 static void onDetectGround(HSD_GObj* gobj)
 {

--- a/src/melee/ft/chara/ftCommon/forward.h
+++ b/src/melee/ft/chara/ftCommon/forward.h
@@ -5,166 +5,158 @@
 #include "ft/forward.h"
 
 static MotionFlags const ftCo_MF_5_6 ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateAnimVel | FtStateChange_Unk_6;
+    Ft_MF_SkipAnimVel | Ft_MF_Unk06;
 static MotionFlags const ftCo_MF_2_5_6 ATTRIBUTE_USED =
-    ftCo_MF_5_6 | FtStateChange_PreserveColAnimHitStatus;
+    ftCo_MF_5_6 | Ft_MF_KeepColAnimHitStatus;
 static MotionFlags const ftCo_MF_Squat ATTRIBUTE_USED =
-    ftCo_MF_2_5_6 | FtStateChange_PreserveFastFall;
+    ftCo_MF_2_5_6 | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_Dash ATTRIBUTE_USED =
-    ftCo_MF_Squat | FtStateChange_PreserveGfx;
+    ftCo_MF_Squat | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_Run ATTRIBUTE_USED =
-    ftCo_MF_5_6 | FtStateChange_SkipUpdateHit;
+    ftCo_MF_5_6 | Ft_MF_SkipHit;
 static MotionFlags const ftCo_MF_Appeal ATTRIBUTE_USED =
-    ftCo_MF_5_6 | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateModel;
+    ftCo_MF_5_6 | Ft_MF_KeepFastFall | Ft_MF_SkipModel;
 static MotionFlags const ftCo_MF_9_10 ATTRIBUTE_USED =
-    FtStateChange_PreserveSfx | FtStateChange_SkipUpdateParasol;
+    Ft_MF_KeepSfx | Ft_MF_SkipParasol;
 static MotionFlags const ftCo_MF_LandingAirN ATTRIBUTE_USED =
-    ftCo_MF_9_10 | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_SkipUpdateHit;
+    ftCo_MF_9_10 | Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipHit;
 static MotionFlags const ftCo_MF_LandingAirF ATTRIBUTE_USED =
-    ftCo_MF_LandingAirN | FtStateChange_PreserveFastFall;
+    ftCo_MF_LandingAirN | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_LandingAirB ATTRIBUTE_USED =
-    ftCo_MF_LandingAirN | FtStateChange_PreserveGfx;
+    ftCo_MF_LandingAirN | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_LandingAirHi ATTRIBUTE_USED =
-    ftCo_MF_LandingAirB | FtStateChange_PreserveFastFall;
+    ftCo_MF_LandingAirB | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_LandingAirLw ATTRIBUTE_USED =
-    ftCo_MF_9_10 | FtStateChange_SkipUpdateModel;
+    ftCo_MF_9_10 | Ft_MF_SkipModel;
 static MotionFlags const ftCo_MF_Turn ATTRIBUTE_USED =
-    ftCo_MF_2_5_6 | FtStateChange_PreserveAccessory;
+    ftCo_MF_2_5_6 | Ft_MF_KeepAccessory;
 static MotionFlags const ftCo_MF_Walk ATTRIBUTE_USED =
-    ftCo_MF_2_5_6 | FtStateChange_PreserveGfx | FtStateChange_UpdateCmd;
+    ftCo_MF_2_5_6 | Ft_MF_KeepGfx | Ft_MF_UpdateCmd;
 static MotionFlags const ftCo_MF_3_5_6 ATTRIBUTE_USED =
-    ftCo_MF_5_6 | FtStateChange_SkipUpdateHit;
+    ftCo_MF_5_6 | Ft_MF_SkipHit;
 static MotionFlags const ftCo_MF_Jump ATTRIBUTE_USED =
-    ftCo_MF_3_5_6 | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateNametagVis;
+    ftCo_MF_3_5_6 | Ft_MF_KeepFastFall | Ft_MF_SkipNametagVis;
 static MotionFlags const ftCo_MF_JumpAir ATTRIBUTE_USED =
-    ftCo_MF_3_5_6 | FtStateChange_PreserveGfx |
-    FtStateChange_PreserveColaNimPartHitStatus;
+    ftCo_MF_3_5_6 | Ft_MF_KeepGfx | Ft_MF_KeepColAnimPartHitStatus;
 static MotionFlags const ftCo_MF_GuardReflect ATTRIBUTE_USED =
-    ftCo_MF_5_6 | FtStateChange_PreserveFastFall | FtStateChange_PreserveGfx |
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateColAnim |
-    FtStateChange_Unk_UpdatePhys;
+    ftCo_MF_5_6 | Ft_MF_KeepFastFall | Ft_MF_KeepGfx | Ft_MF_SkipModel |
+    Ft_MF_SkipColAnim | Ft_MF_UnkUpdatePhys;
 static MotionFlags const ftCo_MF_Guard ATTRIBUTE_USED =
-    FtStateChange_Unk_19 | FtStateChange_Unk_UpdatePhys;
+    Ft_MF_Unk19 | Ft_MF_UnkUpdatePhys;
 static MotionFlags const ftCo_MF_AttackBase ATTRIBUTE_USED =
-    FtStateChange_PreserveSfx | FtStateChange_SkipUpdateItemVis;
+    Ft_MF_KeepSfx | Ft_MF_SkipItemVis;
 static MotionFlags const ftCo_MF_Attack ATTRIBUTE_USED =
-    ftCo_MF_AttackBase | FtStateChange_FreezeState;
+    ftCo_MF_AttackBase | Ft_MF_FreezeState;
 static MotionFlags const ftCo_MF_Attack_2 ATTRIBUTE_USED =
-    ftCo_MF_Attack | FtStateChange_PreserveColAnimHitStatus;
+    ftCo_MF_Attack | Ft_MF_KeepColAnimHitStatus;
 static MotionFlags const ftCo_MF_AttackDash ATTRIBUTE_USED =
-    ftCo_MF_Attack_2 | FtStateChange_PreserveFastFall;
+    ftCo_MF_Attack_2 | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_AttackS3 ATTRIBUTE_USED =
-    ftCo_MF_Attack_2 | FtStateChange_PreserveGfx;
+    ftCo_MF_Attack_2 | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_AttackHi3 ATTRIBUTE_USED =
-    ftCo_MF_AttackS3 | FtStateChange_PreserveFastFall;
+    ftCo_MF_AttackS3 | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_AttackLw3 ATTRIBUTE_USED =
-    ftCo_MF_Attack | FtStateChange_SkipUpdateHit;
+    ftCo_MF_Attack | Ft_MF_SkipHit;
 static MotionFlags const ftCo_MF_CliffAttackQuick ATTRIBUTE_USED =
-    ftCo_MF_AttackLw3 | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateAnimVel;
+    ftCo_MF_AttackLw3 | Ft_MF_KeepFastFall | Ft_MF_KeepGfx |
+    Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipModel | Ft_MF_SkipAnimVel;
 static MotionFlags const ftCo_MF_AttackAir ATTRIBUTE_USED =
-    ftCo_MF_Attack | FtStateChange_SkipUpdateParasol;
+    ftCo_MF_Attack | Ft_MF_SkipParasol;
 static MotionFlags const ftCo_MF_AttackAirN ATTRIBUTE_USED =
-    ftCo_MF_AttackAir | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_SkipUpdateHit | FtStateChange_SkipUpdateParasol;
+    ftCo_MF_AttackAir | Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipHit |
+    Ft_MF_SkipParasol;
 static MotionFlags const ftCo_MF_AttackAirF ATTRIBUTE_USED =
-    ftCo_MF_AttackAirN | FtStateChange_PreserveFastFall;
+    ftCo_MF_AttackAirN | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_AttackAirB ATTRIBUTE_USED =
-    ftCo_MF_AttackAirN | FtStateChange_PreserveGfx;
+    ftCo_MF_AttackAirN | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_AttackAirHi ATTRIBUTE_USED =
-    ftCo_MF_AttackAirF | FtStateChange_PreserveGfx;
+    ftCo_MF_AttackAirF | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_AttackAirLw ATTRIBUTE_USED =
-    ftCo_MF_AttackAir | FtStateChange_SkipUpdateModel;
+    ftCo_MF_AttackAir | Ft_MF_SkipModel;
 static MotionFlags const ftCo_MF_Attack4 ATTRIBUTE_USED =
-    ftCo_MF_AttackLw3 | FtStateChange_SkipUpdateRumble;
+    ftCo_MF_AttackLw3 | Ft_MF_SkipRumble;
 static MotionFlags const ftCo_MF_AttackS4 ATTRIBUTE_USED =
-    ftCo_MF_Attack4 | FtStateChange_PreserveFastFall;
+    ftCo_MF_Attack4 | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_AttackHi4 ATTRIBUTE_USED =
-    ftCo_MF_Attack4 | FtStateChange_PreserveGfx;
+    ftCo_MF_Attack4 | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_AttackLw4 ATTRIBUTE_USED =
-    ftCo_MF_Attack4 | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx;
+    ftCo_MF_Attack4 | Ft_MF_KeepFastFall | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_Attack1 ATTRIBUTE_USED =
-    ftCo_MF_Attack | FtStateChange_Unk_19;
+    ftCo_MF_Attack | Ft_MF_Unk19;
 static MotionFlags const ftCo_MF_Attack11 ATTRIBUTE_USED =
-    ftCo_MF_Attack1 | FtStateChange_PreserveFastFall;
+    ftCo_MF_Attack1 | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_Attack12 ATTRIBUTE_USED =
-    ftCo_MF_Attack1 | FtStateChange_PreserveGfx;
+    ftCo_MF_Attack1 | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_Attack13 ATTRIBUTE_USED =
-    ftCo_MF_Attack12 | FtStateChange_PreserveFastFall;
+    ftCo_MF_Attack12 | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_Attack100 ATTRIBUTE_USED =
-    ftCo_MF_Attack1 | FtStateChange_PreserveColAnimHitStatus;
+    ftCo_MF_Attack1 | Ft_MF_KeepColAnimHitStatus;
 static MotionFlags const ftCo_MF_ItemScope ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateItemVis | FtStateChange_SkipUpdateModelPartVis;
+    Ft_MF_SkipItemVis | Ft_MF_SkipModelPartVis;
 static MotionFlags const ftCo_MF_SwordSwing1 ATTRIBUTE_USED =
-    ftCo_MF_ItemScope | FtStateChange_Unk_6;
+    ftCo_MF_ItemScope | Ft_MF_Unk06;
 static MotionFlags const ftCo_MF_SwordSwing3 ATTRIBUTE_USED =
-    ftCo_MF_SwordSwing1 | FtStateChange_PreserveFastFall;
+    ftCo_MF_SwordSwing1 | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_SwordSwingDash ATTRIBUTE_USED =
-    ftCo_MF_SwordSwing3 | FtStateChange_PreserveGfx;
+    ftCo_MF_SwordSwing3 | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_BatSwing1 ATTRIBUTE_USED =
-    ftCo_MF_SwordSwing1 | FtStateChange_PreserveColAnimHitStatus;
+    ftCo_MF_SwordSwing1 | Ft_MF_KeepColAnimHitStatus;
 static MotionFlags const ftCo_MF_BatSwing3 ATTRIBUTE_USED =
-    ftCo_MF_BatSwing1 | FtStateChange_PreserveFastFall;
+    ftCo_MF_BatSwing1 | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_BatSwingDash ATTRIBUTE_USED =
-    ftCo_MF_BatSwing3 | FtStateChange_PreserveGfx;
+    ftCo_MF_BatSwing3 | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_ParasolSwing1 ATTRIBUTE_USED =
-    ftCo_MF_SwordSwing1 | FtStateChange_SkipUpdateHit;
+    ftCo_MF_SwordSwing1 | Ft_MF_SkipHit;
 static MotionFlags const ftCo_MF_ParasolSwing3 ATTRIBUTE_USED =
-    ftCo_MF_ParasolSwing1 | FtStateChange_PreserveFastFall;
+    ftCo_MF_ParasolSwing1 | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_ParasolSwingDash ATTRIBUTE_USED =
-    ftCo_MF_ParasolSwing3 | FtStateChange_PreserveGfx;
+    ftCo_MF_ParasolSwing3 | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_HarisenSwing1 ATTRIBUTE_USED =
-    ftCo_MF_BatSwing1 | FtStateChange_SkipUpdateHit;
+    ftCo_MF_BatSwing1 | Ft_MF_SkipHit;
 static MotionFlags const ftCo_MF_HarisenSwing3 ATTRIBUTE_USED =
-    ftCo_MF_HarisenSwing1 | FtStateChange_PreserveFastFall;
+    ftCo_MF_HarisenSwing1 | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_HarisenSwingDash ATTRIBUTE_USED =
-    ftCo_MF_HarisenSwing3 | FtStateChange_PreserveGfx;
+    ftCo_MF_HarisenSwing3 | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_StarRodSwing1 ATTRIBUTE_USED =
-    ftCo_MF_SwordSwing1 | FtStateChange_SkipUpdateModel;
+    ftCo_MF_SwordSwing1 | Ft_MF_SkipModel;
 static MotionFlags const ftCo_MF_StarRodSwing3 ATTRIBUTE_USED =
-    ftCo_MF_StarRodSwing1 | FtStateChange_PreserveFastFall;
+    ftCo_MF_StarRodSwing1 | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_StarRodSwingDash ATTRIBUTE_USED =
-    ftCo_MF_StarRodSwing3 | FtStateChange_PreserveGfx;
+    ftCo_MF_StarRodSwing3 | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_LipstickSwing1 ATTRIBUTE_USED =
-    ftCo_MF_StarRodSwing1 | FtStateChange_PreserveColAnimHitStatus;
+    ftCo_MF_StarRodSwing1 | Ft_MF_KeepColAnimHitStatus;
 static MotionFlags const ftCo_MF_LipstickSwing3 ATTRIBUTE_USED =
-    ftCo_MF_LipstickSwing1 | FtStateChange_PreserveFastFall;
+    ftCo_MF_LipstickSwing1 | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_LipstickSwingDash ATTRIBUTE_USED =
-    ftCo_MF_LipstickSwing3 | FtStateChange_PreserveGfx;
+    ftCo_MF_LipstickSwing3 | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_ParasolOpen ATTRIBUTE_USED =
-    ftCo_MF_ParasolSwing1 | FtStateChange_SkipUpdateModel;
+    ftCo_MF_ParasolSwing1 | Ft_MF_SkipModel;
 static MotionFlags const ftCo_MF_HammerBase ATTRIBUTE_USED =
-    ftCo_MF_LipstickSwing1 | FtStateChange_SkipUpdateHit;
+    ftCo_MF_LipstickSwing1 | Ft_MF_SkipHit;
 static MotionFlags const ftCo_MF_Hammer ATTRIBUTE_USED =
-    ftCo_MF_HammerBase | FtStateChange_PreserveGfx;
+    ftCo_MF_HammerBase | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_WarpStarFall ATTRIBUTE_USED =
-    ftCo_MF_Hammer | FtStateChange_PreserveFastFall;
+    ftCo_MF_Hammer | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_ItemScope_5_6 ATTRIBUTE_USED =
     ftCo_MF_5_6 | ftCo_MF_ItemScope;
 static MotionFlags const ftCo_MF_ItemThrow ATTRIBUTE_USED =
-    ftCo_MF_ItemScope_5_6 | FtStateChange_PreserveGfx;
+    ftCo_MF_ItemScope_5_6 | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_LGunShoot ATTRIBUTE_USED =
-    ftCo_MF_ItemScope | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateHit | FtStateChange_SkipUpdateModel |
-    FtStateChange_Unk_6 | FtStateChange_SkipUpdateThrowException;
+    ftCo_MF_ItemScope | Ft_MF_KeepFastFall | Ft_MF_SkipHit | Ft_MF_SkipModel |
+    Ft_MF_Unk06 | Ft_MF_SkipThrowException;
 static MotionFlags const ftCo_MF_ItemScopeFire ATTRIBUTE_USED =
-    ftCo_MF_LGunShoot | FtStateChange_PreserveColAnimHitStatus;
+    ftCo_MF_LGunShoot | Ft_MF_KeepColAnimHitStatus;
 static MotionFlags const ftCo_MF_HammerFall ATTRIBUTE_USED =
-    ftCo_MF_Hammer | FtStateChange_SkipUpdateParasol;
+    ftCo_MF_Hammer | Ft_MF_SkipParasol;
 static MotionFlags const ftCo_MF_ItemThrowAir ATTRIBUTE_USED =
-    ftCo_MF_ItemThrow | FtStateChange_SkipUpdateParasol;
+    ftCo_MF_ItemThrow | Ft_MF_SkipParasol;
 static MotionFlags const ftCo_MF_LGunShootAir ATTRIBUTE_USED =
-    ftCo_MF_LGunShoot | FtStateChange_SkipUpdateParasol;
+    ftCo_MF_LGunShoot | Ft_MF_SkipParasol;
 static MotionFlags const ftCo_MF_ItemScopeAir ATTRIBUTE_USED =
-    ftCo_MF_HammerBase | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateThrowException | FtStateChange_SkipUpdateParasol;
+    ftCo_MF_HammerBase | Ft_MF_KeepFastFall | Ft_MF_SkipThrowException |
+    Ft_MF_SkipParasol;
 static MotionFlags const ftCo_MF_Swing4 ATTRIBUTE_USED =
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateRumble;
+    Ft_MF_KeepGfx | Ft_MF_SkipRumble;
 static MotionFlags const ftCo_MF_SwordSwing4 ATTRIBUTE_USED =
     ftCo_MF_SwordSwing1 | ftCo_MF_Swing4;
 static MotionFlags const ftCo_MF_BatSwing4 ATTRIBUTE_USED =
@@ -180,141 +172,131 @@ static MotionFlags const ftCo_MF_LipstickSwing4 ATTRIBUTE_USED =
 static MotionFlags const ftCo_MF_ItemThrow4 ATTRIBUTE_USED =
     ftCo_MF_ItemScope_5_6 | ftCo_MF_Swing4;
 static MotionFlags const ftCo_MF_ItemThrowAir4 ATTRIBUTE_USED =
-    ftCo_MF_ItemThrow4 | FtStateChange_SkipUpdateParasol;
+    ftCo_MF_ItemThrow4 | Ft_MF_SkipParasol;
 static MotionFlags const ftCo_MF_HammerMove ATTRIBUTE_USED =
-    ftCo_MF_HammerBase | FtStateChange_PreserveGfx;
+    ftCo_MF_HammerBase | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_HammerTurn ATTRIBUTE_USED =
-    ftCo_MF_HammerMove | FtStateChange_PreserveAccessory;
+    ftCo_MF_HammerMove | Ft_MF_KeepAccessory;
 static MotionFlags const ftCo_MF_HammerWalk ATTRIBUTE_USED =
-    ftCo_MF_HammerMove | FtStateChange_UpdateCmd;
+    ftCo_MF_HammerMove | Ft_MF_UpdateCmd;
 static MotionFlags const ftCo_MF_ItemFall ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateHit | FtStateChange_SkipUpdateModel |
-    FtStateChange_Unk_6 | FtStateChange_SkipUpdateModelPartVis;
+    Ft_MF_SkipHit | Ft_MF_SkipModel | Ft_MF_Unk06 | Ft_MF_SkipModelPartVis;
 static MotionFlags const ftCo_MF_ItemScrewBase ATTRIBUTE_USED =
-    ftCo_MF_AttackBase | ftCo_MF_ItemFall | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx;
+    ftCo_MF_AttackBase | ftCo_MF_ItemFall | Ft_MF_KeepFastFall | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_ItemScrew ATTRIBUTE_USED =
-    ftCo_MF_ItemScrewBase | FtStateChange_SkipUpdateNametagVis;
+    ftCo_MF_ItemScrewBase | Ft_MF_SkipNametagVis;
 static MotionFlags const ftCo_MF_HammerJump ATTRIBUTE_USED =
-    ftCo_MF_HammerMove | FtStateChange_SkipUpdateParasol |
-    FtStateChange_SkipUpdateNametagVis;
+    ftCo_MF_HammerMove | Ft_MF_SkipParasol | Ft_MF_SkipNametagVis;
 static MotionFlags const ftCo_MF_ItemScrewAir ATTRIBUTE_USED =
-    ftCo_MF_ItemScrewBase | FtStateChange_SkipUpdateParasol |
-    FtStateChange_PreserveColaNimPartHitStatus;
+    ftCo_MF_ItemScrewBase | Ft_MF_SkipParasol | Ft_MF_KeepColAnimPartHitStatus;
 static MotionFlags const ftCo_MF_LiftWait ATTRIBUTE_USED =
-    FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis;
+    Ft_MF_Unk19 | Ft_MF_SkipModelPartVis;
 static MotionFlags const ftCo_MF_LiftMove ATTRIBUTE_USED =
-    ftCo_MF_LiftWait | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_SkipUpdateAnimVel | FtStateChange_Unk_6;
+    ftCo_MF_LiftWait | Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipAnimVel |
+    Ft_MF_Unk06;
 static MotionFlags const ftCo_MF_LiftTurn ATTRIBUTE_USED =
-    ftCo_MF_LiftMove | FtStateChange_PreserveAccessory;
+    ftCo_MF_LiftMove | Ft_MF_KeepAccessory;
 static MotionFlags const ftCo_MF_LiftWalk ATTRIBUTE_USED =
-    ftCo_MF_LiftMove | FtStateChange_PreserveGfx | FtStateChange_UpdateCmd;
+    ftCo_MF_LiftMove | Ft_MF_KeepGfx | Ft_MF_UpdateCmd;
 static MotionFlags const ftCo_MF_ParasolFall ATTRIBUTE_USED =
-    ftCo_MF_ItemFall | FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_19;
+    ftCo_MF_ItemFall | Ft_MF_SkipItemVis | Ft_MF_Unk19;
 static MotionFlags const ftCo_MF_FireFlowerShoot ATTRIBUTE_USED =
-    ftCo_MF_ParasolFall | FtStateChange_PreserveGfx |
-    FtStateChange_SkipUpdateThrowException;
+    ftCo_MF_ParasolFall | Ft_MF_KeepGfx | Ft_MF_SkipThrowException;
 static MotionFlags const ftCo_MF_ItemScopeRapid ATTRIBUTE_USED =
-    ftCo_MF_ParasolFall | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_SkipUpdateThrowException | FtStateChange_Unk_19;
+    ftCo_MF_ParasolFall | Ft_MF_KeepColAnimHitStatus |
+    Ft_MF_SkipThrowException | Ft_MF_Unk19;
 static MotionFlags const ftCo_MF_FireFlowerShootAir ATTRIBUTE_USED =
-    ftCo_MF_FireFlowerShoot | FtStateChange_SkipUpdateParasol;
+    ftCo_MF_FireFlowerShoot | Ft_MF_SkipParasol;
 static MotionFlags const ftCo_MF_ItemScopeAirRapid ATTRIBUTE_USED =
-    ftCo_MF_ItemScopeRapid | FtStateChange_SkipUpdateParasol;
+    ftCo_MF_ItemScopeRapid | Ft_MF_SkipParasol;
 static MotionFlags const ftCo_MF_Dazed ATTRIBUTE_USED =
-    FtStateChange_Unk_UpdatePhys | FtStateChange_SkipUpdateModelPartVis;
+    Ft_MF_UnkUpdatePhys | Ft_MF_SkipModelPartVis;
 static MotionFlags const ftCo_MF_Damage ATTRIBUTE_USED =
-    ftCo_MF_Dazed | FtStateChange_PreserveSwordTrail;
+    ftCo_MF_Dazed | Ft_MF_KeepSwordTrail;
 static MotionFlags const ftCo_MF_DamageScrew ATTRIBUTE_USED =
-    ftCo_MF_Damage | FtStateChange_SkipUpdateNametagVis;
+    ftCo_MF_Damage | Ft_MF_SkipNametagVis;
 static MotionFlags const ftCo_MF_DamageScrewAir ATTRIBUTE_USED =
-    ftCo_MF_Damage | FtStateChange_PreserveColaNimPartHitStatus;
+    ftCo_MF_Damage | Ft_MF_KeepColAnimPartHitStatus;
 static MotionFlags const ftCo_MF_Down ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateHit | FtStateChange_SkipUpdateAnimVel |
-    FtStateChange_Unk_6 | FtStateChange_FreezeState |
-    FtStateChange_SkipUpdateModelPartVis;
+    Ft_MF_SkipHit | Ft_MF_SkipAnimVel | Ft_MF_Unk06 | Ft_MF_FreezeState |
+    Ft_MF_SkipModelPartVis;
 static MotionFlags const ftCo_MF_DownU ATTRIBUTE_USED =
-    ftCo_MF_Down | FtStateChange_PreserveColAnimHitStatus;
+    ftCo_MF_Down | Ft_MF_KeepColAnimHitStatus;
 static MotionFlags const ftCo_MF_DownD ATTRIBUTE_USED =
-    ftCo_MF_DownU | FtStateChange_PreserveFastFall;
+    ftCo_MF_DownU | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_DownDamageU ATTRIBUTE_USED =
-    ftCo_MF_DownU | FtStateChange_PreserveSwordTrail;
+    ftCo_MF_DownU | Ft_MF_KeepSwordTrail;
 static MotionFlags const ftCo_MF_DownDamageD ATTRIBUTE_USED =
-    ftCo_MF_DownD | FtStateChange_PreserveSwordTrail;
+    ftCo_MF_DownD | Ft_MF_KeepSwordTrail;
 static MotionFlags const ftCo_MF_DownAttack ATTRIBUTE_USED =
-    ftCo_MF_Attack | FtStateChange_SkipUpdateModel |
-    FtStateChange_SkipUpdateAnimVel | FtStateChange_SkipUpdateModelPartVis;
+    ftCo_MF_Attack | Ft_MF_SkipModel | Ft_MF_SkipAnimVel |
+    Ft_MF_SkipModelPartVis;
 static MotionFlags const ftCo_MF_DownAttackU ATTRIBUTE_USED =
-    ftCo_MF_DownAttack | FtStateChange_PreserveFastFall;
+    ftCo_MF_DownAttack | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_DownAttackD ATTRIBUTE_USED =
-    ftCo_MF_DownAttack | FtStateChange_PreserveGfx;
+    ftCo_MF_DownAttack | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_PassiveWall ATTRIBUTE_USED =
-    ftCo_MF_Dazed | FtStateChange_FreezeState;
+    ftCo_MF_Dazed | Ft_MF_FreezeState;
 static MotionFlags const ftCo_MF_Passive ATTRIBUTE_USED =
-    ftCo_MF_Down | FtStateChange_PreserveGfx |
-    FtStateChange_PreserveColAnimHitStatus | FtStateChange_Unk_UpdatePhys;
+    ftCo_MF_Down | Ft_MF_KeepGfx | Ft_MF_KeepColAnimHitStatus |
+    Ft_MF_UnkUpdatePhys;
 static MotionFlags const ftCo_MF_StopWall ATTRIBUTE_USED =
-    FtStateChange_PreserveFastFall | FtStateChange_PreserveGfx |
-    FtStateChange_SkipUpdateHit | FtStateChange_SkipUpdateAnimVel |
-    FtStateChange_Unk_6 | FtStateChange_SkipUpdateMetalB;
+    Ft_MF_KeepFastFall | Ft_MF_KeepGfx | Ft_MF_SkipHit | Ft_MF_SkipAnimVel |
+    Ft_MF_Unk06 | Ft_MF_SkipMetalB;
 static MotionFlags const ftCo_MF_Pass ATTRIBUTE_USED =
-    ftCo_MF_StopWall | FtStateChange_PreserveColAnimHitStatus;
+    ftCo_MF_StopWall | Ft_MF_KeepColAnimHitStatus;
 static MotionFlags const ftCo_MF_OttottoWait ATTRIBUTE_USED =
-    FtStateChange_Unk_19 | FtStateChange_SkipUpdateMetalB;
+    Ft_MF_Unk19 | Ft_MF_SkipMetalB;
 static MotionFlags const ftCo_MF_CliffAction ATTRIBUTE_USED =
-    FtStateChange_Unk_UpdatePhys | FtStateChange_SkipUpdateMetalB;
+    Ft_MF_UnkUpdatePhys | Ft_MF_SkipMetalB;
 static MotionFlags const ftCo_MF_CliffAction_4_5 ATTRIBUTE_USED =
-    ftCo_MF_CliffAction | FtStateChange_SkipUpdateModel |
-    FtStateChange_SkipUpdateAnimVel;
+    ftCo_MF_CliffAction | Ft_MF_SkipModel | Ft_MF_SkipAnimVel;
 static MotionFlags const ftCo_MF_CliffCatch ATTRIBUTE_USED =
-    ftCo_MF_CliffAction_4_5 | FtStateChange_Unk_6;
+    ftCo_MF_CliffAction_4_5 | Ft_MF_Unk06;
 static MotionFlags const ftCo_MF_CliffAttackSlow ATTRIBUTE_USED =
-    ftCo_MF_AttackBase | ftCo_MF_CliffAction_4_5 | FtStateChange_PreserveGfx |
-    FtStateChange_PreserveColAnimHitStatus | FtStateChange_SkipUpdateHit;
+    ftCo_MF_AttackBase | ftCo_MF_CliffAction_4_5 | Ft_MF_KeepGfx |
+    Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipHit;
 static MotionFlags const ftCo_MF_CliffWait ATTRIBUTE_USED =
-    ftCo_MF_CliffAction | FtStateChange_Unk_19;
+    ftCo_MF_CliffAction | Ft_MF_Unk19;
 static MotionFlags const ftCo_MF_CatchWait ATTRIBUTE_USED =
-    FtStateChange_FreezeState | FtStateChange_SkipUpdateMetalB;
+    Ft_MF_FreezeState | Ft_MF_SkipMetalB;
 static MotionFlags const ftCo_MF_CatchBase ATTRIBUTE_USED =
-    ftCo_MF_CatchWait | FtStateChange_SkipUpdateModel |
-    FtStateChange_SkipUpdateAnimVel;
+    ftCo_MF_CatchWait | Ft_MF_SkipModel | Ft_MF_SkipAnimVel;
 static MotionFlags const ftCo_MF_Catch ATTRIBUTE_USED =
-    ftCo_MF_CatchBase | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx;
+    ftCo_MF_CatchBase | Ft_MF_KeepFastFall | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_Throw ATTRIBUTE_USED =
-    ftCo_MF_CatchBase | FtStateChange_SkipUpdateItemVis;
+    ftCo_MF_CatchBase | Ft_MF_SkipItemVis;
 static MotionFlags const ftCo_MF_CatchAttack ATTRIBUTE_USED =
-    ftCo_MF_Throw | FtStateChange_PreserveColAnimHitStatus;
+    ftCo_MF_Throw | Ft_MF_KeepColAnimHitStatus;
 static MotionFlags const ftCo_MF_ThrowF ATTRIBUTE_USED =
-    ftCo_MF_CatchAttack | FtStateChange_PreserveFastFall;
+    ftCo_MF_CatchAttack | Ft_MF_KeepFastFall;
 static MotionFlags const ftCo_MF_ThrowB ATTRIBUTE_USED =
-    ftCo_MF_CatchAttack | FtStateChange_PreserveGfx;
+    ftCo_MF_CatchAttack | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_ThrowHi ATTRIBUTE_USED =
-    ftCo_MF_ThrowF | FtStateChange_PreserveGfx;
+    ftCo_MF_ThrowF | Ft_MF_KeepGfx;
 static MotionFlags const ftCo_MF_ThrowLw ATTRIBUTE_USED =
-    ftCo_MF_Throw | FtStateChange_SkipUpdateHit;
+    ftCo_MF_Throw | Ft_MF_SkipHit;
 static MotionFlags const ftCo_MF_Capture ATTRIBUTE_USED =
-    ftCo_MF_CatchWait | FtStateChange_Unk_UpdatePhys;
+    ftCo_MF_CatchWait | Ft_MF_UnkUpdatePhys;
 static MotionFlags const ftCo_MF_CaptureAir ATTRIBUTE_USED =
-    ftCo_MF_Capture | FtStateChange_SkipUpdateParasol;
+    ftCo_MF_Capture | Ft_MF_SkipParasol;
 static MotionFlags const ftCo_MF_Thrown ATTRIBUTE_USED =
-    ftCo_MF_Capture | FtStateChange_PreserveSwordTrail;
+    ftCo_MF_Capture | Ft_MF_KeepSwordTrail;
 static MotionFlags const ftCo_MF_ThrownAir ATTRIBUTE_USED =
-    ftCo_MF_Thrown | FtStateChange_SkipUpdateParasol;
+    ftCo_MF_Thrown | Ft_MF_SkipParasol;
 static MotionFlags const ftCo_MF_Shouldered ATTRIBUTE_USED =
-    ftCo_MF_Capture | FtStateChange_Unk_19;
+    ftCo_MF_Capture | Ft_MF_Unk19;
 static MotionFlags const ftCo_MF_Rebirth ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModelPartVis | FtStateChange_SkipUpdateMetalB;
+    Ft_MF_SkipModelPartVis | Ft_MF_SkipMetalB;
 static MotionFlags const ftCo_MF_ThrownStar ATTRIBUTE_USED =
-    ftCo_MF_Rebirth | FtStateChange_PreserveSwordTrail;
+    ftCo_MF_Rebirth | Ft_MF_KeepSwordTrail;
 static MotionFlags const ftCo_MF_Dead ATTRIBUTE_USED =
-    ftCo_MF_Dazed | FtStateChange_SkipUpdateMetalB;
+    ftCo_MF_Dazed | Ft_MF_SkipMetalB;
 static MotionFlags const ftCo_MF_Sleep ATTRIBUTE_USED =
-    ftCo_MF_Dead | FtStateChange_PreserveSwordTrail;
+    ftCo_MF_Dead | Ft_MF_KeepSwordTrail;
 static MotionFlags const ftCo_MF_Special ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_UpdatePhys | FtStateChange_FreezeState;
+    Ft_MF_SkipModel | Ft_MF_SkipItemVis | Ft_MF_UnkUpdatePhys |
+    Ft_MF_FreezeState;
 
 typedef enum ftCommon_MotionState {
     ftCo_MS_None = -1,

--- a/src/melee/ft/chara/ftCrazyHand/ftCh_Init.c
+++ b/src/melee/ft/chara/ftCrazyHand/ftCh_Init.c
@@ -12,7 +12,7 @@
 MotionState ftCh_Init_MotionStateTable[] = {
     {
         295,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_341_Anim,
         ftCh_MS_341_IASA,
@@ -22,7 +22,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         296,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_341_Anim,
         ftCh_MS_341_IASA,
@@ -32,7 +32,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         297,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_343_Anim,
         ftCh_MS_343_IASA,
@@ -42,7 +42,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         298,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_344_Anim,
         ftCh_MS_344_IASA,
@@ -52,7 +52,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         299,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_345_Anim,
         ftCh_MS_345_IASA,
@@ -62,7 +62,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         300,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_346_Anim,
         ftCh_MS_346_IASA,
@@ -72,7 +72,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         301,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_Slap_Anim,
         ftCh_Slap_IASA,
@@ -82,7 +82,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         302,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_348_Anim,
         ftCh_MS_348_IASA,
@@ -92,7 +92,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         303,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_Sweep_Anim,
         ftCh_Sweep_IASA,
@@ -102,7 +102,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         304,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_350_Anim,
         ftCh_MS_350_IASA,
@@ -112,7 +112,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         305,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_Walk_Anim,
         ftCh_Walk_IASA,
@@ -122,7 +122,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         306,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_352_Anim,
         ftCh_MS_352_IASA,
@@ -132,7 +132,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         307,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_353_Anim,
         ftCh_MS_353_IASA,
@@ -142,7 +142,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         308,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_Drill_Anim,
         ftCh_Drill_IASA,
@@ -152,7 +152,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         309,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_Punch_Anim,
         ftCh_Punch_IASA,
@@ -162,7 +162,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         310,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_356_Anim,
         ftCh_Punch_IASA,
@@ -172,7 +172,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         311,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_357_Anim,
         ftCh_MS_357_IASA,
@@ -182,7 +182,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         312,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_GroundSlap_Anim,
         ftCh_GroundSlap_IASA,
@@ -192,7 +192,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         313,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_Poke_Anim,
         ftCh_Poke_IASA,
@@ -202,7 +202,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         314,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_360_Anim,
         ftCh_MS_360_IASA,
@@ -212,7 +212,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         315,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_361_Anim,
         ftCh_MS_361_IASA,
@@ -222,7 +222,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         316,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_Lasers_Anim,
         ftCh_Lasers_IASA,
@@ -232,7 +232,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         317,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_363_Anim,
         ftCh_MS_363_IASA,
@@ -242,7 +242,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         318,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_364_Anim,
         ftCh_MS_364_IASA,
@@ -252,7 +252,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         319,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_Gun_Anim,
         ftCh_Gun_IASA,
@@ -262,7 +262,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         320,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_Gun_Anim,
         ftCh_Gun_IASA,
@@ -272,7 +272,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         321,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_Jet_Anim,
         ftCh_Jet_IASA,
@@ -282,7 +282,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         322,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_368_Anim,
         ftCh_MS_368_IASA,
@@ -292,7 +292,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         323,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_369_Anim,
         ftCh_MS_369_IASA,
@@ -302,7 +302,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         324,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_Ram_Anim,
         ftCh_Ram_IASA,
@@ -312,7 +312,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         325,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_Crush_Anim,
         ftCh_Crush_IASA,
@@ -322,7 +322,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         326,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_372_Anim,
         ftCh_MS_372_IASA,
@@ -332,7 +332,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         327,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_373_Anim,
         ftCh_MS_373_IASA,
@@ -342,7 +342,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         328,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_374_Anim,
         ftCh_MS_374_IASA,
@@ -352,7 +352,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         329,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_375_Anim,
         ftCh_MS_375_IASA,
@@ -362,7 +362,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         330,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_376_Anim,
         ftCh_MS_376_IASA,
@@ -372,7 +372,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         331,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_377_Anim,
         ftCh_MS_377_IASA,
@@ -382,7 +382,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         332,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_378_Anim,
         ftCh_MS_378_IASA,
@@ -392,7 +392,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         333,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_GrabUnk0_Anim,
         ftCh_GrabUnk0_IASA,
@@ -402,7 +402,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         334,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_GrabUnk1_Anim,
         ftCh_GrabUnk1_IASA,
@@ -412,7 +412,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         335,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_381_Anim,
         ftCh_MS_381_IASA,
@@ -422,7 +422,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         336,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_382_Anim,
         ftCh_MS_382_IASA,
@@ -432,7 +432,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         337,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_383_Anim,
         ftCh_MS_383_IASA,
@@ -442,7 +442,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         338,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_384_Anim,
         ftCh_MS_384_IASA,
@@ -452,7 +452,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         339,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_385_Anim,
         ftCh_MS_385_IASA,
@@ -462,7 +462,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         340,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_386_Anim,
         ftCh_MS_385_IASA,
@@ -472,7 +472,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         ftMh_MS_Unk341,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_387_Anim,
         ftCh_MS_387_IASA,
@@ -482,7 +482,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         ftMh_MS_Unk342,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_388_Anim,
         NULL,
@@ -492,7 +492,7 @@ MotionState ftCh_Init_MotionStateTable[] = {
     },
     {
         ftMh_MS_Unk343,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCh_MS_388_Anim,
         NULL,

--- a/src/melee/ft/chara/ftDonkey/forward.h
+++ b/src/melee/ft/chara/ftDonkey/forward.h
@@ -6,102 +6,91 @@
 #include "ftCommon/forward.h"
 
 static MotionFlags const ftDk_MF_Special ATTRIBUTE_USED =
-    ftCo_MF_Special | FtStateChange_SkipUpdateModel |
-    FtStateChange_PreserveSfx | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_UpdatePhys | FtStateChange_FreezeState;
+    ftCo_MF_Special | Ft_MF_SkipModel | Ft_MF_KeepSfx | Ft_MF_SkipItemVis |
+    Ft_MF_UnkUpdatePhys | Ft_MF_FreezeState;
 
 static MotionFlags const ftDk_MF_SpecialN ATTRIBUTE_USED =
-    ftDk_MF_Special | FtStateChange_PreserveFastFall;
+    ftDk_MF_Special | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftDk_MF_SpecialS ATTRIBUTE_USED =
-    ftDk_MF_Special | FtStateChange_PreserveGfx;
+    ftDk_MF_Special | Ft_MF_KeepGfx;
 
 static MotionFlags const ftDk_MF_SpecialHi ATTRIBUTE_USED =
-    ftDk_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx;
+    ftDk_MF_Special | Ft_MF_KeepFastFall | Ft_MF_KeepGfx;
 
 static MotionFlags const ftDk_MF_SpecialLwStart ATTRIBUTE_USED =
-    ftDk_MF_Special | FtStateChange_PreserveColAnimHitStatus;
+    ftDk_MF_Special | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftDk_MF_SpecialAirN ATTRIBUTE_USED =
-    ftDk_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateParasol;
+    ftDk_MF_Special | Ft_MF_KeepFastFall | Ft_MF_SkipParasol;
 
 static MotionFlags const ftDk_MF_SpecialAirS ATTRIBUTE_USED =
-    ftDk_MF_Special | FtStateChange_PreserveGfx |
-    FtStateChange_SkipUpdateParasol;
+    ftDk_MF_Special | Ft_MF_KeepGfx | Ft_MF_SkipParasol;
 
 static MotionFlags const ftDk_MF_SpecialAirHi ATTRIBUTE_USED =
-    ftDk_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateParasol;
+    ftDk_MF_Special | Ft_MF_KeepFastFall | Ft_MF_KeepGfx | Ft_MF_SkipParasol;
 
 static MotionFlags const ftDk_MF_MS_386 ATTRIBUTE_USED =
-    ftDk_MF_Special | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_SkipUpdateParasol;
+    ftDk_MF_Special | Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipParasol;
 
 static MotionFlags const ftDk_MF_SpecialLw ATTRIBUTE_USED =
-    ftDk_MF_Special | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_Unk_19;
+    ftDk_MF_Special | Ft_MF_KeepColAnimHitStatus | Ft_MF_Unk19;
 
 static MotionFlags const ftDk_MF_MS_350 ATTRIBUTE_USED =
-    FtStateChange_PreserveSwordTrail | FtStateChange_Unk_19 |
-    FtStateChange_SkipUpdateModelPartVis;
+    Ft_MF_KeepSwordTrail | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis;
 
 static MotionFlags const ftDk_MF_Cargo ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateAnimVel |
-    FtStateChange_FreezeState | FtStateChange_SkipUpdateMetalB;
+    Ft_MF_SkipModel | Ft_MF_SkipAnimVel | Ft_MF_FreezeState | Ft_MF_SkipMetalB;
 
 static MotionFlags const ftDk_MF_CargoThrow ATTRIBUTE_USED =
-    ftDk_MF_Cargo | FtStateChange_SkipUpdateHit |
-    FtStateChange_SkipUpdateItemVis;
+    ftDk_MF_Cargo | Ft_MF_SkipHit | Ft_MF_SkipItemVis;
 
 static MotionFlags const ftDk_MF_CargoThrowF ATTRIBUTE_USED =
-    ftDk_MF_CargoThrow | FtStateChange_PreserveFastFall;
+    ftDk_MF_CargoThrow | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftDk_MF_CargoThrowB ATTRIBUTE_USED =
-    ftDk_MF_CargoThrow | FtStateChange_PreserveGfx;
+    ftDk_MF_CargoThrow | Ft_MF_KeepGfx;
 
 static MotionFlags const ftDk_MF_CargoThrowU ATTRIBUTE_USED =
-    ftDk_MF_CargoThrow | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx;
+    ftDk_MF_CargoThrow | Ft_MF_KeepFastFall | Ft_MF_KeepGfx;
 
 static MotionFlags const ftDk_MF_CargoThrowD ATTRIBUTE_USED =
-    ftDk_MF_CargoThrow | FtStateChange_PreserveColAnimHitStatus;
+    ftDk_MF_CargoThrow | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftDk_MF_CargoWait ATTRIBUTE_USED =
-    ftDk_MF_Cargo | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveColAnimHitStatus | FtStateChange_Unk_19;
+    ftDk_MF_Cargo | Ft_MF_KeepFastFall | Ft_MF_KeepColAnimHitStatus |
+    Ft_MF_Unk19;
 
 static MotionFlags const ftDk_MF_CargoTurn ATTRIBUTE_USED =
-    ftDk_MF_CargoWait | FtStateChange_PreserveAccessory;
+    ftDk_MF_CargoWait | Ft_MF_KeepAccessory;
 
 static MotionFlags const ftDk_MF_CargoWalk ATTRIBUTE_USED =
-    ftDk_MF_CargoWait | FtStateChange_UpdateCmd;
+    ftDk_MF_CargoWait | Ft_MF_UpdateCmd;
 
 static MotionFlags const ftDk_MF_CargoJump ATTRIBUTE_USED =
-    ftDk_MF_CargoWait | FtStateChange_SkipUpdateNametagVis;
+    ftDk_MF_CargoWait | Ft_MF_SkipNametagVis;
 
 static MotionFlags const ftDk_MF_MS_360 ATTRIBUTE_USED =
-    ftDk_MF_CargoWait | FtStateChange_PreserveSwordTrail;
+    ftDk_MF_CargoWait | Ft_MF_KeepSwordTrail;
 
 static MotionFlags const ftDk_MF_MS_341 ATTRIBUTE_USED =
-    FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis;
+    Ft_MF_Unk19 | Ft_MF_SkipModelPartVis;
 
 static MotionFlags const ftDk_MF_Move_53 ATTRIBUTE_USED =
-    ftDk_MF_MS_341 | FtStateChange_SkipUpdateAnimVel | FtStateChange_Unk_6;
+    ftDk_MF_MS_341 | Ft_MF_SkipAnimVel | Ft_MF_Unk06;
 
 static MotionFlags const ftDk_MF_MS_342_Base ATTRIBUTE_USED =
-    ftDk_MF_Move_53 | FtStateChange_PreserveColAnimHitStatus;
+    ftDk_MF_Move_53 | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftDk_MF_MS_342 ATTRIBUTE_USED =
-    ftDk_MF_MS_342_Base | FtStateChange_PreserveGfx | FtStateChange_UpdateCmd;
+    ftDk_MF_MS_342_Base | Ft_MF_KeepGfx | Ft_MF_UpdateCmd;
 
 static MotionFlags const ftDk_MF_MS_345 ATTRIBUTE_USED =
-    ftDk_MF_MS_342_Base | FtStateChange_PreserveAccessory;
+    ftDk_MF_MS_342_Base | Ft_MF_KeepAccessory;
 
 static MotionFlags const ftDk_MF_MS_348 ATTRIBUTE_USED =
-    ftDk_MF_Move_53 | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateHit | FtStateChange_SkipUpdateNametagVis;
+    ftDk_MF_Move_53 | Ft_MF_KeepFastFall | Ft_MF_SkipHit |
+    Ft_MF_SkipNametagVis;
 
 typedef enum ftDk_MotionState {
     ftDk_MS_Unk341 = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftDrMario/forward.h
+++ b/src/melee/ft/chara/ftDrMario/forward.h
@@ -4,7 +4,6 @@
 #include "ft/forward.h"
 
 static MotionFlags const ftDr_MF_Appeal ATTRIBUTE_USED =
-    FtStateChange_PreserveFastFall | FtStateChange_SkipUpdateModel |
-    FtStateChange_SkipUpdateAnimVel | FtStateChange_Unk_6;
+    Ft_MF_KeepFastFall | Ft_MF_SkipModel | Ft_MF_SkipAnimVel | Ft_MF_Unk06;
 
 #endif

--- a/src/melee/ft/chara/ftFox/forward.h
+++ b/src/melee/ft/chara/ftFox/forward.h
@@ -5,50 +5,47 @@
 #include "ftCommon/forward.h"
 
 static MotionFlags const ftFx_MF_Appeal ATTRIBUTE_USED =
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateModel |
-    FtStateChange_SkipUpdateAnimVel | FtStateChange_Unk_6;
+    Ft_MF_KeepGfx | Ft_MF_SkipModel | Ft_MF_SkipAnimVel | Ft_MF_Unk06;
 
 static MotionFlags const ftFx_MF_Special ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_UpdatePhys | FtStateChange_FreezeState;
+    Ft_MF_SkipModel | Ft_MF_SkipItemVis | Ft_MF_UnkUpdatePhys |
+    Ft_MF_FreezeState;
 
 static MotionFlags const ftFx_MF_SpecialN ATTRIBUTE_USED =
-    ftFx_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateThrowException;
+    ftFx_MF_Special | Ft_MF_KeepFastFall | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftFx_MF_SpecialS ATTRIBUTE_USED =
-    ftFx_MF_Special | FtStateChange_PreserveGfx | FtStateChange_PreserveSfx;
+    ftFx_MF_Special | Ft_MF_KeepGfx | Ft_MF_KeepSfx;
 
 static MotionFlags const ftFx_MF_SpecialHi ATTRIBUTE_USED =
-    ftFx_MF_SpecialS | FtStateChange_PreserveFastFall;
+    ftFx_MF_SpecialS | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftFx_MF_SpecialAirN ATTRIBUTE_USED =
-    ftFx_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftFx_MF_SpecialN | Ft_MF_SkipParasol;
 
 static MotionFlags const ftFx_MF_SpecialAirS ATTRIBUTE_USED =
-    ftFx_MF_SpecialS | FtStateChange_SkipUpdateParasol;
+    ftFx_MF_SpecialS | Ft_MF_SkipParasol;
 
 static MotionFlags const ftFx_MF_SpecialAirHiHold ATTRIBUTE_USED =
-    ftFx_MF_SpecialHi | FtStateChange_SkipUpdateParasol;
+    ftFx_MF_SpecialHi | Ft_MF_SkipParasol;
 
 static MotionFlags const ftFx_MF_SpecialLw ATTRIBUTE_USED =
-    ftFx_MF_Special | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_SkipUpdateColAnim;
+    ftFx_MF_Special | Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipColAnim;
 
 static MotionFlags const ftFx_MF_SpecialAirLw ATTRIBUTE_USED =
-    ftFx_MF_SpecialLw | FtStateChange_SkipUpdateParasol;
+    ftFx_MF_SpecialLw | Ft_MF_SkipParasol;
 
 static MotionFlags const ftFx_MF_SpecialNLoop ATTRIBUTE_USED =
-    ftFx_MF_SpecialN | FtStateChange_Unk_19;
+    ftFx_MF_SpecialN | Ft_MF_Unk19;
 
 static MotionFlags const ftFx_MF_SpecialAirNLoop ATTRIBUTE_USED =
-    ftFx_MF_SpecialNLoop | FtStateChange_SkipUpdateParasol;
+    ftFx_MF_SpecialNLoop | Ft_MF_SkipParasol;
 
 static MotionFlags const ftFx_MF_SpecialLwLoop ATTRIBUTE_USED =
-    ftFx_MF_SpecialLw | FtStateChange_Unk_19;
+    ftFx_MF_SpecialLw | Ft_MF_Unk19;
 
 static MotionFlags const ftFx_MF_SpecialAirLwLoop ATTRIBUTE_USED =
-    ftFx_MF_SpecialLwLoop | FtStateChange_SkipUpdateParasol;
+    ftFx_MF_SpecialLwLoop | Ft_MF_SkipParasol;
 
 typedef enum ftFox_MotionState {
     ftFx_MS_SpecialNStart = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftFox/ftFx_SpecialHi.c
+++ b/src/melee/ft/chara/ftFox/ftFx_SpecialHi.c
@@ -18,11 +18,9 @@
 #include <baselib/gobjproc.h>
 
 #define FTFOX_SPECIALHI_COLL_FLAG                                             \
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateMatAnim |             \
-        FtStateChange_UpdateCmd | FtStateChange_SkipUpdateColAnim |           \
-        FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_19 |              \
-        FtStateChange_SkipUpdateModelPartVis |                                \
-        FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27
+    Ft_MF_KeepGfx | Ft_MF_SkipMatAnim | Ft_MF_UpdateCmd | Ft_MF_SkipColAnim | \
+        Ft_MF_SkipItemVis | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |            \
+        Ft_MF_SkipModelFlags | Ft_MF_Unk27
 
 /// @todo Move elsewhere.
 #define HALF_PI32 (1.5707963705062866f)
@@ -428,10 +426,9 @@ void ftFx_SpecialHi_GroundToAir(HSD_GObj* gobj)
 
     ftCommon_8007D60C(fp);
 
-    Fighter_ChangeMotionState(
-        gobj, ftFx_MS_SpecialAirHi,
-        (FtStateChange_SkipUpdateHit | FTFOX_SPECIALHI_COLL_FLAG), NULL,
-        fp->x894_currentAnimFrame, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirHi,
+                              (Ft_MF_SkipHit | FTFOX_SPECIALHI_COLL_FLAG),
+                              NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
 
     fp->x2223_flag.bits.b4 = true;
     fp->cb.x21BC_callback_Accessory4 = ftFx_SpecialHi_CreateLaunchGFX;
@@ -670,10 +667,9 @@ void ftFx_SpecialHiFall_Coll(HSD_GObj* gobj)
 void ftFx_SpecialHiFall_Enter(HSD_GObj* gobj)
 {
     ftCommon_8007D7FC(GET_FIGHTER(gobj));
-    Fighter_ChangeMotionState(
-        gobj, ftFx_MS_SpecialHiEnd,
-        (FtStateChange_SkipUpdateColAnim | FtStateChange_UpdateCmd), NULL,
-        13.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialHiEnd,
+                              (Ft_MF_SkipColAnim | Ft_MF_UpdateCmd), NULL,
+                              13.0f, 1.0f, 0.0f);
     ftAnim_8006EBA4(gobj);
 }
 

--- a/src/melee/ft/chara/ftFox/ftFx_SpecialLw.c
+++ b/src/melee/ft/chara/ftFox/ftFx_SpecialLw.c
@@ -18,11 +18,9 @@
 #include <dolphin/mtx/types.h>
 
 #define FTFOX_SPECIALLW_COLL_FLAG                                             \
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateMatAnim |             \
-        FtStateChange_UpdateCmd | FtStateChange_SkipUpdateColAnim |           \
-        FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_19 |              \
-        FtStateChange_SkipUpdateModelPartVis |                                \
-        FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27
+    Ft_MF_KeepGfx | Ft_MF_SkipMatAnim | Ft_MF_UpdateCmd | Ft_MF_SkipColAnim | \
+        Ft_MF_SkipItemVis | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |            \
+        Ft_MF_SkipModelFlags | Ft_MF_Unk27
 
 void ftFx_SpecialLw_CreateLoopGFX(HSD_GObj* gobj)
 {
@@ -448,8 +446,8 @@ static void ftFx_SpecialLw_CreateReflectHit(HSD_GObj* gobj)
 
 static void ftFx_SpecialLwLoop_Enter(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwLoop,
-                              FtStateChange_PreserveGfx, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwLoop, Ft_MF_KeepGfx, NULL,
+                              0, 1, 0);
 
     ftFx_SpecialLw_CreateReflectHit(gobj);
 }
@@ -457,8 +455,8 @@ static void ftFx_SpecialLwLoop_Enter(HSD_GObj* gobj)
 /// Fox & Falco's aerial Reflector Loop Motion State handler
 static void ftFx_SpecialAirLwLoop_Enter(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwLoop,
-                              FtStateChange_PreserveGfx, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwLoop, Ft_MF_KeepGfx,
+                              NULL, 0, 1, 0);
 
     ftFx_SpecialLw_CreateReflectHit(gobj);
 }
@@ -688,13 +686,11 @@ bool ftFx_SpecialLwTurn_Check(HSD_GObj* gobj)
     if (ft_800C97A8(gobj) != false) {
         if ((s32) fp->ground_or_air == GA_Ground) {
             Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwTurn,
-                                      FtStateChange_PreserveGfx, NULL, 0, 1,
-                                      0);
+                                      Ft_MF_KeepGfx, NULL, 0, 1, 0);
             ftFox_SpecialLwTurn_SetVarAll(gobj);
         } else {
             Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwTurn,
-                                      FtStateChange_PreserveGfx, NULL, 0, 1,
-                                      0);
+                                      Ft_MF_KeepGfx, NULL, 0, 1, 0);
             ftFox_SpecialLwTurn_SetVarAll(gobj);
         }
         fp->cb.x21BC_callback_Accessory4 = ftFx_SpecialLw_CreateLoopGFX;
@@ -730,12 +726,12 @@ bool ftFx_SpecialLwHit_Check(HSD_GObj* gobj)
         return false;
     }
     if ((s32) fp->ground_or_air == GA_Ground) {
-        Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwLoop,
-                                  FtStateChange_PreserveGfx, NULL, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwLoop, Ft_MF_KeepGfx,
+                                  NULL, 0, 1, 0);
         ftFox_SpecialLwHit_CreateReflectInline(gobj);
     } else {
         Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwLoop,
-                                  FtStateChange_PreserveGfx, NULL, 0, 1, 0);
+                                  Ft_MF_KeepGfx, NULL, 0, 1, 0);
         ftFox_SpecialLwHit_CreateReflectInline(gobj);
     }
     return true;
@@ -1020,10 +1016,9 @@ void ftFx_SpecialLwEnd_GroundToAir(HSD_GObj* gobj)
     Fighter* fp = gobj->user_data;
 
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(
-        gobj, ftFx_MS_SpecialAirLwEnd,
-        (FtStateChange_SkipUpdateColAnim | FtStateChange_UpdateCmd), NULL,
-        fp->x894_currentAnimFrame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwEnd,
+                              (Ft_MF_SkipColAnim | Ft_MF_UpdateCmd), NULL,
+                              fp->x894_currentAnimFrame, 1, 0);
 }
 
 // 0x800E9D24
@@ -1034,10 +1029,9 @@ void ftFx_SpecialAirLwEnd_AirToGround(HSD_GObj* gobj)
     Fighter* fp = gobj->user_data;
 
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(
-        gobj, ftFx_MS_SpecialLwEnd,
-        (FtStateChange_SkipUpdateColAnim | FtStateChange_UpdateCmd), NULL,
-        fp->x894_currentAnimFrame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwEnd,
+                              (Ft_MF_SkipColAnim | Ft_MF_UpdateCmd), NULL,
+                              fp->x894_currentAnimFrame, 1, 0);
     ftCommon_8007D468(fp);
 }
 

--- a/src/melee/ft/chara/ftFox/ftFx_SpecialN.c
+++ b/src/melee/ft/chara/ftFox/ftFx_SpecialN.c
@@ -333,10 +333,9 @@ void ftFx_SpecialNStart_Anim(HSD_GObj* gobj)
         it_802AE538(fp->fv.fx.x222C_blasterGObj);
     }
     if (!ftAnim_IsFramesRemaining(gobj)) {
-        Fighter_ChangeMotionState(
-            gobj, ftFx_MS_SpecialNLoop,
-            (FtStateChange_SkipUpdateModel | FtStateChange_PreserveGfx), NULL,
-            0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialNLoop,
+                                  (Ft_MF_SkipModel | Ft_MF_KeepGfx), NULL, 0,
+                                  1, 0);
         ftFox_SpecialN_SetCall(gobj);
         fp->cb.x21BC_callback_Accessory4 = ftFx_SpecialN_CreateBlasterShot;
         it_802ADDD0(fp->fv.fx.x222C_blasterGObj, 1);
@@ -360,21 +359,19 @@ void ftFx_SpecialNLoop_Anim(HSD_GObj* gobj)
     if (!ftAnim_IsFramesRemaining(gobj)) {
         if ((s32) temp_r28->mv.fx.SpecialN.isBlasterLoop == true) {
             temp_r28->cb.x21EC_callback = ftFx_SpecialN_OnChangeAction;
-            Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialNLoop,
-                                      (FtStateChange_SkipUpdateAttackCount |
-                                       FtStateChange_SkipUpdateModel |
-                                       FtStateChange_PreserveGfx),
-                                      NULL, 0, 1, 0);
+            Fighter_ChangeMotionState(
+                gobj, ftFx_MS_SpecialNLoop,
+                (Ft_MF_SkipAttackCount | Ft_MF_SkipModel | Ft_MF_KeepGfx),
+                NULL, 0, 1, 0);
             temp_r28->cb.x21BC_callback_Accessory4 =
                 ftFx_SpecialN_CreateBlasterShot;
             temp_r28->mv.fx.SpecialN.isBlasterLoop = false;
             it_802ADDD0(temp_r28->fv.fx.x222C_blasterGObj, 1);
         } else {
             HSD_GObj* temp;
-            Fighter_ChangeMotionState(
-                gobj, ftFx_MS_SpecialNEnd,
-                (FtStateChange_SkipUpdateModel | FtStateChange_PreserveGfx),
-                NULL, 0, 1, 0);
+            Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialNEnd,
+                                      (Ft_MF_SkipModel | Ft_MF_KeepGfx), NULL,
+                                      0, 1, 0);
             temp = temp_r28->fv.fx.x222C_blasterGObj;
             temp_r28->x2204_ftcmd_var1 = 1;
             it_802ADDD0(temp, 1);
@@ -493,10 +490,9 @@ void ftFx_SpecialAirNStart_Anim(HSD_GObj* gobj)
         it_802AE538(fp->fv.fx.x222C_blasterGObj);
     }
     if (!ftAnim_IsFramesRemaining(gobj)) {
-        Fighter_ChangeMotionState(
-            gobj, ftFx_MS_SpecialAirNLoop,
-            (FtStateChange_SkipUpdateModel | FtStateChange_PreserveGfx), NULL,
-            0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirNLoop,
+                                  (Ft_MF_SkipModel | Ft_MF_KeepGfx), NULL, 0,
+                                  1, 0);
         ftFox_SpecialN_SetCall(gobj);
         fp->cb.x21BC_callback_Accessory4 = ftFx_SpecialN_CreateBlasterShot;
         it_802ADDD0(fp->fv.fx.x222C_blasterGObj, 1);
@@ -520,11 +516,10 @@ void ftFx_SpecialAirNLoop_Anim(HSD_GObj* gobj)
     if (!ftAnim_IsFramesRemaining(gobj)) {
         if ((s32) fp->mv.fx.SpecialN.isBlasterLoop == true) {
             fp->cb.x21EC_callback = ftFx_SpecialN_OnChangeAction;
-            Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirNLoop,
-                                      (FtStateChange_SkipUpdateAttackCount |
-                                       FtStateChange_SkipUpdateModel |
-                                       FtStateChange_PreserveGfx),
-                                      NULL, 0, 1, 0);
+            Fighter_ChangeMotionState(
+                gobj, ftFx_MS_SpecialAirNLoop,
+                (Ft_MF_SkipAttackCount | Ft_MF_SkipModel | Ft_MF_KeepGfx),
+                NULL, 0, 1, 0);
             ftFox_SpecialN_SetCall(gobj);
             fp->cb.x21BC_callback_Accessory4 = ftFx_SpecialN_CreateBlasterShot;
             fp->mv.fx.SpecialN.isBlasterLoop = false;
@@ -532,10 +527,9 @@ void ftFx_SpecialAirNLoop_Anim(HSD_GObj* gobj)
         } else {
             HSD_GObj* temp;
 
-            Fighter_ChangeMotionState(
-                gobj, ftFx_MS_SpecialAirNEnd,
-                (FtStateChange_SkipUpdateModel | FtStateChange_PreserveGfx),
-                NULL, 0, 1, 0);
+            Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirNEnd,
+                                      (Ft_MF_SkipModel | Ft_MF_KeepGfx), NULL,
+                                      0, 1, 0);
             ftFox_SpecialN_SetCall(gobj);
 
             temp = fp->fv.fx.x222C_blasterGObj;

--- a/src/melee/ft/chara/ftFox/ftFx_SpecialS.c
+++ b/src/melee/ft/chara/ftFox/ftFx_SpecialS.c
@@ -15,11 +15,9 @@
 #include "it/it_27CF.h"
 
 #define FTFOX_SPECIALS_COLL_FLAG                                              \
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_SkipUpdateRumble |        \
-        FtStateChange_UpdateCmd | FtStateChange_SkipUpdateColAnim |           \
-        FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_19 |              \
-        FtStateChange_SkipUpdateModelPartVis |                                \
-        FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27
+    Ft_MF_SkipMatAnim | Ft_MF_SkipRumble | Ft_MF_UpdateCmd |                  \
+        Ft_MF_SkipColAnim | Ft_MF_SkipItemVis | Ft_MF_Unk19 |                 \
+        Ft_MF_SkipModelPartVis | Ft_MF_SkipModelFlags | Ft_MF_Unk27
 
 // 0x800E9DF8
 // https://decomp.me/scratch/5Qwzg // Create Fox Illusion / Falco Phantasm GFX
@@ -423,8 +421,8 @@ void ftFx_SpecialS_GroundToAir(HSD_GObj* gobj)
     ftCommon_8007D60C(fp);
     Fighter_ChangeMotionState(
         gobj, ftFx_MS_SpecialAirS,
-        (FtStateChange_PreserveColAnimHitStatus | FTFOX_SPECIALS_COLL_FLAG),
-        NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
+        (Ft_MF_KeepColAnimHitStatus | FTFOX_SPECIALS_COLL_FLAG), NULL,
+        fp->x894_currentAnimFrame, 1.0f, 0.0f);
     fp->x2208_ftcmd_var2 = 0;
 }
 
@@ -438,8 +436,8 @@ void ftFx_SpecialAirS_AirToGround(HSD_GObj* gobj)
     ftCommon_8007D7FC(fp);
     Fighter_ChangeMotionState(
         gobj, ftFx_MS_SpecialS,
-        (FtStateChange_PreserveColAnimHitStatus | FTFOX_SPECIALS_COLL_FLAG),
-        NULL, fp->x894_currentAnimFrame, 1.0f, 0.0f);
+        (Ft_MF_KeepColAnimHitStatus | FTFOX_SPECIALS_COLL_FLAG), NULL,
+        fp->x894_currentAnimFrame, 1.0f, 0.0f);
     fp->x2208_ftcmd_var2 = 0;
 }
 
@@ -473,9 +471,8 @@ void ftFx_SpecialS_Enter(HSD_GObj* gobj)
     u8 _[28];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialS,
-                              FtStateChange_SkipUpdateRumble, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialS, Ft_MF_SkipRumble, NULL,
+                              0.0f, 1.0f, 0.0f);
     ftFox_SpecialS_SetVars(gobj);
 }
 
@@ -489,9 +486,8 @@ void ftFx_SpecialAirS_Enter(HSD_GObj* gobj)
     u8 _[36];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirS,
-                              FtStateChange_SkipUpdateRumble, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirS, Ft_MF_SkipRumble,
+                              NULL, 0.0f, 1.0f, 0.0f);
     ftFox_SpecialS_SetVars(gobj);
 }
 
@@ -639,9 +635,8 @@ void ftFx_SpecialSEnd_Enter(HSD_GObj* gobj)
 
     fp->gr_vel = foxAttrs->x34_FOX_ILLUSION_GROUND_END_VEL_X * fp->facing_dir;
 
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialSEnd,
-                              FtStateChange_SkipUpdateRumble, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialSEnd, Ft_MF_SkipRumble,
+                              NULL, 0.0f, 1.0f, 0.0f);
     ftFox_SpecialSEnd_SetVars(gobj);
 }
 
@@ -656,8 +651,7 @@ void ftFx_SpecialAirSEnd_Enter(HSD_GObj* gobj)
         foxAttrs->x3C_FOX_ILLUSION_AIR_END_VEL_X * fp->facing_dir;
     fp->x80_self_vel.y = 0.0f;
 
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirSEnd,
-                              FtStateChange_SkipUpdateRumble, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirSEnd, Ft_MF_SkipRumble,
+                              NULL, 0.0f, 1.0f, 0.0f);
     ftFox_SpecialSEnd_SetVars(gobj);
 }

--- a/src/melee/ft/chara/ftGameWatch/forward.h
+++ b/src/melee/ft/chara/ftGameWatch/forward.h
@@ -5,79 +5,74 @@
 #include "ftCommon/forward.h"
 
 static MotionFlags const ftGw_MF_Base ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateItemVis | FtStateChange_FreezeState;
+    Ft_MF_SkipItemVis | Ft_MF_FreezeState;
 
 static MotionFlags const ftGw_MF_Landing ATTRIBUTE_USED =
-    FtStateChange_PreserveColAnimHitStatus | FtStateChange_SkipUpdateHit |
-    FtStateChange_PreserveSfx | FtStateChange_SkipUpdateParasol;
+    Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipHit | Ft_MF_KeepSfx |
+    Ft_MF_SkipParasol;
 
 static MotionFlags const ftGw_MF_LandingAirB ATTRIBUTE_USED =
-    ftGw_MF_Landing | FtStateChange_PreserveGfx;
+    ftGw_MF_Landing | Ft_MF_KeepGfx;
 
 static MotionFlags const ftGw_MF_LandingAirHi ATTRIBUTE_USED =
-    ftGw_MF_LandingAirB | FtStateChange_PreserveFastFall;
+    ftGw_MF_LandingAirB | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftGw_MF_Attack ATTRIBUTE_USED =
-    ftGw_MF_Base | FtStateChange_PreserveSfx;
+    ftGw_MF_Base | Ft_MF_KeepSfx;
 
 static MotionFlags const ftGw_MF_AttackLw3 ATTRIBUTE_USED =
-    ftGw_MF_Attack | FtStateChange_SkipUpdateHit;
+    ftGw_MF_Attack | Ft_MF_SkipHit;
 
 static MotionFlags const ftGw_MF_AttackAirN ATTRIBUTE_USED =
     ftGw_MF_Attack | ftGw_MF_Landing;
 
 static MotionFlags const ftGw_MF_AttackAirB ATTRIBUTE_USED =
-    ftGw_MF_AttackAirN | FtStateChange_PreserveGfx;
+    ftGw_MF_AttackAirN | Ft_MF_KeepGfx;
 
 static MotionFlags const ftGw_MF_AttackAirHi ATTRIBUTE_USED =
-    ftGw_MF_AttackAirB | FtStateChange_PreserveFastFall;
+    ftGw_MF_AttackAirB | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftGw_MF_AttackS4 ATTRIBUTE_USED =
-    ftGw_MF_AttackLw3 | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateRumble;
+    ftGw_MF_AttackLw3 | Ft_MF_KeepFastFall | Ft_MF_SkipRumble;
 
 static MotionFlags const ftGw_MF_Attack11 ATTRIBUTE_USED =
-    ftGw_MF_Attack | FtStateChange_PreserveFastFall | FtStateChange_Unk_19;
+    ftGw_MF_Attack | Ft_MF_KeepFastFall | Ft_MF_Unk19;
 
 static MotionFlags const ftGw_MF_Attack100 ATTRIBUTE_USED =
-    ftGw_MF_Attack | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_Unk_19;
+    ftGw_MF_Attack | Ft_MF_KeepColAnimHitStatus | Ft_MF_Unk19;
 
 static MotionFlags const ftGw_MF_Special ATTRIBUTE_USED =
-    ftGw_MF_Base | FtStateChange_SkipUpdateModel |
-    FtStateChange_Unk_UpdatePhys;
+    ftGw_MF_Base | Ft_MF_SkipModel | Ft_MF_UnkUpdatePhys;
 
 static MotionFlags const ftGw_MF_SpecialS ATTRIBUTE_USED =
-    ftGw_MF_Special | FtStateChange_PreserveGfx;
+    ftGw_MF_Special | Ft_MF_KeepGfx;
 
 static MotionFlags const ftGw_MF_SpecialHi ATTRIBUTE_USED =
-    ftGw_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx;
+    ftGw_MF_Special | Ft_MF_KeepFastFall | Ft_MF_KeepGfx;
 
 static MotionFlags const ftGw_MF_SpecialLwCatch ATTRIBUTE_USED =
-    ftGw_MF_Special | FtStateChange_PreserveColAnimHitStatus;
+    ftGw_MF_Special | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftGw_MF_SpecialN ATTRIBUTE_USED =
-    ftGw_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateThrowException;
+    ftGw_MF_Special | Ft_MF_KeepFastFall | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftGw_MF_SpecialAirS ATTRIBUTE_USED =
-    ftGw_MF_SpecialS | FtStateChange_SkipUpdateParasol;
+    ftGw_MF_SpecialS | Ft_MF_SkipParasol;
 
 static MotionFlags const ftGw_MF_SpecialAirHi ATTRIBUTE_USED =
-    ftGw_MF_SpecialHi | FtStateChange_SkipUpdateParasol;
+    ftGw_MF_SpecialHi | Ft_MF_SkipParasol;
 
 static MotionFlags const ftGw_MF_SpecialAirLwCatch ATTRIBUTE_USED =
-    ftGw_MF_SpecialLwCatch | FtStateChange_SkipUpdateParasol;
+    ftGw_MF_SpecialLwCatch | Ft_MF_SkipParasol;
 
 static MotionFlags const ftGw_MF_SpecialAirN ATTRIBUTE_USED =
-    ftGw_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftGw_MF_SpecialN | Ft_MF_SkipParasol;
 
 static MotionFlags const ftGw_MF_SpecialLw ATTRIBUTE_USED =
-    ftGw_MF_SpecialLwCatch | FtStateChange_Unk_19;
+    ftGw_MF_SpecialLwCatch | Ft_MF_Unk19;
 
 static MotionFlags const ftGw_MF_SpecialAirLw ATTRIBUTE_USED =
-    ftGw_MF_SpecialLw | FtStateChange_SkipUpdateParasol;
+    ftGw_MF_SpecialLw | Ft_MF_SkipParasol;
 
 // Mr. Game & Watch Motion State IDs
 typedef enum ftGameWatch_MotionState {

--- a/src/melee/ft/chara/ftGameWatch/ftGw_SpecialLw.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGw_SpecialLw.c
@@ -389,12 +389,10 @@ static inline void ftGameWatch_SpecialLw_UpdateVarsColl(HSD_GObj* gobj)
 }
 
 static u32 const transition_flags0 =
-    FtStateChange_PreserveGfx | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_SkipUpdateHit | FtStateChange_SkipUpdateMatAnim |
-    FtStateChange_SkipUpdateColAnim | FtStateChange_UpdateCmd |
-    FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_19 |
-    FtStateChange_SkipUpdateModelPartVis | FtStateChange_SkipUpdateModelFlag |
-    FtStateChange_Unk_27;
+    Ft_MF_KeepGfx | Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipHit |
+    Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim | Ft_MF_UpdateCmd |
+    Ft_MF_SkipItemVis | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |
+    Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 void ftGw_SpecialLw_GroundToAir(HSD_GObj* gobj)
 {
@@ -447,11 +445,9 @@ static inline void ftGameWatch_SpecialLw_UpdateVarsAction(HSD_GObj* gobj)
 
 /// @todo Combine common flags with #transition_flags0.
 static u32 const transition_flags1 =
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateHit |
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_SkipUpdateColAnim |
-    FtStateChange_UpdateCmd | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis |
-    FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27;
+    Ft_MF_KeepGfx | Ft_MF_SkipHit | Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim |
+    Ft_MF_UpdateCmd | Ft_MF_SkipItemVis | Ft_MF_Unk19 |
+    Ft_MF_SkipModelPartVis | Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 void ftGw_SpecialLw_UpdateAction(HSD_GObj* gobj, f32 anim_frame)
 {

--- a/src/melee/ft/chara/ftGameWatch/ftGw_SpecialN.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGw_SpecialN.c
@@ -371,12 +371,10 @@ void ftGw_SpecialAirN_Coll(HSD_GObj* gobj)
 }
 
 static u32 const transition_flags =
-    FtStateChange_PreserveColAnimHitStatus | FtStateChange_SkipUpdateHit |
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateMatAnim |
-    FtStateChange_SkipUpdateColAnim | FtStateChange_UpdateCmd |
-    FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_19 |
-    FtStateChange_SkipUpdateModelPartVis | FtStateChange_SkipUpdateModelFlag |
-    FtStateChange_Unk_27;
+    Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipHit | Ft_MF_SkipModel |
+    Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim | Ft_MF_UpdateCmd |
+    Ft_MF_SkipItemVis | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |
+    Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 // 0x8014EA3C
 // https://decomp.me/scratch/mtcx1 // Mr. Game & Watch's ground -> air Chef

--- a/src/melee/ft/chara/ftGameWatch/ftGw_SpecialS.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGw_SpecialS.c
@@ -331,12 +331,10 @@ static inline void ftGameWatch_SpecialS_SetCall(HSD_GObj* gobj)
 }
 
 static u32 const transition_flags =
-    FtStateChange_PreserveColAnimHitStatus | FtStateChange_SkipUpdateHit |
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateMatAnim |
-    FtStateChange_SkipUpdateColAnim | FtStateChange_UpdateCmd |
-    FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_19 |
-    FtStateChange_SkipUpdateModelPartVis | FtStateChange_SkipUpdateModelFlag |
-    FtStateChange_Unk_27;
+    Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipHit | Ft_MF_SkipModel |
+    Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim | Ft_MF_UpdateCmd |
+    Ft_MF_SkipItemVis | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |
+    Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 /// Mr. Game & Watch's ground -> air Judgement Motion State handler
 static void ftGw_SpecialS_GroundToAir(HSD_GObj* gobj)

--- a/src/melee/ft/chara/ftGanon/ftGn_Init.c
+++ b/src/melee/ft/chara/ftGanon/ftGn_Init.c
@@ -17,7 +17,7 @@
 MotionState ftGn_Init_MotionStateTable[] = {
     {
         ftCo_MS_None,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -27,7 +27,7 @@ MotionState ftGn_Init_MotionStateTable[] = {
     },
     {
         ftCo_MS_None,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -37,7 +37,7 @@ MotionState ftGn_Init_MotionStateTable[] = {
     },
     {
         ftCo_MS_None,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -47,7 +47,7 @@ MotionState ftGn_Init_MotionStateTable[] = {
     },
     {
         ftCo_MS_None,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -57,7 +57,7 @@ MotionState ftGn_Init_MotionStateTable[] = {
     },
     {
         ftCo_MS_None,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -67,7 +67,7 @@ MotionState ftGn_Init_MotionStateTable[] = {
     },
     {
         ftCo_MS_None,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,

--- a/src/melee/ft/chara/ftKirby/forward.h
+++ b/src/melee/ft/chara/ftKirby/forward.h
@@ -8,303 +8,291 @@
 /// @todo Clean up factorization
 
 static MotionFlags const ftKb_MF_MultiJump ATTRIBUTE_USED =
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateHit |
-    FtStateChange_SkipUpdateAnimVel | FtStateChange_Unk_6;
+    Ft_MF_KeepGfx | Ft_MF_SkipHit | Ft_MF_SkipAnimVel | Ft_MF_Unk06;
 
 static MotionFlags const ftKb_MF_AttackDash ATTRIBUTE_USED =
-    FtStateChange_PreserveFastFall | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_SkipUpdateItemVis | FtStateChange_FreezeState;
+    Ft_MF_KeepFastFall | Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipItemVis |
+    Ft_MF_FreezeState;
 
 static MotionFlags const ftKb_MF_AttackDashAir ATTRIBUTE_USED =
-    ftKb_MF_AttackDash | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_AttackDash | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_18_20_21 ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_UpdatePhys |
-    FtStateChange_FreezeState;
+    Ft_MF_SkipItemVis | Ft_MF_UnkUpdatePhys | Ft_MF_FreezeState;
 
 static MotionFlags const ftKb_MF_4_18_20_21 ATTRIBUTE_USED =
-    ftKb_MF_18_20_21 | FtStateChange_SkipUpdateModel;
+    ftKb_MF_18_20_21 | Ft_MF_SkipModel;
 
 static MotionFlags const ftKb_MF_2_4_18_20_21 ATTRIBUTE_USED =
-    ftKb_MF_4_18_20_21 | FtStateChange_PreserveColAnimHitStatus;
+    ftKb_MF_4_18_20_21 | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftKb_MF_5_18_20_21 ATTRIBUTE_USED =
-    ftKb_MF_18_20_21 | FtStateChange_SkipUpdateAnimVel;
+    ftKb_MF_18_20_21 | Ft_MF_SkipAnimVel;
 
 static MotionFlags const ftKb_MF_SpecialN ATTRIBUTE_USED =
-    ftKb_MF_4_18_20_21 | FtStateChange_PreserveFastFall;
+    ftKb_MF_4_18_20_21 | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftKb_MF_SpecialS ATTRIBUTE_USED =
-    ftKb_MF_4_18_20_21 | FtStateChange_PreserveGfx;
+    ftKb_MF_4_18_20_21 | Ft_MF_KeepGfx;
 
 static MotionFlags const ftKb_MF_SpecialHi ATTRIBUTE_USED =
-    ftKb_MF_4_18_20_21 | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx;
+    ftKb_MF_4_18_20_21 | Ft_MF_KeepFastFall | Ft_MF_KeepGfx;
 
 static MotionFlags const ftKb_MF_SpecialNMr ATTRIBUTE_USED =
-    ftKb_MF_4_18_20_21 | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveColAnimHitStatus;
+    ftKb_MF_4_18_20_21 | Ft_MF_KeepFastFall | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftKb_MF_SpecialNKp ATTRIBUTE_USED =
-    ftKb_MF_4_18_20_21 | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateHit;
+    ftKb_MF_4_18_20_21 | Ft_MF_KeepFastFall | Ft_MF_SkipHit;
 
 static MotionFlags const ftKb_MF_SpecialNPe ATTRIBUTE_USED =
-    ftKb_MF_2_4_18_20_21 | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateHit;
+    ftKb_MF_2_4_18_20_21 | Ft_MF_KeepFastFall | Ft_MF_SkipHit;
 
 static MotionFlags const ftKb_MF_SpecialNYs ATTRIBUTE_USED =
-    ftKb_MF_5_18_20_21 | FtStateChange_PreserveFastFall;
+    ftKb_MF_5_18_20_21 | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftKb_MF_SpecialNLg ATTRIBUTE_USED =
-    ftKb_MF_5_18_20_21 | FtStateChange_PreserveColAnimHitStatus;
+    ftKb_MF_5_18_20_21 | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftKb_MF_SpecialNZd ATTRIBUTE_USED =
-    ftKb_MF_5_18_20_21 | FtStateChange_PreserveGfx |
-    FtStateChange_PreserveColAnimHitStatus;
+    ftKb_MF_5_18_20_21 | Ft_MF_KeepGfx | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftKb_MF_SpecialNDr ATTRIBUTE_USED =
-    ftKb_MF_5_18_20_21 | FtStateChange_SkipUpdateHit;
+    ftKb_MF_5_18_20_21 | Ft_MF_SkipHit;
 
 static MotionFlags const ftKb_MF_SpecialNGk ATTRIBUTE_USED =
-    ftKb_MF_SpecialNZd | FtStateChange_SkipUpdateHit;
+    ftKb_MF_SpecialNZd | Ft_MF_SkipHit;
 
 static MotionFlags const ftKb_MF_SpecialNFx ATTRIBUTE_USED =
-    ftKb_MF_2_4_18_20_21 | FtStateChange_PreserveGfx |
-    FtStateChange_SkipUpdateThrowException;
+    ftKb_MF_2_4_18_20_21 | Ft_MF_KeepGfx | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftKb_MF_SpecialNLk ATTRIBUTE_USED =
-    ftKb_MF_4_18_20_21 | FtStateChange_PreserveGfx |
-    FtStateChange_SkipUpdateHit | FtStateChange_SkipUpdateThrowException;
+    ftKb_MF_4_18_20_21 | Ft_MF_KeepGfx | Ft_MF_SkipHit |
+    Ft_MF_SkipThrowException;
 
 static MotionFlags const ftKb_MF_SpecialNSk ATTRIBUTE_USED =
-    ftKb_MF_SpecialNLk | FtStateChange_PreserveFastFall;
+    ftKb_MF_SpecialNLk | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftKb_MF_SpecialNNs ATTRIBUTE_USED =
-    ftKb_MF_2_4_18_20_21 | FtStateChange_SkipUpdateHit |
-    FtStateChange_SkipUpdateThrowException;
+    ftKb_MF_2_4_18_20_21 | Ft_MF_SkipHit | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftKb_MF_SpecialNPp ATTRIBUTE_USED =
-    ftKb_MF_SpecialNNs | FtStateChange_PreserveGfx;
+    ftKb_MF_SpecialNNs | Ft_MF_KeepGfx;
 
 static MotionFlags const ftKb_MF_SpecialNPk ATTRIBUTE_USED =
-    ftKb_MF_SpecialNPp | FtStateChange_PreserveFastFall;
+    ftKb_MF_SpecialNPp | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftKb_MF_SpecialNSs ATTRIBUTE_USED =
-    ftKb_MF_5_18_20_21 | FtStateChange_SkipUpdateThrowException;
+    ftKb_MF_5_18_20_21 | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftKb_MF_SpecialNSs_1 ATTRIBUTE_USED =
-    ftKb_MF_SpecialNSs | FtStateChange_PreserveGfx;
+    ftKb_MF_SpecialNSs | Ft_MF_KeepGfx;
 
 static MotionFlags const ftKb_MF_SpecialNMt ATTRIBUTE_USED =
-    ftKb_MF_SpecialNSs_1 | FtStateChange_PreserveFastFall;
+    ftKb_MF_SpecialNSs_1 | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftKb_MF_SpecialNCl ATTRIBUTE_USED =
-    ftKb_MF_SpecialNMt | FtStateChange_PreserveColAnimHitStatus;
+    ftKb_MF_SpecialNMt | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftKb_MF_SpecialNFc ATTRIBUTE_USED =
-    ftKb_MF_SpecialNDr | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateThrowException;
+    ftKb_MF_SpecialNDr | Ft_MF_KeepFastFall | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftKb_MF_SpecialNPc ATTRIBUTE_USED =
-    ftKb_MF_SpecialNSs_1 | FtStateChange_SkipUpdateHit;
+    ftKb_MF_SpecialNSs_1 | Ft_MF_SkipHit;
 
 static MotionFlags const ftKb_MF_SpecialNGw ATTRIBUTE_USED =
-    ftKb_MF_SpecialNPc | FtStateChange_PreserveFastFall;
+    ftKb_MF_SpecialNPc | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftKb_MF_SpecialLw ATTRIBUTE_USED =
-    ftKb_MF_2_4_18_20_21 | FtStateChange_PreserveSfx;
+    ftKb_MF_2_4_18_20_21 | Ft_MF_KeepSfx;
 
 static MotionFlags const ftKb_MF_SpecialNCa ATTRIBUTE_USED =
-    ftKb_MF_SpecialLw | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx;
+    ftKb_MF_SpecialLw | Ft_MF_KeepFastFall | Ft_MF_KeepGfx;
 
 static MotionFlags const ftKb_MF_SpecialNDk ATTRIBUTE_USED =
-    ftKb_MF_4_18_20_21 | FtStateChange_SkipUpdateHit |
-    FtStateChange_PreserveSfx;
+    ftKb_MF_4_18_20_21 | Ft_MF_SkipHit | Ft_MF_KeepSfx;
 
 static MotionFlags const ftKb_MF_5_9_18_20_21 ATTRIBUTE_USED =
-    ftKb_MF_5_18_20_21 | FtStateChange_PreserveSfx;
+    ftKb_MF_5_18_20_21 | Ft_MF_KeepSfx;
 
 static MotionFlags const ftKb_MF_2_5_9_18_20_21 ATTRIBUTE_USED =
-    ftKb_MF_5_9_18_20_21 | FtStateChange_PreserveColAnimHitStatus;
+    ftKb_MF_5_9_18_20_21 | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftKb_MF_SpecialNPr ATTRIBUTE_USED =
-    ftKb_MF_5_9_18_20_21 | FtStateChange_PreserveGfx;
+    ftKb_MF_5_9_18_20_21 | Ft_MF_KeepGfx;
 
 static MotionFlags const ftKb_MF_SpecialNMs ATTRIBUTE_USED =
-    ftKb_MF_2_5_9_18_20_21 | FtStateChange_PreserveFastFall;
+    ftKb_MF_2_5_9_18_20_21 | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftKb_MF_SpecialNGn ATTRIBUTE_USED =
-    ftKb_MF_2_5_9_18_20_21 | FtStateChange_SkipUpdateHit;
+    ftKb_MF_2_5_9_18_20_21 | Ft_MF_SkipHit;
 
 static MotionFlags const ftKb_MF_SpecialNFeStart ATTRIBUTE_USED =
-    ftKb_MF_SpecialNMs | FtStateChange_SkipUpdateHit;
+    ftKb_MF_SpecialNMs | Ft_MF_SkipHit;
 
 static MotionFlags const ftKb_MF_SpecialAirN ATTRIBUTE_USED =
-    ftKb_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialN | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirS ATTRIBUTE_USED =
-    ftKb_MF_SpecialS | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialS | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirHi ATTRIBUTE_USED =
-    ftKb_MF_SpecialHi | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialHi | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNMr ATTRIBUTE_USED =
-    ftKb_MF_SpecialNMr | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNMr | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNKp ATTRIBUTE_USED =
-    ftKb_MF_SpecialNKp | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNKp | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNPe ATTRIBUTE_USED =
-    ftKb_MF_SpecialNPe | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNPe | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNYs ATTRIBUTE_USED =
-    ftKb_MF_SpecialNYs | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNYs | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNLg ATTRIBUTE_USED =
-    ftKb_MF_SpecialNLg | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNLg | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNZd ATTRIBUTE_USED =
-    ftKb_MF_SpecialNZd | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNZd | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNDr ATTRIBUTE_USED =
-    ftKb_MF_SpecialNDr | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNDr | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNGk ATTRIBUTE_USED =
-    ftKb_MF_SpecialNGk | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNGk | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNFx ATTRIBUTE_USED =
-    ftKb_MF_SpecialNFx | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNFx | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNLk ATTRIBUTE_USED =
-    ftKb_MF_SpecialNLk | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNLk | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNSk ATTRIBUTE_USED =
-    ftKb_MF_SpecialNSk | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNSk | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNNs ATTRIBUTE_USED =
-    ftKb_MF_SpecialNNs | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNNs | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNPp ATTRIBUTE_USED =
-    ftKb_MF_SpecialNPp | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNPp | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNPk ATTRIBUTE_USED =
-    ftKb_MF_SpecialNPk | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNPk | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNSs ATTRIBUTE_USED =
-    ftKb_MF_SpecialNSs | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNSs | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNMt ATTRIBUTE_USED =
-    ftKb_MF_SpecialNMt | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNMt | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNCl ATTRIBUTE_USED =
-    ftKb_MF_SpecialNCl | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNCl | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNFc ATTRIBUTE_USED =
-    ftKb_MF_SpecialNFc | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNFc | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNPc ATTRIBUTE_USED =
-    ftKb_MF_SpecialNPc | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNPc | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNGw ATTRIBUTE_USED =
-    ftKb_MF_SpecialNGw | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNGw | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirLw ATTRIBUTE_USED =
-    ftKb_MF_SpecialLw | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialLw | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNCa ATTRIBUTE_USED =
-    ftKb_MF_SpecialNCa | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNCa | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNDk ATTRIBUTE_USED =
-    ftKb_MF_SpecialNDk | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNDk | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNPr ATTRIBUTE_USED =
-    ftKb_MF_SpecialNPr | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNPr | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNMs ATTRIBUTE_USED =
-    ftKb_MF_SpecialNMs | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNMs | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNGn ATTRIBUTE_USED =
-    ftKb_MF_SpecialNGn | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNGn | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialNFe ATTRIBUTE_USED =
-    ftKb_MF_SpecialNFeStart | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNFeStart | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_0_4_18_20_21 ATTRIBUTE_USED =
-    ftKb_MF_4_18_20_21 | FtStateChange_PreserveFastFall;
+    ftKb_MF_4_18_20_21 | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftKb_MF_SpecialNCaptureTurn ATTRIBUTE_USED =
-    ftKb_MF_0_4_18_20_21 | FtStateChange_PreserveAccessory;
+    ftKb_MF_0_4_18_20_21 | Ft_MF_KeepAccessory;
 
 static MotionFlags const ftKb_MF_SpecialAirNCaptureTurn ATTRIBUTE_USED =
-    ftKb_MF_SpecialNCaptureTurn | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNCaptureTurn | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialNCaptureWalk ATTRIBUTE_USED =
-    ftKb_MF_0_4_18_20_21 | FtStateChange_UpdateCmd;
+    ftKb_MF_0_4_18_20_21 | Ft_MF_UpdateCmd;
 
 static MotionFlags const ftKb_MF_SpecialNCaptureJumpSquat ATTRIBUTE_USED =
-    ftKb_MF_0_4_18_20_21 | FtStateChange_SkipUpdateNametagVis;
+    ftKb_MF_0_4_18_20_21 | Ft_MF_SkipNametagVis;
 
 static MotionFlags const ftKb_MF_SpecialNLoop ATTRIBUTE_USED =
-    ftKb_MF_0_4_18_20_21 | FtStateChange_Unk_19;
+    ftKb_MF_0_4_18_20_21 | Ft_MF_Unk19;
 
 static MotionFlags const ftKb_MF_SpecialNKpLoop ATTRIBUTE_USED =
-    ftKb_MF_SpecialNKp | FtStateChange_Unk_19;
+    ftKb_MF_SpecialNKp | Ft_MF_Unk19;
 
 static MotionFlags const ftKb_MF_SpecialNGkLoop ATTRIBUTE_USED =
-    ftKb_MF_SpecialNGk | FtStateChange_Unk_19;
+    ftKb_MF_SpecialNGk | Ft_MF_Unk19;
 
 static MotionFlags const ftKb_MF_SpecialNFxLoop ATTRIBUTE_USED =
-    ftKb_MF_SpecialNFx | FtStateChange_Unk_19;
+    ftKb_MF_SpecialNFx | Ft_MF_Unk19;
 
 static MotionFlags const ftKb_MF_SpecialNLkCharged ATTRIBUTE_USED =
-    ftKb_MF_SpecialNLk | FtStateChange_Unk_19;
+    ftKb_MF_SpecialNLk | Ft_MF_Unk19;
 
 static MotionFlags const ftKb_MF_SpecialNSkLoop ATTRIBUTE_USED =
-    ftKb_MF_SpecialNSk | FtStateChange_Unk_19;
+    ftKb_MF_SpecialNSk | Ft_MF_Unk19;
 
 static MotionFlags const ftKb_MF_SpecialNMtLoop ATTRIBUTE_USED =
-    ftKb_MF_SpecialNMt | FtStateChange_Unk_19;
+    ftKb_MF_SpecialNMt | Ft_MF_Unk19;
 
 static MotionFlags const ftKb_MF_SpecialNClCharged ATTRIBUTE_USED =
-    ftKb_MF_SpecialNCl | FtStateChange_Unk_19;
+    ftKb_MF_SpecialNCl | Ft_MF_Unk19;
 
 static MotionFlags const ftKb_MF_SpecialNFcLoop ATTRIBUTE_USED =
-    ftKb_MF_SpecialNFc | FtStateChange_Unk_19;
+    ftKb_MF_SpecialNFc | Ft_MF_Unk19;
 
 static MotionFlags const ftKb_MF_SpecialNPrLoop ATTRIBUTE_USED =
-    ftKb_MF_SpecialNPr | FtStateChange_Unk_19;
+    ftKb_MF_SpecialNPr | Ft_MF_Unk19;
 
 static MotionFlags const ftKb_MF_SpecialAirNLoop ATTRIBUTE_USED =
-    ftKb_MF_SpecialNLoop | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNLoop | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNKpLoop ATTRIBUTE_USED =
-    ftKb_MF_SpecialNKpLoop | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNKpLoop | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNGkLoop ATTRIBUTE_USED =
-    ftKb_MF_SpecialNGkLoop | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNGkLoop | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNFxLoop ATTRIBUTE_USED =
-    ftKb_MF_SpecialNFxLoop | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNFxLoop | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNLkCharged ATTRIBUTE_USED =
-    ftKb_MF_SpecialNLkCharged | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNLkCharged | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNSkLoop ATTRIBUTE_USED =
-    ftKb_MF_SpecialNSkLoop | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNSkLoop | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNMtLoop ATTRIBUTE_USED =
-    ftKb_MF_SpecialNMtLoop | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNMtLoop | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNClCharged ATTRIBUTE_USED =
-    ftKb_MF_SpecialNClCharged | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNClCharged | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNFcLoop ATTRIBUTE_USED =
-    ftKb_MF_SpecialNFcLoop | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNFcLoop | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKb_MF_SpecialAirNPrLoop ATTRIBUTE_USED =
-    ftKb_MF_SpecialNPrLoop | FtStateChange_SkipUpdateParasol;
+    ftKb_MF_SpecialNPrLoop | Ft_MF_SkipParasol;
 
 typedef enum ftKirby_MotionState {
     ftKb_MS_Jump2 = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftKirby/ftKb_Init.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_Init.c
@@ -2236,7 +2236,7 @@ ftKirby_UnkArrayThing* ftKb_Init_803C9FC8[FTKIND_MAX] = {
 MotionState ftKb_Init_UnkMotionStates0[] = {
     {
         14,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -2246,7 +2246,7 @@ MotionState ftKb_Init_UnkMotionStates0[] = {
     },
     {
         15,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -2256,7 +2256,7 @@ MotionState ftKb_Init_UnkMotionStates0[] = {
     },
     {
         16,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -2266,7 +2266,7 @@ MotionState ftKb_Init_UnkMotionStates0[] = {
     },
     {
         17,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,

--- a/src/melee/ft/chara/ftKoopa/forward.h
+++ b/src/melee/ft/chara/ftKoopa/forward.h
@@ -6,40 +6,38 @@
 #include "ftCommon/forward.h"
 
 static MotionFlags const ftKp_MF_Special ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_UpdatePhys | FtStateChange_FreezeState;
+    Ft_MF_SkipModel | Ft_MF_SkipItemVis | Ft_MF_UnkUpdatePhys |
+    Ft_MF_FreezeState;
 
 static MotionFlags const ftKp_MF_SpecialN ATTRIBUTE_USED =
-    ftKp_MF_Special | FtStateChange_PreserveFastFall;
+    ftKp_MF_Special | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftKp_MF_SpecialS ATTRIBUTE_USED =
-    ftKp_MF_Special | FtStateChange_PreserveGfx;
+    ftKp_MF_Special | Ft_MF_KeepGfx;
 
 static MotionFlags const ftKp_MF_SpecialHi ATTRIBUTE_USED =
-    ftKp_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx | FtStateChange_PreserveSfx;
+    ftKp_MF_Special | Ft_MF_KeepFastFall | Ft_MF_KeepGfx | Ft_MF_KeepSfx;
 
 static MotionFlags const ftKp_MF_SpecialLwStart ATTRIBUTE_USED =
-    ftKp_MF_Special | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_PreserveSfx;
+    ftKp_MF_Special | Ft_MF_KeepColAnimHitStatus | Ft_MF_KeepSfx;
 
 static MotionFlags const ftKp_MF_SpecialNStart ATTRIBUTE_USED =
-    ftKp_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftKp_MF_SpecialN | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKp_MF_SpecialAirS ATTRIBUTE_USED =
-    ftKp_MF_SpecialS | FtStateChange_SkipUpdateParasol;
+    ftKp_MF_SpecialS | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKp_MF_SpecialAirHi ATTRIBUTE_USED =
-    ftKp_MF_SpecialHi | FtStateChange_SkipUpdateParasol;
+    ftKp_MF_SpecialHi | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKp_MF_SpecialAirLw ATTRIBUTE_USED =
-    ftKp_MF_SpecialLwStart | FtStateChange_SkipUpdateParasol;
+    ftKp_MF_SpecialLwStart | Ft_MF_SkipParasol;
 
 static MotionFlags const ftKp_MF_SpecialNLoop ATTRIBUTE_USED =
-    ftKp_MF_SpecialN | FtStateChange_Unk_19;
+    ftKp_MF_SpecialN | Ft_MF_Unk19;
 
 static MotionFlags const ftKp_MF_SpecialAirNLoop ATTRIBUTE_USED =
-    ftKp_MF_SpecialNLoop | FtStateChange_SkipUpdateParasol;
+    ftKp_MF_SpecialNLoop | Ft_MF_SkipParasol;
 
 typedef enum ftKoopa_MotionState {
     ftKp_MS_SpecialNStart = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftKoopa/ftKp_Init.c
+++ b/src/melee/ft/chara/ftKoopa/ftKp_Init.c
@@ -498,7 +498,7 @@ void ftKp_SpecialAirS_Enter(HSD_GObj* gobj)
     }
 }
 
-static u32 const transition_flags0 = FtStateChange_SkipUpdateMatAnim;
+static u32 const transition_flags0 = Ft_MF_SkipMatAnim;
 
 void ftKp_SpecialS_8013302C(HSD_GObj* gobj)
 {
@@ -542,11 +542,9 @@ void ftKp_SpecialS_801330E4(HSD_GObj* gobj)
 }
 
 static u32 const transition_flags1 =
-    FtStateChange_SkipUpdateHit | FtStateChange_SkipUpdateMatAnim |
-    FtStateChange_SkipUpdateColAnim | FtStateChange_UpdateCmd |
-    FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_19 |
-    FtStateChange_SkipUpdateModelPartVis | FtStateChange_SkipUpdateModelFlag |
-    FtStateChange_Unk_27;
+    Ft_MF_SkipHit | Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim | Ft_MF_UpdateCmd |
+    Ft_MF_SkipItemVis | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |
+    Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 void ftKp_SpecialS_8013319C(HSD_GObj* gobj)
 {
@@ -634,9 +632,8 @@ void ftKp_SpecialS_80133398(HSD_GObj* gobj)
 }
 /// @todo Combine common flags with #transition_flags0.
 static u32 const transition_flags2 =
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_SkipUpdateColAnim |
-    FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_19 |
-    FtStateChange_SkipUpdateModelPartVis | FtStateChange_SkipUpdateModelFlag;
+    Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim | Ft_MF_SkipItemVis | Ft_MF_Unk19 |
+    Ft_MF_SkipModelPartVis | Ft_MF_SkipModelFlags;
 
 void ftKp_SpecialS_801333F8(HSD_GObj* gobj)
 {
@@ -736,8 +733,7 @@ void ftKp_SpecialAirS_Anim(HSD_GObj* gobj)
     }
 }
 
-static u32 const transition_flags3 =
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_Unk_19;
+static u32 const transition_flags3 = Ft_MF_SkipMatAnim | Ft_MF_Unk19;
 
 void ftKp_SpecialSCatch_Anim(HSD_GObj* gobj)
 {
@@ -778,7 +774,7 @@ void ftKp_SpecialSCatch_Anim(HSD_GObj* gobj)
                         ftKp_Init_804D9ADC, ftKp_Init_804D9AD8);
                 } else {
                     Fighter_ChangeMotionState(
-                        gobj, 348, FtStateChange_None, 0, ftKp_Init_804D9AD8,
+                        gobj, 348, Ft_MF_None, 0, ftKp_Init_804D9AD8,
                         ftKp_Init_804D9ADC, ftKp_Init_804D9AD8);
                 }
 

--- a/src/melee/ft/chara/ftLink/forward.h
+++ b/src/melee/ft/chara/ftLink/forward.h
@@ -5,63 +5,60 @@
 #include "ftCommon/forward.h"
 
 static MotionFlags const ftLk_MF_Base0 ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateThrowException;
+    Ft_MF_SkipModel | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftLk_MF_Base1 ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateItemVis | FtStateChange_FreezeState;
+    Ft_MF_SkipItemVis | Ft_MF_FreezeState;
 
 static MotionFlags const ftLk_MF_Base2 ATTRIBUTE_USED =
-    ftLk_MF_Base1 | FtStateChange_PreserveFastFall;
+    ftLk_MF_Base1 | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftLk_MF_Base3 ATTRIBUTE_USED =
-    ftLk_MF_Base0 | FtStateChange_Unk_UpdatePhys;
+    ftLk_MF_Base0 | Ft_MF_UnkUpdatePhys;
 
 static MotionFlags const ftLk_MF_AttackS42 ATTRIBUTE_USED =
-    ftLk_MF_Base2 | FtStateChange_SkipUpdateHit;
+    ftLk_MF_Base2 | Ft_MF_SkipHit;
 
 static MotionFlags const ftLk_MF_SpecialN ATTRIBUTE_USED =
     ftLk_MF_Base2 | ftLk_MF_Base3;
 
 static MotionFlags const ftLk_MF_SpecialNFullyCharged ATTRIBUTE_USED =
-    ftLk_MF_SpecialN | FtStateChange_Unk_19;
+    ftLk_MF_SpecialN | Ft_MF_Unk19;
 
 static MotionFlags const ftLk_MF_SpecialAirNCharge ATTRIBUTE_USED =
-    ftLk_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftLk_MF_SpecialN | Ft_MF_SkipParasol;
 
 static MotionFlags const ftLk_MF_SpecialAirNFullyCharged ATTRIBUTE_USED =
-    ftLk_MF_SpecialNFullyCharged | FtStateChange_SkipUpdateParasol;
+    ftLk_MF_SpecialNFullyCharged | Ft_MF_SkipParasol;
 
 static MotionFlags const ftLk_MF_SpecialAirNFire ATTRIBUTE_USED =
-    ftLk_MF_SpecialAirNCharge | FtStateChange_Unk_UpdatePhys;
+    ftLk_MF_SpecialAirNCharge | Ft_MF_UnkUpdatePhys;
 
 static MotionFlags const ftLk_MF_SpecialSThrow ATTRIBUTE_USED =
-    ftLk_MF_Base3 | ftLk_MF_Base1 | FtStateChange_PreserveGfx;
+    ftLk_MF_Base3 | ftLk_MF_Base1 | Ft_MF_KeepGfx;
 
 static MotionFlags const ftLk_MF_SpecialSCatch ATTRIBUTE_USED =
-    ftLk_MF_SpecialSThrow | FtStateChange_Unk_UpdatePhys;
+    ftLk_MF_SpecialSThrow | Ft_MF_UnkUpdatePhys;
 
 static MotionFlags const ftLk_MF_SpecialAirSThrow ATTRIBUTE_USED =
-    ftLk_MF_SpecialSThrow | ftLk_MF_Base3 | FtStateChange_SkipUpdateParasol;
+    ftLk_MF_SpecialSThrow | ftLk_MF_Base3 | Ft_MF_SkipParasol;
 
 static MotionFlags const ftLk_MF_SpecialAirSThrowEmpty ATTRIBUTE_USED =
-    ftLk_MF_SpecialSCatch | ftLk_MF_Base1 | FtStateChange_SkipUpdateParasol;
+    ftLk_MF_SpecialSCatch | ftLk_MF_Base1 | Ft_MF_SkipParasol;
 
 static MotionFlags const ftLk_MF_SpecialHi ATTRIBUTE_USED =
-    FtStateChange_PreserveFastFall | FtStateChange_PreserveGfx |
-    FtStateChange_SkipUpdateModel | FtStateChange_PreserveSfx |
-    FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_UpdatePhys |
-    FtStateChange_FreezeState;
+    Ft_MF_KeepFastFall | Ft_MF_KeepGfx | Ft_MF_SkipModel | Ft_MF_KeepSfx |
+    Ft_MF_SkipItemVis | Ft_MF_UnkUpdatePhys | Ft_MF_FreezeState;
 
 static MotionFlags const ftLk_MF_SpecialLw ATTRIBUTE_USED =
-    FtStateChange_PreserveColAnimHitStatus | FtStateChange_SkipUpdateModel |
-    FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_UpdatePhys |
-    FtStateChange_FreezeState;
+    Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipModel | Ft_MF_SkipItemVis |
+    Ft_MF_UnkUpdatePhys | Ft_MF_FreezeState;
 
 static MotionFlags const ftLk_MF_SpecialAirLw ATTRIBUTE_USED =
-    ftLk_MF_SpecialLw | FtStateChange_SkipUpdateParasol;
+    ftLk_MF_SpecialLw | Ft_MF_SkipParasol;
 
 static MotionFlags const ftLk_MF_ZairCatch ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModelPartVis | FtStateChange_SkipUpdateMetalB;
+    Ft_MF_SkipModelPartVis | Ft_MF_SkipMetalB;
 
 typedef enum ftLink_MotionState {
     ftLk_MS_AttackS42 = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftLink/ftLk_Init.c
+++ b/src/melee/ft/chara/ftLink/ftLk_Init.c
@@ -35,7 +35,7 @@ MotionState ftLk_Init_MotionStateTable[] = {
     },
     {
         -1,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -45,7 +45,7 @@ MotionState ftLk_Init_MotionStateTable[] = {
     },
     {
         -1,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -215,7 +215,7 @@ MotionState ftLk_Init_MotionStateTable[] = {
     },
     {
         312,
-        FtStateChange_FreezeState,
+        Ft_MF_FreezeState,
         FtMoveId_Default << 24,
         ftCo_Zair_Anim,
         ftCo_Zair_IASA,

--- a/src/melee/ft/chara/ftLuigi/forward.h
+++ b/src/melee/ft/chara/ftLuigi/forward.h
@@ -5,35 +5,32 @@
 #include "ftCommon/forward.h"
 
 static MotionFlags const ftLg_MF_Special ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_UpdatePhys | FtStateChange_FreezeState;
+    Ft_MF_SkipModel | Ft_MF_SkipItemVis | Ft_MF_UnkUpdatePhys |
+    Ft_MF_FreezeState;
 
 static MotionFlags const ftLg_MF_SpecialN ATTRIBUTE_USED =
-    ftLg_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateThrowException;
+    ftLg_MF_Special | Ft_MF_KeepFastFall | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftLg_MF_SpecialS ATTRIBUTE_USED =
-    ftLg_MF_Special | FtStateChange_PreserveGfx | FtStateChange_PreserveSfx;
+    ftLg_MF_Special | Ft_MF_KeepGfx | Ft_MF_KeepSfx;
 
 static MotionFlags const ftLg_MF_SpecialHi ATTRIBUTE_USED =
-    ftLg_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx | FtStateChange_PreserveSfx;
+    ftLg_MF_Special | Ft_MF_KeepFastFall | Ft_MF_KeepGfx | Ft_MF_KeepSfx;
 
 static MotionFlags const ftLg_MF_SpecialLw ATTRIBUTE_USED =
-    ftLg_MF_Special | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_PreserveSfx;
+    ftLg_MF_Special | Ft_MF_KeepColAnimHitStatus | Ft_MF_KeepSfx;
 
 static MotionFlags const ftLg_MF_SpecialAirN ATTRIBUTE_USED =
-    ftLg_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftLg_MF_SpecialN | Ft_MF_SkipParasol;
 
 static MotionFlags const ftLg_MF_SpecialAirS ATTRIBUTE_USED =
-    ftLg_MF_SpecialS | FtStateChange_SkipUpdateParasol;
+    ftLg_MF_SpecialS | Ft_MF_SkipParasol;
 
 static MotionFlags const ftLg_MF_SpecialAirHi ATTRIBUTE_USED =
-    ftLg_MF_SpecialHi | FtStateChange_SkipUpdateParasol;
+    ftLg_MF_SpecialHi | Ft_MF_SkipParasol;
 
 static MotionFlags const ftLg_MF_SpecialAirLw ATTRIBUTE_USED =
-    ftLg_MF_SpecialLw | FtStateChange_SkipUpdateParasol;
+    ftLg_MF_SpecialLw | Ft_MF_SkipParasol;
 
 typedef enum ftLuigi_MotionState {
     ftLg_MS_SpecialN = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftLuigi/ftLg_Init.c
+++ b/src/melee/ft/chara/ftLuigi/ftLg_Init.c
@@ -201,7 +201,7 @@ MotionState ftLg_Init_MotionStateTable[] = {
 MotionState ftLg_Init_UnkMotionStates0[] = {
     {
         14,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -211,7 +211,7 @@ MotionState ftLg_Init_UnkMotionStates0[] = {
     },
     {
         15,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,

--- a/src/melee/ft/chara/ftLuigi/ftLg_SpecialLw.c
+++ b/src/melee/ft/chara/ftLuigi/ftLg_SpecialLw.c
@@ -15,11 +15,9 @@
 
 // SpecialLw (Luigi Cyclone)
 #define FTLUIGI_SPECIALLW_FLAG                                                \
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateHit |                 \
-        FtStateChange_SkipUpdateMatAnim | FtStateChange_UpdateCmd |           \
-        FtStateChange_SkipUpdateColAnim | FtStateChange_SkipUpdateItemVis |   \
-        FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis |         \
-        FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27
+    Ft_MF_KeepGfx | Ft_MF_SkipHit | Ft_MF_SkipMatAnim | Ft_MF_UpdateCmd |     \
+        Ft_MF_SkipColAnim | Ft_MF_SkipItemVis | Ft_MF_Unk19 |                 \
+        Ft_MF_SkipModelPartVis | Ft_MF_SkipModelFlags | Ft_MF_Unk27
 
 // 0x801445C4
 // https://decomp.me/scratch/TTyNT // Luigi Cyclone Rotation Update

--- a/src/melee/ft/chara/ftLuigi/ftLg_SpecialN.c
+++ b/src/melee/ft/chara/ftLuigi/ftLg_SpecialN.c
@@ -16,8 +16,7 @@
 #include <dolphin/mtx/types.h>
 
 // SpecialN/SpecialAirN (Fireball)
-#define FTLUIGI_SPECIALN_COLL_FLAG                                            \
-    FtStateChange_UpdateCmd | FtStateChange_SkipUpdateColAnim
+#define FTLUIGI_SPECIALN_COLL_FLAG Ft_MF_UpdateCmd | Ft_MF_SkipColAnim
 
 // 0x8014267C
 // https://decomp.me/scratch/dB9mj // Luigi's grounded Fireball Motion State

--- a/src/melee/ft/chara/ftLuigi/ftLg_SpecialS.c
+++ b/src/melee/ft/chara/ftLuigi/ftLg_SpecialS.c
@@ -176,11 +176,9 @@ void ftLg_SpecialAirSStart_Coll(HSD_GObj* gobj)
 }
 
 static u32 const transition_flags0 =
-    FtStateChange_PreserveColAnimHitStatus | FtStateChange_SkipUpdateMatAnim |
-    FtStateChange_PreserveSfx | FtStateChange_UpdateCmd |
-    FtStateChange_SkipUpdateColAnim | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis |
-    FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27;
+    Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipMatAnim | Ft_MF_KeepSfx |
+    Ft_MF_UpdateCmd | Ft_MF_SkipColAnim | Ft_MF_SkipItemVis | Ft_MF_Unk19 |
+    Ft_MF_SkipModelPartVis | Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 /// Luigi's Green Missile Start ground -> air Motion State handler
 void ftLg_SpecialSStart_GroundToAir(HSD_GObj* gobj)
@@ -300,8 +298,7 @@ void ftLg_SpecialAirSHold_Coll(HSD_GObj* gobj)
     }
 }
 
-static u32 const transition_flags1 =
-    transition_flags0 | FtStateChange_PreserveGfx;
+static u32 const transition_flags1 = transition_flags0 | Ft_MF_KeepGfx;
 
 /// Luigi's Green Missile Charge ground -> air Acion State handler
 void ftLg_SpecialSHold_GroundToAir(HSD_GObj* gobj)
@@ -333,8 +330,8 @@ void ftLg_SpecialSHold_Enter(HSD_GObj* gobj)
 
     /// @todo Shared @c inline with #ftLg_SpecialAirSHold_Enter.
 
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialSHold,
-                              FtStateChange_PreserveSfx, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialSHold, Ft_MF_KeepSfx, NULL,
+                              0, 1, 0);
 
     {
         Fighter* fp = GET_FIGHTER(gobj);
@@ -350,8 +347,8 @@ void ftLg_SpecialAirSHold_Enter(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirSHold,
-                              FtStateChange_PreserveSfx, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirSHold, Ft_MF_KeepSfx,
+                              NULL, 0, 1, 0);
     {
         Fighter* fp = GET_FIGHTER(gobj);
         fp->cb.x21BC_callback_Accessory4 = ftLg_SpecialS_SetGFX;
@@ -448,11 +445,9 @@ void ftLg_SpecialAirSLaunch_Coll(HSD_GObj* gobj)
 
 /// @todo Combine common flags with #transition_flags0.
 static u32 const transition_flags2 =
-    FtStateChange_PreserveGfx | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_UpdateCmd |
-    FtStateChange_SkipUpdateColAnim | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis |
-    FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27;
+    Ft_MF_KeepGfx | Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipMatAnim |
+    Ft_MF_UpdateCmd | Ft_MF_SkipColAnim | Ft_MF_SkipItemVis | Ft_MF_Unk19 |
+    Ft_MF_SkipModelPartVis | Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 /// Luigi's Green Missile Launch ground -> air Acion State handler
 void ftLg_SpecialSLaunch_GroundToAir(HSD_GObj* gobj)
@@ -743,11 +738,9 @@ void ftLg_SpecialAirSFly_Coll(HSD_GObj* gobj)
 
 /// @todo Combine common flags with #transition_flags0.
 static u32 const transition_flags3 =
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateHit |
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_UpdateCmd |
-    FtStateChange_SkipUpdateColAnim | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis |
-    FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27;
+    Ft_MF_KeepGfx | Ft_MF_SkipHit | Ft_MF_SkipMatAnim | Ft_MF_UpdateCmd |
+    Ft_MF_SkipColAnim | Ft_MF_SkipItemVis | Ft_MF_Unk19 |
+    Ft_MF_SkipModelPartVis | Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 /// Luigi's Green Missile Fly Setup
 void ftLg_SpecialSFly_Enter(HSD_GObj* gobj)

--- a/src/melee/ft/chara/ftMario/forward.h
+++ b/src/melee/ft/chara/ftMario/forward.h
@@ -5,33 +5,29 @@
 #include "ftCommon/forward.h"
 
 static MotionFlags const ftMr_MF_Special ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_UpdatePhys | FtStateChange_FreezeState;
+    Ft_MF_SkipModel | Ft_MF_SkipItemVis | Ft_MF_UnkUpdatePhys |
+    Ft_MF_FreezeState;
 
 static MotionFlags const ftMr_MF_SpecialN ATTRIBUTE_USED =
-    ftMr_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateThrowException;
+    ftMr_MF_Special | Ft_MF_KeepFastFall | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftMr_MF_SpecialHi ATTRIBUTE_USED =
-    ftMr_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx | FtStateChange_PreserveSfx;
+    ftMr_MF_Special | Ft_MF_KeepFastFall | Ft_MF_KeepGfx | Ft_MF_KeepSfx;
 
 static MotionFlags const ftMr_MF_SpecialLw ATTRIBUTE_USED =
-    ftMr_MF_Special | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_PreserveSfx;
+    ftMr_MF_Special | Ft_MF_KeepColAnimHitStatus | Ft_MF_KeepSfx;
 
 static MotionFlags const ftMr_MF_SpecialAirN ATTRIBUTE_USED =
-    ftMr_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftMr_MF_SpecialN | Ft_MF_SkipParasol;
 
 static MotionFlags const ftMr_MF_SpecialAirHi ATTRIBUTE_USED =
-    ftMr_MF_SpecialHi | FtStateChange_SkipUpdateParasol;
+    ftMr_MF_SpecialHi | Ft_MF_SkipParasol;
 
 static MotionFlags const ftMr_MF_SpecialAirLw ATTRIBUTE_USED =
-    ftMr_MF_SpecialLw | FtStateChange_SkipUpdateParasol;
+    ftMr_MF_SpecialLw | Ft_MF_SkipParasol;
 
 static MotionFlags const ftMr_MF_SpecialS ATTRIBUTE_USED =
-    ftMr_MF_Special | FtStateChange_PreserveGfx |
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateColAnim;
+    ftMr_MF_Special | Ft_MF_KeepGfx | Ft_MF_SkipModel | Ft_MF_SkipColAnim;
 
 typedef enum ftMario_MotionState {
     ftMr_MS_AppealR = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftMario/ftMr_Init.c
+++ b/src/melee/ft/chara/ftMario/ftMr_Init.c
@@ -20,7 +20,7 @@
 MotionState ftMr_Init_MotionStateTable[states_count] = {
     {
         -1,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -30,7 +30,7 @@ MotionState ftMr_Init_MotionStateTable[states_count] = {
     },
     {
         -1,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -123,7 +123,7 @@ MotionState ftMr_Init_MotionStateTable[states_count] = {
 MotionState ftMr_Init_UnkMotionStates0[aux_states_count] = {
     {
         14,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -133,7 +133,7 @@ MotionState ftMr_Init_UnkMotionStates0[aux_states_count] = {
     },
     {
         15,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,

--- a/src/melee/ft/chara/ftMario/ftMr_SpecialLw.c
+++ b/src/melee/ft/chara/ftMario/ftMr_SpecialLw.c
@@ -161,11 +161,9 @@ void ftMr_SpecialLw_IASA(HSD_GObj* gobj) {}
 void ftMr_SpecialAirLw_IASA(HSD_GObj* gobj) {}
 
 static usize_t const transition_flags =
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateHit |
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_UpdateCmd |
-    FtStateChange_SkipUpdateColAnim | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis |
-    FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27;
+    Ft_MF_KeepGfx | Ft_MF_SkipHit | Ft_MF_SkipMatAnim | Ft_MF_UpdateCmd |
+    Ft_MF_SkipColAnim | Ft_MF_SkipItemVis | Ft_MF_Unk19 |
+    Ft_MF_SkipModelPartVis | Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 static void doPhys(HSD_GObj* gobj)
 {

--- a/src/melee/ft/chara/ftMario/ftMr_SpecialN.c
+++ b/src/melee/ft/chara/ftMario/ftMr_SpecialN.c
@@ -164,10 +164,9 @@ void ftMr_SpecialN_GroundToAir(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(
-        gobj, ftMr_MS_SpecialAirN,
-        (FtStateChange_UpdateCmd | FtStateChange_SkipUpdateColAnim), NULL,
-        fp->x894_currentAnimFrame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialAirN,
+                              (Ft_MF_UpdateCmd | Ft_MF_SkipColAnim), NULL,
+                              fp->x894_currentAnimFrame, 1, 0);
 
     fp->cb.x21BC_callback_Accessory4 = ftMr_SpecialN_ItemFireSpawn;
 }
@@ -176,10 +175,9 @@ void ftMr_SpecialAirN_AirToGround(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(
-        gobj, ftMr_MS_SpecialN,
-        (FtStateChange_UpdateCmd | FtStateChange_SkipUpdateColAnim), NULL,
-        fp->x894_currentAnimFrame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialN,
+                              (Ft_MF_UpdateCmd | Ft_MF_SkipColAnim), NULL,
+                              fp->x894_currentAnimFrame, 1, 0);
 
     fp->cb.x21BC_callback_Accessory4 = ftMr_SpecialN_ItemFireSpawn;
 }

--- a/src/melee/ft/chara/ftMario/ftMr_SpecialS.c
+++ b/src/melee/ft/chara/ftMario/ftMr_SpecialS.c
@@ -288,11 +288,9 @@ static void collUpdateVars(HSD_GObj* gobj)
 }
 
 static usize_t const transition_flags =
-    FtStateChange_PreserveColAnimHitStatus | FtStateChange_SkipUpdateHit |
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_UpdateCmd |
-    FtStateChange_SkipUpdateColAnim | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis |
-    FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27;
+    Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipHit | Ft_MF_SkipMatAnim |
+    Ft_MF_UpdateCmd | Ft_MF_SkipColAnim | Ft_MF_SkipItemVis | Ft_MF_Unk19 |
+    Ft_MF_SkipModelPartVis | Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 void ftMr_SpecialS_GroundToAir(HSD_GObj* gobj)
 {

--- a/src/melee/ft/chara/ftMars/forward.h
+++ b/src/melee/ft/chara/ftMars/forward.h
@@ -5,36 +5,32 @@
 #include "ftCommon/forward.h"
 
 static MotionFlags const ftMs_MF_Special ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModel | FtStateChange_PreserveSfx |
-    FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_UpdatePhys |
-    FtStateChange_FreezeState;
+    Ft_MF_SkipModel | Ft_MF_KeepSfx | Ft_MF_SkipItemVis | Ft_MF_UnkUpdatePhys |
+    Ft_MF_FreezeState;
 
 static MotionFlags const ftMs_MF_SpecialN ATTRIBUTE_USED =
-    ftMs_MF_Special | FtStateChange_PreserveFastFall;
+    ftMs_MF_Special | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftMs_MF_SpecialS ATTRIBUTE_USED =
-    ftMs_MF_Special | FtStateChange_PreserveGfx;
+    ftMs_MF_Special | Ft_MF_KeepGfx;
 
 static MotionFlags const ftMs_MF_SpecialHi ATTRIBUTE_USED =
-    ftMs_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx;
+    ftMs_MF_Special | Ft_MF_KeepFastFall | Ft_MF_KeepGfx;
 
 static MotionFlags const ftMs_MF_SpecialLw ATTRIBUTE_USED =
-    ftMs_MF_Special | FtStateChange_PreserveColAnimHitStatus;
+    ftMs_MF_Special | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftMs_MF_SpecialAirN ATTRIBUTE_USED =
-    ftMs_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateParasol;
+    ftMs_MF_Special | Ft_MF_KeepFastFall | Ft_MF_SkipParasol;
 
 static MotionFlags const ftMs_MF_SpecialS1 ATTRIBUTE_USED =
-    ftMs_MF_Special | FtStateChange_PreserveGfx |
-    FtStateChange_SkipUpdateParasol;
+    ftMs_MF_Special | Ft_MF_KeepGfx | Ft_MF_SkipParasol;
 
 static MotionFlags const ftMs_MF_SpecialAirHi ATTRIBUTE_USED =
-    ftMs_MF_SpecialHi | FtStateChange_SkipUpdateParasol;
+    ftMs_MF_SpecialHi | Ft_MF_SkipParasol;
 
 static MotionFlags const ftMs_MF_SpecialAirLw ATTRIBUTE_USED =
-    ftMs_MF_SpecialLw | FtStateChange_SkipUpdateParasol;
+    ftMs_MF_SpecialLw | Ft_MF_SkipParasol;
 
 typedef enum ftMars_MotionState {
     ftMs_MS_SpecialNChargeStart = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftMars/ftMs_SpecialS.c
+++ b/src/melee/ft/chara/ftMars/ftMs_SpecialS.c
@@ -141,12 +141,10 @@ void ftMs_SpecialS1_Coll(HSD_GObj* gobj)
 }
 
 static u32 const transition_flags =
-    FtStateChange_PreserveColAnimHitStatus | FtStateChange_SkipUpdateHit |
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_SkipUpdateColAnim |
-    FtStateChange_UpdateCmd | FtStateChange_PreserveSwordTrail |
-    FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_19 |
-    FtStateChange_SkipUpdateModelPartVis | FtStateChange_SkipUpdateModelFlag |
-    FtStateChange_Unk_27;
+    Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipHit | Ft_MF_SkipMatAnim |
+    Ft_MF_SkipColAnim | Ft_MF_UpdateCmd | Ft_MF_KeepSwordTrail |
+    Ft_MF_SkipItemVis | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |
+    Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 void ftMs_SpecialS_801376E8(HSD_GObj* gobj)
 {
@@ -316,8 +314,7 @@ void ftMs_SpecialS_80137A9C(HSD_GObj* gobj)
             msid = 360;
         }
     }
-    Fighter_ChangeMotionState(gobj, msid, FtStateChange_SkipUpdateAttackCount,
-                              0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_SkipAttackCount, 0, 0, 1, 0);
 }
 
 void ftMs_SpecialS3_Anim(HSD_GObj* gobj)
@@ -472,8 +469,7 @@ void ftMs_SpecialS_80137E0C(HSD_GObj* gobj)
         }
     }
 
-    Fighter_ChangeMotionState(gobj, msid, FtStateChange_SkipUpdateAttackCount,
-                              0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_SkipAttackCount, 0, 0, 1, 0);
 }
 
 void ftMs_SpecialS4_Anim(HSD_GObj* gobj)
@@ -617,6 +613,5 @@ void ftMs_SpecialS_80138148(HSD_GObj* gobj)
             }
         }
     }
-    Fighter_ChangeMotionState(gobj, msid, FtStateChange_SkipUpdateAttackCount,
-                              0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_SkipAttackCount, 0, 0, 1, 0);
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Init.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Init.c
@@ -39,7 +39,7 @@
 MotionState ftMh_Init_MotionStateTable[] = {
     {
         295,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_341_Anim,
         ftMh_MS_341_IASA,
@@ -49,7 +49,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         296,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_341_Anim,
         ftMh_MS_341_IASA,
@@ -59,7 +59,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         297,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_343_Anim,
         ftMh_MS_343_IASA,
@@ -69,7 +69,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         298,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_344_Anim,
         ftMh_MS_344_IASA,
@@ -79,7 +79,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         299,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_345_Anim,
         ftMh_MS_344_IASA,
@@ -89,7 +89,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         300,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_346_Anim,
         ftMh_MS_346_IASA,
@@ -99,7 +99,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         301,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_347_Anim,
         ftMh_MS_347_IASA,
@@ -109,7 +109,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         302,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_348_Anim,
         ftMh_MS_348_IASA,
@@ -119,7 +119,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         303,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_349_Anim,
         ftMh_MS_349_IASA,
@@ -129,7 +129,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         304,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_350_Anim,
         ftMh_MS_350_IASA,
@@ -139,7 +139,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         305,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_351_Anim,
         ftMh_MS_351_IASA,
@@ -149,7 +149,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         306,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_352_Anim,
         ftMh_MS_352_IASA,
@@ -159,7 +159,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         307,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_353_Anim,
         ftMh_MS_353_IASA,
@@ -169,7 +169,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         308,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_354_Anim,
         ftMh_MS_354_IASA,
@@ -179,7 +179,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         309,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_355_Anim,
         ftMh_MS_355_IASA,
@@ -189,7 +189,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         310,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_356_Anim,
         ftMh_MS_356_IASA,
@@ -199,7 +199,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         311,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_357_Anim,
         ftMh_MS_357_IASA,
@@ -209,7 +209,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         312,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_358_Anim,
         ftMh_MS_358_IASA,
@@ -219,7 +219,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         313,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_359_Anim,
         ftMh_MS_359_IASA,
@@ -229,7 +229,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         314,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_360_Anim,
         ftMh_MS_359_IASA,
@@ -239,7 +239,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         315,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_361_Anim,
         ftMh_MS_361_IASA,
@@ -249,7 +249,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         316,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_362_Anim,
         ftMh_MS_362_IASA,
@@ -259,7 +259,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         317,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_363_Anim,
         ftMh_MS_363_IASA,
@@ -269,7 +269,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         318,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_364_Anim,
         ftMh_MS_364_IASA,
@@ -279,7 +279,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         319,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_365_Anim,
         ftMh_MS_365_IASA,
@@ -289,7 +289,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         320,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_366_Anim,
         ftMh_MS_366_IASA,
@@ -299,7 +299,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         321,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_367_Anim,
         ftMh_MS_367_IASA,
@@ -309,7 +309,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         322,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_368_Anim,
         ftMh_MS_368_IASA,
@@ -319,7 +319,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         323,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_369_Anim,
         ftMh_MS_369_IASA,
@@ -329,7 +329,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         324,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_370_Anim,
         ftMh_MS_370_IASA,
@@ -339,7 +339,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         325,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_371_Anim,
         ftMh_MS_371_IASA,
@@ -349,7 +349,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         326,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_372_Anim,
         ftMh_MS_372_IASA,
@@ -359,7 +359,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         327,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_373_Anim,
         ftMh_MS_373_IASA,
@@ -369,7 +369,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         328,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_374_Anim,
         ftMh_MS_374_IASA,
@@ -379,7 +379,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         329,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_375_Anim,
         ftMh_MS_375_IASA,
@@ -389,7 +389,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         330,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_376_Anim,
         ftMh_MS_376_IASA,
@@ -399,7 +399,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         331,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_376_Anim,
         ftMh_MS_376_IASA,
@@ -409,7 +409,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         332,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_378_Anim,
         ftMh_MS_378_IASA,
@@ -419,7 +419,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         333,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_379_Anim,
         ftMh_MS_379_IASA,
@@ -429,7 +429,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         334,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_380_Anim,
         ftMh_MS_380_IASA,
@@ -439,7 +439,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         335,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_381_Anim,
         ftMh_MS_381_IASA,
@@ -449,7 +449,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         336,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_382_Anim,
         ftMh_MS_382_IASA,
@@ -459,7 +459,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         337,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_383_Anim,
         ftMh_MS_383_IASA,
@@ -469,7 +469,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         338,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_384_Anim,
         ftMh_MS_384_IASA,
@@ -479,7 +479,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         339,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_385_Anim,
         ftMh_MS_385_IASA,
@@ -489,7 +489,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         340,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_386_Anim,
         ftMh_MS_386_IASA,
@@ -499,7 +499,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         ftMh_MS_Unk341,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_387_Anim,
         ftMh_MS_387_IASA,
@@ -509,7 +509,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         ftMh_MS_Unk342,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_388_Anim,
         ftMh_MS_388_IASA,
@@ -519,7 +519,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         ftMh_MS_Unk343,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_389_Anim,
         NULL,
@@ -529,7 +529,7 @@ MotionState ftMh_Init_MotionStateTable[] = {
     },
     {
         ftMh_MS_Unk344,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftMh_MS_389_Anim,
         NULL,

--- a/src/melee/ft/chara/ftMewtwo/forward.h
+++ b/src/melee/ft/chara/ftMewtwo/forward.h
@@ -5,42 +5,38 @@
 #include "ftCommon/forward.h"
 
 static MotionFlags const ftMt_MF_Special ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_UpdatePhys | FtStateChange_FreezeState;
+    Ft_MF_SkipModel | Ft_MF_SkipItemVis | Ft_MF_UnkUpdatePhys |
+    Ft_MF_FreezeState;
 
 static MotionFlags const ftMt_MF_SpecialHiStart ATTRIBUTE_USED =
-    ftMt_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx;
+    ftMt_MF_Special | Ft_MF_KeepFastFall | Ft_MF_KeepGfx;
 
 static MotionFlags const ftMt_MF_SpecialNStart ATTRIBUTE_USED =
-    ftMt_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateThrowException;
+    ftMt_MF_Special | Ft_MF_KeepFastFall | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftMt_MF_SpecialLw ATTRIBUTE_USED =
-    ftMt_MF_Special | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_SkipUpdateThrowException;
+    ftMt_MF_Special | Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftMt_MF_SpecialAirHiStart ATTRIBUTE_USED =
-    ftMt_MF_SpecialHiStart | FtStateChange_SkipUpdateParasol;
+    ftMt_MF_SpecialHiStart | Ft_MF_SkipParasol;
 
 static MotionFlags const ftMt_MF_SpecialAirNStart ATTRIBUTE_USED =
-    ftMt_MF_SpecialNStart | FtStateChange_SkipUpdateParasol;
+    ftMt_MF_SpecialNStart | Ft_MF_SkipParasol;
 
 static MotionFlags const ftMt_MF_SpecialAirLw ATTRIBUTE_USED =
-    ftMt_MF_SpecialLw | FtStateChange_SkipUpdateParasol;
+    ftMt_MF_SpecialLw | Ft_MF_SkipParasol;
 
 static MotionFlags const ftMt_MF_SpecialS ATTRIBUTE_USED =
-    ftMt_MF_Special | FtStateChange_PreserveGfx |
-    FtStateChange_SkipUpdateColAnim;
+    ftMt_MF_Special | Ft_MF_KeepGfx | Ft_MF_SkipColAnim;
 
 static MotionFlags const ftMt_MF_SpecialAirS ATTRIBUTE_USED =
-    ftMt_MF_SpecialS | FtStateChange_SkipUpdateParasol;
+    ftMt_MF_SpecialS | Ft_MF_SkipParasol;
 
 static MotionFlags const ftMt_MF_SpecialN ATTRIBUTE_USED =
-    ftMt_MF_SpecialNStart | FtStateChange_Unk_19;
+    ftMt_MF_SpecialNStart | Ft_MF_Unk19;
 
 static MotionFlags const ftMt_MF_SpecialAirN ATTRIBUTE_USED =
-    ftMt_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftMt_MF_SpecialN | Ft_MF_SkipParasol;
 
 typedef enum ftMewtwo_MotionState {
     ftMt_MS_SpecialNStart = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftMewtwo/ftMt_SpecialHi.c
+++ b/src/melee/ft/chara/ftMewtwo/ftMt_SpecialHi.c
@@ -182,14 +182,12 @@ void ftMt_SpecialAirHiStart_Coll(HSD_GObj* gobj)
 }
 
 static u32 const transition_flags0 =
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateHit |
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_SkipUpdateColAnim |
-    FtStateChange_UpdateCmd | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis |
-    FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27;
+    Ft_MF_KeepGfx | Ft_MF_SkipHit | Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim |
+    Ft_MF_UpdateCmd | Ft_MF_SkipItemVis | Ft_MF_Unk19 |
+    Ft_MF_SkipModelPartVis | Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 static u32 const transition_flags1 =
-    transition_flags0 | FtStateChange_PreserveColAnimHitStatus;
+    transition_flags0 | Ft_MF_KeepColAnimHitStatus;
 
 /// Mewtwo's ground -> air Teleport Start Motion State handler
 void ftMt_SpecialHiStart_GroundToAir(HSD_GObj* gobj)

--- a/src/melee/ft/chara/ftMewtwo/ftMt_SpecialLw.c
+++ b/src/melee/ft/chara/ftMewtwo/ftMt_SpecialLw.c
@@ -13,11 +13,9 @@
 // SpecialLw/SpecialAirLw
 
 #define FTMEWTWO_SPECIALLW_COLL_FLAG                                          \
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateMatAnim |             \
-        FtStateChange_SkipUpdateColAnim | FtStateChange_UpdateCmd |           \
-        FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_19 |              \
-        FtStateChange_SkipUpdateModelPartVis |                                \
-        FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27
+    Ft_MF_KeepGfx | Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim | Ft_MF_UpdateCmd | \
+        Ft_MF_SkipItemVis | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |            \
+        Ft_MF_SkipModelFlags | Ft_MF_Unk27
 
 // 0x80146198
 // https://decomp.me/scratch/QML6g // Reset Disable Stall flag

--- a/src/melee/ft/chara/ftMewtwo/ftMt_SpecialN.c
+++ b/src/melee/ft/chara/ftMewtwo/ftMt_SpecialN.c
@@ -15,15 +15,13 @@
 // SpecialN/SpecialAirN
 
 #define FTMEWTWO_SPECIALN_ACTION_FLAG                                         \
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_PreserveSfx |             \
-        FtStateChange_UpdateCmd | FtStateChange_SkipUpdateItemVis |           \
-        FtStateChange_Unk_19
+    Ft_MF_SkipMatAnim | Ft_MF_KeepSfx | Ft_MF_UpdateCmd | Ft_MF_SkipItemVis | \
+        Ft_MF_Unk19
 
 #define FTMEWTWO_SPECIALN_COLL_FLAG                                           \
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_SkipUpdateColAnim |       \
-        FtStateChange_UpdateCmd | FtStateChange_SkipUpdateItemVis |           \
-        FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis |         \
-        FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27
+    Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim | Ft_MF_UpdateCmd |                 \
+        Ft_MF_SkipItemVis | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |            \
+        Ft_MF_SkipModelFlags | Ft_MF_Unk27
 
 // 0x80146CCC
 // https://decomp.me/scratch/qxdYd
@@ -1064,7 +1062,7 @@ void ftMt_SpecialNLoop_Coll(HSD_GObj* gobj)
         ftCommon_8007D5D4(fp);
         Fighter_ChangeMotionState(
             gobj, ftMt_MS_SpecialAirNLoop,
-            (FtStateChange_PreserveSfx | FTMEWTWO_SPECIALN_COLL_FLAG), NULL,
+            (Ft_MF_KeepSfx | FTMEWTWO_SPECIALN_COLL_FLAG), NULL,
             fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftMewtwo_SpecialN_SetCall(gobj);
     }
@@ -1084,7 +1082,7 @@ void ftMt_SpecialNFull_Coll(HSD_GObj* gobj)
         ftCommon_8007D5D4(fp);
         Fighter_ChangeMotionState(
             gobj, ftMt_MS_SpecialAirNFull,
-            (FtStateChange_PreserveSfx | FTMEWTWO_SPECIALN_COLL_FLAG), NULL,
+            (Ft_MF_KeepSfx | FTMEWTWO_SPECIALN_COLL_FLAG), NULL,
             fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftMewtwo_SpecialN_SetCall(gobj);
     }
@@ -1161,7 +1159,7 @@ void ftMt_SpecialAirNLoop_Coll(HSD_GObj* gobj)
         ftCommon_8007D7FC(fp);
         Fighter_ChangeMotionState(
             gobj, ftMt_MS_SpecialNLoop,
-            (FtStateChange_PreserveSfx | FTMEWTWO_SPECIALN_COLL_FLAG), NULL,
+            (Ft_MF_KeepSfx | FTMEWTWO_SPECIALN_COLL_FLAG), NULL,
             fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftMewtwo_SpecialN_SetCall(gobj);
     }
@@ -1181,7 +1179,7 @@ void ftMt_SpecialAirNFull_Coll(HSD_GObj* gobj)
         ftCommon_8007D7FC(fp);
         Fighter_ChangeMotionState(
             gobj, ftMt_MS_SpecialNFull,
-            (FtStateChange_PreserveSfx | FTMEWTWO_SPECIALN_COLL_FLAG), NULL,
+            (Ft_MF_KeepSfx | FTMEWTWO_SPECIALN_COLL_FLAG), NULL,
             fp->x894_currentAnimFrame, 1.0f, 0.0f);
         ftMewtwo_SpecialN_SetCall(gobj);
     }

--- a/src/melee/ft/chara/ftMewtwo/ftMt_SpecialS.c
+++ b/src/melee/ft/chara/ftMewtwo/ftMt_SpecialS.c
@@ -22,11 +22,9 @@
 // SpecialS/SpecialAirS
 
 #define FTMEWTWO_SPECIALS_COLL_FLAG                                           \
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateMatAnim |             \
-        FtStateChange_SkipUpdateColAnim | FtStateChange_UpdateCmd |           \
-        FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_19 |              \
-        FtStateChange_SkipUpdateModelPartVis |                                \
-        FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27
+    Ft_MF_KeepGfx | Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim | Ft_MF_UpdateCmd | \
+        Ft_MF_SkipItemVis | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |            \
+        Ft_MF_SkipModelFlags | Ft_MF_Unk27
 
 // 0x8014665C
 // https://decomp.me/scratch/ktG8y // Set flags

--- a/src/melee/ft/chara/ftNess/forward.h
+++ b/src/melee/ft/chara/ftNess/forward.h
@@ -6,61 +6,59 @@
 #include "ftCommon/forward.h"
 
 static MotionFlags const ftNs_MF_Attack4 ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateHit | FtStateChange_SkipUpdateRumble |
-    FtStateChange_SkipUpdateItemVis | FtStateChange_FreezeState;
+    Ft_MF_SkipHit | Ft_MF_SkipRumble | Ft_MF_SkipItemVis | Ft_MF_FreezeState;
 
 static MotionFlags const ftNs_MF_AttackHi4 ATTRIBUTE_USED =
-    ftNs_MF_Attack4 | FtStateChange_PreserveGfx;
+    ftNs_MF_Attack4 | Ft_MF_KeepGfx;
 
 static MotionFlags const ftNs_MF_AttackLw4 ATTRIBUTE_USED =
-    ftNs_MF_AttackHi4 | FtStateChange_PreserveFastFall;
+    ftNs_MF_AttackHi4 | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftNs_MF_AttackHi4Start ATTRIBUTE_USED =
-    ftNs_MF_AttackHi4 | FtStateChange_PreserveSfx;
+    ftNs_MF_AttackHi4 | Ft_MF_KeepSfx;
 
 static MotionFlags const ftNs_MF_AttackLw4Start ATTRIBUTE_USED =
-    ftNs_MF_AttackLw4 | FtStateChange_PreserveSfx;
+    ftNs_MF_AttackLw4 | Ft_MF_KeepSfx;
 
 static MotionFlags const ftNs_MF_AttackS4 ATTRIBUTE_USED =
-    ftNs_MF_Attack4 | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveSfx | FtStateChange_SkipUpdateColAnim;
+    ftNs_MF_Attack4 | Ft_MF_KeepFastFall | Ft_MF_KeepSfx | Ft_MF_SkipColAnim;
 
 static MotionFlags const ftNs_MF_Special ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_UpdatePhys | FtStateChange_FreezeState;
+    Ft_MF_SkipModel | Ft_MF_SkipItemVis | Ft_MF_UnkUpdatePhys |
+    Ft_MF_FreezeState;
 
 static MotionFlags const ftNs_MF_SpecialLw ATTRIBUTE_USED =
-    ftNs_MF_Special | FtStateChange_PreserveColAnimHitStatus;
+    ftNs_MF_Special | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftNs_MF_Special_SkipUpdateThrowException
-    ATTRIBUTE_USED = ftNs_MF_Special | FtStateChange_SkipUpdateThrowException;
+    ATTRIBUTE_USED = ftNs_MF_Special | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftNs_MF_SpecialN ATTRIBUTE_USED =
-    ftNs_MF_Special_SkipUpdateThrowException | FtStateChange_PreserveFastFall;
+    ftNs_MF_Special_SkipUpdateThrowException | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftNs_MF_SpecialS ATTRIBUTE_USED =
-    ftNs_MF_Special_SkipUpdateThrowException | FtStateChange_PreserveGfx;
+    ftNs_MF_Special_SkipUpdateThrowException | Ft_MF_KeepGfx;
 
 static MotionFlags const ftNs_MF_SpecialHi ATTRIBUTE_USED =
-    ftNs_MF_SpecialN | FtStateChange_PreserveGfx;
+    ftNs_MF_SpecialN | Ft_MF_KeepGfx;
 
 static MotionFlags const ftNs_MF_SpecialAirLw ATTRIBUTE_USED =
-    ftNs_MF_SpecialLw | FtStateChange_SkipUpdateParasol;
+    ftNs_MF_SpecialLw | Ft_MF_SkipParasol;
 
 static MotionFlags const ftNs_MF_SpecialAirN ATTRIBUTE_USED =
-    ftNs_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftNs_MF_SpecialN | Ft_MF_SkipParasol;
 
 static MotionFlags const ftNs_MF_SpecialAirS ATTRIBUTE_USED =
-    ftNs_MF_SpecialS | FtStateChange_SkipUpdateParasol;
+    ftNs_MF_SpecialS | Ft_MF_SkipParasol;
 
 static MotionFlags const ftNs_MF_SpecialAirHi ATTRIBUTE_USED =
-    ftNs_MF_SpecialHi | FtStateChange_SkipUpdateParasol;
+    ftNs_MF_SpecialHi | Ft_MF_SkipParasol;
 
 static MotionFlags const ftNs_MF_SpecialLwLoop ATTRIBUTE_USED =
-    ftNs_MF_SpecialLw | FtStateChange_Unk_19;
+    ftNs_MF_SpecialLw | Ft_MF_Unk19;
 
 static MotionFlags const ftNs_MF_SpecialAirLwLoop ATTRIBUTE_USED =
-    ftNs_MF_SpecialLwLoop | FtStateChange_SkipUpdateParasol;
+    ftNs_MF_SpecialLwLoop | Ft_MF_SkipParasol;
 
 typedef enum ftNess_MotionState {
     ftNs_MS_AttackS4 = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftNess/ftNs_AttackHi4.c
+++ b/src/melee/ft/chara/ftNess/ftNs_AttackHi4.c
@@ -908,9 +908,8 @@ void ftNs_AttackHi4Charge_Enter(
 {
     Fighter* fp = GET_FIGHTER(gobj);
 
-    Fighter_ChangeMotionState(gobj, ftNs_MS_AttackHi4Charge,
-                              FtStateChange_SkipUpdateItemVis, NULL, 12.0f,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_AttackHi4Charge, Ft_MF_SkipItemVis,
+                              NULL, 12.0f, 1.0f, 0.0f);
     ftAnim_8006EBA4(gobj);
     ftAnim_SetAnimRate(gobj, 0.0f);
     ftNs_AttackHi4_YoyoApplySmash(gobj);
@@ -1051,8 +1050,7 @@ void ftNs_AttackHi4Release_Enter(HSD_GObj* gobj)
 
     fp = GET_FIGHTER(gobj);
     Fighter_ChangeMotionState(gobj, ftNs_MS_AttackHi4Release,
-                              FtStateChange_SkipUpdateItemVis, NULL, 13.0f,
-                              1.0f, 0.0f);
+                              Ft_MF_SkipItemVis, NULL, 13.0f, 1.0f, 0.0f);
     ftAnim_8006EBA4(gobj);
 
     fighter_data2 = getFighter(gobj);

--- a/src/melee/ft/chara/ftNess/ftNs_AttackLw4.c
+++ b/src/melee/ft/chara/ftNess/ftNs_AttackLw4.c
@@ -145,9 +145,8 @@ void ftNs_AttackLw4Charge_Enter(
 {
     Fighter* fp = GET_FIGHTER(gobj);
 
-    Fighter_ChangeMotionState(gobj, ftNs_MS_AttackLw4Charge,
-                              FtStateChange_SkipUpdateItemVis, NULL, 12.0f,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_AttackLw4Charge, Ft_MF_SkipItemVis,
+                              NULL, 12.0f, 1.0f, 0.0f);
     ftAnim_8006EBA4(gobj);
     ftAnim_SetAnimRate(gobj, 0.0f);
     ftNs_AttackHi4_YoyoApplySmash(gobj);
@@ -236,8 +235,7 @@ void ftNs_AttackLw4Release_Enter(
     Fighter* fp = GET_FIGHTER(gobj);
 
     Fighter_ChangeMotionState(gobj, ftNs_MS_AttackLw4Release,
-                              FtStateChange_SkipUpdateItemVis, NULL, 13.0f,
-                              1.0f, 0.0f);
+                              Ft_MF_SkipItemVis, NULL, 13.0f, 1.0f, 0.0f);
     ftAnim_8006EBA4(gobj);
     ftNs_AttackHi4_YoyoSetChargeDamage(gobj);
     fp->x2222_flag.bits.b2 = 1;

--- a/src/melee/ft/chara/ftNess/ftNs_SpecialHi.c
+++ b/src/melee/ft/chara/ftNess/ftNs_SpecialHi.c
@@ -21,18 +21,15 @@
 
 // SpecialHi/SpecialAirHi (PK Thunder)
 #define FTNESS_SPECIALHI_COLL_FLAG                                            \
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_SkipUpdateColAnim |       \
-        FtStateChange_UpdateCmd | FtStateChange_SkipUpdateItemVis |           \
-        FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis |         \
-        FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27
+    Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim | Ft_MF_UpdateCmd |                 \
+        Ft_MF_SkipItemVis | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |            \
+        Ft_MF_SkipModelFlags | Ft_MF_Unk27
 
 // SpecialHi Jibaku (PK Thunder 2 Self-Hit)
 #define FTNESS_JIBAKU_COLL_FLAG                                               \
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateHit |                 \
-        FtStateChange_SkipUpdateMatAnim | FtStateChange_SkipUpdateColAnim |   \
-        FtStateChange_UpdateCmd | FtStateChange_SkipUpdateItemVis |           \
-        FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis |         \
-        FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27
+    Ft_MF_KeepGfx | Ft_MF_SkipHit | Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim |   \
+        Ft_MF_UpdateCmd | Ft_MF_SkipItemVis | Ft_MF_Unk19 |                   \
+        Ft_MF_SkipModelPartVis | Ft_MF_SkipModelFlags | Ft_MF_Unk27
 
 // Setup float order
 static f32 return_float1(void) // -25264
@@ -1853,8 +1850,7 @@ void ftNs_SpecialAirHi_Coll(HSD_GObj* gobj)
             new_var->facing_dir = phi_f0;
             ftNs_SpecialHiStopGFX(gobj);
             Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiRebound,
-                                      FtStateChange_PreserveGfx, NULL, 0.0f,
-                                      1.0f, 0.0f);
+                                      Ft_MF_KeepGfx, NULL, 0.0f, 1.0f, 0.0f);
             ftAnim_8006EBA4(gobj);
             spC4.x = atan2f(-fighter_r31->x6F0_collData.x188_ceiling.normal.x,
                             fighter_r31->x6F0_collData.x188_ceiling.normal.y);
@@ -1892,8 +1888,8 @@ void ftNs_SpecialAirHi_Coll(HSD_GObj* gobj)
                 fighter_data4->facing_dir = phi_f0;
                 ftNs_SpecialHiStopGFX(gobj);
                 Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiRebound,
-                                          FtStateChange_PreserveGfx, NULL,
-                                          0.0f, 1.0f, 0.0f);
+                                          Ft_MF_KeepGfx, NULL, 0.0f, 1.0f,
+                                          0.0f);
                 ftAnim_8006EBA4(gobj);
                 spB8.x =
                     atan2f(-fighter_r31->x6F0_collData.x160_rightwall.normal.x,
@@ -1935,8 +1931,8 @@ void ftNs_SpecialAirHi_Coll(HSD_GObj* gobj)
                 fighter_data5->facing_dir = phi_f0;
                 ftNs_SpecialHiStopGFX(gobj);
                 Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiRebound,
-                                          FtStateChange_PreserveGfx, NULL,
-                                          0.0f, 1.0f, 0.0f);
+                                          Ft_MF_KeepGfx, NULL, 0.0f, 1.0f,
+                                          0.0f);
                 ftAnim_8006EBA4(gobj);
                 spAC.x =
                     atan2f(-fighter_r31->x6F0_collData.x174_leftwall.normal.x,

--- a/src/melee/ft/chara/ftNess/ftNs_SpecialLw.c
+++ b/src/melee/ft/chara/ftNess/ftNs_SpecialLw.c
@@ -15,17 +15,14 @@
 
 // SpecialLw (PSI Magnet)
 #define FTNESS_SPECIALLW_COLL_FLAG                                            \
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateMatAnim |             \
-        FtStateChange_SkipUpdateColAnim | FtStateChange_UpdateCmd |           \
-        FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_19 |              \
-        FtStateChange_SkipUpdateModelPartVis |                                \
-        FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27
+    Ft_MF_KeepGfx | Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim | Ft_MF_UpdateCmd | \
+        Ft_MF_SkipItemVis | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |            \
+        Ft_MF_SkipModelFlags | Ft_MF_Unk27
 
 #define FTNESS_SPECIALLW_END_FLAG                                             \
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_SkipUpdateColAnim |       \
-        FtStateChange_UpdateCmd | FtStateChange_SkipUpdateItemVis |           \
-        FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis |         \
-        FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27
+    Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim | Ft_MF_UpdateCmd |                 \
+        Ft_MF_SkipItemVis | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |            \
+        Ft_MF_SkipModelFlags | Ft_MF_Unk27
 
 // 0x80119E14
 // https://decomp.me/scratch/LwTKg
@@ -453,9 +450,8 @@ void ftNs_SpecialLwHold_Enter(
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialLwHold,
-                              FtStateChange_PreserveGfx, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialLwHold, Ft_MF_KeepGfx, NULL,
+                              0.0f, 1.0f, 0.0f);
     fp = GET_FIGHTER(gobj);
     ness_attr = fp->x2D4_specialAttributes;
     ftColl_CreateAbsorbHit(gobj, &ness_attr->x98_PSI_MAGNET_ABSORPTION);
@@ -474,9 +470,8 @@ void ftNs_SpecialAirLwHold_Enter(
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirLwHold,
-                              FtStateChange_PreserveGfx, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirLwHold, Ft_MF_KeepGfx,
+                              NULL, 0.0f, 1.0f, 0.0f);
     fp = GET_FIGHTER(gobj);
     ness_attr = fp->x2D4_specialAttributes;
     ftColl_CreateAbsorbHit(gobj, &ness_attr->x98_PSI_MAGNET_ABSORPTION);
@@ -693,9 +688,8 @@ bool ftNs_SpecialLwHold_GroundOrAir(
         return false;
     }
     if ((s32) fp->ground_or_air == GA_Ground) {
-        Fighter_ChangeMotionState(arg0, ftNs_MS_SpecialLwHold,
-                                  FtStateChange_PreserveGfx, NULL, 0.0f, 1.0f,
-                                  0.0f);
+        Fighter_ChangeMotionState(arg0, ftNs_MS_SpecialLwHold, Ft_MF_KeepGfx,
+                                  NULL, 0.0f, 1.0f, 0.0f);
 
         {
             Fighter* fp = GET_FIGHTER(arg0);
@@ -704,8 +698,7 @@ bool ftNs_SpecialLwHold_GroundOrAir(
         }
     } else {
         Fighter_ChangeMotionState(arg0, ftNs_MS_SpecialAirLwHold,
-                                  FtStateChange_PreserveGfx, NULL, 0.0f, 1.0f,
-                                  0.0f);
+                                  Ft_MF_KeepGfx, NULL, 0.0f, 1.0f, 0.0f);
 
         {
             Fighter* fp = GET_FIGHTER(arg0);
@@ -770,16 +763,16 @@ void ftNs_SpecialLwHit_Anim(
         } else {
             if ((s32) temp_r3_2->ground_or_air == GA_Ground) {
                 Fighter_ChangeMotionState(arg0, ftNs_MS_SpecialLwHold,
-                                          FtStateChange_PreserveGfx, NULL,
-                                          0.0f, 1.0f, 0.0f);
+                                          Ft_MF_KeepGfx, NULL, 0.0f, 1.0f,
+                                          0.0f);
 
                 temp_e1 = arg0->user_data;
                 attr = temp_e1->x2D4_specialAttributes;
                 ftColl_CreateAbsorbHit(arg0, &attr->x98_PSI_MAGNET_ABSORPTION);
             } else {
                 Fighter_ChangeMotionState(arg0, ftNs_MS_SpecialAirLwHold,
-                                          FtStateChange_PreserveGfx, NULL,
-                                          0.0f, 1.0f, 0.0f);
+                                          Ft_MF_KeepGfx, NULL, 0.0f, 1.0f,
+                                          0.0f);
                 temp_e2 = arg0->user_data;
                 attr = temp_e2->x2D4_specialAttributes;
                 ftColl_CreateAbsorbHit(arg0, &attr->x98_PSI_MAGNET_ABSORPTION);

--- a/src/melee/ft/chara/ftNess/ftNs_SpecialN.c
+++ b/src/melee/ft/chara/ftNess/ftNs_SpecialN.c
@@ -12,10 +12,9 @@
 
 // SpecialN/SpecialAirN (PK Flash)
 #define FTNESS_SPECIALN_COLL_FLAG                                             \
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_SkipUpdateColAnim |       \
-        FtStateChange_UpdateCmd | FtStateChange_SkipUpdateItemVis |           \
-        FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis |         \
-        FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27
+    Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim | Ft_MF_UpdateCmd |                 \
+        Ft_MF_SkipItemVis | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |            \
+        Ft_MF_SkipModelFlags | Ft_MF_Unk27
 
 /// Ness PK Flash Charge msid check
 bool ftNs_SpecialN_CheckSpecialNHold(HSD_GObj* gobj)

--- a/src/melee/ft/chara/ftPeach/forward.h
+++ b/src/melee/ft/chara/ftPeach/forward.h
@@ -5,65 +5,60 @@
 #include "ftCommon/forward.h"
 
 static MotionFlags const ftPe_MF_Base ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateItemVis | FtStateChange_FreezeState;
+    Ft_MF_SkipItemVis | Ft_MF_FreezeState;
 
 static MotionFlags const ftPe_MF_FloatAttack ATTRIBUTE_USED =
-    ftPe_MF_Base | FtStateChange_SkipUpdateParasol;
+    ftPe_MF_Base | Ft_MF_SkipParasol;
 
 static MotionFlags const ftPe_MF_FloatAttackAirN ATTRIBUTE_USED =
-    ftPe_MF_FloatAttack | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_SkipUpdateHit;
+    ftPe_MF_FloatAttack | Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipHit;
 
 static MotionFlags const ftPe_MF_Move_14 ATTRIBUTE_USED =
-    ftPe_MF_FloatAttackAirN | FtStateChange_PreserveFastFall;
+    ftPe_MF_FloatAttackAirN | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftPe_MF_FloatAttackAirB ATTRIBUTE_USED =
-    ftPe_MF_FloatAttackAirN | FtStateChange_PreserveGfx;
+    ftPe_MF_FloatAttackAirN | Ft_MF_KeepGfx;
 
 static MotionFlags const ftPe_MF_FloatAttackAirHi ATTRIBUTE_USED =
-    ftPe_MF_FloatAttackAirN | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx;
+    ftPe_MF_FloatAttackAirN | Ft_MF_KeepFastFall | Ft_MF_KeepGfx;
 
 static MotionFlags const ftPe_MF_Move_17 ATTRIBUTE_USED =
-    ftPe_MF_FloatAttack | FtStateChange_SkipUpdateModel;
+    ftPe_MF_FloatAttack | Ft_MF_SkipModel;
 
 static MotionFlags const ftPe_MF_AttackS4 ATTRIBUTE_USED =
-    ftPe_MF_Base | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateHit | FtStateChange_PreserveSfx |
-    FtStateChange_SkipUpdateRumble;
+    ftPe_MF_Base | Ft_MF_KeepFastFall | Ft_MF_SkipHit | Ft_MF_KeepSfx |
+    Ft_MF_SkipRumble;
 
 static MotionFlags const ftPe_MF_Special ATTRIBUTE_USED =
-    ftPe_MF_Base | FtStateChange_SkipUpdateModel |
-    FtStateChange_Unk_UpdatePhys;
+    ftPe_MF_Base | Ft_MF_SkipModel | Ft_MF_UnkUpdatePhys;
 
 static MotionFlags const ftPe_MF_SpecialN ATTRIBUTE_USED =
-    ftPe_MF_Special | FtStateChange_PreserveFastFall;
+    ftPe_MF_Special | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftPe_MF_SpecialHi ATTRIBUTE_USED =
-    ftPe_MF_SpecialN | FtStateChange_PreserveGfx;
+    ftPe_MF_SpecialN | Ft_MF_KeepGfx;
 
 static MotionFlags const ftPe_MF_SpecialLw ATTRIBUTE_USED =
-    ftPe_MF_Special | FtStateChange_PreserveColAnimHitStatus;
+    ftPe_MF_Special | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftPe_MF_SpecialS ATTRIBUTE_USED =
-    ftPe_MF_Special | FtStateChange_PreserveGfx | FtStateChange_PreserveSfx;
+    ftPe_MF_Special | Ft_MF_KeepGfx | Ft_MF_KeepSfx;
 
 static MotionFlags const ftPe_MF_SpecialAirN ATTRIBUTE_USED =
-    ftPe_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftPe_MF_SpecialN | Ft_MF_SkipParasol;
 
 static MotionFlags const ftPe_MF_SpecialAirHi ATTRIBUTE_USED =
-    ftPe_MF_SpecialHi | FtStateChange_SkipUpdateParasol;
+    ftPe_MF_SpecialHi | Ft_MF_SkipParasol;
 
 static MotionFlags const ftPe_MF_SpecialAirS ATTRIBUTE_USED =
-    ftPe_MF_SpecialS | FtStateChange_SkipUpdateParasol;
+    ftPe_MF_SpecialS | Ft_MF_SkipParasol;
 
 static MotionFlags const ftPe_MF_ParasolOpen ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateHit | FtStateChange_SkipUpdateModel |
-    FtStateChange_Unk_6 | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_SkipUpdateModelPartVis;
+    Ft_MF_SkipHit | Ft_MF_SkipModel | Ft_MF_Unk06 | Ft_MF_SkipItemVis |
+    Ft_MF_SkipModelPartVis;
 
 static MotionFlags const ftPe_MF_ParasolFallSpecial ATTRIBUTE_USED =
-    ftPe_MF_ParasolOpen | FtStateChange_Unk_19;
+    ftPe_MF_ParasolOpen | Ft_MF_Unk19;
 
 typedef enum ftPeach_MotionState {
     ftPe_MS_Float = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftPeach/ftPe_Init.c
+++ b/src/melee/ft/chara/ftPeach/ftPe_Init.c
@@ -16,7 +16,7 @@
 MotionState ftPe_Init_MotionStateTable[] = {
     {
         295,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftPe_Float_Anim,
         ftPe_Float_IASA,
@@ -26,7 +26,7 @@ MotionState ftPe_Init_MotionStateTable[] = {
     },
     {
         296,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftPe_FloatEnd_Anim,
         ftPe_FloatEnd_IASA,
@@ -36,7 +36,7 @@ MotionState ftPe_Init_MotionStateTable[] = {
     },
     {
         297,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftPe_FloatEnd_Anim,
         ftPe_FloatEnd_IASA,

--- a/src/melee/ft/chara/ftPikachu/forward.h
+++ b/src/melee/ft/chara/ftPikachu/forward.h
@@ -6,34 +6,33 @@
 #include "ftCommon/forward.h"
 
 static MotionFlags const ftPk_MF_Special ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_UpdatePhys | FtStateChange_FreezeState;
+    Ft_MF_SkipModel | Ft_MF_SkipItemVis | Ft_MF_UnkUpdatePhys |
+    Ft_MF_FreezeState;
 
 static MotionFlags const ftPk_MF_SpecialLw ATTRIBUTE_USED =
-    ftPk_MF_Special | FtStateChange_PreserveColAnimHitStatus;
+    ftPk_MF_Special | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftPk_MF_SpecialN ATTRIBUTE_USED =
-    ftPk_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateThrowException;
+    ftPk_MF_Special | Ft_MF_KeepFastFall | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftPk_MF_SpecialHi ATTRIBUTE_USED =
-    ftPk_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateThrowException;
+    ftPk_MF_Special | Ft_MF_KeepFastFall | Ft_MF_KeepGfx |
+    Ft_MF_SkipThrowException;
 
 static MotionFlags const ftPk_MF_SpecialS ATTRIBUTE_USED =
-    ftPk_MF_Special | FtStateChange_PreserveGfx | FtStateChange_PreserveSfx;
+    ftPk_MF_Special | Ft_MF_KeepGfx | Ft_MF_KeepSfx;
 
 static MotionFlags const ftPk_MF_SpecialAirLw ATTRIBUTE_USED =
-    ftPk_MF_SpecialLw | FtStateChange_SkipUpdateParasol;
+    ftPk_MF_SpecialLw | Ft_MF_SkipParasol;
 
 static MotionFlags const ftPk_MF_SpecialAirN ATTRIBUTE_USED =
-    ftPk_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftPk_MF_SpecialN | Ft_MF_SkipParasol;
 
 static MotionFlags const ftPk_MF_SpecialAirHi ATTRIBUTE_USED =
-    ftPk_MF_SpecialHi | FtStateChange_SkipUpdateParasol;
+    ftPk_MF_SpecialHi | Ft_MF_SkipParasol;
 
 static MotionFlags const ftPk_MF_SpecialAirS ATTRIBUTE_USED =
-    ftPk_MF_SpecialS | FtStateChange_SkipUpdateParasol;
+    ftPk_MF_SpecialS | Ft_MF_SkipParasol;
 
 typedef enum ftPikachu_MotionState {
     ftPk_MS_SpecialN = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftPikachu/ftPk_SpecialS.c
+++ b/src/melee/ft/chara/ftPikachu/ftPk_SpecialS.c
@@ -113,11 +113,9 @@ void ftPk_SpecialAirSStart_Coll(HSD_GObj* gobj)
 }
 
 static const u32 transition_flags0 =
-    FtStateChange_PreserveColAnimHitStatus | FtStateChange_SkipUpdateMatAnim |
-    FtStateChange_PreserveSfx | FtStateChange_SkipUpdateColAnim |
-    FtStateChange_UpdateCmd | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis |
-    FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27;
+    Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipMatAnim | Ft_MF_KeepSfx |
+    Ft_MF_SkipColAnim | Ft_MF_UpdateCmd | Ft_MF_SkipItemVis | Ft_MF_Unk19 |
+    Ft_MF_SkipModelPartVis | Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 void ftPk_SpecialS_ChangeMotion_Unk00(HSD_GObj* gobj)
 {
@@ -220,12 +218,9 @@ void ftPk_SpecialAirSCharge_Coll(HSD_GObj* gobj)
 }
 
 static u32 const transition_flags1 =
-    FtStateChange_PreserveGfx | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_PreserveSfx |
-    FtStateChange_SkipUpdateColAnim | FtStateChange_UpdateCmd |
-    FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_19 |
-    FtStateChange_SkipUpdateModelPartVis | FtStateChange_SkipUpdateModelFlag |
-    FtStateChange_Unk_27;
+    Ft_MF_KeepGfx | Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipMatAnim |
+    Ft_MF_KeepSfx | Ft_MF_SkipColAnim | Ft_MF_UpdateCmd | Ft_MF_SkipItemVis |
+    Ft_MF_Unk19 | Ft_MF_SkipModelPartVis | Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 void ftPk_SpecialS_ChangeMotion_Unk02(HSD_GObj* gobj)
 {
@@ -249,8 +244,7 @@ void ftPk_SpecialS_ChangeMotion_Unk04(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, 344, FtStateChange_PreserveSfx, 0, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, 344, Ft_MF_KeepSfx, 0, 0, 1, 0);
 
     {
         Fighter* fp = GET_FIGHTER(gobj);
@@ -265,8 +259,7 @@ void ftPk_SpecialS_ChangeMotion_Unk05(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, 349, FtStateChange_PreserveSfx, 0, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, 349, Ft_MF_KeepSfx, 0, 0, 1, 0);
 
     {
         Fighter* fp = GET_FIGHTER(gobj);
@@ -344,11 +337,9 @@ void ftPk_SpecialAirSLaunch_Coll(HSD_GObj* gobj)
 }
 
 static u32 const transition_flags2 =
-    FtStateChange_PreserveGfx | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_SkipUpdateColAnim |
-    FtStateChange_UpdateCmd | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis |
-    FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27;
+    Ft_MF_KeepGfx | Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipMatAnim |
+    Ft_MF_SkipColAnim | Ft_MF_UpdateCmd | Ft_MF_SkipItemVis | Ft_MF_Unk19 |
+    Ft_MF_SkipModelPartVis | Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 void ftPk_SpecialS_ChangeMotion_Unk06(HSD_GObj* gobj)
 {
@@ -454,8 +445,7 @@ void ftPk_SpecialAirS_Coll(HSD_GObj* gobj)
     }
 }
 
-static u32 const transition_flags3 =
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateHit;
+static u32 const transition_flags3 = Ft_MF_KeepGfx | Ft_MF_SkipHit;
 
 void ftPk_SpecialS_ChangeMotion_Unk10(HSD_GObj* gobj)
 {

--- a/src/melee/ft/chara/ftPopo/forward.h
+++ b/src/melee/ft/chara/ftPopo/forward.h
@@ -6,33 +6,32 @@
 #include "ftCommon/forward.h"
 
 static MotionFlags const ftPp_MF_Special ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_UpdatePhys | FtStateChange_FreezeState;
+    Ft_MF_SkipModel | Ft_MF_SkipItemVis | Ft_MF_UnkUpdatePhys |
+    Ft_MF_FreezeState;
 
 static MotionFlags const ftPp_MF_SpecialLw ATTRIBUTE_USED =
-    ftPp_MF_Special | FtStateChange_PreserveColAnimHitStatus;
+    ftPp_MF_Special | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftPp_MF_SpecialN ATTRIBUTE_USED =
-    ftPp_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateThrowException;
+    ftPp_MF_Special | Ft_MF_KeepFastFall | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftPp_MF_SpecialS ATTRIBUTE_USED =
-    ftPp_MF_Special | FtStateChange_PreserveGfx | FtStateChange_PreserveSfx;
+    ftPp_MF_Special | Ft_MF_KeepGfx | Ft_MF_KeepSfx;
 
 static MotionFlags const ftPp_MF_SpecialHi ATTRIBUTE_USED =
-    ftPp_MF_SpecialS | FtStateChange_PreserveFastFall;
+    ftPp_MF_SpecialS | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftPp_MF_MS_358 ATTRIBUTE_USED =
-    ftPp_MF_SpecialLw | FtStateChange_SkipUpdateParasol;
+    ftPp_MF_SpecialLw | Ft_MF_SkipParasol;
 
 static MotionFlags const ftPp_MF_SpecialAirN ATTRIBUTE_USED =
-    ftPp_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftPp_MF_SpecialN | Ft_MF_SkipParasol;
 
 static MotionFlags const ftPp_MF_SpecialAirS ATTRIBUTE_USED =
-    ftPp_MF_SpecialS | FtStateChange_SkipUpdateParasol;
+    ftPp_MF_SpecialS | Ft_MF_SkipParasol;
 
 static MotionFlags const ftPp_MF_SpecialAirHi ATTRIBUTE_USED =
-    ftPp_MF_SpecialHi | FtStateChange_SkipUpdateParasol;
+    ftPp_MF_SpecialHi | Ft_MF_SkipParasol;
 
 typedef enum ftPopo_MotionState {
     ftPp_MS_SpecialN = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftPurin/forward.h
+++ b/src/melee/ft/chara/ftPurin/forward.h
@@ -6,40 +6,38 @@
 #include "ftCommon/forward.h"
 
 static MotionFlags const ftPr_MF_Special ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_UpdatePhys | FtStateChange_FreezeState;
+    Ft_MF_SkipModel | Ft_MF_SkipItemVis | Ft_MF_UnkUpdatePhys |
+    Ft_MF_FreezeState;
 
 static MotionFlags const ftPr_MF_SpecialHi ATTRIBUTE_USED =
-    ftPr_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx;
+    ftPr_MF_Special | Ft_MF_KeepFastFall | Ft_MF_KeepGfx;
 
 static MotionFlags const ftPr_MF_SpecialLw ATTRIBUTE_USED =
-    ftPr_MF_Special | FtStateChange_PreserveColAnimHitStatus;
+    ftPr_MF_Special | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftPr_MF_SpecialN ATTRIBUTE_USED =
-    ftPr_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveSfx;
+    ftPr_MF_Special | Ft_MF_KeepFastFall | Ft_MF_KeepSfx;
 
 static MotionFlags const ftPr_MF_SpecialS ATTRIBUTE_USED =
-    ftPr_MF_Special | FtStateChange_PreserveGfx | FtStateChange_PreserveSfx;
+    ftPr_MF_Special | Ft_MF_KeepGfx | Ft_MF_KeepSfx;
 
 static MotionFlags const ftPr_MF_SpecialAirHi ATTRIBUTE_USED =
-    ftPr_MF_SpecialHi | FtStateChange_SkipUpdateParasol;
+    ftPr_MF_SpecialHi | Ft_MF_SkipParasol;
 
 static MotionFlags const ftPr_MF_SpecialAirLw ATTRIBUTE_USED =
-    ftPr_MF_SpecialLw | FtStateChange_SkipUpdateParasol;
+    ftPr_MF_SpecialLw | Ft_MF_SkipParasol;
 
 static MotionFlags const ftPr_MF_SpecialAirN ATTRIBUTE_USED =
-    ftPr_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftPr_MF_SpecialN | Ft_MF_SkipParasol;
 
 static MotionFlags const ftPr_MF_SpecialAirS ATTRIBUTE_USED =
-    ftPr_MF_SpecialS | FtStateChange_SkipUpdateParasol;
+    ftPr_MF_SpecialS | Ft_MF_SkipParasol;
 
 static MotionFlags const ftPr_MF_SpecialNCharged ATTRIBUTE_USED =
-    ftPr_MF_SpecialN | FtStateChange_Unk_19;
+    ftPr_MF_SpecialN | Ft_MF_Unk19;
 
 static MotionFlags const ftPr_SpecialAirNCharged ATTRIBUTE_USED =
-    ftPr_MF_SpecialNCharged | FtStateChange_SkipUpdateParasol;
+    ftPr_MF_SpecialNCharged | Ft_MF_SkipParasol;
 
 typedef enum ftPurin_MotionState {
     ftPr_MS_Jump2 = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftPurin/ftPr_Init.c
+++ b/src/melee/ft/chara/ftPurin/ftPr_Init.c
@@ -30,7 +30,7 @@
 MotionState ftPr_Init_MotionStateTable[] = {
     {
         295,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCo_MultiJump_Anim,
         ftCo_MultiJump_IASA,
@@ -40,7 +40,7 @@ MotionState ftPr_Init_MotionStateTable[] = {
     },
     {
         296,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCo_MultiJump_Anim,
         ftCo_MultiJump_IASA,
@@ -50,7 +50,7 @@ MotionState ftPr_Init_MotionStateTable[] = {
     },
     {
         297,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCo_MultiJump_Anim,
         ftCo_MultiJump_IASA,
@@ -60,7 +60,7 @@ MotionState ftPr_Init_MotionStateTable[] = {
     },
     {
         298,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCo_MultiJump_Anim,
         ftCo_MultiJump_IASA,
@@ -70,7 +70,7 @@ MotionState ftPr_Init_MotionStateTable[] = {
     },
     {
         299,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCo_MultiJump_Anim,
         ftCo_MultiJump_IASA,

--- a/src/melee/ft/chara/ftSamus/forward.h
+++ b/src/melee/ft/chara/ftSamus/forward.h
@@ -6,45 +6,41 @@
 #include "ftCommon/forward.h"
 
 static MotionFlags const ftSs_MF_Special ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_UpdatePhys | FtStateChange_FreezeState;
+    Ft_MF_SkipModel | Ft_MF_SkipItemVis | Ft_MF_UnkUpdatePhys |
+    Ft_MF_FreezeState;
 
 static MotionFlags const ftSs_MF_SpecialN ATTRIBUTE_USED =
-    ftSs_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateThrowException;
+    ftSs_MF_Special | Ft_MF_KeepFastFall | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftSs_MF_SpecialS ATTRIBUTE_USED =
-    ftSs_MF_Special | FtStateChange_PreserveGfx |
-    FtStateChange_SkipUpdateThrowException;
+    ftSs_MF_Special | Ft_MF_KeepGfx | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftSs_MF_SpecialLw ATTRIBUTE_USED =
-    ftSs_MF_Special | FtStateChange_PreserveColAnimHitStatus |
-    FtStateChange_SkipUpdateThrowException;
+    ftSs_MF_Special | Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftSs_MF_SpecialHi ATTRIBUTE_USED =
-    ftSs_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx | FtStateChange_PreserveSfx;
+    ftSs_MF_Special | Ft_MF_KeepFastFall | Ft_MF_KeepGfx | Ft_MF_KeepSfx;
 
 static MotionFlags const ftSs_MF_SpecialAirN ATTRIBUTE_USED =
-    ftSs_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftSs_MF_SpecialN | Ft_MF_SkipParasol;
 
 static MotionFlags const ftSs_MF_SpecialAirS ATTRIBUTE_USED =
-    ftSs_MF_SpecialS | FtStateChange_SkipUpdateParasol;
+    ftSs_MF_SpecialS | Ft_MF_SkipParasol;
 
 static MotionFlags const ftSs_MF_SpecialAirLw ATTRIBUTE_USED =
-    ftSs_MF_SpecialLw | FtStateChange_SkipUpdateParasol;
+    ftSs_MF_SpecialLw | Ft_MF_SkipParasol;
 
 static MotionFlags const ftSs_MF_SpecialAirHi ATTRIBUTE_USED =
-    ftSs_MF_SpecialHi | FtStateChange_SkipUpdateParasol;
+    ftSs_MF_SpecialHi | Ft_MF_SkipParasol;
 
 static MotionFlags const ftSs_MF_SpecialSSmash ATTRIBUTE_USED =
-    ftSs_MF_SpecialS | FtStateChange_SkipUpdateRumble;
+    ftSs_MF_SpecialS | Ft_MF_SkipRumble;
 
 static MotionFlags const ftSs_MF_SpecialAirSSmash ATTRIBUTE_USED =
-    ftSs_MF_SpecialSSmash | FtStateChange_SkipUpdateParasol;
+    ftSs_MF_SpecialSSmash | Ft_MF_SkipParasol;
 
 static MotionFlags const ftSs_MF_ZairCatch ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModelPartVis | FtStateChange_SkipUpdateMetalB;
+    Ft_MF_SkipModelPartVis | Ft_MF_SkipMetalB;
 
 typedef enum ftSamus_MotionState {
     ftSs_MS_SpecialLw = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftSamus/ftSs_Init.c
+++ b/src/melee/ft/chara/ftSamus/ftSs_Init.c
@@ -23,7 +23,7 @@
 MotionState ftSs_Init_MotionStateTable[] = {
     {
         295,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftSs_SpecialLw_Anim,
         ftSs_SpecialLw_IASA,
@@ -33,7 +33,7 @@ MotionState ftSs_Init_MotionStateTable[] = {
     },
     {
         296,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftSs_SpecialAirLw_Anim,
         ftSs_SpecialAirLw_IASA,
@@ -183,7 +183,7 @@ MotionState ftSs_Init_MotionStateTable[] = {
     },
     {
         311,
-        FtStateChange_FreezeState,
+        Ft_MF_FreezeState,
         FtMoveId_Default << 24,
         ftCo_Zair_Anim,
         ftCo_Zair_IASA,

--- a/src/melee/ft/chara/ftSandbag/ftSb_Init.c
+++ b/src/melee/ft/chara/ftSandbag/ftSb_Init.c
@@ -13,7 +13,7 @@
 MotionState ftSb_Init_MotionStateTable[] = {
     {
         295,
-        FtStateChange_None,
+        Ft_MF_None,
         (FtMoveId_Default << 24) | (1 << 22),
         ftSb_MS_341_Anim,
         ftSb_MS_341_IASA,

--- a/src/melee/ft/chara/ftSeak/forward.h
+++ b/src/melee/ft/chara/ftSeak/forward.h
@@ -6,46 +6,44 @@
 #include "ftCommon/forward.h"
 
 static MotionFlags const ftSk_MF_Special ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_UpdatePhys | FtStateChange_FreezeState;
+    Ft_MF_SkipModel | Ft_MF_SkipItemVis | Ft_MF_UnkUpdatePhys |
+    Ft_MF_FreezeState;
 
 static MotionFlags const ftSk_MF_SpecialS ATTRIBUTE_USED =
-    ftSk_MF_Special | FtStateChange_PreserveGfx;
+    ftSk_MF_Special | Ft_MF_KeepGfx;
 
 static MotionFlags const ftSk_MF_SpecialLw ATTRIBUTE_USED =
-    ftSk_MF_Special | FtStateChange_PreserveColAnimHitStatus;
+    ftSk_MF_Special | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftSk_MF_SpecialN ATTRIBUTE_USED =
-    ftSk_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateThrowException;
+    ftSk_MF_Special | Ft_MF_KeepFastFall | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftSk_MF_SpecialHi ATTRIBUTE_USED =
-    ftSk_MF_SpecialS | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveSfx;
+    ftSk_MF_SpecialS | Ft_MF_KeepFastFall | Ft_MF_KeepSfx;
 
 static MotionFlags const ftSk_MF_SpecialAirS ATTRIBUTE_USED =
-    ftSk_MF_SpecialS | FtStateChange_SkipUpdateParasol;
+    ftSk_MF_SpecialS | Ft_MF_SkipParasol;
 
 static MotionFlags const ftSk_MF_SpecialAirLw ATTRIBUTE_USED =
-    ftSk_MF_SpecialLw | FtStateChange_SkipUpdateParasol;
+    ftSk_MF_SpecialLw | Ft_MF_SkipParasol;
 
 static MotionFlags const ftSk_MF_SpecialAirN ATTRIBUTE_USED =
-    ftSk_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftSk_MF_SpecialN | Ft_MF_SkipParasol;
 
 static MotionFlags const ftSk_MF_SpecialAirHi ATTRIBUTE_USED =
-    ftSk_MF_SpecialHi | FtStateChange_SkipUpdateParasol;
+    ftSk_MF_SpecialHi | Ft_MF_SkipParasol;
 
 static MotionFlags const ftSk_MF_SpecialSLoop ATTRIBUTE_USED =
-    ftSk_MF_SpecialS | FtStateChange_Unk_19;
+    ftSk_MF_SpecialS | Ft_MF_Unk19;
 
 static MotionFlags const ftSk_MF_SpecialNLoop ATTRIBUTE_USED =
-    ftSk_MF_SpecialN | FtStateChange_Unk_19;
+    ftSk_MF_SpecialN | Ft_MF_Unk19;
 
 static MotionFlags const ftSk_MF_SpecialAirSLoop ATTRIBUTE_USED =
-    ftSk_MF_SpecialSLoop | FtStateChange_SkipUpdateParasol;
+    ftSk_MF_SpecialSLoop | Ft_MF_SkipParasol;
 
 static MotionFlags const ftSk_MF_SpecialAirNLoop ATTRIBUTE_USED =
-    ftSk_MF_SpecialNLoop | FtStateChange_SkipUpdateParasol;
+    ftSk_MF_SpecialNLoop | Ft_MF_SkipParasol;
 
 typedef enum ftSeak_MotionState {
     ftSk_MS_SpecialN_ChargeStart = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftSeak/ftSk_SpecialS.c
+++ b/src/melee/ft/chara/ftSeak/ftSk_SpecialS.c
@@ -650,11 +650,9 @@ void ftSk_SpecialAirSStart_Coll(HSD_GObj* gobj)
 }
 
 static u32 const transition_flags =
-    FtStateChange_SkipUpdateHit | FtStateChange_SkipUpdateMatAnim |
-    FtStateChange_SkipUpdateColAnim | FtStateChange_UpdateCmd |
-    FtStateChange_SkipUpdateItemVis | FtStateChange_Unk_19 |
-    FtStateChange_SkipUpdateModelPartVis | FtStateChange_SkipUpdateModelFlag |
-    FtStateChange_Unk_27;
+    Ft_MF_SkipHit | Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim | Ft_MF_UpdateCmd |
+    Ft_MF_SkipItemVis | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |
+    Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 void ftSk_SpecialS_80111440(HSD_GObj* gobj)
 {

--- a/src/melee/ft/chara/ftYoshi/forward.h
+++ b/src/melee/ft/chara/ftYoshi/forward.h
@@ -8,48 +8,44 @@ struct S_UNK_YOSHI1;
 
 /// @todo Fix names
 static MotionFlags const ftYs_MF_Special ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_UpdatePhys | FtStateChange_FreezeState;
+    Ft_MF_SkipModel | Ft_MF_SkipItemVis | Ft_MF_UnkUpdatePhys |
+    Ft_MF_FreezeState;
 
-static MotionFlags const ftYs_MF_MS_341 ATTRIBUTE_USED =
-    FtStateChange_Unk_UpdatePhys;
+static MotionFlags const ftYs_MF_MS_341 ATTRIBUTE_USED = Ft_MF_UnkUpdatePhys;
 
 static MotionFlags const ftYs_MF_ShieldStart ATTRIBUTE_USED =
-    FtStateChange_PreserveFastFall | FtStateChange_PreserveGfx |
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateAnimVel |
-    FtStateChange_Unk_6 | FtStateChange_SkipUpdateColAnim |
-    FtStateChange_Unk_UpdatePhys;
+    Ft_MF_KeepFastFall | Ft_MF_KeepGfx | Ft_MF_SkipModel | Ft_MF_SkipAnimVel |
+    Ft_MF_Unk06 | Ft_MF_SkipColAnim | Ft_MF_UnkUpdatePhys;
 
 static MotionFlags const ftYs_MF_ShieldHold ATTRIBUTE_USED =
-    FtStateChange_Unk_19 | FtStateChange_Unk_UpdatePhys;
+    Ft_MF_Unk19 | Ft_MF_UnkUpdatePhys;
 
 static MotionFlags const ftYs_MF_SpecialN ATTRIBUTE_USED =
-    ftYs_MF_Special | FtStateChange_PreserveFastFall;
+    ftYs_MF_Special | Ft_MF_KeepFastFall;
 
 static MotionFlags const ftYs_MF_SpecialAirHi ATTRIBUTE_USED =
-    ftYs_MF_SpecialN | FtStateChange_PreserveGfx |
-    FtStateChange_SkipUpdateThrowException;
+    ftYs_MF_SpecialN | Ft_MF_KeepGfx | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftYs_MF_UnkBase ATTRIBUTE_USED =
-    ftYs_MF_Special | FtStateChange_PreserveSfx;
+    ftYs_MF_Special | Ft_MF_KeepSfx;
 
 static MotionFlags const ftYs_MF_SpecialAirS ATTRIBUTE_USED =
-    ftYs_MF_UnkBase | FtStateChange_PreserveGfx;
+    ftYs_MF_UnkBase | Ft_MF_KeepGfx;
 
 static MotionFlags const ftYs_MF_MS_366 ATTRIBUTE_USED =
-    ftYs_MF_UnkBase | FtStateChange_PreserveColAnimHitStatus;
+    ftYs_MF_UnkBase | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftYs_MF_SpecialS ATTRIBUTE_USED =
-    ftYs_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftYs_MF_SpecialN | Ft_MF_SkipParasol;
 
 static MotionFlags const ftYs_MF_MS_365 ATTRIBUTE_USED =
-    ftYs_MF_SpecialAirHi | FtStateChange_SkipUpdateParasol;
+    ftYs_MF_SpecialAirHi | Ft_MF_SkipParasol;
 
 static MotionFlags const ftYs_MF_SpecialHi ATTRIBUTE_USED =
-    ftYs_MF_SpecialAirS | FtStateChange_SkipUpdateParasol;
+    ftYs_MF_SpecialAirS | Ft_MF_SkipParasol;
 
 static MotionFlags const ftYs_MF_MS_368 ATTRIBUTE_USED =
-    ftYs_MF_MS_366 | FtStateChange_SkipUpdateParasol;
+    ftYs_MF_MS_366 | Ft_MF_SkipParasol;
 
 typedef enum ftYoshi_MotionState {
     ftYs_MS_Unk_341 = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftZelda/forward.h
+++ b/src/melee/ft/chara/ftZelda/forward.h
@@ -5,35 +5,32 @@
 #include "ftCommon/forward.h"
 
 static MotionFlags const ftZd_MF_Special ATTRIBUTE_USED =
-    FtStateChange_SkipUpdateModel | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_UpdatePhys | FtStateChange_FreezeState;
+    Ft_MF_SkipModel | Ft_MF_SkipItemVis | Ft_MF_UnkUpdatePhys |
+    Ft_MF_FreezeState;
 
 static MotionFlags const ftZd_MF_SpecialN ATTRIBUTE_USED =
-    ftZd_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_SkipUpdateColAnim;
+    ftZd_MF_Special | Ft_MF_KeepFastFall | Ft_MF_SkipColAnim;
 
 static MotionFlags const ftZd_MF_SpecialHi ATTRIBUTE_USED =
-    ftZd_MF_Special | FtStateChange_PreserveFastFall |
-    FtStateChange_PreserveGfx;
+    ftZd_MF_Special | Ft_MF_KeepFastFall | Ft_MF_KeepGfx;
 
 static MotionFlags const ftZd_MF_SpecialLw ATTRIBUTE_USED =
-    ftZd_MF_Special | FtStateChange_PreserveColAnimHitStatus;
+    ftZd_MF_Special | Ft_MF_KeepColAnimHitStatus;
 
 static MotionFlags const ftZd_MF_SpecialS ATTRIBUTE_USED =
-    ftZd_MF_Special | FtStateChange_PreserveGfx |
-    FtStateChange_SkipUpdateThrowException;
+    ftZd_MF_Special | Ft_MF_KeepGfx | Ft_MF_SkipThrowException;
 
 static MotionFlags const ftZd_MF_SpecialAirN ATTRIBUTE_USED =
-    ftZd_MF_SpecialN | FtStateChange_SkipUpdateParasol;
+    ftZd_MF_SpecialN | Ft_MF_SkipParasol;
 
 static MotionFlags const ftZd_MF_SpecialAirHi ATTRIBUTE_USED =
-    ftZd_MF_SpecialHi | FtStateChange_SkipUpdateParasol;
+    ftZd_MF_SpecialHi | Ft_MF_SkipParasol;
 
 static MotionFlags const ftZd_MF_SpecialAirLw ATTRIBUTE_USED =
-    ftZd_MF_SpecialLw | FtStateChange_SkipUpdateParasol;
+    ftZd_MF_SpecialLw | Ft_MF_SkipParasol;
 
 static MotionFlags const ftZd_MF_SpecialAirS ATTRIBUTE_USED =
-    ftZd_MF_SpecialS | FtStateChange_SkipUpdateParasol;
+    ftZd_MF_SpecialS | Ft_MF_SkipParasol;
 
 enum ftZelda_AS {
     ftZd_MS_SpecialN = ftCo_MS_Count,

--- a/src/melee/ft/chara/ftZelda/ftZd_SpecialHi.c
+++ b/src/melee/ft/chara/ftZelda/ftZd_SpecialHi.c
@@ -209,14 +209,12 @@ void ftZd_SpecialAirHiStart_Coll(HSD_GObj* gobj)
 }
 
 static u32 const transition_flags0 =
-    FtStateChange_PreserveGfx | FtStateChange_SkipUpdateHit |
-    FtStateChange_SkipUpdateMatAnim | FtStateChange_SkipUpdateColAnim |
-    FtStateChange_UpdateCmd | FtStateChange_SkipUpdateItemVis |
-    FtStateChange_Unk_19 | FtStateChange_SkipUpdateModelPartVis |
-    FtStateChange_SkipUpdateModelFlag | FtStateChange_Unk_27;
+    Ft_MF_KeepGfx | Ft_MF_SkipHit | Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim |
+    Ft_MF_UpdateCmd | Ft_MF_SkipItemVis | Ft_MF_Unk19 |
+    Ft_MF_SkipModelPartVis | Ft_MF_SkipModelFlags | Ft_MF_Unk27;
 
 static u32 const transition_flags1 =
-    transition_flags0 | FtStateChange_PreserveColAnimHitStatus;
+    transition_flags0 | Ft_MF_KeepColAnimHitStatus;
 
 void ftZd_SpecialHi_80139B44(HSD_GObj* gobj)
 {

--- a/src/melee/ft/fighter.c
+++ b/src/melee/ft/fighter.c
@@ -937,7 +937,7 @@ void Fighter_ChangeMotionState(HSD_GObj* gobj, s32 new_motion_state_index,
     HSD_JObjSetTranslate(jobj, &fp->cur_pos);
     efAsync_80067624(gobj, &fp->x60C);
 
-    if ((arg2 & FtStateChange_SkipUpdateHit) == 0) {
+    if ((arg2 & Ft_MF_SkipHit) == 0) {
         if (fp->x2219_flag.bits.b3 != 0) {
             ftColl_8007AFF8(gobj);
         }
@@ -946,11 +946,11 @@ void Fighter_ChangeMotionState(HSD_GObj* gobj, s32 new_motion_state_index,
         }
     }
 
-    if ((arg2 & FtStateChange_SkipUpdateThrowException) == 0) {
+    if ((arg2 & Ft_MF_SkipThrowException) == 0) {
         fp->x1064_thrownHitbox.owner = NULL;
     }
 
-    if ((arg2 & FtStateChange_PreserveColAnimHitStatus) == 0) {
+    if ((arg2 & Ft_MF_KeepColAnimHitStatus) == 0) {
         if (fp->x1988 != 0) {
             ftColl_8007B62C(gobj, 0);
         }
@@ -963,19 +963,15 @@ void Fighter_ChangeMotionState(HSD_GObj* gobj, s32 new_motion_state_index,
         ftColl_8007B4E0(gobj);
     }
 
-    if (((arg2 & FtStateChange_SkipUpdateModel) == 0) &&
-        (fp->x221D_flag.bits.b2 != 0U))
-    {
+    if (((arg2 & Ft_MF_SkipModel) == 0) && (fp->x221D_flag.bits.b2 != 0U)) {
         ftParts_80074A8C(gobj);
     }
 
-    if (((arg2 & FtStateChange_SkipUpdateMatAnim) == 0) &&
-        ((fp->x221E_flag.bits.b7) != 0))
-    {
+    if (((arg2 & Ft_MF_SkipMatAnim) == 0) && ((fp->x221E_flag.bits.b7) != 0)) {
         ftAnim_80070654(gobj);
     }
 
-    if ((arg2 & FtStateChange_SkipUpdateParasol) == 0) {
+    if ((arg2 & Ft_MF_SkipParasol) == 0) {
         fp->x2221_flag.bits.b4 = 0;
         if ((ftCo_GetParasolStatus(gobj) != -1) &&
             (ftCo_GetParasolStatus(gobj) != 6))
@@ -990,12 +986,12 @@ void Fighter_ChangeMotionState(HSD_GObj* gobj, s32 new_motion_state_index,
     ftCommon_8007ECD4(fp, 8);
     ftCommon_8007ECD4(fp, 0x24);
 
-    if ((arg2 & FtStateChange_SkipUpdateRumble) == 0) {
+    if ((arg2 & Ft_MF_SkipRumble) == 0) {
         ftCommon_8007ECD4(fp, 1);
         ftCommon_8007ECD4(fp, 0x19);
     }
 
-    if (((arg2 & FtStateChange_PreserveColaNimPartHitStatus) == 0) &&
+    if (((arg2 & Ft_MF_KeepColAnimPartHitStatus) == 0) &&
         (fp->x2221_flag.bits.b1 != 0U))
     {
         ftColl_8007B6EC(gobj);
@@ -1009,21 +1005,19 @@ void Fighter_ChangeMotionState(HSD_GObj* gobj, s32 new_motion_state_index,
         fp->x2220_flag.bits.b4 = 0;
     }
 
-    if ((arg2 & FtStateChange_Unk_19) == 0) {
+    if ((arg2 & Ft_MF_Unk19) == 0) {
         fp->x2222_flag.bits.b2 = 0;
     }
 
-    if ((arg2 & FtStateChange_SkipUpdateMetalB) == 0) {
+    if ((arg2 & Ft_MF_SkipMetalB) == 0) {
         fp->x2223_flag.bits.b4 = 0;
     }
 
-    if ((arg2 & FtStateChange_Unk_27) == 0) {
+    if ((arg2 & Ft_MF_Unk27) == 0) {
         fp->x2227_flag.bits.b2 = 0;
     }
 
-    if (((arg2 & FtStateChange_SkipUpdateHitStunFlag) == 0) &&
-        (fp->x221C_flag.bits.b6 != 0U))
-    {
+    if (((arg2 & Ft_MF_SkipHitStun) == 0) && (fp->x221C_flag.bits.b6 != 0U)) {
         fp->x221C_flag.bits.b6 = 0;
         fp->x2098 = p_ftCommonData->x4CC;
     }
@@ -1077,35 +1071,33 @@ void Fighter_ChangeMotionState(HSD_GObj* gobj, s32 new_motion_state_index,
     fp->x2114_SmashAttr.x2138_smashSinceHitbox = -1.0f;
     fp->x2224_flag.bits.b4 = 0;
 
-    if ((arg2 & FtStateChange_SkipUpdateItemVis) == 0) {
+    if ((arg2 & Ft_MF_SkipItemVis) == 0) {
         fp->x221E_flag.bits.b3 = 1;
     } else if (fp->x221E_flag.bits.b3 == 0U) {
         ftCommon_8007F578(gobj);
     }
 
-    if ((arg2 & FtStateChange_SkipUpdateModelPartVis) == 0) {
+    if ((arg2 & Ft_MF_SkipModelPartVis) == 0) {
         fp->x221E_flag.bits.b4 = 1;
     }
 
-    if ((arg2 & FtStateChange_SkipUpdateModelFlag) == 0) {
+    if ((arg2 & Ft_MF_SkipModelFlags) == 0) {
         fp->x2225_b2 = 1;
     }
 
-    if ((arg2 & FtStateChange_PreserveFastFall) == 0) {
+    if ((arg2 & Ft_MF_KeepFastFall) == 0) {
         fp->x221A_flag.bits.b4 = 0;
     }
 
-    if ((arg2 & FtStateChange_SkipUpdateColAnim) == 0) {
+    if ((arg2 & Ft_MF_SkipColAnim) == 0) {
         ft_800C0134(fp);
     }
 
-    if (((arg2 & FtStateChange_PreserveGfx) == 0) &&
-        (fp->x2219_flag.bits.b0 != 0U))
-    {
+    if (((arg2 & Ft_MF_KeepGfx) == 0) && (fp->x2219_flag.bits.b0 != 0U)) {
         ftCommon_8007DB24(gobj);
     }
 
-    if (((arg2 & FtStateChange_PreserveAccessory) == 0) &&
+    if (((arg2 & Ft_MF_KeepAccessory) == 0) &&
         ((u32) fp->x20A0_accessory != 0U))
     {
         HSD_JObjRemoveAll(fp->x20A0_accessory);
@@ -1140,28 +1132,28 @@ void Fighter_ChangeMotionState(HSD_GObj* gobj, s32 new_motion_state_index,
         fp->x196C_hitlag_mult = 0.0f;
     }
 
-    if ((arg2 & FtStateChange_PreserveSfx) == 0) {
+    if ((arg2 & Ft_MF_KeepSfx) == 0) {
         ft_80088884(fp);
         ft_800888E0(fp);
         ft_800887CC(fp);
     }
 
-    if ((arg2 & FtStateChange_PreserveSwordTrail) == 0) {
+    if ((arg2 & Ft_MF_KeepSwordTrail) == 0) {
         fp->x2100 = -1;
     }
-    if ((arg2 & FtStateChange_SkipUpdateNametagVis) == 0) {
+    if ((arg2 & Ft_MF_SkipNametagVis) == 0) {
         fp->x209A = 0;
     }
 
     fp->x2222_flag.bits.b7 = 0;
 
-    if ((arg2 & FtStateChange_Unk_UpdatePhys) != 0) {
+    if ((arg2 & Ft_MF_UnkUpdatePhys) != 0) {
         fp->x100 = 0.0f;
     } else {
         fp->x100 = -1.0f;
     }
 
-    if ((arg2 & FtStateChange_Unk_24) == 0) {
+    if ((arg2 & Ft_MF_Unk24) == 0) {
         fp->x221C_u16_y = 0;
     }
 
@@ -1212,7 +1204,7 @@ void Fighter_ChangeMotionState(HSD_GObj* gobj, s32 new_motion_state_index,
             fp->cb.x21EC_callback = 0U;
         }
 
-        if ((arg2 & FtStateChange_SkipUpdateAttackCount) == 0) {
+        if ((arg2 & Ft_MF_SkipAttackCount) == 0) {
             pl_80037C60(gobj, x2070.x2070_int);
         }
 
@@ -1237,7 +1229,7 @@ void Fighter_ChangeMotionState(HSD_GObj* gobj, s32 new_motion_state_index,
 
             bone_index = fp->x596_bits.x7;
 
-            if ((arg2 & FtStateChange_FreezeState) != 0) {
+            if ((arg2 & Ft_MF_FreezeState) != 0) {
                 fp->x2223_flag.bits.b0 = 1;
                 fp->x104 = 0x14;
                 fp->x89C_frameSpeedMul = 0.0f;
@@ -1255,7 +1247,7 @@ void Fighter_ChangeMotionState(HSD_GObj* gobj, s32 new_motion_state_index,
             }
             fp->x594_s32 = unk_struct_x18->x10_animCurrFlags;
             ft_8009E7B4(fp, unk_byte_ptr);
-            if ((arg2 & FtStateChange_SkipUpdateAnim) == 0) {
+            if ((arg2 & Ft_MF_SkipAnim) == 0) {
                 if (otherObj != 0U) {
                     ftData_80085CD8(fp, GET_FIGHTER(otherObj), fp->anim_id);
                     ftColl_8007B8CC(fp, otherObj);
@@ -1315,8 +1307,7 @@ void Fighter_ChangeMotionState(HSD_GObj* gobj, s32 new_motion_state_index,
                         fp->x6A4_transNOffset.x = fp->x6A4_transNOffset.y =
                             fp->x6A4_transNOffset.z = c;
                         fp->x698 = fp->x68C_transNPos;
-                    } else if (((arg2 & FtStateChange_SkipUpdateAnimVel) ==
-                                0) &&
+                    } else if (((arg2 & Ft_MF_SkipAnimVel) == 0) &&
                                (fp->ground_or_air == GA_Ground))
                     {
                         f32 temp_vel =
@@ -1332,8 +1323,7 @@ void Fighter_ChangeMotionState(HSD_GObj* gobj, s32 new_motion_state_index,
                         fp->x6E4.x = fp->x6E4.y = fp->x6E4.z = c;
                         fp->x6D8.x = fp->x6D8.y = fp->x6D8.z = c;
                         fp->x6CC = fp->x6C0;
-                    } else if (((arg2 & FtStateChange_SkipUpdateAnimVel) ==
-                                0) &&
+                    } else if (((arg2 & Ft_MF_SkipAnimVel) == 0) &&
                                (fp->ground_or_air == GA_Ground))
                     {
                         f32 temp_vel = fp->x6D8.z * fp->facing_dir;
@@ -1341,7 +1331,7 @@ void Fighter_ChangeMotionState(HSD_GObj* gobj, s32 new_motion_state_index,
                         fp->gr_vel = temp_vel;
                     }
                 }
-                if ((arg2 & FtStateChange_UpdateCmd) != 0) {
+                if ((arg2 & Ft_MF_UpdateCmd) != 0) {
                     ftAction_8007349C(gobj);
                 } else if (arg8) {
                     ftAction_80073354(gobj);

--- a/src/melee/ft/forward.h
+++ b/src/melee/ft/forward.h
@@ -98,104 +98,87 @@ typedef enum CharacterKind {
     CHKIND_MAX = CHKIND_NONE
 } CharacterKind;
 
-static MotionFlags const FtStateChange_None ATTRIBUTE_USED = 0;
+static MotionFlags const Ft_MF_None ATTRIBUTE_USED = 0;
 
-static MotionFlags const FtStateChange_PreserveFastFall ATTRIBUTE_USED = 1
-                                                                         << 0;
+static MotionFlags const Ft_MF_KeepFastFall ATTRIBUTE_USED = 1 << 0;
 
-static MotionFlags const FtStateChange_PreserveGfx ATTRIBUTE_USED = 1 << 1;
+static MotionFlags const Ft_MF_KeepGfx ATTRIBUTE_USED = 1 << 1;
 
 /// Preserve full body collision state
-static MotionFlags const FtStateChange_PreserveColAnimHitStatus
-    ATTRIBUTE_USED = 1 << 2;
+static MotionFlags const Ft_MF_KeepColAnimHitStatus ATTRIBUTE_USED = 1 << 2;
 
 /// Keep hitboxes
-static MotionFlags const FtStateChange_SkipUpdateHit ATTRIBUTE_USED = 1 << 3;
+static MotionFlags const Ft_MF_SkipHit ATTRIBUTE_USED = 1 << 3;
 
 /// Ignore model state change ?
-static MotionFlags const FtStateChange_SkipUpdateModel ATTRIBUTE_USED = 1 << 4;
+static MotionFlags const Ft_MF_SkipModel ATTRIBUTE_USED = 1 << 4;
 
-static MotionFlags const FtStateChange_SkipUpdateAnimVel ATTRIBUTE_USED = 1
-                                                                          << 5;
+static MotionFlags const Ft_MF_SkipAnimVel ATTRIBUTE_USED = 1 << 5;
 
-static MotionFlags const FtStateChange_Unk_6 ATTRIBUTE_USED = 1 << 6;
+static MotionFlags const Ft_MF_Unk06 ATTRIBUTE_USED = 1 << 6;
 
 /// Ignore switching to character's "hurt" textures ?
-static MotionFlags const FtStateChange_SkipUpdateMatAnim ATTRIBUTE_USED = 1
-                                                                          << 7;
+static MotionFlags const Ft_MF_SkipMatAnim ATTRIBUTE_USED = 1 << 7;
 
 /// Resets thrower GObj pointer to NULL if false?
-static MotionFlags const FtStateChange_SkipUpdateThrowException
-    ATTRIBUTE_USED = 1 << 8;
+static MotionFlags const Ft_MF_SkipThrowException ATTRIBUTE_USED = 1 << 8;
 
-static MotionFlags const FtStateChange_PreserveSfx ATTRIBUTE_USED = 1 << 9;
+static MotionFlags const Ft_MF_KeepSfx ATTRIBUTE_USED = 1 << 9;
 
 /// Ignore Parasol state change
-static MotionFlags const FtStateChange_SkipUpdateParasol ATTRIBUTE_USED =
-    1 << 10;
+static MotionFlags const Ft_MF_SkipParasol ATTRIBUTE_USED = 1 << 10;
 
 /// Ignore rumble update?
-static MotionFlags const FtStateChange_SkipUpdateRumble ATTRIBUTE_USED = 1
-                                                                         << 11;
+static MotionFlags const Ft_MF_SkipRumble ATTRIBUTE_USED = 1 << 11;
 
-static MotionFlags const FtStateChange_SkipUpdateColAnim ATTRIBUTE_USED =
-    1 << 12;
+static MotionFlags const Ft_MF_SkipColAnim ATTRIBUTE_USED = 1 << 12;
 
 /// Keep respawn platform?
-static MotionFlags const FtStateChange_PreserveAccessory ATTRIBUTE_USED =
-    1 << 13;
+static MotionFlags const Ft_MF_KeepAccessory ATTRIBUTE_USED = 1 << 13;
 
 /// Run all Subaction Events up to the current animation frame
-static MotionFlags const FtStateChange_UpdateCmd ATTRIBUTE_USED = 1 << 14;
+static MotionFlags const Ft_MF_UpdateCmd ATTRIBUTE_USED = 1 << 14;
 
-static MotionFlags const FtStateChange_SkipUpdateNametagVis ATTRIBUTE_USED =
-    1 << 15;
+static MotionFlags const Ft_MF_SkipNametagVis ATTRIBUTE_USED = 1 << 15;
 
 /// Assume this is for individual bones?
-static MotionFlags const FtStateChange_PreserveColaNimPartHitStatus
-    ATTRIBUTE_USED = 1 << 16;
+static MotionFlags const Ft_MF_KeepColAnimPartHitStatus ATTRIBUTE_USED = 1
+                                                                         << 16;
 
-static MotionFlags const FtStateChange_PreserveSwordTrail ATTRIBUTE_USED =
-    1 << 17;
+static MotionFlags const Ft_MF_KeepSwordTrail ATTRIBUTE_USED = 1 << 17;
 
 /// Used by Ness during Up/Down Smash
-static MotionFlags const FtStateChange_SkipUpdateItemVis ATTRIBUTE_USED =
-    1 << 18;
+static MotionFlags const Ft_MF_SkipItemVis ATTRIBUTE_USED = 1 << 18;
 
 /// Skips updating bit 5 of #Fighter::x2222_flag?
-static MotionFlags const FtStateChange_Unk_19 ATTRIBUTE_USED = 1 << 19;
+static MotionFlags const Ft_MF_Unk19 ATTRIBUTE_USED = 1 << 19;
 
-static MotionFlags const FtStateChange_Unk_UpdatePhys ATTRIBUTE_USED = 1 << 20;
+static MotionFlags const Ft_MF_UnkUpdatePhys ATTRIBUTE_USED = 1 << 20;
 
 /// Sets anim rate to 0 and some other stuff
-static MotionFlags const FtStateChange_FreezeState ATTRIBUTE_USED = 1 << 21;
+static MotionFlags const Ft_MF_FreezeState ATTRIBUTE_USED = 1 << 21;
 
-static MotionFlags const FtStateChange_SkipUpdateModelPartVis ATTRIBUTE_USED =
-    1 << 22;
+static MotionFlags const Ft_MF_SkipModelPartVis ATTRIBUTE_USED = 1 << 22;
 
-static MotionFlags const FtStateChange_SkipUpdateMetalB ATTRIBUTE_USED = 1
-                                                                         << 23;
+static MotionFlags const Ft_MF_SkipMetalB ATTRIBUTE_USED = 1 << 23;
 
-static MotionFlags const FtStateChange_Unk_24 ATTRIBUTE_USED = 1 << 24;
+static MotionFlags const Ft_MF_Unk24 ATTRIBUTE_USED = 1 << 24;
 
-static MotionFlags const FtStateChange_SkipUpdateAttackCount ATTRIBUTE_USED =
-    1 << 25;
+static MotionFlags const Ft_MF_SkipAttackCount ATTRIBUTE_USED = 1 << 25;
 
-static MotionFlags const FtStateChange_SkipUpdateModelFlag ATTRIBUTE_USED =
-    1 << 26;
+static MotionFlags const Ft_MF_SkipModelFlags ATTRIBUTE_USED = 1 << 26;
 
-static MotionFlags const FtStateChange_Unk_27 ATTRIBUTE_USED = 1 << 27;
+static MotionFlags const Ft_MF_Unk27 ATTRIBUTE_USED = 1 << 27;
 
-static MotionFlags const FtStateChange_SkipUpdateHitStunFlag ATTRIBUTE_USED =
-    1 << 28;
+static MotionFlags const Ft_MF_SkipHitStun ATTRIBUTE_USED = 1 << 28;
 
 /// Keeps current fighter animation?
-static MotionFlags const FtStateChange_SkipUpdateAnim ATTRIBUTE_USED = 1 << 29;
+static MotionFlags const Ft_MF_SkipAnim ATTRIBUTE_USED = 1 << 29;
 
-static MotionFlags const FtStateChange_Unk_30 ATTRIBUTE_USED = 1 << 30;
+static MotionFlags const Ft_MF_Unk30 ATTRIBUTE_USED = 1 << 30;
 
 /// Unused?
-static MotionFlags const FtStateChange_Unk_31 ATTRIBUTE_USED = 1 << 31;
+static MotionFlags const Ft_MF_Unk31 ATTRIBUTE_USED = 1 << 31;
 
 // Ledge Grab Macros
 

--- a/src/melee/ft/ftdata3.c
+++ b/src/melee/ft/ftdata3.c
@@ -168,7 +168,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_Wait = 14
         2,
-        FtStateChange_None,
+        Ft_MF_None,
         (FtMoveId_Default << 24) | (1 << 22) | (1 << 23),
         ftCo_Wait_Anim,
         ftCo_Wait_IASA,
@@ -267,7 +267,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_RunBrake = 23
         14,
-        FtStateChange_None,
+        Ft_MF_None,
         (FtMoveId_Default << 24) | (1 << 23),
         ftCo_RunBrake_Anim,
         ftCo_RunBrake_IASA,
@@ -278,7 +278,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_KneeBend = 24
         15,
-        FtStateChange_None,
+        Ft_MF_None,
         (FtMoveId_Default << 24) | (1 << 22) | (1 << 23),
         ftCo_KneeBend_Anim,
         ftCo_KneeBend_IASA,
@@ -333,7 +333,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_Fall = 29
         20,
-        FtStateChange_None,
+        Ft_MF_None,
         (FtMoveId_Default << 24) | (1 << 23),
         ftCo_Fall_Anim,
         ftCo_Fall_IASA,
@@ -344,7 +344,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_FallF = 30
         -1,
-        FtStateChange_None,
+        Ft_MF_None,
         (FtMoveId_Default << 24) | (1 << 23),
         ftCo_Fall_Anim,
         ftCo_Fall_IASA,
@@ -355,7 +355,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_FallB = 31
         -1,
-        FtStateChange_None,
+        Ft_MF_None,
         (FtMoveId_Default << 24) | (1 << 23),
         ftCo_Fall_Anim,
         ftCo_Fall_IASA,
@@ -366,7 +366,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_FallAerial = 32
         23,
-        FtStateChange_None,
+        Ft_MF_None,
         (FtMoveId_Default << 24) | (1 << 23),
         ftCo_FallAerial_Anim,
         ftCo_FallAerial_IASA,
@@ -377,7 +377,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_FallAerialF = 33
         24,
-        FtStateChange_None,
+        Ft_MF_None,
         (FtMoveId_Default << 24) | (1 << 23),
         ftCo_Fall_Anim,
         ftCo_FallAerial_IASA,
@@ -388,7 +388,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_FallAerialB = 34
         25,
-        FtStateChange_None,
+        Ft_MF_None,
         (FtMoveId_Default << 24) | (1 << 23),
         ftCo_Fall_Anim,
         ftCo_FallAerial_IASA,
@@ -399,7 +399,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_FallSpecial = 35
         26,
-        FtStateChange_None,
+        Ft_MF_None,
         (FtMoveId_Default << 24) | (1 << 23),
         ftCo_FallSpecial_Anim,
         ftCo_FallSpecial_IASA,
@@ -410,7 +410,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_FallSpecialF = 36
         27,
-        FtStateChange_None,
+        Ft_MF_None,
         (FtMoveId_Default << 24) | (1 << 23),
         ftCo_FallSpecial_Anim,
         ftCo_FallSpecial_IASA,
@@ -421,7 +421,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_FallSpecialB = 37
         28,
-        FtStateChange_None,
+        Ft_MF_None,
         (FtMoveId_Default << 24) | (1 << 23),
         ftCo_FallSpecial_Anim,
         ftCo_FallSpecial_IASA,
@@ -476,7 +476,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_Landing = 42
         35,
-        FtStateChange_None,
+        Ft_MF_None,
         (FtMoveId_Default << 24) | (1 << 22),
         ftCo_Landing_Anim,
         ftCo_Landing_IASA,
@@ -487,7 +487,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_LandingFallSpecial = 43
         36,
-        FtStateChange_None,
+        Ft_MF_None,
         (FtMoveId_Default << 24) | (1 << 22),
         ftCo_Landing_Anim,
         ftCo_Landing_IASA,
@@ -1026,7 +1026,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_LightGet = 92
         78,
-        FtStateChange_SkipUpdateModelPartVis,
+        Ft_MF_SkipModelPartVis,
         (FtMoveId_Default << 24) | (1 << 23),
         ftCo_ItemGet_Anim,
         ftCo_ItemGet_IASA,
@@ -1037,7 +1037,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_HeavyGet = 93
         89,
-        FtStateChange_SkipUpdateModelPartVis,
+        Ft_MF_SkipModelPartVis,
         FtMoveId_Default << 24,
         ftCo_ItemGet_Anim,
         ftCo_ItemGet_IASA,
@@ -1972,7 +1972,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_GuardOn = 178
         37,
-        FtStateChange_Unk_UpdatePhys,
+        Ft_MF_UnkUpdatePhys,
         (FtMoveId_Default << 24) | (1 << 22) | (1 << 23),
         ftCo_GuardOn_Anim,
         ftCo_GuardOn_IASA,
@@ -1994,7 +1994,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_GuardOff = 180
         39,
-        FtStateChange_Unk_UpdatePhys,
+        Ft_MF_UnkUpdatePhys,
         (FtMoveId_Default << 24) | (1 << 23),
         ftCo_GuardOff_Anim,
         ftCo_GuardOff_IASA,
@@ -2005,7 +2005,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_GuardSetOff = 181
         40,
-        FtStateChange_Unk_UpdatePhys,
+        Ft_MF_UnkUpdatePhys,
         (FtMoveId_Default << 24) | (1 << 23),
         ftCo_GuardSetOff_Anim,
         ftCo_GuardSetOff_IASA,
@@ -2577,7 +2577,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_EscapeF = 233
         42,
-        FtStateChange_Unk_UpdatePhys,
+        Ft_MF_UnkUpdatePhys,
         FtMoveId_Default << 24,
         ftCo_EscapeF_Anim,
         ftCo_EscapeF_IASA,
@@ -2588,7 +2588,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_EscapeB = 234
         43,
-        FtStateChange_Unk_UpdatePhys,
+        Ft_MF_UnkUpdatePhys,
         FtMoveId_Default << 24,
         ftCo_EscapeF_Anim,
         ftCo_EscapeF_IASA,
@@ -2599,7 +2599,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_Escape = 235
         41,
-        FtStateChange_Unk_UpdatePhys,
+        Ft_MF_UnkUpdatePhys,
         FtMoveId_Default << 24,
         ftCo_EscapeB_Anim,
         ftCo_EscapeB_IASA,
@@ -2610,7 +2610,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_EscapeAir = 236
         44,
-        FtStateChange_Unk_UpdatePhys,
+        Ft_MF_UnkUpdatePhys,
         FtMoveId_Default << 24,
         ftCo_EscapeAir_Anim,
         ftCo_EscapeAir_IASA,
@@ -2621,7 +2621,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_ReboundStop = 237
         -1,
-        FtStateChange_Unk_UpdatePhys,
+        Ft_MF_UnkUpdatePhys,
         FtMoveId_Default << 24,
         ftCo_ReboundStop_Anim,
         NULL,
@@ -2632,7 +2632,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_Rebound = 238
         45,
-        FtStateChange_Unk_UpdatePhys,
+        Ft_MF_UnkUpdatePhys,
         FtMoveId_Default << 24,
         ftCo_Rebound_Anim,
         ftCo_Rebound_IASA,
@@ -2709,7 +2709,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_Ottotto = 245
         210,
-        FtStateChange_SkipUpdateMetalB,
+        Ft_MF_SkipMetalB,
         FtMoveId_Default << 24,
         ftCo_Ottotto_Anim,
         ftCo_Ottotto_IASA,
@@ -2742,7 +2742,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_FlyReflectCeil = 248
         214,
-        FtStateChange_SkipUpdateMetalB,
+        Ft_MF_SkipMetalB,
         FtMoveId_Default << 24,
         ftCo_FlyReflect_Anim,
         ftCo_FlyReflect_IASA,
@@ -2764,7 +2764,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_StopCeil = 250
         214,
-        FtStateChange_SkipUpdateMetalB,
+        Ft_MF_SkipMetalB,
         FtMoveId_Default << 24,
         ftCo_StopCeil_Anim,
         ftCo_StopCeil_IASA,
@@ -2775,7 +2775,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_MissFoot = 251
         215,
-        FtStateChange_SkipUpdateMetalB,
+        Ft_MF_SkipMetalB,
         FtMoveId_Default << 24,
         ftCo_MissFoot_Anim,
         ftCo_MissFoot_IASA,
@@ -3270,7 +3270,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_BuryJump = 296
         16,
-        FtStateChange_None,
+        Ft_MF_None,
         (FtMoveId_Default << 24) | (1 << 23),
         ftCo_BuryJump_Anim,
         ftCo_BuryJump_IASA,
@@ -3468,7 +3468,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_KinokoGiantStart = 314
         -1,
-        FtStateChange_SkipUpdateModelPartVis,
+        Ft_MF_SkipModelPartVis,
         FtMoveId_Default << 24,
         ftCo_KinokoGiantStart_Anim,
         NULL,
@@ -3479,7 +3479,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_KinokoGiantStartAir = 315
         -1,
-        FtStateChange_SkipUpdateModelPartVis,
+        Ft_MF_SkipModelPartVis,
         FtMoveId_Default << 24,
         ftCo_KinokoGiantStartAir_Anim,
         NULL,
@@ -3490,7 +3490,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_KinokoGiantEnd = 316
         -1,
-        FtStateChange_SkipUpdateModelPartVis,
+        Ft_MF_SkipModelPartVis,
         FtMoveId_Default << 24,
         ftCo_KinokoGiantEnd_Anim,
         NULL,
@@ -3501,7 +3501,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_KinokoGiantEndAir = 317
         -1,
-        FtStateChange_SkipUpdateModelPartVis,
+        Ft_MF_SkipModelPartVis,
         FtMoveId_Default << 24,
         ftCo_KinokoGiantEndAir_Anim,
         NULL,
@@ -3512,7 +3512,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_KinokoSmallStart = 318
         -1,
-        FtStateChange_SkipUpdateModelPartVis,
+        Ft_MF_SkipModelPartVis,
         FtMoveId_Default << 24,
         ftCo_KinokoSmallStart_Anim,
         NULL,
@@ -3523,7 +3523,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_KinokoSmallStartAir = 319
         -1,
-        FtStateChange_SkipUpdateModelPartVis,
+        Ft_MF_SkipModelPartVis,
         FtMoveId_Default << 24,
         ftCo_KinokoSmallStartAir_Anim,
         NULL,
@@ -3534,7 +3534,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_KinokoSmallEnd = 320
         -1,
-        FtStateChange_SkipUpdateModelPartVis,
+        Ft_MF_SkipModelPartVis,
         FtMoveId_Default << 24,
         ftCo_KinokoSmallEnd_Anim,
         NULL,
@@ -3545,7 +3545,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_KinokoSmallEndAir = 321
         -1,
-        FtStateChange_SkipUpdateModelPartVis,
+        Ft_MF_SkipModelPartVis,
         FtMoveId_Default << 24,
         ftCo_KinokoSmallEndAir_Anim,
         NULL,
@@ -3600,7 +3600,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_DamageIceJump = 326
         20,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ftCo_DamageIceJump_Anim,
         ftCo_DamageIceJump_IASA,
@@ -3699,7 +3699,7 @@ MotionState ftData_MotionStateList[] = {
     {
         // ftCo_MS_DownReflect = 335
         212,
-        FtStateChange_SkipUpdateMetalB,
+        Ft_MF_SkipMetalB,
         FtMoveId_Default << 24,
         ftCo_DownReflect_Anim,
         ftCo_DownReflect_IASA,
@@ -3767,7 +3767,7 @@ MotionState ftData_MotionStateList[] = {
 MotionState ftData_803C52A0[] = {
     {
         0,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ft_800BED84,
         NULL,
@@ -3777,7 +3777,7 @@ MotionState ftData_803C52A0[] = {
     },
     {
         1,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -3787,7 +3787,7 @@ MotionState ftData_803C52A0[] = {
     },
     {
         2,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ft_800BEF00,
         NULL,
@@ -3797,7 +3797,7 @@ MotionState ftData_803C52A0[] = {
     },
     {
         3,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -3807,7 +3807,7 @@ MotionState ftData_803C52A0[] = {
     },
     {
         4,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -3817,7 +3817,7 @@ MotionState ftData_803C52A0[] = {
     },
     {
         5,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         ft_800BEFD0,
         NULL,
@@ -3827,7 +3827,7 @@ MotionState ftData_803C52A0[] = {
     },
     {
         6,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -3837,7 +3837,7 @@ MotionState ftData_803C52A0[] = {
     },
     {
         7,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -3847,7 +3847,7 @@ MotionState ftData_803C52A0[] = {
     },
     {
         8,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -3857,7 +3857,7 @@ MotionState ftData_803C52A0[] = {
     },
     {
         9,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -3867,7 +3867,7 @@ MotionState ftData_803C52A0[] = {
     },
     {
         10,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -3877,7 +3877,7 @@ MotionState ftData_803C52A0[] = {
     },
     {
         11,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -3887,7 +3887,7 @@ MotionState ftData_803C52A0[] = {
     },
     {
         12,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,
@@ -3897,7 +3897,7 @@ MotionState ftData_803C52A0[] = {
     },
     {
         13,
-        FtStateChange_None,
+        Ft_MF_None,
         FtMoveId_Default << 24,
         NULL,
         NULL,


### PR DESCRIPTION
```sh
#!/usr/bin/env bash
cat <<EOF | cargo run -rp melee-replace-symbols
  FtStateChange_None:Ft_MF_None
  FtStateChange_PreserveFastFall:Ft_MF_KeepFastFall
  FtStateChange_PreserveGfx:Ft_MF_KeepGfx
  FtStateChange_PreserveColAnimHitStatus:Ft_MF_KeepColAnimHitStatus
  FtStateChange_SkipUpdateHit:Ft_MF_SkipHit
  FtStateChange_SkipUpdateModel:Ft_MF_SkipModel
  FtStateChange_SkipUpdateAnimVel:Ft_MF_SkipAnimVel
  FtStateChange_Unk_6:Ft_MF_Unk06
  FtStateChange_SkipUpdateMatAnim:Ft_MF_SkipMatAnim
  FtStateChange_SkipUpdateThrowException:Ft_MF_SkipThrowException
  FtStateChange_PreserveSfx:Ft_MF_KeepSfx
  FtStateChange_SkipUpdateParasol:Ft_MF_SkipParasol
  FtStateChange_SkipUpdateRumble:Ft_MF_SkipRumble
  FtStateChange_SkipUpdateColAnim:Ft_MF_SkipColAnim
  FtStateChange_PreserveAccessory:Ft_MF_KeepAccessory
  FtStateChange_UpdateCmd:Ft_MF_UpdateCmd
  FtStateChange_SkipUpdateNametagVis:Ft_MF_SkipNametagVis
  FtStateChange_PreserveColaNimPartHitStatus:Ft_MF_KeepColAnimPartHitStatus
  FtStateChange_PreserveSwordTrail:Ft_MF_KeepSwordTrail
  FtStateChange_SkipUpdateItemVis:Ft_MF_SkipItemVis
  FtStateChange_Unk_19:Ft_MF_Unk19
  FtStateChange_Unk_UpdatePhys:Ft_MF_UnkUpdatePhys
  FtStateChange_FreezeState:Ft_MF_FreezeState
  FtStateChange_SkipUpdateModelPartVis:Ft_MF_SkipModelPartVis
  FtStateChange_SkipUpdateMetalB:Ft_MF_SkipMetalB
  FtStateChange_Unk_24:Ft_MF_Unk24
  FtStateChange_SkipUpdateAttackCount:Ft_MF_SkipAttackCount
  FtStateChange_SkipUpdateModelFlag:Ft_MF_SkipModelFlags
  FtStateChange_Unk_27:Ft_MF_Unk27
  FtStateChange_SkipUpdateHitStunFlag:Ft_MF_SkipHitStun
  FtStateChange_SkipUpdateAnim:Ft_MF_SkipAnim
  FtStateChange_Unk_30:Ft_MF_Unk30
  FtStateChange_Unk_31:Ft_MF_Unk31
EOF
```