### PR TITLE
Tweak `Makefile` to be more convenient with `objdiff`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ SKIP_CHECK ?= 0
 REQUIRE_PROTOS ?= 1
 MSG_STYLE ?= gcc
 WARN_ERROR ?= 1
+WIP ?= 0
+
+ifeq ($(WIP),1)
+	SKIP_CHECK := 1
+	REQUIRE_PROTOS := 0
+endif
 
 VERBOSE ?= 0
 MAX_ERRORS ?= 0     # 0 = no maximum
@@ -20,7 +26,12 @@ endif
 
 TARGET := ssbm.us.1.2
 
-BUILD_DIR := build/$(TARGET)
+ifeq ($(WIP),1)
+	BUILD_DIR := build/wip/$(TARGET)
+else
+	BUILD_DIR := build/$(TARGET)
+endif
+
 VANILLA_DIR := $(BUILD_DIR)/vanilla
 PROFILE_DIR := $(BUILD_DIR)/profile
 
@@ -133,6 +144,10 @@ ifeq ($(VERBOSE),1)
 	CFLAGS += -verbose
 endif
 
+ifeq ($(WIP),1)
+	CFLAGS += -DWIP
+endif
+
 $(BUILD_DIR)/src/melee/pl/player.c.o: CC_EPI := $(CC)
 $(BUILD_DIR)/src/melee/lb/lbtime.c.o: CC_EPI := $(CC)
 
@@ -164,7 +179,7 @@ format:
 	$(QUIET) tools/newlines.sh
 
 clean:
-	rm -f -d -r build/ssbm.us.1.2 build/o_files $(ELF2DOL)
+	rm -f -d -r $(BUILD_DIR) build/o_files $(ELF2DOL)
 
 ALL_DIRS := $(sort $(dir $(O_FILES)))
 ALL_DIRS += $(patsubst $(BUILD_DIR)/%,$(VANILLA_DIR)/%,$(ALL_DIRS)) \

--- a/tools/objdiff-make.sh
+++ b/tools/objdiff-make.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+make GENERATE_MAP=1 MAX_ERRORS=1 WIP=1 "-j$(nproc)" WINE=wibo "$@"


### PR DESCRIPTION
Set "Custom make program" in `objdiff` to point to `tools/objdiff-make.sh`. Requires `wibo` on your path. If you're on Windows, alias `wibo` it to a no-op or something idk.