### PR TITLE
Reorder `Fighter_ChangeMotionState` arguments

### DIFF
--- a/src/melee/ft/chara/ftCaptain/ftCa_SpecialHi.c
+++ b/src/melee/ft/chara/ftCaptain/ftCa_SpecialHi.c
@@ -136,8 +136,8 @@ void ftCa_SpecialHi_Enter(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     fp->cb.x21EC_callback = ftCa_SpecialLw_800E49FC;
-    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialHi, Ft_MF_None, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialHi, Ft_MF_None, 0, 1, 0,
+                              NULL);
     ftCommon_8007E2D0(fp, 2, ftCa_SpecialLw_800E5128, NULL, ftCo_8009CA0C);
     ftAnim_8006EBA4(gobj);
 }
@@ -381,8 +381,8 @@ void ftCa_SpecialAirHi_Enter(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     fp->cb.x21EC_callback = ftCa_SpecialLw_800E49FC;
-    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialAirHi, Ft_MF_None, NULL, 0,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialAirHi, Ft_MF_None, 0, 1, 0,
+                              NULL);
     ftCommon_8007E2D0(fp, 2, ftCa_SpecialLw_800E5128, NULL, ftCo_8009CA0C);
     ftAnim_8006EBA4(gobj);
 }
@@ -724,7 +724,7 @@ void ftCa_SpecialLw_800E5128(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     Fighter* vic_fp = GET_FIGHTER(fp->victim_gobj);
-    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialHiCatch, 2, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialHiCatch, 2, 0, 1, 0, NULL);
     fp->x2222_b2 = true;
     ftCommon_8007E2F4(fp, 511);
     ftCommon_8007E2FC(gobj);
@@ -817,7 +817,7 @@ static void doCatchAnim(HSD_GObj* gobj)
     fp->mv.ca.specialhi.vel.x = 0;
     fp->mv.ca.specialhi.vel.y = 0;
     Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialHiThrow,
-                              Ft_MF_Unk19 | Ft_MF_KeepGfx, NULL, 0, 1, 0);
+                              Ft_MF_Unk19 | Ft_MF_KeepGfx, 0, 1, 0, NULL);
     ftCommon_8007E2F4(fp, 0);
     ftCo_800DE2A8(gobj, vic_gobj);
     ftCo_800DE7C0(vic_gobj, 0, 0);

--- a/src/melee/ft/chara/ftCaptain/ftCa_SpecialLw.c
+++ b/src/melee/ft/chara/ftCaptain/ftCa_SpecialLw.c
@@ -205,8 +205,8 @@ void ftCa_SpecialLw_Enter(HSD_GObj* gobj)
     fp->throw_flags = 0;
     fp->mv.ca.speciallw.x0 = 0;
     fp->mv.ca.speciallw.friction = 1;
-    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialLw, Ft_MF_None, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialLw, Ft_MF_None, 0, 1, 0,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     fp->cb.x21C0_callback_OnGiveDamage = ftCa_SpecialHi_800E400C;
     fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
@@ -267,8 +267,8 @@ void ftCa_SpecialAirLw_Enter(HSD_GObj* gobj)
     fp->cmd_vars[1] = 0;
     fp->cmd_vars[0] = 0;
     fp->throw_flags = 0;
-    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialAirLw, Ft_MF_None, NULL, 0,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialAirLw, Ft_MF_None, 0, 1, 0,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
     fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
@@ -370,8 +370,8 @@ void ftCa_SpecialLw_Anim(HSD_GObj* gobj)
             fp->throw_flags = 0;
             ftCommon_8007D7FC(fp);
             Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialLwEnd, Ft_MF_None,
-                                      NULL, 0, da->speciallw_ground_lag_mul,
-                                      0);
+                                      0, da->speciallw_ground_lag_mul, 0,
+                                      NULL);
             fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
             fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
         } else {
@@ -382,7 +382,7 @@ void ftCa_SpecialLw_Anim(HSD_GObj* gobj)
             fp->throw_flags = 0;
             ftCommon_8007D5D4(fp);
             Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialLwEndAir,
-                                      Ft_MF_None, NULL, 0, 1, 0);
+                                      Ft_MF_None, 0, 1, 0, NULL);
             fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
             fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
         }
@@ -457,7 +457,7 @@ void ftCa_SpecialAirLw_Anim(HSD_GObj* gobj)
         fp->throw_flags = 0;
         ftCommon_8007D5D4(fp);
         Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialAirLwEndAir, Ft_MF_None,
-                                  NULL, 0, 1, 0);
+                                  0, 1, 0, NULL);
     }
 }
 #endif
@@ -878,7 +878,7 @@ void ftCa_SpecialLw_Coll(HSD_GObj* gobj)
             fp->throw_flags = 0;
             ftCommon_8007D5D4(fp);
             Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialHiThrow1,
-                                      Ft_MF_None, NULL, 0, 1, 0);
+                                      Ft_MF_None, 0, 1, 0, NULL);
         }
     }
 }
@@ -1018,8 +1018,8 @@ void ftCa_SpecialAirLw_Coll(HSD_GObj* gobj)
         fp->cmd_vars[0] = 0;
         fp->throw_flags = 0;
         ftCommon_8007D7FC(fp);
-        Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialAirLwEnd, Ft_MF_None,
-                                  NULL, 0, da->speciallw_landing_lag_mul, 0);
+        Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialAirLwEnd, Ft_MF_None, 0,
+                                  da->speciallw_landing_lag_mul, 0, NULL);
     }
 }
 #endif
@@ -1081,8 +1081,8 @@ void ftCa_SpecialAirLwEndAir_Coll(HSD_GObj* gobj)
         fp->cmd_vars[0] = 0;
         fp->throw_flags = 0;
         ftCommon_8007D7FC(fp);
-        Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialAirLwEnd, Ft_MF_None,
-                                  NULL, 0, da->speciallw_landing_lag_mul, 0);
+        Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialAirLwEnd, Ft_MF_None, 0,
+                                  da->speciallw_landing_lag_mul, 0, NULL);
     }
 }
 #endif

--- a/src/melee/ft/chara/ftCaptain/ftCa_SpecialN.c
+++ b/src/melee/ft/chara/ftCaptain/ftCa_SpecialN.c
@@ -79,7 +79,7 @@ void ftCa_SpecialN_Enter(HSD_GObj* gobj)
     fp->cmd_vars[1] = 0;
     fp->cmd_vars[0] = 0;
     fp->throw_flags = 0;
-    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialN, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialN, 0, 0, 1, 0, NULL);
     fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
     fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
     ftAnim_8006EBA4(gobj);
@@ -95,7 +95,7 @@ void ftCa_SpecialAirN_Enter(HSD_GObj* gobj)
     fp->cmd_vars[1] = 0;
     fp->cmd_vars[0] = 0;
     fp->throw_flags = 0;
-    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialAirN, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialAirN, 0, 0, 1, 0, NULL);
     fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
     fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
     ftAnim_8006EBA4(gobj);
@@ -211,7 +211,7 @@ void ftCa_SpecialN_Coll(HSD_GObj* gobj)
         Fighter* fp = GET_FIGHTER(gobj);
         ftCommon_8007D5D4(fp);
         Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialAirN, transition_flags,
-                                  NULL, fp->cur_anim_frame, 1, 0);
+                                  fp->cur_anim_frame, 1, 0, NULL);
         fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
         fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
         ftCommon_8007D468(fp);
@@ -224,7 +224,7 @@ void ftCa_SpecialAirN_Coll(HSD_GObj* gobj)
         Fighter* fp = GET_FIGHTER(gobj);
         ftCommon_8007D7FC(fp);
         Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialN, transition_flags,
-                                  NULL, fp->cur_anim_frame, 1, 0);
+                                  fp->cur_anim_frame, 1, 0, NULL);
         fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
         fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
     }

--- a/src/melee/ft/chara/ftCaptain/ftCa_SpecialS.c
+++ b/src/melee/ft/chara/ftCaptain/ftCa_SpecialS.c
@@ -49,7 +49,7 @@ void ftCa_SpecialS_Enter(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     resetCmdVarsGround(gobj);
-    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialSStart, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialSStart, 0, 0, 1, 0, NULL);
     setCallbacks(gobj);
     ftAnim_8006EBA4(gobj);
     switch (ftLib_800872A4(gobj)) {
@@ -80,8 +80,8 @@ static inline void setupAirStart(HSD_GObj* gobj)
         u32* vars = &fp->cmd_vars[0];
         vars[0] = vars[1] = vars[2] = vars[3] = 0;
     }
-    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialAirSStart, 0, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialAirSStart, 0, 0, 1, 0,
+                              NULL);
     setCallbacks(gobj);
     ftAnim_8006EBA4(gobj);
     switch (ftLib_800872A4(gobj)) {
@@ -125,8 +125,8 @@ static void onDetectGround(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     ftCaptain_DatAttrs* sa = getFtSpecialAttrsD(fp);
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialS, transition_flags, NULL,
-                              0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialS, transition_flags, 0, 1,
+                              0, NULL);
     setCallbacks(gobj);
     {
         Vec3* vel = &fp->self_vel;
@@ -138,8 +138,8 @@ static void onDetectGround(HSD_GObj* gobj)
 static void onDetectAir(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialAirS, transition_flags,
-                              NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftCa_MS_SpecialAirS, transition_flags, 0,
+                              1, 0, NULL);
     setCallbacks(gobj);
     fp->self_vel.z = 0;
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_Attack1.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Attack1.c
@@ -114,7 +114,7 @@ static void checkAttack11(ftCo_GObj* gobj)
         fp->allow_interrupt = false;
         fp->x2218_b1 = false;
         Fighter_ChangeMotionState(gobj, ftCo_MS_Attack11, getMotionFlags(fp),
-                                  NULL, 0, 1, 0);
+                                  0, 1, 0, NULL);
         ftAnim_8006EBA4(gobj);
         fp->hitlag_mul = fp->co_attrs.jab_2_input_window;
         fp->unk_msid = ftCo_MS_Attack11;
@@ -186,8 +186,8 @@ static void doAttack12Normal(ftCo_GObj* gobj)
     if (!ftCo_80094790(gobj)) {
         fp->allow_interrupt = false;
         fp->x2218_b1 = false;
-        Fighter_ChangeMotionState(gobj, ftCo_MS_Attack12, Ft_MF_None, NULL, 0,
-                                  1, 0);
+        Fighter_ChangeMotionState(gobj, ftCo_MS_Attack12, Ft_MF_None, 0, 1, 0,
+                                  NULL);
         fp->hitlag_mul = fp->co_attrs.jab_3_input_window;
         fp->unk_msid = ftCo_MS_Attack12;
         fp->mv.co.attack1.x0 = 0;
@@ -271,8 +271,8 @@ static void doAttack13(ftCo_GObj* gobj)
         if (!ftCo_80094790(gobj)) {
             fp->allow_interrupt = false;
             fp->x2218_b1 = false;
-            Fighter_ChangeMotionState(gobj, ftCo_MS_Attack13, Ft_MF_None, NULL,
-                                      0, 1, 0);
+            Fighter_ChangeMotionState(gobj, ftCo_MS_Attack13, Ft_MF_None, 0, 1,
+                                      0, NULL);
         }
         return;
     }

--- a/src/melee/ft/chara/ftCommon/ftCo_AttackAir.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_AttackAir.c
@@ -126,7 +126,7 @@ void ftCo_AttackAir_EnterFromMsid(ftCo_GObj* gobj, FtMotionId msid)
     fp->allow_interrupt = false;
     fp->cmd_vars[0] = 0;
     fp->throw_flags = 0;
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_KeepFastFall, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_KeepFastFall, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 }
 

--- a/src/melee/ft/chara/ftCommon/ftCo_AttackDash.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_AttackDash.c
@@ -58,8 +58,8 @@ static void doEnter(ftCo_GObj* gobj)
 {
     ftCo_Fighter* fp = GET_FIGHTER(gobj);
     fp->allow_interrupt = false;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_AttackDash, Ft_MF_None, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_AttackDash, Ft_MF_None, 0, 1, 0,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     fp->mv.co.attackdash.x0 = 0;
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_AttackHi3.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_AttackHi3.c
@@ -39,8 +39,8 @@ void doEnter(ftCo_GObj* gobj)
 {
     ftCo_Fighter* fp = GET_FIGHTER(gobj);
     fp->allow_interrupt = false;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_AttackHi3, Ft_MF_None, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_AttackHi3, Ft_MF_None, 0, 1, 0,
+                              NULL);
     ftAnim_8006EBA4(gobj);
 }
 

--- a/src/melee/ft/chara/ftCommon/ftCo_AttackHi4.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_AttackHi4.c
@@ -85,8 +85,8 @@ void doEnter(ftCo_GObj* gobj)
 {
     ftCo_Fighter* fp = GET_FIGHTER(gobj);
     fp->allow_interrupt = false;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_AttackHi4, Ft_MF_None, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_AttackHi4, Ft_MF_None, 0, 1, 0,
+                              NULL);
     ftAnim_8006EBA4(gobj);
 }
 

--- a/src/melee/ft/chara/ftCommon/ftCo_AttackLw3.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_AttackLw3.c
@@ -79,7 +79,7 @@ static void doEnter(ftCo_GObj* gobj)
         fp->mv.co.attacklw3.x0 = 0;
         fp->cb.x21EC_callback = callUnk;
         Fighter_ChangeMotionState(gobj, ftCo_MS_AttackLw3,
-                                  Ft_MF_SkipAttackCount, NULL, 0, 1, 0);
+                                  Ft_MF_SkipAttackCount, 0, 1, 0, NULL);
         ftAnim_8006EBA4(gobj);
     }
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_AttackLw4.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_AttackLw4.c
@@ -53,8 +53,8 @@ void doEnter(ftCo_GObj* gobj)
 {
     ftCo_Fighter* fp = GET_FIGHTER(gobj);
     fp->allow_interrupt = false;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_AttackLw4, Ft_MF_None, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_AttackLw4, Ft_MF_None, 0, 1, 0,
+                              NULL);
     ftAnim_8006EBA4(gobj);
 }
 

--- a/src/melee/ft/chara/ftCommon/ftCo_AttackS3.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_AttackS3.c
@@ -77,7 +77,7 @@ static void decideAngle(ftCo_GObj* gobj)
             msid = ftCo_MS_AttackS3S;
         }
         fp->allow_interrupt = false;
-        Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, 1, 0, NULL);
         ftAnim_8006EBA4(gobj);
     }
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_AttackS4.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_AttackS4.c
@@ -182,7 +182,7 @@ static void doEnter(ftCo_GObj* gobj, float stick_angle)
     fp->allow_interrupt = false;
     fp->cmd_vars[cmd_unk0_bool] = false;
     fp->throw_flags = 0;
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 }
 

--- a/src/melee/ft/chara/ftCommon/ftCo_CargoFall.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_CargoFall.c
@@ -21,7 +21,7 @@ void ftCo_8009BC58(ftCo_GObj* gobj)
 #endif
     ftCo_Fighter* fp = gobj->user_data;
     Fighter_ChangeMotionState(gobj, fp->x2CC->x4_motion_state + 6,
-                              Ft_MF_KeepFastFall, NULL, 0, 1, 0);
+                              Ft_MF_KeepFastFall, 0, 1, 0, NULL);
     ftAnim_SetAnimRate(gobj, 0);
     if (fp->ground_or_air == GA_Ground) {
         ftCommon_8007D5D4(fp);

--- a/src/melee/ft/chara/ftCommon/ftCo_CargoJump.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_CargoJump.c
@@ -32,7 +32,7 @@ void ftCo_8009BB64(ftCo_GObj* gobj)
     ftCo_Fighter* fp = gobj->user_data;
     ftCommon_8007D5D4(fp);
     Fighter_ChangeMotionState(gobj, fp->x2CC->x4_motion_state + 7, Ft_MF_None,
-                              NULL, 0, 1, 0);
+                              0, 1, 0, NULL);
     ftAnim_SetAnimRate(gobj, 0);
     ftCo_800CB110(gobj, 1, 1);
     ftCo_8009C5A4(fp->victim_gobj, ftCo_MS_ShoulderedWait);

--- a/src/melee/ft/chara/ftCommon/ftCo_CargoKneebend.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_CargoKneebend.c
@@ -26,7 +26,7 @@ void ftCo_8009B9C8(ftCo_GObj* gobj, int arg1)
     fp->mv.co.cargokneebend.x0 = 0;
     fp->mv.co.cargokneebend.x8 = fp_x2CC->cargo_hold.x24_JUMP_STARTUP_LAG;
     Fighter_ChangeMotionState(gobj, fp->x2CC->x4_motion_state + 5, Ft_MF_None,
-                              NULL, 0, 1, 0);
+                              0, 1, 0, NULL);
     ftAnim_SetAnimRate(gobj, 0);
     ftCo_8009C5A4(fp->victim_gobj, ftCo_MS_ShoulderedWait);
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_CargoThrow.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_CargoThrow.c
@@ -174,7 +174,7 @@ bool ftCo_8009C02C(ftCo_GObj* gobj, FtMotionId msid)
         } else {
             msid1 = msid;
         }
-        Fighter_ChangeMotionState(gobj, msid1, mf, NULL, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, msid1, mf, 0, 1, 0, NULL);
     }
     ftAnim_8006EBA4(gobj);
     ftCommon_8007E2F4(fp, 0x1FF);
@@ -216,7 +216,7 @@ static inline void inlineB0(ftCo_GObj* gobj, FtMotionId msid)
                                   Ft_MF_UpdateCmd | Ft_MF_SkipItemVis |
                                   Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |
                                   Ft_MF_SkipModelFlags | Ft_MF_Unk27,
-                              NULL, fp->cur_anim_frame, 1, 0);
+                              fp->cur_anim_frame, 1, 0, NULL);
     fp->facing_dir = facing_dir;
     ftCommon_8007E2F4(fp, 0x1FF);
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_CargoWait.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_CargoWait.c
@@ -27,8 +27,8 @@ bool ftCo_8009B4D0(ftCo_GObj* gobj)
 static inline void inlineA0(ftCo_GObj* gobj, void (*cb)(ftCo_GObj* gobj, int))
 {
     ftCo_Fighter* fp = gobj->user_data;
-    Fighter_ChangeMotionState(gobj, fp->x2CC->x4_motion_state, Ft_MF_None,
-                              NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, fp->x2CC->x4_motion_state, Ft_MF_None, 0,
+                              1, 0, NULL);
     cb(fp->victim_gobj, 266);
 }
 

--- a/src/melee/ft/chara/ftCommon/ftCo_CliffAttack.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_CliffAttack.c
@@ -41,7 +41,7 @@ void ftCo_8009AEA4(ftCo_GObj* gobj)
     FtMotionId msid = (float) fp->dmg.x1830_percent < p_ftCommonData->x488
                           ? ftCo_MS_CliffAttackQuick
                           : ftCo_MS_CliffAttackSlow;
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     ftCommon_8007E2F4(fp, 32);
     fp->x221D_b7 = true;

--- a/src/melee/ft/chara/ftCommon/ftCo_CliffClimb.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_CliffClimb.c
@@ -68,7 +68,7 @@ void ftCo_8009AB9C(ftCo_GObj* gobj)
     FtMotionId msid = (float) fp->dmg.x1830_percent < p_ftCommonData->x488
                           ? ftCo_MS_CliffClimbQuick
                           : ftCo_MS_CliffClimbSlow;
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     ftCommon_8007E2F4(fp, 32);
     fp->x221D_b7 = true;

--- a/src/melee/ft/chara/ftCommon/ftCo_CliffEscape.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_CliffEscape.c
@@ -16,7 +16,7 @@ void ftCo_8009B040(ftCo_GObj* gobj)
     FtMotionId msid = (float) fp->dmg.x1830_percent < p_ftCommonData->x488
                           ? ftCo_MS_CliffEscapeQuick
                           : ftCo_MS_CliffEscapeSlow;
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     ftCommon_8007E2F4(fp, 32);
     fp->x221D_b7 = true;

--- a/src/melee/ft/chara/ftCommon/ftCo_CliffJump.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_CliffJump.c
@@ -33,7 +33,7 @@ void ftCo_8009B1B8(ftCo_GObj* gobj)
     FtMotionId msid = (float) fp->dmg.x1830_percent < p_ftCommonData->x488
                           ? ftCo_MS_CliffJumpQuick1
                           : ftCo_MS_CliffJumpSlow1;
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     ftCommon_8007E2F4(fp, 32);
     fp->x221D_b7 = true;
@@ -69,7 +69,7 @@ void ftCo_8009B2F8(ftCo_GObj* gobj)
     FtMotionId msid = fp->motion_id == ftCo_MS_CliffJumpQuick1
                           ? ftCo_MS_CliffJumpQuick2
                           : ftCo_MS_CliffJumpSlow2;
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     fp->mv.co.cliffjump.x0 = false;
     fp->self_vel.x +=
@@ -87,7 +87,7 @@ void ftCo_8009B390(ftCo_GObj* gobj, float force_mul)
     FtMotionId msid = fp->motion_id == ftCo_MS_CliffJumpQuick1
                           ? ftCo_MS_CliffJumpQuick2
                           : ftCo_MS_CliffJumpSlow2;
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     fp->mv.co.cliffjump.x0 = false;
     fp->self_vel.y = fp->co_attrs.ledge_jump_vertical_velocity * force_mul;

--- a/src/melee/ft/chara/ftCommon/ftCo_CliffWait.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_CliffWait.c
@@ -17,8 +17,8 @@
 void ftCo_8009A804(ftCo_GObj* gobj)
 {
     ftCo_Fighter* fp = gobj->user_data;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_CliffWait, Ft_MF_SkipNametagVis,
-                              NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_CliffWait, Ft_MF_SkipNametagVis, 0,
+                              1, 0, NULL);
     ftCommon_8007E2F4(fp, 511);
     fp->x221D_b7 = true;
     fp->mv.co.cliff.x8 = 0;

--- a/src/melee/ft/chara/ftCommon/ftCo_Damage.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Damage.c
@@ -1356,7 +1356,7 @@ block_44:
 
     ftCo_8008DA4C(gobj, var_r28, 0);
     ftCo_8008DB10(gobj, (s32) M2C_FIELD(fp, u32*, 0x1860), kb_applied);
-    Fighter_ChangeMotionState(gobj, msid, 0x40U, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, 0x40U, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     if (!gm_8016B014()) {
         goto block_60;

--- a/src/melee/ft/chara/ftCommon/ftCo_DamageFall.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_DamageFall.c
@@ -163,8 +163,8 @@ void ftCo_80090780(HSD_GObj* gobj)
     if (ftCo_GetParasolStatus(gobj) != -1) {
         ftCo_800CF4DC(gobj);
     } else {
-        Fighter_ChangeMotionState(gobj, 0x26, 0x18001U, NULL, 0.0f, 1.0f,
-                                  0.0f);
+        Fighter_ChangeMotionState(gobj, 0x26, 0x18001U, 0.0f, 1.0f, 0.0f,
+                                  NULL);
         ftCommon_8007D468((Fighter*) fp);
         ftCommon_8007EBAC((Fighter*) fp, 8U, 0U);
     }

--- a/src/melee/ft/chara/ftCommon/ftCo_DamageIce.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_DamageIce.c
@@ -697,8 +697,8 @@ void ftCo_80091030(ftCo_GObj* gobj)
     ftCo_8009750C(gobj);
     ftCo_800DD168(gobj);
     fp->x2227_flag.bits.b6 = true;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_DamageIce, (1 << 1) | (1 << 6),
-                              NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_DamageIce, (1 << 1) | (1 << 6), 0,
+                              1, 0, NULL);
     ftCo_8009E140(fp, 0);
     ftCommon_8007F824(fp->gobj);
     fp->x2222_b3 = true;
@@ -1299,7 +1299,7 @@ void ftCo_80091854(HSD_GObj* gobj)
     } else {
         ftCommon_8007D5D4(fp);
         fp->x2227_flag.bits.b5 = false;
-        Fighter_ChangeMotionState(gobj, 0x146, 0x40U, NULL, 0, 0, 0);
+        Fighter_ChangeMotionState(gobj, 0x146, 0x40U, 0, 0, 0, NULL);
         ft_80088148(fp, 0x123, 0x7F, 0x40);
         {
             HSD_JObj* jobj =

--- a/src/melee/ft/chara/ftCommon/ftCo_Down.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Down.c
@@ -175,7 +175,7 @@ asm void ftCo_80098324(ftCo_GObj* gobj, FtMotionId msid)
 void ftCo_80098324(ftCo_GObj* gobj, FtMotionId msid)
 {
     ftCo_Fighter* fp = gobj->user_data;
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     ftCommon_8007CCE8(fp);
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_DownAttack.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_DownAttack.c
@@ -35,7 +35,7 @@ int ftCo_800984D4(ftCo_GObj* gobj)
 
 void ftCo_8009856C(ftCo_GObj* gobj, FtMotionId msid)
 {
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 }
 

--- a/src/melee/ft/chara/ftCommon/ftCo_DownBound.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_DownBound.c
@@ -525,8 +525,8 @@ void ftCo_8009794C(ftCo_GObj* gobj)
         }
         Fighter_ChangeMotionState(
             gobj, b ? ftCo_MS_DownBoundU : ftCo_MS_DownBoundD,
-            Ft_MF_SkipNametagVis | Ft_MF_KeepColAnimPartHitStatus, NULL, 0, 1,
-            0);
+            Ft_MF_SkipNametagVis | Ft_MF_KeepColAnimPartHitStatus, 0, 1, 0,
+            NULL);
         ftCo_800978D4(gobj);
         ftCo_800976A4(gobj);
         fp->x67C = 255;
@@ -881,7 +881,7 @@ void ftCo_80097E8C(ftCo_GObj* gobj)
                                   Ft_MF_SkipModel | Ft_MF_SkipMatAnim |
                                       Ft_MF_SkipNametagVis |
                                       Ft_MF_KeepColAnimPartHitStatus,
-                                  NULL, 0, 1, 0);
+                                  0, 1, 0, NULL);
     }
     ftAnim_8006EBA4(gobj);
     ftCommon_8007E2F4(fp, true);
@@ -942,7 +942,7 @@ void ftCo_80097F38(ftCo_GObj* gobj)
                                              : ftCo_MS_DownWaitD,
         Ft_MF_SkipModel | Ft_MF_SkipMatAnim | Ft_MF_SkipNametagVis |
             Ft_MF_KeepColAnimPartHitStatus,
-        NULL, 0, 1, 0);
+        0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     ftCommon_8007E2F4(fp, 1);
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_DownStand.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_DownStand.c
@@ -32,7 +32,7 @@ bool ftCo_800980BC(Fighter_GObj* gobj)
 
 void ftCo_80098160(ftCo_GObj* gobj, FtMotionId msid)
 {
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, 1, 0, NULL);
 }
 
 void ftCo_DownStand_Anim(Fighter_GObj* gobj)

--- a/src/melee/ft/chara/ftCommon/ftCo_Escape.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Escape.c
@@ -88,7 +88,7 @@ void ftCo_80099314(ftCo_GObj* gobj, FtMotionId msid, bool arg2)
 {
     ftCo_Fighter* fp = gobj->user_data;
     fp->throw_flags = 0;
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     fp->x221D_b5 = true;
     fp->mv.co.escape.x0 = arg2;
@@ -242,8 +242,8 @@ void ftCo_80099894(ftCo_GObj* gobj)
 void ftCo_800998EC(ftCo_GObj* gobj)
 {
     ftCo_Fighter* fp = gobj->user_data;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_EscapeN, Ft_MF_None, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_EscapeN, Ft_MF_None, 0, 1, 0,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     fp->x221D_b5 = true;
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_EscapeAir.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_EscapeAir.c
@@ -57,8 +57,8 @@ void ftCo_80099A9C(Fighter_GObj* gobj, int timer)
     inlineA0(fp);
     fp->cmd_vars[cmd_skip_decay] = false;
     fp->mv.co.escapeair.timer = timer;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_EscapeAir, Ft_MF_None, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_EscapeAir, Ft_MF_None, 0, 1, 0,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     ftCommon_8007EBAC(fp, 23, 0);
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_FallSpecial.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_FallSpecial.c
@@ -111,8 +111,8 @@ void ftCo_80096900(ftCo_GObj* gobj, int arg1, int arg2, bool allow_interrupt,
         ftCo_80090780(gobj);
         return;
     }
-    Fighter_ChangeMotionState(gobj, ftCo_MS_FallSpecial, Ft_MF_KeepFastFall,
-                              NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_FallSpecial, Ft_MF_KeepFastFall, 0,
+                              1, 0, NULL);
     fp->mv.co.fallspecial.x8 = ca->air_drift_max * arg4;
     fp->mv.co.fallspecial.xC = arg1;
     fp->mv.co.fallspecial.x10 = arg2;
@@ -206,8 +206,8 @@ void ftCo_800969D8(ftCo_GObj* gobj, int arg1, int arg2, int allow_interrupt,
         ftCo_80090780(gobj);
         return;
     }
-    Fighter_ChangeMotionState(gobj, ftCo_MS_FallSpecial, Ft_MF_KeepFastFall,
-                              NULL, 0, 1, arg6);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_FallSpecial, Ft_MF_KeepFastFall, 0,
+                              1, arg6, NULL);
     fp->mv.co.fallspecial.x8 = ca->air_drift_max * arg4;
     fp->mv.co.fallspecial.xC = arg1;
     fp->mv.co.fallspecial.x10 = arg2;

--- a/src/melee/ft/chara/ftCommon/ftCo_Furafura.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Furafura.c
@@ -13,8 +13,8 @@ void ftCo_80099010(ftCo_GObj* gobj)
 {
     ftCo_Fighter* fp = gobj->user_data;
     Fighter_ChangeMotionState(gobj, ftCo_MS_Furafura,
-                              Ft_MF_SkipModel | Ft_MF_SkipMatAnim, NULL, 0, 1,
-                              0);
+                              Ft_MF_SkipModel | Ft_MF_SkipMatAnim, 0, 1, 0,
+                              NULL);
     fp->shield_health = p_ftCommonData->x280_unkShieldHealth;
     {
         float percent = p_ftCommonData->x2F8 - fp->dmg.x1830_percent;

--- a/src/melee/ft/chara/ftCommon/ftCo_Guard.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Guard.c
@@ -1177,8 +1177,8 @@ void ftCo_800924C0(ftCo_GObj* gobj)
     void* fp;
 
     fp = gobj->user_data;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_GuardOn, Ft_MF_SkipAnim, NULL, 0,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_GuardOn, Ft_MF_SkipAnim, 0, 1, 0,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     M2C_FIELD(fp, u8*, 0x221C) = (u8) (M2C_FIELD(fp, u8*, 0x221C) & ~0x10);
     M2C_FIELD(fp, u8*, 0x221C) = (u8) (M2C_FIELD(fp, u8*, 0x221C) & ~0x40);
@@ -1622,8 +1622,8 @@ asm void ftCo_80092908(ftCo_GObj* gobj)
 void ftCo_80092908(ftCo_GObj* gobj)
 {
     ftCo_Fighter* fp = gobj->user_data;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_Guard, Ft_MF_SkipAnim, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_Guard, Ft_MF_SkipAnim, 0, 1, 0,
+                              NULL);
     {
         HSD_JObj* jobj = fp->parts[fp->ft_data->x8->unk11].joint;
         ftCo_80092158(gobj, 1048, jobj);
@@ -1832,8 +1832,8 @@ asm void ftCo_80092C54(ftCo_GObj* gobj)
 void ftCo_80092C54(ftCo_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_GuardOff, Ft_MF_None, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_GuardOff, Ft_MF_None, 0, 1, 0,
+                              NULL);
     ft_80088148(fp, 127, 127, 64);
 }
 #endif
@@ -2193,8 +2193,8 @@ lbl_8009321C:
 void ftCo_80092F2C(HSD_GObj* gobj, bool arg1)
 {
     ftCo_Fighter* fp = gobj->user_data;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_GuardSetOff, Ft_MF_None, NULL, 0,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_GuardSetOff, Ft_MF_None, 0, 1, 0,
+                              NULL);
     fp->cb.x21D0_callback_EveryHitlag = ftCo_80093240;
     fp->x670_timer_lstick_tilt_x = -2;
     fp->cb.x21D8_callback_ExitHitlag = ftCo_800932DC;
@@ -2882,8 +2882,8 @@ void ftCo_8009388C(HSD_GObj* gobj)
 {
     ftCo_Fighter* fp = gobj->user_data;
     Fighter_ChangeMotionState(gobj, ftCo_MS_GuardReflect,
-                              Ft_MF_SkipAnim | Ft_MF_KeepGfx, NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              Ft_MF_SkipAnim | Ft_MF_KeepGfx,
+                              fp->cur_anim_frame, 1, 0, NULL);
     fp->x672_input_timer_counter = 0xFE;
     fp->x221A_b7 = false;
     fp->x221B_b0 = false;
@@ -3022,7 +3022,7 @@ asm void ftCo_80093A50(ftCo_GObj*)
 void ftCo_80093A50(ftCo_GObj* gobj)
 {
     ftCo_Fighter* fp = gobj->user_data;
-    Fighter_ChangeMotionState(gobj, 182, Ft_MF_SkipAnim, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 182, Ft_MF_SkipAnim, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     fp->x672_input_timer_counter = 0xFE;
     fp->x221C_b3 = true;

--- a/src/melee/ft/chara/ftCommon/ftCo_ItemGet.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_ItemGet.c
@@ -611,8 +611,8 @@ void ftCo_80094694(HSD_GObj* gobj, FtMotionId msid, bool loop)
             anim_spd = 1;
         }
         fp->throw_flags = 0;
-        Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, anim_spd,
-                                  0);
+        Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, anim_spd, 0,
+                                  NULL);
     }
     if (loop) {
         while (!ftCheckThrowB3(fp)) {

--- a/src/melee/ft/chara/ftCommon/ftCo_ItemThrow.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_ItemThrow.c
@@ -986,8 +986,8 @@ void ftCo_800957F4(ftCo_GObj* gobj, int msid)
                 numerator * (1 / it_8026B334(GET_FIGHTER(gobj)->item_gobj));
             fp->mv.co.itemthrow4.anim_spd = anim_spd;
             ftCo_80095700(gobj, msid);
-            Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0,
-                                      anim_spd, 0);
+            Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, anim_spd, 0,
+                                      NULL);
         }
     }
     ftAnim_8006EBA4(gobj);
@@ -1134,7 +1134,7 @@ void ftCo_800958FC(HSD_GObj* gobj, FtMotionId msid)
             (float) M2C_FIELD(temp_r4, float*, 0x2C);
         break;
     }
-    Fighter_ChangeMotionState(gobj, msid, 0U, NULL, 0.0f, temp_f2, 0.0f);
+    Fighter_ChangeMotionState(gobj, msid, 0U, 0.0f, temp_f2, 0.0f, NULL);
     ftAnim_8006EBA4(gobj);
     M2C_FIELD(temp_r31, void (**)(HSD_GObj*), 0x21BC) = ftCo_80095EFC;
     M2C_FIELD(temp_r31, void (**)(HSD_GObj*), 0x21DC) = ftCo_800974C4;
@@ -2022,7 +2022,7 @@ static inline void inlineA1(ftCo_GObj* gobj, FtMotionId msid)
         Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim | Ft_MF_UpdateCmd |
             Ft_MF_SkipItemVis | Ft_MF_Unk19 | Ft_MF_SkipModelPartVis |
             Ft_MF_SkipModelFlags | Ft_MF_Unk27,
-        NULL, fp->cur_anim_frame, fp->mv.co.itemthrow4.anim_spd, 0);
+        fp->cur_anim_frame, fp->mv.co.itemthrow4.anim_spd, 0, NULL);
     fp->facing_dir = facing_dir;
 }
 

--- a/src/melee/ft/chara/ftCommon/ftCo_LandingAir.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_LandingAir.c
@@ -64,7 +64,7 @@ void ftCo_LandingAir_EnterWithMsidLag(ftCo_GObj* gobj, FtMotionId msid,
     u8 _[8] = { 0 };
 #endif
     ftCommon_8007D7FC(GET_FIGHTER(gobj));
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, 1, 0, NULL);
     ftAnim_SetAnimRate(gobj, (ftAnim_8006F484(gobj) + 0.1f) / lag);
 }
 

--- a/src/melee/ft/chara/ftCommon/ftCo_Lift.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Lift.c
@@ -23,8 +23,8 @@ void ftCo_80096D9C(ftCo_GObj* gobj)
 {
     ftCo_Fighter* fp = gobj->user_data;
     fp->mv.co.lift.x0 = false;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_LiftWait, Ft_MF_None, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_LiftWait, Ft_MF_None, 0, 1, 0,
+                              NULL);
     fp->cb.x21DC_callback_OnTakeDamage = ftCo_800974C4;
 }
 
@@ -88,7 +88,7 @@ void ftCo_80096F48(HSD_GObj* gobj)
         msid = ftCo_MS_LiftWalk2;
     }
     fp->mv.co.lift.x0 ^= true;
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     fp->cb.x21DC_callback_OnTakeDamage = ftCo_800974C4;
 }
@@ -101,8 +101,8 @@ void ftCo_LiftWalk_Anim(HSD_GObj* gobj)
 #endif
     if (!ftAnim_IsFramesRemaining(gobj) && !ftCo_80096EF8(gobj)) {
         ftCo_Fighter* fp = gobj->user_data;
-        Fighter_ChangeMotionState(gobj, ftCo_MS_LiftWait, Ft_MF_Unk24, NULL, 0,
-                                  1, 0);
+        Fighter_ChangeMotionState(gobj, ftCo_MS_LiftWait, Ft_MF_Unk24, 0, 1, 0,
+                                  NULL);
         fp->cb.x21DC_callback_OnTakeDamage = ftCo_800974C4;
     }
 }
@@ -137,8 +137,8 @@ void ftCo_80097130(HSD_GObj* gobj)
     ftCo_Fighter* fp = gobj->user_data;
     fp->mv.co.lift.x4 = p_ftCommonData->x230;
     fp->mv.co.lift.x8 = false;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_LiftTurn, Ft_MF_Unk24, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_LiftTurn, Ft_MF_Unk24, 0, 1, 0,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     fp->cb.x21DC_callback_OnTakeDamage = ftCo_800974C4;
     ftCo_LiftTurn_Anim(gobj);
@@ -175,7 +175,7 @@ void ftCo_LiftTurn_Anim(HSD_GObj* gobj)
     }
     if (fp->mv.co.lift.x4 <= 0) {
         ftCo_Fighter* fp = gobj->user_data;
-        Fighter_ChangeMotionState(gobj, 174, Ft_MF_Unk24, NULL, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, 174, Ft_MF_Unk24, 0, 1, 0, NULL);
         fp->cb.x21DC_callback_OnTakeDamage = ftCo_800974C4;
     }
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_Ottotto.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Ottotto.c
@@ -36,8 +36,8 @@ bool ftCo_8009A3C8(ftCo_GObj* gobj)
 void ftCo_8009A410(ftCo_GObj* gobj)
 {
     ftCo_Fighter* fp = gobj->user_data;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_Ottotto, Ft_MF_None, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_Ottotto, Ft_MF_None, 0, 1, 0,
+                              NULL);
     fp->self_vel.x = fp->self_vel.y = fp->self_vel.z = 0;
     fp->gr_vel = 0;
 }
@@ -115,8 +115,8 @@ void ftCo_Ottotto_Coll(ftCo_GObj* gobj)
 void ftCo_8009A6B8(ftCo_GObj* gobj)
 {
     ftCo_Fighter* fp = gobj->user_data;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_OttottoWait, Ft_MF_None, NULL, 0,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_OttottoWait, Ft_MF_None, 0, 1, 0,
+                              NULL);
     ft_80088770(fp);
     ft_800887CC(fp);
     ft_80088328(fp, fp->ft_data->x4C_collisionData->x18, 127, 64);

--- a/src/melee/ft/chara/ftCommon/ftCo_Pass.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Pass.c
@@ -85,7 +85,7 @@ void ftCo_8009A184(ftCo_GObj* gobj, FtMotionId msid, MotionFlags mf,
     ftCommon_8007D5D4(fp);
     ftCommon_8007D468(fp);
     fp->self_vel.y = p_ftCommonData->x46C;
-    Fighter_ChangeMotionState(gobj, msid, mf, NULL, anim_start, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, mf, anim_start, 1, 0, NULL);
     mpColl_8004CBE8(&fp->coll_data);
     fp->x671_timer_lstick_tilt_y = 0xFE;
 }
@@ -100,7 +100,7 @@ void ftCo_8009A228(ftCo_GObj* gobj)
     ftCommon_8007D5D4(fp);
     ftCommon_8007D468(fp);
     fp->self_vel.y = p_ftCommonData->x46C;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_Pass, Ft_MF_None, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_Pass, Ft_MF_None, 0, 1, 0, NULL);
     mpColl_8004CBE8(&fp->coll_data);
     fp->x671_timer_lstick_tilt_y = 0xFE;
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_Passive.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Passive.c
@@ -17,7 +17,7 @@ void ftCo_800987D0(Fighter_GObj* gobj)
     if (fp->ground_or_air == GA_Air) {
         ftCommon_8007D7FC(fp);
     }
-    Fighter_ChangeMotionState(gobj, 199, Ft_MF_None, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 199, Ft_MF_None, 0, 1, 0, NULL);
     ft_800881D8(fp, fp->ft_data->x4C_collisionData->x24, 127, 64);
     ft_80088148(fp, 3, 127, 64);
     ftCommon_8007CCE8(fp);

--- a/src/melee/ft/chara/ftCommon/ftCo_PassiveStand.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_PassiveStand.c
@@ -37,7 +37,7 @@ void ftCo_800989D4(Fighter_GObj* gobj, FtMotionId msid)
     if (fp->ground_or_air == GA_Air) {
         ftCommon_8007D7FC(fp);
     }
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, 1, 0, NULL);
     ft_800881D8(fp, fp->ft_data->x4C_collisionData->x24, 127, 64);
     ft_80088148(fp, 3, 127, 64);
     ftCo_SpawnEf(gobj, fp->parts[FtPart_TopN].joint, 1, 1053);

--- a/src/melee/ft/chara/ftCommon/ftCo_Rebound.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Rebound.c
@@ -17,8 +17,8 @@ void ftCo_80099D9C(ftCo_GObj* gobj)
     u8 _[8] = { 0 };
 #endif
     ftCo_Fighter* fp = gobj->user_data;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_ReboundStop, Ft_MF_None, NULL, 0,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_ReboundStop, Ft_MF_None, 0, 1, 0,
+                              NULL);
     {
         float fp_x191C = fp->dmg.x191C;
         fp->mv.co.rebound.anim_start = (fp->co_attrs.x9C + 0.1f) / fp_x191C;
@@ -37,8 +37,8 @@ void ftCo_ReboundStop_Anim(ftCo_GObj* gobj)
 void ftCo_80099E44(ftCo_GObj* gobj)
 {
     ftCo_Fighter* fp = gobj->user_data;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_Rebound, Ft_MF_None, NULL, 0,
-                              fp->mv.co.rebound.anim_start, 0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_Rebound, Ft_MF_None, 0,
+                              fp->mv.co.rebound.anim_start, 0, NULL);
 }
 
 void ftCo_Rebound_Anim(ftCo_GObj* gobj)

--- a/src/melee/ft/chara/ftCommon/ftCo_ShieldBreakDown.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_ShieldBreakDown.c
@@ -23,7 +23,7 @@ void ftCo_80098E3C(Fighter_GObj* gobj, float lag)
                                   Ft_MF_KeepColAnimHitStatus |
                                       Ft_MF_SkipModel | Ft_MF_SkipMatAnim |
                                       Ft_MF_SkipColAnim,
-                                  NULL, 0, 1, 0);
+                                  0, 1, 0, NULL);
     }
     ftCo_800978D4(gobj);
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_ShieldBreakFall.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_ShieldBreakFall.c
@@ -17,7 +17,7 @@ void ftCo_80098D90(ftCo_GObj* gobj)
                               Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipModel |
                                   Ft_MF_Unk06 | Ft_MF_SkipMatAnim |
                                   Ft_MF_SkipColAnim,
-                              NULL, 0, 1, 0);
+                              0, 1, 0, NULL);
     ftCommon_8007D468(fp);
     ftCommon_8007EBAC(fp, 8, 0);
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_ShieldBreakFly.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_ShieldBreakFly.c
@@ -19,7 +19,7 @@ void ftCo_80098B20(Fighter_GObj* gobj)
 {
     ftCo_Fighter* fp = gobj->user_data;
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, 205, 64, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 205, 64, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     fp->self_vel.x = 0;
     fp->self_vel.y = fp->co_attrs.shield_break_initial_velocity;

--- a/src/melee/ft/chara/ftCommon/ftCo_ShieldBreakStand.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_ShieldBreakStand.c
@@ -20,7 +20,7 @@ void ftCo_80098F3C(ftCo_GObj* gobj)
     Fighter_ChangeMotionState(gobj, msid,
                               Ft_MF_KeepColAnimHitStatus | Ft_MF_SkipModel |
                                   Ft_MF_SkipMatAnim | Ft_MF_SkipColAnim,
-                              NULL, 0, 1, 0);
+                              0, 1, 0, NULL);
 }
 
 void ftCo_ShieldBreakStand_Anim(ftCo_GObj* gobj)

--- a/src/melee/ft/chara/ftCommon/ftCo_Shouldered.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Shouldered.c
@@ -36,18 +36,9 @@ ASM void ftCo_8009C5A4(ftCo_GObj* gobj, FtMotionId msid)
 #endif
     ftCo_Fighter* fp = gobj->user_data;
     if (fp->motion_id != msid || msid != ftCo_MS_ShoulderedWait) {
-#define SOLUTION 1
-#if SOLUTION == 0
-        ftCo_GObj* temp = fp->victim_gobj;
         Fighter_ChangeMotionState(
-            gobj, msid, fp->x2222_b6 ? Ft_MF_FreezeState : Ft_MF_None, temp, 0,
-            1, 0);
-#elif SOLUTION == 1
-        Fighter_ChangeMotionState(
-            gobj, msid, fp->x2222_b6 ? Ft_MF_FreezeState : Ft_MF_None,
-            fp->victim_gobj, 0, 1, 0);
-#endif
-#undef SOLUTION
+            gobj, msid, fp->x2222_b6 ? Ft_MF_FreezeState : Ft_MF_None, 0, 1, 0,
+            fp->victim_gobj);
         ftCommon_8007E2FC(gobj);
         ftCommon_8007E2F4(fp, 0x1FF);
         fp->cb.x21B0_callback_Accessory1 = ftCo_800DB464;

--- a/src/melee/ft/chara/ftDonkey/ftDk_HeavyFall.c
+++ b/src/melee/ft/chara/ftDonkey/ftDk_HeavyFall.c
@@ -45,8 +45,8 @@ void ftDk_MS_347_800E03C0(HSD_GObj* gobj)
     ftDonkeyAttributes* donkey_attr;
     ftCommon_8007D5D4(fp);
     donkey_attr = getFtSpecialAttrs2CC(fp);
-    Fighter_ChangeMotionState(gobj, donkey_attr->motion_state + 7, 0, NULL, 0,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, donkey_attr->motion_state + 7, 0, 0, 1, 0,
+                              NULL);
     ftAnim_SetAnimRate(gobj, 0);
     ftCo_800CB110(gobj, 1, 1);
 }

--- a/src/melee/ft/chara/ftDonkey/ftDk_HeavyJump.c
+++ b/src/melee/ft/chara/ftDonkey/ftDk_HeavyJump.c
@@ -33,8 +33,8 @@ void ftDk_MS_348_800E04A4(HSD_GObj* gobj, s32 arg1)
     fp->mv.dk.unk7.x0 = 0;
     fp->mv.dk.unk7.x8 = donkey_attr->cargo_hold.x24_JUMP_STARTUP_LAG;
     donkey_attr2 = getFtSpecialAttrs2CC(fp);
-    Fighter_ChangeMotionState(gobj, donkey_attr2->motion_state + 5, 0, NULL, 0,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, donkey_attr2->motion_state + 5, 0, 0, 1, 0,
+                              NULL);
     ftAnim_SetAnimRate(gobj, 0);
 }
 

--- a/src/melee/ft/chara/ftDonkey/ftDk_HeavyTurn.c
+++ b/src/melee/ft/chara/ftDonkey/ftDk_HeavyTurn.c
@@ -43,8 +43,8 @@ void ftDk_MS_345_800E0294(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs2CC(fp);
-    Fighter_ChangeMotionState(gobj, donkey_attr->motion_state + 6, 1, NULL, 0,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, donkey_attr->motion_state + 6, 1, 0, 1, 0,
+                              NULL);
     ftAnim_SetAnimRate(gobj, 0);
     if (fp->ground_or_air == GA_Ground) {
         ftCommon_8007D5D4(fp);

--- a/src/melee/ft/chara/ftDonkey/ftDk_HeavyWait0.c
+++ b/src/melee/ft/chara/ftDonkey/ftDk_HeavyWait0.c
@@ -35,8 +35,8 @@ void ftDk_MS_341_800DF980(HSD_GObj* gobj)
     }
     {
         ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs2CC(fp);
-        Fighter_ChangeMotionState(gobj, donkey_attr->motion_state, 0, NULL, 0,
-                                  1, 0);
+        Fighter_ChangeMotionState(gobj, donkey_attr->motion_state, 0, 0, 1, 0,
+                                  NULL);
     }
 }
 

--- a/src/melee/ft/chara/ftDonkey/ftDk_SpecialHi.c
+++ b/src/melee/ft/chara/ftDonkey/ftDk_SpecialHi.c
@@ -27,7 +27,7 @@ void ftDk_SpecialHi_Enter(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftDonkeyAttributes* donkey_attr = getFtSpecialAttrs(fp);
-    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialHi, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialHi, 0, 0, 1, 0, NULL);
     setCallbacks(gobj);
     fp->cmd_vars[0] = fp->cmd_vars[1] = fp->cmd_vars[2] = fp->cmd_vars[3] = 0;
     ftCommon_8007CC78(fp,
@@ -47,7 +47,7 @@ void ftDk_SpecialAirHi_Enter(HSD_GObj* gobj)
 #ifdef MUST_MATCH
     u8 _[8];
 #endif
-    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirHi, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirHi, 0, 0, 1, 0, NULL);
     setCallbacks(gobj);
     fp->cmd_vars[0] = fp->cmd_vars[1] = fp->cmd_vars[2] = fp->cmd_vars[3] = 0;
     ftCommon_8007D440(fp,
@@ -124,8 +124,8 @@ void ftDk_SpecialHi_Coll(HSD_GObj* gobj)
 
     if (!ft_80082708(gobj)) {
         ftCommon_8007D60C(fp);
-        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirHi, 0x0C4C5080, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirHi, 0x0C4C5080,
+                                  fp->cur_anim_frame, 1, 0, NULL);
         setCallbacks(gobj);
         ftCommon_8007D440(
             fp, donkey_attr->SpecialHi.x58_AERIAL_HORIZONTAL_VELOCITY);
@@ -144,7 +144,7 @@ void ftDk_SpecialAirHi_Coll(HSD_GObj* gobj)
         if (ft_80081D0C(gobj)) {
             ftCommon_8007D7FC(fp);
             Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialHi, 0x0C4C5080,
-                                      NULL, fp->cur_anim_frame, 1, 0);
+                                      fp->cur_anim_frame, 1, 0, NULL);
             setCallbacks(gobj);
             ftCommon_8007CC78(
                 fp, donkey_attr->SpecialHi.x54_GROUNDED_HORIZONTAL_VELOCITY);
@@ -153,7 +153,7 @@ void ftDk_SpecialAirHi_Coll(HSD_GObj* gobj)
         if (ft_CheckGroundAndLedge(gobj, 0)) {
             ftCommon_8007D7FC(fp);
             Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialHi, 0x0C4C5080,
-                                      NULL, fp->cur_anim_frame, 1, 0);
+                                      fp->cur_anim_frame, 1, 0, NULL);
             setCallbacks(gobj);
             ftCommon_8007CC78(
                 fp, donkey_attr->SpecialHi.x54_GROUNDED_HORIZONTAL_VELOCITY);

--- a/src/melee/ft/chara/ftDonkey/ftDk_SpecialLw.c
+++ b/src/melee/ft/chara/ftDonkey/ftDk_SpecialLw.c
@@ -16,7 +16,7 @@ void ftDk_SpecialLw_Enter(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     fp->mv.dk.speciallw.x0 = 0;
-    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialLwStart, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialLwStart, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -110,7 +110,7 @@ static void doAnim(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     fp->cb.x21EC_callback = callback;
     fp->throw_flags = 0;
-    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialLwLoop, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialLwLoop, 0, 0, 1, 0, NULL);
     ftDonkey_8010DE88_inner(gobj);
     fp->cb.x21BC_callback_Accessory4 = ftDk_Init_8010DB3C;
 }
@@ -142,7 +142,7 @@ void ftDk_SpecialLwEnd0_Coll(HSD_GObj* gobj)
 
 static void doTransition(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialLwEnd0, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialLwEnd0, 0, 0, 1, 0, NULL);
 }
 
 void ftDk_SpecialLwEnd1_Anim(HSD_GObj* gobj)

--- a/src/melee/ft/chara/ftDonkey/ftDk_SpecialN.c
+++ b/src/melee/ft/chara/ftDonkey/ftDk_SpecialN.c
@@ -43,14 +43,14 @@ void ftDk_SpecialN_Enter(HSD_GObj* gobj)
     u8 _[8];
 #endif
     if (fp->fv.dk.x222C == donkey_attr->SpecialN.x2C_MAX_ARM_SWINGS) {
-        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialNFull, 0, NULL, 0, 1,
-                                  0);
+        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialNFull, 0, 0, 1, 0,
+                                  NULL);
         fp->mv.dk.specialn.x8 = 1;
         fp->mv.dk.specialn.xC = fp->fv.dk.x222C;
         fp->fv.dk.x222C = 0;
     } else {
-        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialNStart, 0, NULL, 0, 1,
-                                  0);
+        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialNStart, 0, 0, 1, 0,
+                                  NULL);
         fp->mv.dk.specialn.x8 = 0;
         fp->mv.dk.specialn.xC = 0;
     }
@@ -74,14 +74,14 @@ void ftDk_SpecialAirN_Enter(HSD_GObj* gobj)
     u8 _[8];
 #endif
     if (fp->fv.dk.x222C == donkey_attr->SpecialN.x2C_MAX_ARM_SWINGS) {
-        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirNFull, 0, NULL, 0, 1,
-                                  0);
+        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirNFull, 0, 0, 1, 0,
+                                  NULL);
         fp->mv.dk.specialn.x8 = 1;
         fp->mv.dk.specialn.xC = fp->fv.dk.x222C;
         fp->fv.dk.x222C = 0;
     } else {
-        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirNStart, 0, NULL, 0,
-                                  1, 0);
+        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirNStart, 0, 0, 1, 0,
+                                  NULL);
         fp->mv.dk.specialn.x8 = 0;
         fp->mv.dk.specialn.xC = 0;
     }
@@ -97,8 +97,8 @@ void ftDk_SpecialAirN_Enter(HSD_GObj* gobj)
 void ftDk_SpecialNStart_Anim(HSD_GObj* gobj)
 {
     if (!ftAnim_IsFramesRemaining(gobj)) {
-        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialNLoop, 0, NULL, 0, 1,
-                                  0);
+        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialNLoop, 0, 0, 1, 0,
+                                  NULL);
         setCallbacks(gobj);
     }
 }
@@ -227,8 +227,8 @@ void ftDk_SpecialNFull_Anim(HSD_GObj* gobj)
 void ftDk_SpecialAirNStart_Anim(HSD_GObj* gobj)
 {
     if (!ftAnim_IsFramesRemaining(gobj)) {
-        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirNLoop, 0, NULL, 0, 1,
-                                  0);
+        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirNLoop, 0, 0, 1, 0,
+                                  NULL);
         setCallbacks(gobj);
     }
 }
@@ -361,8 +361,8 @@ void ftDk_SpecialNLoop_IASA(HSD_GObj* gobj)
 #endif
     if (!ftCo_8009917C(gobj)) {
         if ((fp->input.x668 & 512)) {
-            Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialN, 0, NULL, 0, 1,
-                                      0);
+            Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialN, 0, 0, 1, 0,
+                                      NULL);
             fp->mv.dk.specialn.xC = fp->fv.dk.x222C;
             fp->fv.dk.x222C = 0;
             setCallbacks(gobj);
@@ -372,8 +372,8 @@ void ftDk_SpecialNLoop_IASA(HSD_GObj* gobj)
             fp->mv.dk.specialn.x0 = 1;
         }
         if (fp->cur_anim_frame == 0 && fp->mv.dk.specialn.x0) {
-            Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialNCancel, 0, NULL, 0,
-                                      1, 0);
+            Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialNCancel, 0, 0, 1, 0,
+                                      NULL);
             setCallbacks(gobj);
         }
     }
@@ -395,7 +395,7 @@ void ftDk_SpecialAirNLoop_IASA(HSD_GObj* gobj)
     u8 _[4];
 #endif
     if (fp->input.x668 & 512) {
-        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirN, 0, NULL, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirN, 0, 0, 1, 0, NULL);
         fp->mv.dk.specialn.xC = fp->fv.dk.x222C;
         fp->fv.dk.x222C = 0;
         setCallbacks(gobj);
@@ -405,8 +405,8 @@ void ftDk_SpecialAirNLoop_IASA(HSD_GObj* gobj)
         fp->mv.dk.specialn.x0 = 1;
     }
     if (fp->cur_anim_frame == 0 && fp->mv.dk.specialn.x0) {
-        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirNCancel, 0, NULL, 0,
-                                  1, 0);
+        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirNCancel, 0, 0, 1, 0,
+                                  NULL);
         setCallbacks(gobj);
     }
 }
@@ -473,7 +473,7 @@ void ftDk_SpecialNStart_Coll(HSD_GObj* gobj)
     if (!ft_80082708(gobj)) {
         ftCommon_8007D5D4(fp);
         Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirNStart, 0x0C4C5080,
-                                  NULL, fp->cur_anim_frame, 1, 0);
+                                  fp->cur_anim_frame, 1, 0, NULL);
         setCallbacks(gobj);
     }
 }
@@ -484,7 +484,7 @@ void ftDk_SpecialNLoop_Coll(HSD_GObj* gobj)
     if (!ft_80082708(gobj)) {
         ftCommon_8007D5D4(fp);
         Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirNLoop, 0x0C4C5080,
-                                  NULL, fp->cur_anim_frame, 1, 0);
+                                  fp->cur_anim_frame, 1, 0, NULL);
         setCallbacks(gobj);
     }
 }
@@ -495,7 +495,7 @@ void ftDk_SpecialNCancel_Coll(HSD_GObj* gobj)
     if (!ft_80082708(gobj)) {
         ftCommon_8007D5D4(fp);
         Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirNCancel, 0x0C4C5080,
-                                  NULL, fp->cur_anim_frame, 1, 0);
+                                  fp->cur_anim_frame, 1, 0, NULL);
         setCallbacks(gobj);
     }
 }
@@ -505,8 +505,8 @@ void ftDk_SpecialN_Coll(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     if (ft_800827A0(gobj) == 0) {
         ftCommon_8007D5D4(fp);
-        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirN, 0x0C4D508E, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirN, 0x0C4D508E,
+                                  fp->cur_anim_frame, 1, 0, NULL);
         setCallbacks(gobj);
     }
 }
@@ -517,7 +517,7 @@ void ftDk_SpecialNFull_Coll(HSD_GObj* gobj)
     if (ft_800827A0(gobj) == 0) {
         ftCommon_8007D5D4(fp);
         Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirNFull, 0x0C4D508E,
-                                  NULL, fp->cur_anim_frame, 1, 0);
+                                  fp->cur_anim_frame, 1, 0, NULL);
         setCallbacks(gobj);
     }
 }
@@ -528,7 +528,7 @@ void ftDk_SpecialAirNStart_Coll(HSD_GObj* gobj)
     if (ft_80081D0C(gobj) == 1) {
         ftCommon_8007D7FC(fp);
         Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialNStart, 0x0C4C5080,
-                                  NULL, fp->cur_anim_frame, 1, 0);
+                                  fp->cur_anim_frame, 1, 0, NULL);
         setCallbacks(gobj);
     }
 }
@@ -538,8 +538,8 @@ void ftDk_SpecialAirNLoop_Coll(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     if (ft_80081D0C(gobj) == 1) {
         ftCommon_8007D7FC(fp);
-        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialNLoop, 0x0C4C5080, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialNLoop, 0x0C4C5080,
+                                  fp->cur_anim_frame, 1, 0, NULL);
         setCallbacks(gobj);
     }
 }
@@ -550,7 +550,7 @@ void ftDk_SpecialAirNCancel_Coll(HSD_GObj* gobj)
     if (ft_80081D0C(gobj) == 1) {
         ftCommon_8007D7FC(fp);
         Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialNCancel, 0x0C4C5080,
-                                  NULL, fp->cur_anim_frame, 1, 0);
+                                  fp->cur_anim_frame, 1, 0, NULL);
         setCallbacks(gobj);
     }
 }
@@ -560,8 +560,8 @@ void ftDk_SpecialAirN_Coll(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     if (ft_80081D0C(gobj)) {
         ftCommon_8007D7FC(fp);
-        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialN, 0x0C4D508E, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialN, 0x0C4D508E,
+                                  fp->cur_anim_frame, 1, 0, NULL);
         setCallbacks(gobj);
     }
 }
@@ -571,8 +571,8 @@ void ftDk_SpecialAirNFull_Coll(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     if (ft_80081D0C(gobj)) {
         ftCommon_8007D7FC(fp);
-        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialNFull, 0x0C4D508E, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialNFull, 0x0C4D508E,
+                                  fp->cur_anim_frame, 1, 0, NULL);
         setCallbacks(gobj);
     }
 }

--- a/src/melee/ft/chara/ftDonkey/ftDk_SpecialS.c
+++ b/src/melee/ft/chara/ftDonkey/ftDk_SpecialS.c
@@ -18,7 +18,7 @@ void ftDk_SpecialS_Enter(HSD_GObj* gobj)
 #ifdef MUST_MATCH
     u8 _[8];
 #endif
-    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialS, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialS, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     Fighter_UnsetCmdVar0(gobj);
     fp->cb.x21BC_callback_Accessory4 = ftDk_SpecialLw_8010E0CC;
@@ -30,7 +30,7 @@ void ftDk_SpecialAirS_Enter(HSD_GObj* gobj)
     ftDonkeyAttributes* donkey_attr = fp->dat_attrs;
     fp->self_vel.x /= donkey_attr->SpecialS.x3C_MIN_STICK_X_MOMENTUM;
     fp->self_vel.y = 0;
-    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirS, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirS, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     Fighter_UnsetCmdVar0(gobj);
     fp->cb.x21BC_callback_Accessory4 = &ftDk_SpecialLw_8010E148;
@@ -102,8 +102,8 @@ void doAirTransition(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirS, 0x0C4C508A, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialAirS, 0x0C4C508A,
+                              fp->cur_anim_frame, 1, 0, NULL);
     if (fp->x2219_b0 == true) {
         fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
         fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
@@ -114,8 +114,8 @@ static void doGroundTransition(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialS, 0x0C4C508A, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftDk_MS_SpecialS, 0x0C4C508A,
+                              fp->cur_anim_frame, 1, 0, NULL);
     if (fp->x2219_b0 == true) {
         fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
         fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;

--- a/src/melee/ft/chara/ftFox/ftFx_AppealS.c
+++ b/src/melee/ft/chara/ftFox/ftFx_AppealS.c
@@ -96,7 +96,7 @@ void ftFx_AppealS_Enter(HSD_GObj* gobj)
     animCount = fp->mv.fx.AppealS.animCount;
 
     Fighter_ChangeMotionState(gobj, ASID_AppealS[actionDir][animCount], 0,
-                              NULL, 0.0f, 1.0f, 0.0f);
+                              0.0f, 1.0f, 0.0f, NULL);
 }
 
 /// Fox & Falco's Special Taunt OnTakeDamage/OnDeath callback
@@ -141,7 +141,7 @@ void ftFx_AppealS_Anim(HSD_GObj* gobj)
         Fighter_ChangeMotionState(gobj,
                                   ASID_AppealS[fp->mv.fx.AppealS.facingDir]
                                               [fp->mv.fx.AppealS.animCount],
-                                  0, NULL, 0.0f, 1.0f, 0.0f);
+                                  0, 0.0f, 1.0f, 0.0f, NULL);
     }
 }
 

--- a/src/melee/ft/chara/ftFox/ftFx_SpecialHi.c
+++ b/src/melee/ft/chara/ftFox/ftFx_SpecialHi.c
@@ -73,8 +73,8 @@ void ftFx_SpecialHi_Enter(HSD_GObj* gobj)
     fp->mv.fx.SpecialHi.gravityDelay = (s32) da->x54_FOX_FIREFOX_GRAVITY_DELAY;
     fp->gr_vel /= da->x58_FOX_FIREFOX_VEL_X;
 
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialHiHold, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialHiHold, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
 
     fp->cb.x21BC_callback_Accessory4 = ftFx_SpecialHi_CreateChargeGFX;
@@ -89,8 +89,8 @@ void ftFx_SpecialAirHiStart_Enter(HSD_GObj* gobj)
     fp->self_vel.x /= da->x58_FOX_FIREFOX_VEL_X;
     fp->self_vel.y = 0.0f;
 
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialHiHoldAir, 0, NULL, 0.0f,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialHiHoldAir, 0, 0.0f, 1.0f,
+                              0.0f, NULL);
 
     ftAnim_8006EBA4(gobj);
 
@@ -202,8 +202,8 @@ void ftFx_SpecialHiHold_GroundToAir(HSD_GObj* gobj)
 
     ftCommon_8007D60C(fp);
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialHiHoldAir,
-                              FTFOX_SPECIALHI_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+                              FTFOX_SPECIALHI_COLL_FLAG, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
 
     fp->cb.x21BC_callback_Accessory4 = ftFx_SpecialHi_CreateChargeGFX;
 }
@@ -214,8 +214,8 @@ void ftFx_SpecialHiHoldAir_AirToGround(HSD_GObj* gobj)
 
     ftCommon_8007D7FC(fp);
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialHiHold,
-                              FTFOX_SPECIALHI_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+                              FTFOX_SPECIALHI_COLL_FLAG, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
 
     fp->cb.x21BC_callback_Accessory4 = ftFx_SpecialHi_CreateChargeGFX;
 
@@ -427,7 +427,7 @@ void ftFx_SpecialHi_GroundToAir(HSD_GObj* gobj)
 
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirHi,
                               (Ft_MF_SkipHit | FTFOX_SPECIALHI_COLL_FLAG),
-                              NULL, fp->cur_anim_frame, 1.0f, 0.0f);
+                              fp->cur_anim_frame, 1.0f, 0.0f, NULL);
 
     fp->x2223_flag.bits.b4 = true;
     fp->cb.x21BC_callback_Accessory4 = ftFx_SpecialHi_CreateLaunchGFX;
@@ -472,8 +472,8 @@ void ftFx_SpecialAirHi_AirToGround(HSD_GObj* gobj)
         {
             ftCommon_8007D9FC(fp);
 
-            Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialHi, 0, NULL, 0.0f,
-                                      1.0f, 0.0f);
+            Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialHi, 0, 0.0f, 1.0f,
+                                      0.0f, NULL);
 
             tempAttrs = fp->dat_attrs;
             fp->x2223_flag.bits.b4 = 1;
@@ -540,8 +540,8 @@ void ftFx_SpecialAirHi_Enter(HSD_GObj* gobj)
         fp->mv.fx.SpecialHi.rotateModel = HALF_PI32;
     }
 
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirHi, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirHi, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
 
     tempAttrs = fp->dat_attrs;
     fp->x2223_flag.bits.b4 = 1;
@@ -660,8 +660,8 @@ void ftFx_SpecialHiFall_Enter(HSD_GObj* gobj)
 {
     ftCommon_8007D7FC(GET_FIGHTER(gobj));
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialHiLanding,
-                              (Ft_MF_SkipColAnim | Ft_MF_UpdateCmd), NULL,
-                              13.0f, 1.0f, 0.0f);
+                              (Ft_MF_SkipColAnim | Ft_MF_UpdateCmd), 13.0f,
+                              1.0f, 0.0f, NULL);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -676,8 +676,8 @@ void ftFx_SpecialHiFall_AirToGround(HSD_GObj* gobj)
     if ((s32) fp->ground_or_air == GA_Air) {
         ftCommon_8007D7FC(fp);
     }
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialHiLanding, 0, NULL, 0.0f,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialHiLanding, 0, 0.0f, 1.0f,
+                              0.0f, NULL);
     fp->cb.x21F8_callback = ftCommon_8007F76C;
 }
 
@@ -690,8 +690,8 @@ void ftFx_SpecialHiLanding_GroundToAir(HSD_GObj* gobj)
 
     ftCommon_8007DB24(gobj);
 
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialHiFall, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialHiFall, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     fp->cb.x21F8_callback = ftCommon_8007F76C;
 }
 
@@ -809,8 +809,8 @@ void ftFx_SpecialHiBound_Enter(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     ftFoxAttributes* da = fp->dat_attrs;
 
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialHiBound, 0, NULL, 0.0f,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialHiBound, 0, 0.0f, 1.0f,
+                              0.0f, NULL);
     ftAnim_8006EBA4(gobj);
     fp->cb.x21F8_callback = ftCommon_8007F76C;
     fp->self_vel.x *= da->x84_FOX_FIREFOX_BOUND_VEL_X;

--- a/src/melee/ft/chara/ftFox/ftFx_SpecialLw.c
+++ b/src/melee/ft/chara/ftFox/ftFx_SpecialLw.c
@@ -92,7 +92,7 @@ void ftFx_SpecialLw_Enter(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwStart, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwStart, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 
     ftFox_SpecialLw_SetVars(gobj);
@@ -106,8 +106,8 @@ void ftFx_SpecialAirLw_Enter(HSD_GObj* gobj)
     fp->self_vel.y = 0;
     fp->self_vel.x /= da->xA8_FOX_REFLECTOR_MOMENTUM_PRESERVE_X;
 
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwStart, 0, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwStart, 0, 0, 1, 0,
+                              NULL);
     ftAnim_8006EBA4(gobj);
 
     ftFox_SpecialLw_SetVars(gobj);
@@ -249,8 +249,8 @@ void ftFx_SpecialLwStart_GroundToAir(HSD_GObj* gobj)
     ftCommon_8007D5D4(fp);
 
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwStart,
-                              FTFOX_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              FTFOX_SPECIALLW_COLL_FLAG, fp->cur_anim_frame, 1,
+                              0, NULL);
 }
 
 void ftFx_SpecialAirLwStart_AirToGround(HSD_GObj* gobj)
@@ -260,8 +260,8 @@ void ftFx_SpecialAirLwStart_AirToGround(HSD_GObj* gobj)
     ftCommon_8007D7FC(fp);
 
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwStart,
-                              FTFOX_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              FTFOX_SPECIALLW_COLL_FLAG, fp->cur_anim_frame, 1,
+                              0, NULL);
 
     ftCommon_8007D468(fp);
 }
@@ -416,8 +416,8 @@ static void ftFx_SpecialLwLoop_GroundToAir(HSD_GObj* gobj)
     ftCommon_8007D5D4(fp);
 
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwLoop,
-                              FTFOX_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              FTFOX_SPECIALLW_COLL_FLAG, fp->cur_anim_frame, 1,
+                              0, NULL);
 
     ftFx_SpecialLw_CreateReflectHit(gobj);
 }
@@ -429,8 +429,8 @@ static void ftFx_SpecialAirLwLoop_AirToGround(HSD_GObj* gobj)
     ftCommon_8007D7FC(fp);
 
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwLoop,
-                              FTFOX_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              FTFOX_SPECIALLW_COLL_FLAG, fp->cur_anim_frame, 1,
+                              0, NULL);
 
     ftCommon_8007D468(fp);
     ftFx_SpecialLw_CreateReflectHit(gobj);
@@ -447,8 +447,8 @@ static void ftFx_SpecialLw_CreateReflectHit(HSD_GObj* gobj)
 
 static void ftFx_SpecialLwLoop_Enter(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwLoop, Ft_MF_KeepGfx, NULL,
-                              0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwLoop, Ft_MF_KeepGfx, 0, 1,
+                              0, NULL);
 
     ftFx_SpecialLw_CreateReflectHit(gobj);
 }
@@ -456,8 +456,8 @@ static void ftFx_SpecialLwLoop_Enter(HSD_GObj* gobj)
 /// Fox & Falco's aerial Reflector Loop Motion State handler
 static void ftFx_SpecialAirLwLoop_Enter(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwLoop, Ft_MF_KeepGfx,
-                              NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwLoop, Ft_MF_KeepGfx, 0,
+                              1, 0, NULL);
 
     ftFx_SpecialLw_CreateReflectHit(gobj);
 }
@@ -643,8 +643,8 @@ void ftFx_SpecialLwTurn_GroundToAir(HSD_GObj* gobj)
 
     ftCommon_8007D5D4(fp);
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwTurn,
-                              FTFOX_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              FTFOX_SPECIALLW_COLL_FLAG, fp->cur_anim_frame, 1,
+                              0, NULL);
     ftFox_SpecialLw_SetReflectVars(gobj);
 }
 
@@ -657,8 +657,8 @@ void ftFx_SpecialAirLwTurn_GroundToAir(HSD_GObj* gobj)
 
     ftCommon_8007D7FC(fp);
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwTurn,
-                              FTFOX_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              FTFOX_SPECIALLW_COLL_FLAG, fp->cur_anim_frame, 1,
+                              0, NULL);
     ftCommon_8007D468(fp);
     ftFox_SpecialLw_SetReflectVars(gobj);
 }
@@ -684,11 +684,11 @@ bool ftFx_SpecialLwTurn_Check(HSD_GObj* gobj)
     if (ftCo_800C97A8(gobj) != false) {
         if ((s32) fp->ground_or_air == GA_Ground) {
             Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwTurn,
-                                      Ft_MF_KeepGfx, NULL, 0, 1, 0);
+                                      Ft_MF_KeepGfx, 0, 1, 0, NULL);
             ftFox_SpecialLwTurn_SetVarAll(gobj);
         } else {
             Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwTurn,
-                                      Ft_MF_KeepGfx, NULL, 0, 1, 0);
+                                      Ft_MF_KeepGfx, 0, 1, 0, NULL);
             ftFox_SpecialLwTurn_SetVarAll(gobj);
         }
         fp->cb.x21BC_callback_Accessory4 = ftFx_SpecialLw_CreateLoopGFX;
@@ -725,11 +725,11 @@ bool ftFx_SpecialLwHit_Check(HSD_GObj* gobj)
     }
     if ((s32) fp->ground_or_air == GA_Ground) {
         Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwLoop, Ft_MF_KeepGfx,
-                                  NULL, 0, 1, 0);
+                                  0, 1, 0, NULL);
         ftFox_SpecialLwHit_CreateReflectInline(gobj);
     } else {
         Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwLoop,
-                                  Ft_MF_KeepGfx, NULL, 0, 1, 0);
+                                  Ft_MF_KeepGfx, 0, 1, 0, NULL);
         ftFox_SpecialLwHit_CreateReflectInline(gobj);
     }
     return true;
@@ -860,8 +860,8 @@ void ftFx_SpecialLwHit_GroundToAir(HSD_GObj* gobj)
 
     ftCommon_8007D5D4(fp);
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwHit,
-                              FTFOX_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              FTFOX_SPECIALLW_COLL_FLAG, fp->cur_anim_frame, 1,
+                              0, NULL);
     ftFx_SpecialLwHit_SetCall(gobj);
 }
 
@@ -874,8 +874,8 @@ void ftFx_SpecialAirLwHit_AirToGround(HSD_GObj* gobj)
 
     ftCommon_8007D7FC(fp);
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwHit,
-                              FTFOX_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              FTFOX_SPECIALLW_COLL_FLAG, fp->cur_anim_frame, 1,
+                              0, NULL);
     ftCommon_8007D468(fp);
     ftFx_SpecialLwHit_SetCall(gobj);
 }
@@ -913,7 +913,7 @@ void ftFx_SpecialLwHit_Enter(HSD_GObj* gobj)
         msid = 367;
     }
 
-    Fighter_ChangeMotionState(gobj, msid, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, 0, 0, 1, 0, NULL);
     ftFx_SpecialLwHit_SetCall(gobj);
 
     fp->cb.x21BC_callback_Accessory4 = ftFx_SpecialLw_CreateReflectGFX;
@@ -1015,8 +1015,8 @@ void ftFx_SpecialLwEnd_GroundToAir(HSD_GObj* gobj)
 
     ftCommon_8007D5D4(fp);
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwEnd,
-                              (Ft_MF_SkipColAnim | Ft_MF_UpdateCmd), NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              (Ft_MF_SkipColAnim | Ft_MF_UpdateCmd),
+                              fp->cur_anim_frame, 1, 0, NULL);
 }
 
 // 0x800E9D24
@@ -1028,8 +1028,8 @@ void ftFx_SpecialAirLwEnd_AirToGround(HSD_GObj* gobj)
 
     ftCommon_8007D7FC(fp);
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwEnd,
-                              (Ft_MF_SkipColAnim | Ft_MF_UpdateCmd), NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              (Ft_MF_SkipColAnim | Ft_MF_UpdateCmd),
+                              fp->cur_anim_frame, 1, 0, NULL);
     ftCommon_8007D468(fp);
 }
 
@@ -1038,11 +1038,11 @@ void ftFx_SpecialAirLwEnd_AirToGround(HSD_GObj* gobj)
 // Motion State handler
 void ftFx_SpecialLwEnd_Enter(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwEnd, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialLwEnd, 0, 0, 1, 0, NULL);
 }
 
 // 0x800E9DC0 - Fox & Falco's aerial Reflector End Motion State handler
 void ftFx_SpecialAirLwEnd_Enter(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwEnd, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirLwEnd, 0, 0, 1, 0, NULL);
 }

--- a/src/melee/ft/chara/ftFox/ftFx_SpecialN.c
+++ b/src/melee/ft/chara/ftFox/ftFx_SpecialN.c
@@ -251,7 +251,7 @@ void ftFx_SpecialN_Enter(HSD_GObj* gobj)
 
     ftCommon_8007D7FC(fp);
 
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialNStart, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialNStart, 0, 0, 1, 0, NULL);
 
     fp->cmd_vars[3] = 0;
     fp->cmd_vars[2] = 0;
@@ -291,8 +291,8 @@ void ftFx_SpecialAirN_Enter(
     ftFoxAttributes* da = fp->dat_attrs;
     HSD_GObj* blasterGObj;
 
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirNStart, 0, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirNStart, 0, 0, 1, 0,
+                              NULL);
 
     fp->cmd_vars[3] = 0;
     fp->cmd_vars[2] = 0;
@@ -336,8 +336,8 @@ void ftFx_SpecialNStart_Anim(HSD_GObj* gobj)
     }
     if (!ftAnim_IsFramesRemaining(gobj)) {
         Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialNLoop,
-                                  (Ft_MF_SkipModel | Ft_MF_KeepGfx), NULL, 0,
-                                  1, 0);
+                                  (Ft_MF_SkipModel | Ft_MF_KeepGfx), 0, 1, 0,
+                                  NULL);
         ftFox_SpecialN_SetCall(gobj);
         fp->cb.x21BC_callback_Accessory4 = ftFx_SpecialN_CreateBlasterShot;
         it_802ADDD0(fp->fv.fx.x222C_blasterGObj, 1);
@@ -363,8 +363,8 @@ void ftFx_SpecialNLoop_Anim(HSD_GObj* gobj)
             temp_r28->cb.x21EC_callback = ftFx_SpecialN_OnChangeAction;
             Fighter_ChangeMotionState(
                 gobj, ftFx_MS_SpecialNLoop,
-                (Ft_MF_SkipAttackCount | Ft_MF_SkipModel | Ft_MF_KeepGfx),
-                NULL, 0, 1, 0);
+                (Ft_MF_SkipAttackCount | Ft_MF_SkipModel | Ft_MF_KeepGfx), 0,
+                1, 0, NULL);
             temp_r28->cb.x21BC_callback_Accessory4 =
                 ftFx_SpecialN_CreateBlasterShot;
             temp_r28->mv.fx.SpecialN.isBlasterLoop = false;
@@ -372,8 +372,8 @@ void ftFx_SpecialNLoop_Anim(HSD_GObj* gobj)
         } else {
             HSD_GObj* temp;
             Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialNEnd,
-                                      (Ft_MF_SkipModel | Ft_MF_KeepGfx), NULL,
-                                      0, 1, 0);
+                                      (Ft_MF_SkipModel | Ft_MF_KeepGfx), 0, 1,
+                                      0, NULL);
             temp = temp_r28->fv.fx.x222C_blasterGObj;
             temp_r28->cmd_vars[1] = 1;
             it_802ADDD0(temp, 1);
@@ -491,8 +491,8 @@ void ftFx_SpecialAirNStart_Anim(HSD_GObj* gobj)
     }
     if (!ftAnim_IsFramesRemaining(gobj)) {
         Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirNLoop,
-                                  (Ft_MF_SkipModel | Ft_MF_KeepGfx), NULL, 0,
-                                  1, 0);
+                                  (Ft_MF_SkipModel | Ft_MF_KeepGfx), 0, 1, 0,
+                                  NULL);
         ftFox_SpecialN_SetCall(gobj);
         fp->cb.x21BC_callback_Accessory4 = ftFx_SpecialN_CreateBlasterShot;
         it_802ADDD0(fp->fv.fx.x222C_blasterGObj, 1);
@@ -517,8 +517,8 @@ void ftFx_SpecialAirNLoop_Anim(HSD_GObj* gobj)
             fp->cb.x21EC_callback = ftFx_SpecialN_OnChangeAction;
             Fighter_ChangeMotionState(
                 gobj, ftFx_MS_SpecialAirNLoop,
-                (Ft_MF_SkipAttackCount | Ft_MF_SkipModel | Ft_MF_KeepGfx),
-                NULL, 0, 1, 0);
+                (Ft_MF_SkipAttackCount | Ft_MF_SkipModel | Ft_MF_KeepGfx), 0,
+                1, 0, NULL);
             ftFox_SpecialN_SetCall(gobj);
             fp->cb.x21BC_callback_Accessory4 = ftFx_SpecialN_CreateBlasterShot;
             fp->mv.fx.SpecialN.isBlasterLoop = false;
@@ -527,8 +527,8 @@ void ftFx_SpecialAirNLoop_Anim(HSD_GObj* gobj)
             HSD_GObj* temp;
 
             Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirNEnd,
-                                      (Ft_MF_SkipModel | Ft_MF_KeepGfx), NULL,
-                                      0, 1, 0);
+                                      (Ft_MF_SkipModel | Ft_MF_KeepGfx), 0, 1,
+                                      0, NULL);
             ftFox_SpecialN_SetCall(gobj);
 
             temp = fp->fv.fx.x222C_blasterGObj;

--- a/src/melee/ft/chara/ftFox/ftFx_SpecialS.c
+++ b/src/melee/ft/chara/ftFox/ftFx_SpecialS.c
@@ -95,8 +95,8 @@ void ftFx_SpecialSStart_Enter(HSD_GObj* gobj)
 
     fp->gr_vel /= da->x28_FOX_ILLUSION_GROUND_VEL_X;
 
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialSStart, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialSStart, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -118,8 +118,8 @@ void ftFx_SpecialAirSStart_Enter(HSD_GObj* gobj)
     fp->self_vel.y = 0.0f;
     fp->self_vel.x /= da->x28_FOX_ILLUSION_GROUND_VEL_X;
 
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirSStart, 0, NULL, 0.0f,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirSStart, 0, 0.0f, 1.0f,
+                              0.0f, NULL);
     ftAnim_8006EBA4(gobj);
 
     fp->x1968_jumpsUsed = fp->co_attrs.max_jumps;
@@ -235,8 +235,8 @@ void ftFx_SpecialSStart_GroundToAir(HSD_GObj* gobj)
 
     ftCommon_8007D60C(fp);
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirSStart,
-                              FTFOX_SPECIALS_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+                              FTFOX_SPECIALS_COLL_FLAG, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
 }
 
 // 0x800EA234
@@ -248,8 +248,8 @@ void ftFx_SpecialAirSStart_AirToGround(HSD_GObj* gobj)
 
     ftCommon_8007D7FC(fp);
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialSStart,
-                              FTFOX_SPECIALS_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+                              FTFOX_SPECIALS_COLL_FLAG, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
 }
 
 static inline void ftFox_SpecialS_CreateGhostItem(HSD_GObj* gobj)
@@ -420,8 +420,8 @@ void ftFx_SpecialS_GroundToAir(HSD_GObj* gobj)
     ftCommon_8007D60C(fp);
     Fighter_ChangeMotionState(
         gobj, ftFx_MS_SpecialAirS,
-        (Ft_MF_KeepColAnimHitStatus | FTFOX_SPECIALS_COLL_FLAG), NULL,
-        fp->cur_anim_frame, 1.0f, 0.0f);
+        (Ft_MF_KeepColAnimHitStatus | FTFOX_SPECIALS_COLL_FLAG),
+        fp->cur_anim_frame, 1.0f, 0.0f, NULL);
     fp->cmd_vars[2] = 0;
 }
 
@@ -435,8 +435,8 @@ void ftFx_SpecialAirS_AirToGround(HSD_GObj* gobj)
     ftCommon_8007D7FC(fp);
     Fighter_ChangeMotionState(
         gobj, ftFx_MS_SpecialS,
-        (Ft_MF_KeepColAnimHitStatus | FTFOX_SPECIALS_COLL_FLAG), NULL,
-        fp->cur_anim_frame, 1.0f, 0.0f);
+        (Ft_MF_KeepColAnimHitStatus | FTFOX_SPECIALS_COLL_FLAG),
+        fp->cur_anim_frame, 1.0f, 0.0f, NULL);
     fp->cmd_vars[2] = 0;
 }
 
@@ -470,8 +470,8 @@ void ftFx_SpecialS_Enter(HSD_GObj* gobj)
     u8 _[28];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialS, Ft_MF_SkipRumble, NULL,
-                              0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialS, Ft_MF_SkipRumble, 0.0f,
+                              1.0f, 0.0f, NULL);
     ftFox_SpecialS_SetVars(gobj);
 }
 
@@ -486,7 +486,7 @@ void ftFx_SpecialAirS_Enter(HSD_GObj* gobj)
 #endif
 
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirS, Ft_MF_SkipRumble,
-                              NULL, 0.0f, 1.0f, 0.0f);
+                              0.0f, 1.0f, 0.0f, NULL);
     ftFox_SpecialS_SetVars(gobj);
 }
 
@@ -634,7 +634,7 @@ void ftFx_SpecialSEnd_Enter(HSD_GObj* gobj)
     fp->gr_vel = da->x34_FOX_ILLUSION_GROUND_END_VEL_X * fp->facing_dir;
 
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialSEnd, Ft_MF_SkipRumble,
-                              NULL, 0.0f, 1.0f, 0.0f);
+                              0.0f, 1.0f, 0.0f, NULL);
     ftFox_SpecialSEnd_SetVars(gobj);
 }
 
@@ -649,6 +649,6 @@ void ftFx_SpecialAirSEnd_Enter(HSD_GObj* gobj)
     fp->self_vel.y = 0.0f;
 
     Fighter_ChangeMotionState(gobj, ftFx_MS_SpecialAirSEnd, Ft_MF_SkipRumble,
-                              NULL, 0.0f, 1.0f, 0.0f);
+                              0.0f, 1.0f, 0.0f, NULL);
     ftFox_SpecialSEnd_SetVars(gobj);
 }

--- a/src/melee/ft/chara/ftGameWatch/ftGw_Attack100.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGw_Attack100.c
@@ -57,8 +57,8 @@ void ftGw_Attack100Loop_Enter(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
 
-    Fighter_ChangeMotionState(gobj, ftGw_MS_Attack100Loop, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftGw_MS_Attack100Loop, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     fp->cb.x21BC_callback_Accessory4 = ftGw_Attack11_DecideAction;
 }
 
@@ -94,8 +94,8 @@ void ftGw_Attack100End_Enter(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
 
-    Fighter_ChangeMotionState(gobj, ftGw_MS_Attack100End, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftGw_MS_Attack100End, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     fp->cb.x21BC_callback_Accessory4 = ftGw_Attack11_DecideAction;
 }
 

--- a/src/melee/ft/chara/ftGameWatch/ftGw_Attack11.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGw_Attack11.c
@@ -168,8 +168,8 @@ void ftGw_Attack11_Enter(HSD_GObj* gobj)
     if (ftCo_80094790(gobj) == false) {
         fp->allow_interrupt = 0;
         fp->x2218_b1 = 0;
-        Fighter_ChangeMotionState(gobj, ftGw_MS_Attack11, 0, NULL, 0.0f, 1.0f,
-                                  0.0f);
+        Fighter_ChangeMotionState(gobj, ftGw_MS_Attack11, 0, 0.0f, 1.0f, 0.0f,
+                                  NULL);
         ftAnim_8006EBA4(gobj);
         fp->hitlag_mul = (f32) fp->co_attrs.jab_2_input_window;
         fp->unk_msid = 44;

--- a/src/melee/ft/chara/ftGameWatch/ftGw_AttackLw3.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGw_AttackLw3.c
@@ -140,8 +140,8 @@ void ftGw_AttackLw3_Enter(HSD_GObj* gobj)
 
     if (ftCo_80094790(gobj) == false) {
         fp->allow_interrupt = 0;
-        Fighter_ChangeMotionState(gobj, ftGw_MS_AttackLw3, 0, NULL, 0.0f, 1.0f,
-                                  0.0f);
+        Fighter_ChangeMotionState(gobj, ftGw_MS_AttackLw3, 0, 0.0f, 1.0f, 0.0f,
+                                  NULL);
         ftAnim_8006EBA4(gobj);
         fp->cb.x21BC_callback_Accessory4 = ftGw_AttackLw3_ItemManholeSetup;
     }

--- a/src/melee/ft/chara/ftGameWatch/ftGw_AttackS4.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGw_AttackS4.c
@@ -118,8 +118,8 @@ void ftGw_AttackS4_Enter(HSD_GObj* gobj)
 
     fp->allow_interrupt = 0;
     fp->cmd_vars[0] = 0;
-    Fighter_ChangeMotionState(gobj, ftGw_MS_AttackS4, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftGw_MS_AttackS4, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     fp->cb.x21BC_callback_Accessory4 = ftGw_ItemTorchSetup;
 }

--- a/src/melee/ft/chara/ftGameWatch/ftGw_SpecialHi.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGw_SpecialHi.c
@@ -131,8 +131,8 @@ void ftGw_SpecialHi_Enter(HSD_GObj* gobj)
     fp->x74_anim_vel.y = 0.0f;
     fp->self_vel.y = 0.0f;
     ftCommon_8007D60C(fp);
-    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialHi, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialHi, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftGameWatch_SpecialHi_SetVars(gobj);
     ftAnim_8006EBA4(gobj);
     ft_80088510(fp, 290066, 127, 64);
@@ -149,8 +149,8 @@ void ftGw_SpecialAirHi_Enter(HSD_GObj* gobj)
 #endif
 
     ftCommon_8007D60C(fp);
-    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialAirHi, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialAirHi, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftGameWatch_SpecialHi_SetVars(gobj);
     ftAnim_8006EBA4(gobj);
     ft_80088510(fp, 290066, 127, 64);

--- a/src/melee/ft/chara/ftGameWatch/ftGw_SpecialLw.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGw_SpecialLw.c
@@ -158,7 +158,7 @@ void ftGw_SpecialLw_Enter(HSD_GObj* gobj)
 
     fp->self_vel.y = 0;
 
-    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialLw, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialLw, 0, 0, 1, 0, NULL);
 
     ftAnim_8006EBA4(gobj);
     ftGameWatch_SpecialLw_SetVars(gobj);
@@ -177,7 +177,7 @@ void ftGw_SpecialAirLw_Enter(HSD_GObj* gobj)
     fp->self_vel.x /= sa->x64_GAMEWATCH_PANIC_MOMENTUM_PRESERVE;
     fp->self_vel.y = 0;
 
-    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialAirLw, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialAirLw, 0, 0, 1, 0, NULL);
 
     ftAnim_8006EBA4(gobj);
     ftGameWatch_SpecialLw_SetVars(gobj);
@@ -405,7 +405,7 @@ void ftGw_SpecialLw_GroundToAir(HSD_GObj* gobj)
 
     ftCommon_8007D5D4(fp);
     Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialAirLw, transition_flags0,
-                              NULL, fp->cur_anim_frame, 1, 0);
+                              fp->cur_anim_frame, 1, 0, NULL);
 
     ftGameWatch_SpecialLw_UpdateVarsColl(gobj);
 }
@@ -421,8 +421,8 @@ void ftGw_SpecialAirLw_AirToGround(HSD_GObj* gobj)
 
     ftCommon_8007D7FC(fp);
 
-    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialLw, transition_flags0, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialLw, transition_flags0,
+                              fp->cur_anim_frame, 1, 0, NULL);
 
     ftGameWatch_SpecialLw_UpdateVarsColl(gobj);
 }
@@ -451,8 +451,8 @@ static u32 const transition_flags1 =
 
 void ftGw_SpecialLw_UpdateAction(HSD_GObj* gobj, f32 anim_frame)
 {
-    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialLw, transition_flags1, NULL,
-                              anim_frame - 1, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialLw, transition_flags1,
+                              anim_frame - 1, 1, 0, NULL);
 
     ftAnim_8006EBA4(gobj);
     ftGameWatch_SpecialLw_UpdateVarsAction(gobj);
@@ -461,7 +461,7 @@ void ftGw_SpecialLw_UpdateAction(HSD_GObj* gobj, f32 anim_frame)
 void ftGw_SpecialAirLw_UpdateAction(HSD_GObj* gobj, f32 anim_frame)
 {
     Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialAirLw, transition_flags1,
-                              NULL, anim_frame - 1, 1, 0);
+                              anim_frame - 1, 1, 0, NULL);
 
     ftAnim_8006EBA4(gobj);
     ftGameWatch_SpecialLw_UpdateVarsAction(gobj);
@@ -481,8 +481,8 @@ void ftGw_SpecialLwCatch_Anim(HSD_GObj* gobj)
         return;
     }
 
-    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialLw, transition_flags1, NULL,
-                              4, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialLw, transition_flags1, 4, 1,
+                              0, NULL);
 
     ftAnim_8006EBA4(gobj);
     ftGameWatch_SpecialLw_UpdateVarsAction(gobj);
@@ -502,8 +502,8 @@ void ftGw_SpecialAirLwCatch_Anim(HSD_GObj* gobj)
         return;
     }
 
-    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialAirLw, transition_flags1,
-                              NULL, 4, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialAirLw, transition_flags1, 4,
+                              1, 0, NULL);
 
     ftAnim_8006EBA4(gobj);
     ftGameWatch_SpecialLw_UpdateVarsAction(gobj);
@@ -550,8 +550,8 @@ void ftGw_SpecialLwCatch_GroundToAir(HSD_GObj* gobj)
     ftCommon_8007D5D4(fp);
 
     Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialAirLwCatch,
-                              transition_flags0, NULL, fp->cur_anim_frame, 1,
-                              0);
+                              transition_flags0, fp->cur_anim_frame, 1, 0,
+                              NULL);
 }
 
 /// Mr. Game & Watch's air -> ground Oil Panic Fill Motion State handler
@@ -561,7 +561,7 @@ void ftGw_SpecialAirLwCatch_AirToGround(HSD_GObj* gobj)
     ftCommon_8007D7FC(fp);
 
     Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialLwCatch, transition_flags0,
-                              NULL, fp->cur_anim_frame, 1, 0);
+                              fp->cur_anim_frame, 1, 0, NULL);
 }
 
 /// Check to enter grounded or aerial Oil Panic Fill
@@ -585,7 +585,7 @@ void ftGw_SpecialLw_AbsorbThink_DecideAction(HSD_GObj* gobj)
         msid = ftGw_MS_SpecialAirLwCatch;
     }
 
-    Fighter_ChangeMotionState(gobj, msid, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, 0, 0, 1, 0, NULL);
     ftGw_SpecialLw_UpdateBucketModel(gobj);
 }
 
@@ -674,8 +674,8 @@ void ftGw_SpecialLwShoot_GroundToAir(HSD_GObj* gobj)
     ftCommon_8007D5D4(fp);
 
     Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialAirLwShoot,
-                              transition_flags0, NULL, fp->cur_anim_frame, 1,
-                              0);
+                              transition_flags0, fp->cur_anim_frame, 1, 0,
+                              NULL);
 
     ftGw_SpecialLw_UpdateBucketModel(gobj);
     fp->cb.x21BC_callback_Accessory4 = ftGw_SpecialLw_ItemPanicSetup;
@@ -689,7 +689,7 @@ void ftGw_SpecialAirLwShoot_AirToGround(HSD_GObj* gobj)
     ftCommon_8007D7FC(fp);
 
     Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialLwShoot, transition_flags0,
-                              NULL, fp->cur_anim_frame, 1, 0);
+                              fp->cur_anim_frame, 1, 0, NULL);
 
     ftGw_SpecialLw_UpdateBucketModel(gobj);
     fp->cb.x21BC_callback_Accessory4 = ftGw_SpecialLw_ItemPanicSetup;
@@ -706,7 +706,7 @@ void ftGw_SpecialLwShoot_ReleaseOil(HSD_GObj* gobj)
     /// @todo Shared @c inline with #ftGw_SpecialAirLwShoot_ReleaseOil
     /// @todo Please for the love of god stop copy-pasting code
 
-    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialLwShoot, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialLwShoot, 0, 0, 1, 0, NULL);
 
     ftAnim_8006EBA4(gobj);
 
@@ -742,8 +742,8 @@ void ftGw_SpecialAirLwShoot_ReleaseOil(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialAirLwShoot, 0, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialAirLwShoot, 0, 0, 1, 0,
+                              NULL);
 
     ftAnim_8006EBA4(gobj);
 

--- a/src/melee/ft/chara/ftGameWatch/ftGw_SpecialN.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGw_SpecialN.c
@@ -214,8 +214,8 @@ static inline void ftGameWatch_SpecialN_SetVars(HSD_GObj* gobj)
 void ftGw_SpecialN_Enter(HSD_GObj* gobj)
 {
     GET_FIGHTER(gobj)->self_vel.y = 0.0f;
-    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialN, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialN, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     ftGameWatch_SpecialN_SetVars(gobj);
 }
@@ -226,8 +226,8 @@ void ftGw_SpecialN_Enter(HSD_GObj* gobj)
 void ftGw_SpecialAirN_Enter(HSD_GObj* gobj)
 {
     GET_FIGHTER(gobj)->self_vel.y = 0.0f;
-    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialAirN, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialAirN, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     ftGameWatch_SpecialN_SetVars(gobj);
 }
@@ -382,7 +382,7 @@ void ftGw_SpecialN_GroundToAir(HSD_GObj* gobj)
 
     ftCommon_8007D5D4(fp);
     Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialAirN, transition_flags,
-                              NULL, fp->cur_anim_frame, 1.0f, 0.0f);
+                              fp->cur_anim_frame, 1.0f, 0.0f, NULL);
     GET_FIGHTER(gobj)->cb.x21BC_callback_Accessory4 =
         &ftGw_SpecialN_CreateSausage;
 }
@@ -395,8 +395,8 @@ void ftGw_SpecialAirN_AirToGround(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
 
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialN, transition_flags, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialN, transition_flags,
+                              fp->cur_anim_frame, 1.0f, 0.0f, NULL);
     GET_FIGHTER(gobj)->cb.x21BC_callback_Accessory4 =
         &ftGw_SpecialN_CreateSausage;
 }
@@ -414,8 +414,8 @@ void ftGw_SpecialN_Loop(HSD_GObj* gobj, f32 anim_frame)
     u8 _[4];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialN, transition_flags, NULL,
-                              anim_frame - 1.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialN, transition_flags,
+                              anim_frame - 1.0f, 1.0f, 0.0f, NULL);
 
     ftAnim_8006EBA4(gobj);
 
@@ -445,7 +445,7 @@ void ftGw_SpecialAirN_Loop(HSD_GObj* gobj, f32 anim_frame)
 #endif
 
     Fighter_ChangeMotionState(gobj, ftGw_MS_SpecialAirN, transition_flags,
-                              NULL, anim_frame - 1.0f, 1.0f, 0.0f);
+                              anim_frame - 1.0f, 1.0f, 0.0f, NULL);
     ftAnim_8006EBA4(gobj);
 
 #ifdef MUST_MATCH

--- a/src/melee/ft/chara/ftGameWatch/ftGw_SpecialS.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGw_SpecialS.c
@@ -191,7 +191,7 @@ void ftGw_SpecialS_Enter(HSD_GObj* gobj)
     ftGw_SpecialS_GetRandomInt(gobj);
     Fighter_ChangeMotionState(gobj,
                               fp->fv.gw.x222C_judgeVar1 + ftGw_MS_SpecialS1, 0,
-                              NULL, 0.0f, 1.0f, 0.0f);
+                              0.0f, 1.0f, 0.0f, NULL);
     ftAnim_8006EBA4(gobj);
     ftGameWatch_SpecialS_SetVars(gobj);
 }
@@ -214,7 +214,7 @@ void ftGw_SpecialAirS_Enter(HSD_GObj* gobj)
     ftGw_SpecialS_GetRandomInt(gobj);
     Fighter_ChangeMotionState(gobj,
                               fp->fv.gw.x222C_judgeVar1 + ftGw_MS_SpecialAirS1,
-                              0, NULL, 0.0f, 1.0f, 0.0f);
+                              0, 0.0f, 1.0f, 0.0f, NULL);
     ftAnim_8006EBA4(gobj);
     ftGameWatch_SpecialS_SetVars(gobj);
 }
@@ -350,7 +350,7 @@ static void ftGw_SpecialS_GroundToAir(HSD_GObj* gobj)
     !gobj;
     Fighter_ChangeMotionState(
         gobj, fp->fv.gw.x222C_judgeVar1 + ftGw_MS_SpecialAirS1,
-        transition_flags, NULL, fp->cur_anim_frame, 1.0f, 0.0f);
+        transition_flags, fp->cur_anim_frame, 1.0f, 0.0f, NULL);
     if ((u32) fp->cmd_vars[0] == 1) {
         fp->cmd_vars[0] = 2;
     }
@@ -372,6 +372,6 @@ static void ftGw_SpecialAirS_AirToGround(HSD_GObj* gobj)
     !gobj;
     Fighter_ChangeMotionState(
         gobj, fp->fv.gw.x222C_judgeVar1 + ftGw_MS_SpecialS1, transition_flags,
-        NULL, fp->cur_anim_frame, 1.0f, 0.0f);
+        fp->cur_anim_frame, 1.0f, 0.0f, NULL);
     ftGameWatch_SpecialS_SetCall(gobj);
 }

--- a/src/melee/ft/chara/ftKoopa/ftKp_Init.c
+++ b/src/melee/ft/chara/ftKoopa/ftKp_Init.c
@@ -481,8 +481,8 @@ void ftKp_SpecialS_Enter(HSD_GObj* gobj)
         fp->mv.kp.unk1.xC = 0;
     }
 
-    Fighter_ChangeMotionState(gobj, 347, 0, 0, ftKp_Init_804D9AD8,
-                              ftKp_Init_804D9ADC, ftKp_Init_804D9AD8);
+    Fighter_ChangeMotionState(gobj, 347, 0, ftKp_Init_804D9AD8,
+                              ftKp_Init_804D9ADC, ftKp_Init_804D9AD8, 0);
 
     ftAnim_8006EBA4(gobj);
 
@@ -507,8 +507,8 @@ void ftKp_SpecialAirS_Enter(HSD_GObj* gobj)
         fp->mv.kp.unk1.xC = 0;
     }
 
-    Fighter_ChangeMotionState(gobj, 353, 0, 0, ftKp_Init_804D9AD8,
-                              ftKp_Init_804D9ADC, ftKp_Init_804D9AD8);
+    Fighter_ChangeMotionState(gobj, 353, 0, ftKp_Init_804D9AD8,
+                              ftKp_Init_804D9ADC, ftKp_Init_804D9AD8, 0);
 
     ftAnim_8006EBA4(gobj);
 
@@ -529,12 +529,12 @@ void ftKp_SpecialS_8013302C(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
 
     if ((signed) fp->mv.kp.unk1.x4 != 0) {
-        Fighter_ChangeMotionState(gobj, 349, transition_flags0, 0,
+        Fighter_ChangeMotionState(gobj, 349, transition_flags0,
                                   ftKp_Init_804D9AD8, ftKp_Init_804D9ADC,
-                                  ftKp_Init_804D9AD8);
+                                  ftKp_Init_804D9AD8, 0);
     } else {
-        Fighter_ChangeMotionState(gobj, 348, 0, 0, ftKp_Init_804D9AD8,
-                                  ftKp_Init_804D9ADC, ftKp_Init_804D9AD8);
+        Fighter_ChangeMotionState(gobj, 348, 0, ftKp_Init_804D9AD8,
+                                  ftKp_Init_804D9ADC, ftKp_Init_804D9AD8, 0);
     }
 
     fp->x2222_b2 = true;
@@ -550,12 +550,12 @@ void ftKp_SpecialS_801330E4(HSD_GObj* gobj)
 
     fp = gobj->user_data;
     if ((signed) fp->mv.kp.unk1.x4 != 0) {
-        Fighter_ChangeMotionState(gobj, 355, transition_flags0, 0,
+        Fighter_ChangeMotionState(gobj, 355, transition_flags0,
                                   ftKp_Init_804D9AD8, ftKp_Init_804D9ADC,
-                                  ftKp_Init_804D9AD8);
+                                  ftKp_Init_804D9AD8, 0);
     } else {
-        Fighter_ChangeMotionState(gobj, 354, 0, 0, ftKp_Init_804D9AD8,
-                                  ftKp_Init_804D9ADC, ftKp_Init_804D9AD8);
+        Fighter_ChangeMotionState(gobj, 354, 0, ftKp_Init_804D9AD8,
+                                  ftKp_Init_804D9ADC, ftKp_Init_804D9AD8, 0);
     }
 
     fp->x2222_b2 = true;
@@ -575,9 +575,8 @@ void ftKp_SpecialS_8013319C(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
 
-    Fighter_ChangeMotionState(gobj, 353, transition_flags1, 0,
-                              fp->cur_anim_frame, ftKp_Init_804D9ADC,
-                              ftKp_Init_804D9AD8);
+    Fighter_ChangeMotionState(gobj, 353, transition_flags1, fp->cur_anim_frame,
+                              ftKp_Init_804D9ADC, ftKp_Init_804D9AD8, 0);
 
     {
         Fighter* fp = GET_FIGHTER(gobj);
@@ -596,9 +595,9 @@ void ftKp_SpecialS_8013322C(HSD_GObj* gobj)
 
     ftCommon_8007D7FC(fp1);
 
-    Fighter_ChangeMotionState(gobj, 347, transition_flags1, 0,
+    Fighter_ChangeMotionState(gobj, 347, transition_flags1,
                               fp1->cur_anim_frame, ftKp_Init_804D9ADC,
-                              ftKp_Init_804D9AD8);
+                              ftKp_Init_804D9AD8, 0);
 
     {
         fp0 = GET_FIGHTER(gobj);
@@ -632,9 +631,8 @@ void ftKp_SpecialS_80133324(HSD_GObj* gobj)
 
     ftCommon_8007D7FC(fp);
 
-    Fighter_ChangeMotionState(gobj, 348, transition_flags1, 0,
-                              fp->cur_anim_frame, ftKp_Init_804D9ADC,
-                              ftKp_Init_804D9AD8);
+    Fighter_ChangeMotionState(gobj, 348, transition_flags1, fp->cur_anim_frame,
+                              ftKp_Init_804D9ADC, ftKp_Init_804D9AD8, 0);
 
     ftCommon_8007E2F4(fp, 511);
     ftCommon_8007E2FC(gobj);
@@ -665,9 +663,8 @@ void ftKp_SpecialS_801333F8(HSD_GObj* gobj)
 
     ftCommon_8007D7FC(fp);
 
-    Fighter_ChangeMotionState(gobj, 350, transition_flags2, 0,
-                              fp->cur_anim_frame, ftKp_Init_804D9ADC,
-                              ftKp_Init_804D9AD8);
+    Fighter_ChangeMotionState(gobj, 350, transition_flags2, fp->cur_anim_frame,
+                              ftKp_Init_804D9ADC, ftKp_Init_804D9AD8, 0);
 
     ftCommon_8007E2F4(fp, 511);
     ftCommon_8007E2FC(gobj);
@@ -701,9 +698,8 @@ void ftKp_SpecialS_801334E4(HSD_GObj* gobj)
         fp->facing_dir = -fp->facing_dir;
     }
 
-    Fighter_ChangeMotionState(gobj, 351, transition_flags1, 0,
-                              fp->cur_anim_frame, ftKp_Init_804D9ADC,
-                              ftKp_Init_804D9AD8);
+    Fighter_ChangeMotionState(gobj, 351, transition_flags1, fp->cur_anim_frame,
+                              ftKp_Init_804D9ADC, ftKp_Init_804D9AD8, 0);
 
     if ((s32) fp->mv.kp.unk1.xC != 0) {
         fp->facing_dir = -fp->facing_dir;
@@ -727,9 +723,8 @@ void ftKp_SpecialS_8013359C(HSD_GObj* gobj)
         fp->facing_dir = -fp->facing_dir;
     }
 
-    Fighter_ChangeMotionState(gobj, 352, transition_flags1, 0,
-                              fp->cur_anim_frame, ftKp_Init_804D9ADC,
-                              ftKp_Init_804D9AD8);
+    Fighter_ChangeMotionState(gobj, 352, transition_flags1, fp->cur_anim_frame,
+                              ftKp_Init_804D9ADC, ftKp_Init_804D9AD8, 0);
 
     if ((signed) fp->mv.kp.unk1.xC != 0) {
         fp->facing_dir = -fp->facing_dir;
@@ -793,12 +788,12 @@ void ftKp_SpecialSHit_Anim(HSD_GObj* gobj)
 
                 if ((signed) fp0->mv.kp.unk1.x4 != false) {
                     Fighter_ChangeMotionState(
-                        gobj, 349, transition_flags0, 0, ftKp_Init_804D9AD8,
-                        ftKp_Init_804D9ADC, ftKp_Init_804D9AD8);
+                        gobj, 349, transition_flags0, ftKp_Init_804D9AD8,
+                        ftKp_Init_804D9ADC, ftKp_Init_804D9AD8, 0);
                 } else {
                     Fighter_ChangeMotionState(
-                        gobj, 348, Ft_MF_None, 0, ftKp_Init_804D9AD8,
-                        ftKp_Init_804D9ADC, ftKp_Init_804D9AD8);
+                        gobj, 348, Ft_MF_None, ftKp_Init_804D9AD8,
+                        ftKp_Init_804D9ADC, ftKp_Init_804D9AD8, 0);
                 }
 
                 fp0->x2222_b2 = true;
@@ -813,9 +808,9 @@ void ftKp_SpecialSHit_Anim(HSD_GObj* gobj)
         } else {
             /// @todo Combine @c fp0 with other branch somehow
             fp0 = GET_FIGHTER(gobj);
-            Fighter_ChangeMotionState(gobj, 350, transition_flags3, 0,
+            Fighter_ChangeMotionState(gobj, 350, transition_flags3,
                                       fp0->cur_anim_frame, ftKp_Init_804D9ADC,
-                                      ftKp_Init_804D9AD8);
+                                      ftKp_Init_804D9AD8, 0);
 
             ftAnim_8006F0FC(gobj, ftKp_Init_804D9AD8);
             fp0->mv.kp.unk1.x0 = 0;

--- a/src/melee/ft/chara/ftLink/ftLk_AttackAir.c
+++ b/src/melee/ft/chara/ftLink/ftLk_AttackAir.c
@@ -61,8 +61,8 @@ static void lwOnHit(HSD_GObj* gobj)
     fp->x221A_b4 = false;
     fp->mv.lk.attackair.lw_frame_start = da->attackairlw_hit_anim_frame_start;
     if (fp->cur_anim_frame > frame_len) {
-        Fighter_ChangeMotionState(gobj, ftCo_MS_AttackAirLw, Ft_MF_None, NULL,
-                                  frame_len, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftCo_MS_AttackAirLw, Ft_MF_None,
+                                  frame_len, 1, 0, NULL);
     }
 }
 

--- a/src/melee/ft/chara/ftLink/ftLk_SpecialHi.c
+++ b/src/melee/ft/chara/ftLink/ftLk_SpecialHi.c
@@ -49,8 +49,8 @@ static void onAccessory4(HSD_GObj* gobj)
 void ftLk_SpecialHi_Enter(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialHi, Ft_MF_None, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialHi, Ft_MF_None, 0, 1, 0,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     fp->cb.x21BC_callback_Accessory4 = onAccessory4;
 }
@@ -63,8 +63,8 @@ void ftLk_SpecialAirHi_Enter(HSD_GObj* gobj)
 #endif
     Fighter* fp = GET_FIGHTER(gobj);
     ftLk_DatAttrs* da = fp->dat_attrs;
-    Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirHi, Ft_MF_None, NULL, 0,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirHi, Ft_MF_None, 0, 1, 0,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     fp->self_vel.x *= da->x34;
     fp->self_vel.y = da->x40;
@@ -166,8 +166,8 @@ static void doColl(HSD_GObj* gobj)
         Ft_MF_SkipModelPartVis | Ft_MF_SkipModelFlags | Ft_MF_Unk27;
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D60C(fp);
-    Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirHi, coll_mf, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirHi, coll_mf,
+                              fp->cur_anim_frame, 1, 0, NULL);
 }
 
 void ftLk_SpecialHi_ProcessPartLThumbNb(HSD_GObj* gobj)

--- a/src/melee/ft/chara/ftLink/ftLk_SpecialLw.c
+++ b/src/melee/ft/chara/ftLink/ftLk_SpecialLw.c
@@ -28,7 +28,7 @@ static void doEnter(HSD_GObj* gobj, FtMotionId msid0, FtMotionId msid1)
     Fighter* fp = GET_FIGHTER(gobj);
     if (updateBomb(gobj, msid0) != true) {
         fp->throw_flags = 0;
-        Fighter_ChangeMotionState(gobj, msid1, Ft_MF_None, NULL, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, msid1, Ft_MF_None, 0, 1, 0, NULL);
         ftAnim_8006EBA4(gobj);
         fp->cb.x21BC_callback_Accessory4 = spawnBomb;
     }
@@ -125,8 +125,8 @@ void ftLk_SpecialLw_Coll(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     if (!ft_80082708(gobj)) {
         ftCommon_8007D5D4(fp);
-        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirLw, coll_mf, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirLw, coll_mf,
+                                  fp->cur_anim_frame, 1, 0, NULL);
         fp->cb.x21BC_callback_Accessory4 = spawnBomb;
     }
 }
@@ -137,8 +137,8 @@ void ftLk_SpecialAirLw_Coll(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     if (ft_80081D0C(gobj)) {
         ftCommon_8007D7FC(fp);
-        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialLw, coll_mf, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialLw, coll_mf,
+                                  fp->cur_anim_frame, 1, 0, NULL);
         fp->cb.x21BC_callback_Accessory4 = spawnBomb;
     }
 }

--- a/src/melee/ft/chara/ftLink/ftLk_SpecialN.c
+++ b/src/melee/ft/chara/ftLink/ftLk_SpecialN.c
@@ -309,8 +309,8 @@ void ftLk_SpecialN_Enter(ftLk_GObj* gobj)
     fp->cmd_vars[0] = fp->cmd_vars[1] = fp->cmd_vars[2] = fp->cmd_vars[3] = 0;
     ftCommon_8007D7FC(fp);
     fp->self_vel.y = 0;
-    Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialNStart, Ft_MF_None, NULL, 0,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialNStart, Ft_MF_None, 0, 1, 0,
+                              NULL);
     setCallbacks(gobj);
     ftAnim_SetAnimRate(gobj, da->specialn_anim_rate);
     ftAnim_8006EBA4(gobj);
@@ -468,8 +468,8 @@ void ftLk_SpecialAirN_Enter(ftLk_GObj* gobj)
     fp->mv.lk.specialn.x0.x = fp->mv.lk.specialn.x0.y = 0;
     fp->mv.lk.specialn.unk_timer = 0;
     fp->cmd_vars[0] = fp->cmd_vars[1] = fp->cmd_vars[2] = fp->cmd_vars[3] = 0;
-    Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirNStart, Ft_MF_None, NULL,
-                              0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirNStart, Ft_MF_None, 0, 1,
+                              0, NULL);
     setCallbacks(gobj);
     ftAnim_SetAnimRate(gobj, da->specialn_anim_rate);
     ftAnim_8006EBA4(gobj);
@@ -753,8 +753,8 @@ static inline void bar(ftLk_GObj* gobj)
         it_802A8398(fp->fv.lk.arrow_gobj, &vecs.b);
     }
     if (ftAnim_IsFramesRemaining(gobj)) {
-        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialNLoop, mf, NULL, 0, 1,
-                                  0);
+        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialNLoop, mf, 0, 1, 0,
+                                  NULL);
         setCallbacks(gobj);
         ftAnim_8006EBA4(gobj);
     }
@@ -1170,8 +1170,8 @@ void ftLk_SpecialAirNStart_Anim(ftLk_GObj* gobj)
             it_802A8398(fp->fv.lk.arrow_gobj, &vecs.b);
         }
         if (!ftAnim_IsFramesRemaining(gobj)) {
-            Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirNLoop, mf, NULL,
-                                      0, 1, 0);
+            Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirNLoop, mf, 0, 1,
+                                      0, NULL);
             setCallbacks(gobj);
             ftAnim_8006EBA4(gobj);
         }
@@ -1523,8 +1523,8 @@ void ftLk_SpecialNStart_IASA(ftLk_GObj* gobj)
         }
         /// @todo Shared with #ftLk_SpecialNLoop_IASA
         if (!(fp->input.held_inputs & HSD_PAD_B)) {
-            Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialNEnd, mf, NULL, 0,
-                                      1, 0);
+            Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialNEnd, mf, 0, 1, 0,
+                                      NULL);
             setCallbacks(gobj);
         }
     }
@@ -1578,7 +1578,7 @@ static void doLoopIASA(ftLk_GObj* gobj, FtMotionId msid)
     ftLk_DatAttrs* da = fp->dat_attrs;
     fp->mv.lk.specialn.x0.y = da->x0;
     if (!(fp->input.held_inputs & HSD_PAD_B)) {
-        Fighter_ChangeMotionState(gobj, msid, mf, NULL, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, msid, mf, 0, 1, 0, NULL);
         setCallbacks(gobj);
     }
 }
@@ -1659,8 +1659,8 @@ void ftLk_SpecialAirNStart_IASA(ftLk_GObj* gobj)
             fp->mv.lk.specialn.x0.y = da->x0;
         }
         if (!(fp->input.held_inputs & HSD_PAD_B)) {
-            Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirNEnd, mf, NULL,
-                                      0, 1, 0);
+            Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirNEnd, mf, 0, 1,
+                                      0, NULL);
             setCallbacks(gobj);
         }
     }
@@ -1800,8 +1800,8 @@ static void doColl(ftLk_GObj* gobj, FtMotionId msid)
     ftLk_Fighter* fp = GET_FIGHTER(gobj);
     if (!ft_80082708(gobj)) {
         ftCommon_8007D5D4(fp);
-        Fighter_ChangeMotionState(gobj, msid, coll_mf, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, msid, coll_mf, fp->cur_anim_frame, 1,
+                                  0, NULL);
         setCallbacks(gobj);
         ftAnim_8006EBA4(gobj);
     }
@@ -1986,8 +1986,8 @@ void ftLk_SpecialNEnd_Coll(ftLk_GObj* gobj)
     doEndColl(gobj);
     if (ft_80082708(gobj) == GA_Ground) {
         ftCommon_8007D5D4(fp);
-        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirNEnd, coll_mf, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirNEnd, coll_mf,
+                                  fp->cur_anim_frame, 1, 0, NULL);
         setCallbacks(gobj);
         ftAnim_8006EBA4(gobj);
     }
@@ -2043,8 +2043,8 @@ static void doAirColl(ftLk_GObj* gobj, FtMotionId msid)
     ftLk_Fighter* fp = GET_FIGHTER(gobj);
     if (ft_80081D0C(gobj) == GA_Air) {
         ftCommon_8007D7FC(fp);
-        Fighter_ChangeMotionState(gobj, msid, coll_mf, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, msid, coll_mf, fp->cur_anim_frame, 1,
+                                  0, NULL);
         setCallbacks(gobj);
         ftAnim_8006EBA4(gobj);
     }
@@ -2206,8 +2206,8 @@ void ftLk_SpecialAirNEnd_Coll(ftLk_GObj* gobj)
     doEndColl(gobj);
     if (ft_80081D0C(gobj) == GA_Air) {
         ftCommon_8007D5D4(fp);
-        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialNEnd, coll_mf, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialNEnd, coll_mf,
+                                  fp->cur_anim_frame, 1, 0, NULL);
         setCallbacks(gobj);
         ftAnim_8006EBA4(gobj);
     }

--- a/src/melee/ft/chara/ftLink/ftLk_SpecialS.c
+++ b/src/melee/ft/chara/ftLink/ftLk_SpecialS.c
@@ -207,11 +207,11 @@ static void doEnter(HSD_GObj* gobj)
     fp->cmd_vars[cmd_unk0_bool] = false;
     fp->cb.x21EC_callback = on21EC;
     if (fp->fv.lk.used_boomerang) {
-        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialS1Empty, Ft_MF_None,
-                                  NULL, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialS1Empty, Ft_MF_None, 0,
+                                  1, 0, NULL);
     } else {
-        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialS1, Ft_MF_None, NULL, 0,
-                                  1, 0);
+        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialS1, Ft_MF_None, 0, 1, 0,
+                                  NULL);
     }
     ftAnim_8006EBA4(gobj);
     fp->cb.x21BC_callback_Accessory4 = onAccessory4;
@@ -224,11 +224,11 @@ void ftLk_SpecialS_Enter(HSD_GObj* gobj)
     fp->cmd_vars[cmd_unk0_bool] = false;
     fp->cb.x21EC_callback = on21EC;
     if (fp->fv.lk.used_boomerang) {
-        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialS1Empty, Ft_MF_None,
-                                  NULL, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialS1Empty, Ft_MF_None, 0,
+                                  1, 0, NULL);
     } else {
-        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialS1, Ft_MF_None, NULL, 0,
-                                  1, 0);
+        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialS1, Ft_MF_None, 0, 1, 0,
+                                  NULL);
     }
     ftAnim_8006EBA4(gobj);
     fp->cb.x21BC_callback_Accessory4 = onAccessory4;
@@ -243,10 +243,10 @@ void ftLk_SpecialAirS_Enter(HSD_GObj* gobj)
     fp->cb.x21EC_callback = on21EC;
     if (fp->fv.lk.used_boomerang) {
         Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirS1Empty, Ft_MF_None,
-                                  NULL, 0, 1, 0);
+                                  0, 1, 0, NULL);
     } else {
-        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirS1, Ft_MF_None, NULL,
-                                  0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirS1, Ft_MF_None, 0, 1,
+                                  0, NULL);
     }
     ftAnim_8006EBA4(gobj);
     fp->cb.x21BC_callback_Accessory4 = onAccessory4;
@@ -256,11 +256,11 @@ void ftLk_SpecialS2_Enter(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     if (fp->ground_or_air == GA_Air) {
-        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirS2, Ft_MF_None, NULL,
-                                  0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirS2, Ft_MF_None, 0, 1,
+                                  0, NULL);
     } else {
-        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialS2, Ft_MF_None, NULL, 0,
-                                  1, 0);
+        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialS2, Ft_MF_None, 0, 1, 0,
+                                  NULL);
     }
     fp->cb.x21DC_callback_OnTakeDamage = ftLk_800EAF58;
     ftAnim_8006EBA4(gobj);
@@ -404,8 +404,8 @@ void ftLk_SpecialS1_Coll(HSD_GObj* gobj)
     if (!ft_80082708(gobj)) {
         Fighter* fp = GET_FIGHTER(gobj);
         ftCommon_8007D5D4(fp);
-        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirS1, coll_mf, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirS1, coll_mf,
+                                  fp->cur_anim_frame, 1, 0, NULL);
         fp->cb.x21BC_callback_Accessory4 = onAccessory4;
     }
 }
@@ -428,7 +428,7 @@ void ftLk_SpecialS1Empty_Coll(HSD_GObj* gobj)
         Fighter* fp = GET_FIGHTER(gobj);
         ftCommon_8007D5D4(fp);
         Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialAirS1Empty, coll_mf,
-                                  NULL, fp->cur_anim_frame, 1, 0);
+                                  fp->cur_anim_frame, 1, 0, NULL);
     }
 }
 
@@ -437,8 +437,8 @@ void ftLk_SpecialAirS1_Coll(HSD_GObj* gobj)
     if (ft_80081D0C(gobj)) {
         Fighter* fp = GET_FIGHTER(gobj);
         ftCommon_8007D7FC(fp);
-        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialS1, coll_mf, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialS1, coll_mf,
+                                  fp->cur_anim_frame, 1, 0, NULL);
         fp->cb.x21BC_callback_Accessory4 = onAccessory4;
     }
 }
@@ -459,7 +459,7 @@ void ftLk_SpecialAirS1Empty_Coll(HSD_GObj* gobj)
     if (ft_80081D0C(gobj)) {
         Fighter* fp = GET_FIGHTER(gobj);
         ftCommon_8007D7FC(fp);
-        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialS1Empty, coll_mf, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftLk_MS_SpecialS1Empty, coll_mf,
+                                  fp->cur_anim_frame, 1, 0, NULL);
     }
 }

--- a/src/melee/ft/chara/ftLuigi/ftLg_SpecialHi.c
+++ b/src/melee/ft/chara/ftLuigi/ftLg_SpecialHi.c
@@ -23,8 +23,8 @@ void ftLg_SpecialHi_Enter(HSD_GObj* gobj)
 
     fp->cmd_vars[0] = 0;
     fp->throw_flags = 0;
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialHi, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialHi, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -43,8 +43,8 @@ void ftLg_SpecialAirHi_Enter(HSD_GObj* gobj)
     fp->throw_flags = 0;
     fp->self_vel.y = 0.0f;
     fp->self_vel.x *= luigiAttrs->x64_LUIGI_SUPERJUMP_VEL_X;
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirHi, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirHi, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
 }
 

--- a/src/melee/ft/chara/ftLuigi/ftLg_SpecialLw.c
+++ b/src/melee/ft/chara/ftLuigi/ftLg_SpecialLw.c
@@ -75,8 +75,8 @@ void ftLg_SpecialLw_Enter(HSD_GObj* gobj)
     luigiAttrs = temp_fp->dat_attrs;
     fp2 = temp_fp;
     GET_FIGHTER(gobj)->cmd_vars[2] = 0;
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirLw, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirLw, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     fp2->self_vel.y = (f32) (luigiAttrs->x70_LUIGI_CYCLONE_TAP_MOMENTUM -
                              luigiAttrs->x8C_LUIGI_CYCLONE_TAP_Y_VEL_MAX);
@@ -108,8 +108,8 @@ void ftLg_SpecialAirLw_Enter(HSD_GObj* gobj)
     luigiAttrs = temp_fp->dat_attrs;
     fp2 = temp_fp;
     GET_FIGHTER(gobj)->cmd_vars[2] = 0;
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirLw, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirLw, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     if (fp2->fv.lg.x222C_cycloneCharge != 0) {
         cycloneVar = 0.0f;
@@ -185,8 +185,8 @@ static inline void ftLuigi_SpecialLw_GroundToAir(HSD_GObj* gobj)
     ftLuigiAttributes* luigiAttrs = getFtSpecialAttrs(fp);
     fp->cmd_vars[2] = 0;
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, 0x166, 0x0C4C508A, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x166, 0x0C4C508A, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
     ftCommon_ClampFallSpeed(fp, luigiAttrs->x90_LUIGI_CYCLONE_TAP_GRAVITY);
     ftCommon_8007D440(fp, luigiAttrs->x78_LUIGI_CYCLONE_MOMENTUM_X_AIR);
     fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
@@ -328,7 +328,7 @@ static inline void ftLuigi_SpecialAirLw_AirToGround(HSD_GObj* gobj)
     fp->self_vel.y = 0.0f;
     fp->fv.lg.x222C_cycloneCharge = false;
     Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialLw, FTLUIGI_SPECIALLW_FLAG,
-                              NULL, fp->cur_anim_frame, 1.0f, 0.0f);
+                              fp->cur_anim_frame, 1.0f, 0.0f, NULL);
     ftCommon_8007CC78(fp, luigiAttrs->x74_LUIGI_CYCLONE_MOMENTUM_X_GROUND);
     fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
     fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;

--- a/src/melee/ft/chara/ftLuigi/ftLg_SpecialN.c
+++ b/src/melee/ft/chara/ftLuigi/ftLg_SpecialN.c
@@ -28,8 +28,8 @@ void ftLg_SpecialN_Enter(HSD_GObj* gobj)
 
     fp->cmd_vars[0] = 0;
     fp->throw_flags = 0;
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialN, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialN, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     fp->cb.x21BC_callback_Accessory4 = &ftLg_SpecialN_FireSpawn;
 }
@@ -41,8 +41,8 @@ void ftLg_SpecialAirN_Enter(HSD_GObj* gobj)
 
     fp->cmd_vars[0] = 0;
     fp->throw_flags = 0;
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirN, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirN, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     fp->cb.x21BC_callback_Accessory4 = &ftLg_SpecialN_FireSpawn;
 }
@@ -105,8 +105,8 @@ void ftLg_SpecialN_Coll(HSD_GObj* gobj)
         fp = GET_FIGHTER(gobj);
         ftCommon_8007D5D4(fp);
         Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirN,
-                                  FTLUIGI_SPECIALN_COLL_FLAG, NULL,
-                                  fp->cur_anim_frame, 1.0f, 0.0f);
+                                  FTLUIGI_SPECIALN_COLL_FLAG,
+                                  fp->cur_anim_frame, 1.0f, 0.0f, NULL);
         fp->cb.x21BC_callback_Accessory4 = &ftLg_SpecialN_FireSpawn;
     }
 }
@@ -120,8 +120,8 @@ void ftLg_SpecialAirN_Coll(HSD_GObj* gobj)
         fp = GET_FIGHTER(gobj);
         ftCommon_8007D7FC(fp);
         Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialN,
-                                  FTLUIGI_SPECIALN_COLL_FLAG, NULL,
-                                  fp->cur_anim_frame, 1.0f, 0.0f);
+                                  FTLUIGI_SPECIALN_COLL_FLAG,
+                                  fp->cur_anim_frame, 1.0f, 0.0f, NULL);
         fp->cb.x21BC_callback_Accessory4 = &ftLg_SpecialN_FireSpawn;
     }
 }

--- a/src/melee/ft/chara/ftLuigi/ftLg_SpecialS.c
+++ b/src/melee/ft/chara/ftLuigi/ftLg_SpecialS.c
@@ -68,7 +68,7 @@ void ftLg_SpecialS_Enter(HSD_GObj* gobj)
     fp->cb.x21EC_callback = ftLg_SpecialS_SetVars;
     fp->gr_vel /= sa->x18_LUIGI_GREENMISSILE_TRACTION;
 
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialSStart, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialSStart, 0, 0, 1, 0, NULL);
 
     ftAnim_8006EBA4(gobj);
 }
@@ -88,8 +88,8 @@ void ftLg_SpecialAirS_Enter(HSD_GObj* gobj)
     fp->self_vel.x /= sa->x18_LUIGI_GREENMISSILE_TRACTION;
     fp->self_vel.y = 0;
 
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirSStart, 0, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirSStart, 0, 0, 1, 0,
+                              NULL);
 
     ftAnim_8006EBA4(gobj);
 }
@@ -188,8 +188,8 @@ void ftLg_SpecialSStart_GroundToAir(HSD_GObj* gobj)
     ftCommon_8007D5D4(fp);
 
     Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirSStart,
-                              transition_flags0, NULL, fp->cur_anim_frame, 1,
-                              0);
+                              transition_flags0, fp->cur_anim_frame, 1, 0,
+                              NULL);
 }
 
 /// Luigi's Green Missile Start air -> ground Motion State handler
@@ -199,7 +199,7 @@ void ftLg_SpecialAirSStart_AirToGround(HSD_GObj* gobj)
     ftCommon_8007D7FC(fp);
 
     Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialSStart, transition_flags0,
-                              NULL, fp->cur_anim_frame, 1, 0);
+                              fp->cur_anim_frame, 1, 0, NULL);
 }
 
 /// Luigi's grounded Green Missile Charge Animation callback
@@ -308,7 +308,7 @@ void ftLg_SpecialSHold_GroundToAir(HSD_GObj* gobj)
     ftCommon_8007D5D4(fp);
 
     Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirSHold, transition_flags1,
-                              NULL, fp->cur_anim_frame, 1, 0);
+                              fp->cur_anim_frame, 1, 0, NULL);
 }
 
 /// Luigi's Green Missile Charge air -> ground Motion State handler
@@ -318,7 +318,7 @@ void ftLg_SpecialAirSHold_AirToGround(HSD_GObj* gobj)
 
     ftCommon_8007D7FC(fp);
     Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialSHold, transition_flags1,
-                              NULL, fp->cur_anim_frame, 1, 0);
+                              fp->cur_anim_frame, 1, 0, NULL);
 }
 
 /// Luigi's grounded Green Missile Charge Motion State handler
@@ -331,8 +331,8 @@ void ftLg_SpecialSHold_Enter(HSD_GObj* gobj)
 
     /// @todo Shared @c inline with #ftLg_SpecialAirSHold_Enter.
 
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialSHold, Ft_MF_KeepSfx, NULL,
-                              0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialSHold, Ft_MF_KeepSfx, 0, 1,
+                              0, NULL);
 
     {
         Fighter* fp = GET_FIGHTER(gobj);
@@ -348,8 +348,8 @@ void ftLg_SpecialAirSHold_Enter(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirSHold, Ft_MF_KeepSfx,
-                              NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirSHold, Ft_MF_KeepSfx, 0,
+                              1, 0, NULL);
     {
         Fighter* fp = GET_FIGHTER(gobj);
         fp->cb.x21BC_callback_Accessory4 = ftLg_SpecialS_SetGFX;
@@ -457,7 +457,7 @@ void ftLg_SpecialSLaunch_GroundToAir(HSD_GObj* gobj)
     ftCommon_8007D5D4(fp);
 
     Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirS, transition_flags2,
-                              NULL, fp->cur_anim_frame, 1, 0);
+                              fp->cur_anim_frame, 1, 0, NULL);
 }
 
 /// Luigi's Green Missile Launch air -> ground Motion State handler
@@ -466,8 +466,8 @@ void ftLg_SpecialAirSLaunch_AirToGround(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
 
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialS, transition_flags2, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialS, transition_flags2,
+                              fp->cur_anim_frame, 1, 0, NULL);
 }
 
 static inline void ftLuigi_SpecialS_RemoveGFX(HSD_GObj* gobj)
@@ -507,7 +507,7 @@ void ftLg_SpecialSLaunch_Enter(HSD_GObj* gobj)
         return;
     }
 
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialS, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialS, 0, 0, 1, 0, NULL);
 
     ftLuigi_SpecialS_RemoveGFX(gobj);
     ftLuigi_SpecialS_Setup(gobj);
@@ -523,7 +523,7 @@ void ftLg_SpecialAirSLaunch_Enter(HSD_GObj* gobj)
         return;
     }
 
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirS, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirS, 0, 0, 1, 0, NULL);
 
     ftLuigi_SpecialS_RemoveGFX(gobj);
     ftLuigi_SpecialS_Setup(gobj);
@@ -623,8 +623,8 @@ void ftLg_SpecialSMisfire_GroundToAir(HSD_GObj* gobj)
     ftCommon_8007D5D4(fp);
 
     Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirSMisfire,
-                              transition_flags2, NULL, fp->cur_anim_frame, 1,
-                              0);
+                              transition_flags2, fp->cur_anim_frame, 1, 0,
+                              NULL);
 }
 
 /// Luigi's Green Missile Misfire air -> ground Motion State Handler
@@ -634,7 +634,7 @@ void ftLg_SpecialAirSMisfire_AirToGround(HSD_GObj* gobj)
     ftCommon_8007D7FC(fp);
 
     Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialSMisfire, transition_flags2,
-                              NULL, fp->cur_anim_frame, 1, 0);
+                              fp->cur_anim_frame, 1, 0, NULL);
 }
 
 /// Luigi's grounded Green Missile Misfire Motion State handler
@@ -645,7 +645,7 @@ void ftLg_SpecialSMisfire_Enter(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialSMisfire, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialSMisfire, 0, 0, 1, 0, NULL);
 
     ftLuigi_SpecialS_RemoveGFX(gobj);
     ftLuigi_SpecialS_Setup(gobj);
@@ -659,8 +659,8 @@ void ftLg_SpecialAirSMisfire_Enter(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirSMisfire, 0, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirSMisfire, 0, 0, 1, 0,
+                              NULL);
 
     ftLuigi_SpecialS_RemoveGFX(gobj);
     ftLuigi_SpecialS_Setup(gobj);
@@ -777,7 +777,7 @@ void ftLg_SpecialSFly_Enter(HSD_GObj* gobj)
     }
 
     Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirS2, transition_flags3,
-                              NULL, fp->cur_anim_frame, 1, 0);
+                              fp->cur_anim_frame, 1, 0, NULL);
 
     fp->cb.x21F8_callback = ftCommon_8007F76C;
     fp->cb.x21C0_callback_OnGiveDamage = ftLg_SpecialS_OnGiveDamage;
@@ -853,7 +853,7 @@ void ftLg_SpecialSEnd_Enter(HSD_GObj* gobj)
 
     fp->cmd_vars[0] = 0;
     fp->gr_vel /= sa->x38_LUIGI_GREENMISSILE_FRICTION_END;
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialSEnd, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialSEnd, 0, 0, 1, 0, NULL);
 }
 
 /// Luigi's Green Missile End ground -> air Motion State handler
@@ -865,5 +865,5 @@ void ftLg_SpecialAirSEnd_Enter(HSD_GObj* gobj)
     fp->cmd_vars[0] = 0;
     fp->self_vel.x /= sa->x38_LUIGI_GREENMISSILE_FRICTION_END;
 
-    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirSEnd, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftLg_MS_SpecialAirSEnd, 0, 0, 1, 0, NULL);
 }

--- a/src/melee/ft/chara/ftMario/ftMr_SpecialHi.c
+++ b/src/melee/ft/chara/ftMario/ftMr_SpecialHi.c
@@ -20,7 +20,7 @@ void ftMr_SpecialHi_Enter(HSD_GObj* gobj)
     fp = GET_FIGHTER(gobj);
     fp->cmd_vars[0] = 0;
     fp->throw_flags = 0;
-    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialHi, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialHi, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -38,7 +38,7 @@ void ftMr_SpecialAirHi_Enter(HSD_GObj* gobj)
     fp->throw_flags = 0;
     fp->self_vel.y = 0;
     fp->self_vel.x = fp->self_vel.x * sa->specialhi.vel_x;
-    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialAirHi, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialAirHi, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 }
 

--- a/src/melee/ft/chara/ftMario/ftMr_SpecialLw.c
+++ b/src/melee/ft/chara/ftMario/ftMr_SpecialLw.c
@@ -83,7 +83,7 @@ void ftMr_SpecialLw_Enter(HSD_GObj* gobj)
 #endif
 
     setCmdVar2(gobj);
-    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialAirLw, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialAirLw, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     fp->self_vel.y = sa->speciallw.vel_y - sa->speciallw.tap_y_vel_max;
     ftCommon_8007D440(fp, sa->speciallw.air_momentum_x);
@@ -104,7 +104,7 @@ void ftMr_SpecialAirLw_Enter(HSD_GObj* gobj)
 #endif
 
     setCmdVar2(gobj);
-    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialAirLw, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialAirLw, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     if ((s32) fp->fv.mr.x2234_tornadoCharge != 0) {
         sub_val = 0;
@@ -174,7 +174,7 @@ static void doPhys(HSD_GObj* gobj)
     fp->cmd_vars[2] = 0;
     ftCommon_8007D5D4(fp);
     Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialAirLw, transition_flags,
-                              NULL, fp->cur_anim_frame, 1, 0);
+                              fp->cur_anim_frame, 1, 0, NULL);
     ftCommon_ClampFallSpeed(fp, sa->speciallw.tap_grav);
     ftCommon_8007D440(fp, sa->speciallw.air_momentum_x);
     fp->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
@@ -306,8 +306,8 @@ static void doAirCollIfUnk(HSD_GObj* gobj)
     ftCommon_8007D7FC(fp);
     fp->self_vel.y = 0;
     fp->fv.mr.x2234_tornadoCharge = 0;
-    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialLw, transition_flags, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialLw, transition_flags,
+                              fp->cur_anim_frame, 1, 0, NULL);
     ftCommon_8007CC78(ft_tmp = fp, sa->speciallw.momentum_x);
     fp->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
     fp->cb.x21D8_callback_ExitHitlag = &efLib_ResumeAll;

--- a/src/melee/ft/chara/ftMario/ftMr_SpecialN.c
+++ b/src/melee/ft/chara/ftMario/ftMr_SpecialN.c
@@ -51,7 +51,7 @@ void ftMr_SpecialN_Enter(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     fp->cmd_vars[0] = 0;
     fp->throw_flags = 0;
-    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialN, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialN, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     fp->cb.x21BC_callback_Accessory4 = ftMr_SpecialN_ItemFireSpawn;
 }
@@ -128,7 +128,7 @@ void ftMr_SpecialAirN_Enter(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     fp->cmd_vars[0] = 0;
     fp->throw_flags = 0;
-    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialAirN, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialAirN, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     fp->cb.x21BC_callback_Accessory4 = ftMr_SpecialN_ItemFireSpawn;
 }
@@ -165,8 +165,8 @@ void ftMr_SpecialN_GroundToAir(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
     Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialAirN,
-                              (Ft_MF_UpdateCmd | Ft_MF_SkipColAnim), NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              (Ft_MF_UpdateCmd | Ft_MF_SkipColAnim),
+                              fp->cur_anim_frame, 1, 0, NULL);
 
     fp->cb.x21BC_callback_Accessory4 = ftMr_SpecialN_ItemFireSpawn;
 }
@@ -176,8 +176,8 @@ void ftMr_SpecialAirN_AirToGround(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
     Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialN,
-                              (Ft_MF_UpdateCmd | Ft_MF_SkipColAnim), NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              (Ft_MF_UpdateCmd | Ft_MF_SkipColAnim),
+                              fp->cur_anim_frame, 1, 0, NULL);
 
     fp->cb.x21BC_callback_Accessory4 = ftMr_SpecialN_ItemFireSpawn;
 }

--- a/src/melee/ft/chara/ftMario/ftMr_SpecialS.c
+++ b/src/melee/ft/chara/ftMario/ftMr_SpecialS.c
@@ -110,7 +110,7 @@ bool ftMr_SpecialS_CheckItemCapeRemove(HSD_GObj* gobj)
 
 static void changeAction(HSD_GObj* gobj, ftMario_MotionState msid)
 {
-    Fighter_ChangeMotionState(gobj, msid, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 
     {
@@ -296,7 +296,7 @@ void ftMr_SpecialS_GroundToAir(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
     Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialAirS, transition_flags,
-                              NULL, fp->cur_anim_frame, 1, 0);
+                              fp->cur_anim_frame, 1, 0, NULL);
     if ((s32) fp->cmd_vars[0] == 1U) {
         fp->cmd_vars[0] = 2U;
     }
@@ -316,8 +316,8 @@ void ftMr_SpecialAirS_AirToGround(HSD_GObj* gobj)
     fp = gobj->user_data;
     fp->fv.mr.x2238_isCapeBoost = false;
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialS, transition_flags, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMr_MS_SpecialS, transition_flags,
+                              fp->cur_anim_frame, 1, 0, NULL);
 
     collUpdateVars(gobj);
 }

--- a/src/melee/ft/chara/ftMars/ftMs_SpecialHi.c
+++ b/src/melee/ft/chara/ftMars/ftMs_SpecialHi.c
@@ -21,7 +21,7 @@ void ftMs_SpecialHi_Enter(HSD_GObj* gobj)
     fp->cmd_vars[0] = 0;
     fp->throw_flags = 0;
     // MotionStateChange
-    Fighter_ChangeMotionState(gobj, 0x16F, 0, NULL, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x16F, 0, 0.0f, 1.0f, 0.0f, NULL);
     // MS_AnimationFrameUpdate&More
     ftAnim_8006EBA4(gobj);
 }
@@ -45,7 +45,7 @@ void ftMs_SpecialAirHi_Enter(HSD_GObj* gobj)
     fp->self_vel.y = 0.0f;
     fp->self_vel.x *= da->x3C;
     // MotionStateChange
-    Fighter_ChangeMotionState(gobj, 0x170, 0, NULL, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x170, 0, 0.0f, 1.0f, 0.0f, NULL);
     // MS_AnimationFrameUpdate&More
     ftAnim_8006EBA4(gobj);
 }

--- a/src/melee/ft/chara/ftMars/ftMs_SpecialLw.c
+++ b/src/melee/ft/chara/ftMars/ftMs_SpecialLw.c
@@ -21,7 +21,7 @@ void ftMs_SpecialLw_Enter(HSD_GObj* gobj)
     Fighter* fp0 = GET_FIGHTER(gobj);
     fp0->self_vel.y = 0;
 
-    Fighter_ChangeMotionState(gobj, 369, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 369, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 
     {
@@ -45,7 +45,7 @@ void ftMs_SpecialAirLw_Enter(HSD_GObj* gobj)
         fp->self_vel.y = 0;
     }
 
-    Fighter_ChangeMotionState(gobj, 371, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 371, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 
     {
@@ -158,8 +158,8 @@ void ftMs_SpecialLw_80138D38(HSD_GObj* gobj)
     {
         Fighter* fp = gobj->user_data;
         ftCommon_8007D5D4(fp);
-        Fighter_ChangeMotionState(gobj, 371, 0x0C4C508C, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, 371, 0x0C4C508C, fp->cur_anim_frame, 1,
+                                  0, NULL);
     }
 
     {
@@ -183,8 +183,8 @@ void ftMs_SpecialLw_80138DD0(HSD_GObj* gobj)
     {
         Fighter* fp0 = gobj->user_data;
         ftCommon_8007D7FC(fp0);
-        Fighter_ChangeMotionState(gobj, 369, 0x0C4C508C, NULL,
-                                  fp0->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, 369, 0x0C4C508C, fp0->cur_anim_frame,
+                                  1, 0, NULL);
     }
 
     {
@@ -333,8 +333,8 @@ void ftMs_SpecialLw_80139080(HSD_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, 372, 0x0C4C508E, NULL, fp->cur_anim_frame,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, 372, 0x0C4C508E, fp->cur_anim_frame, 1, 0,
+                              NULL);
 }
 
 // 801390E0 00135CC0
@@ -343,8 +343,8 @@ void ftMs_SpecialLw_801390E0(HSD_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, 370, 0x0C4C508E, NULL, fp->cur_anim_frame,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, 370, 0x0C4C508E, fp->cur_anim_frame, 1, 0,
+                              NULL);
 }
 
 void ftMs_SpecialLw_80139140(HSD_GObj* gobj)
@@ -386,7 +386,7 @@ void ftMs_SpecialLw_80139140(HSD_GObj* gobj)
                 msid = 372;
             }
 
-            Fighter_ChangeMotionState(gobj, msid, 0, NULL, 0, 1, 0);
+            Fighter_ChangeMotionState(gobj, msid, 0, 0, 1, 0, NULL);
         }
     }
 

--- a/src/melee/ft/chara/ftMars/ftMs_SpecialN.c
+++ b/src/melee/ft/chara/ftMars/ftMs_SpecialN.c
@@ -28,7 +28,7 @@ void ftMs_SpecialN_Enter(HSD_GObj* gobj)
     fp->cb.x21EC_callback = &ftMs_SpecialN_80136730;
 
     fp->gr_vel /= attrs->xC;
-    Fighter_ChangeMotionState(gobj, 0x155, 0, 0, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x155, 0, 0.0f, 1.0f, 0.0f, 0);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -50,7 +50,7 @@ void ftMs_SpecialAirN_Enter(HSD_GObj* gobj)
         fp->self_vel.y = 0.0f;
     }
 
-    Fighter_ChangeMotionState(gobj, 0x159, 0, 0, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x159, 0, 0.0f, 1.0f, 0.0f, 0);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -149,8 +149,8 @@ void ftMs_SpecialN_80136A1C(HSD_GObj* gobj)
     Fighter* fp = gobj->user_data;
     ftCommon_8007D5D4(fp);
 
-    Fighter_ChangeMotionState(gobj, 0x159, 0x0C4C5084, 0, fp->cur_anim_frame,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x159, 0x0C4C5084, fp->cur_anim_frame,
+                              1.0f, 0.0f, 0);
 }
 
 // 80136A7C 0013365C
@@ -160,8 +160,8 @@ void ftMs_SpecialN_80136A7C(HSD_GObj* gobj)
     Fighter* fp = gobj->user_data;
     ftCommon_8007D7FC(fp);
 
-    Fighter_ChangeMotionState(gobj, 0x155, 0x0C4C5084, 0, fp->cur_anim_frame,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x155, 0x0C4C5084, fp->cur_anim_frame,
+                              1.0f, 0.0f, 0);
 }
 
 void ftMs_SpecialNLoop_Anim(HSD_GObj* gobj)
@@ -274,8 +274,8 @@ void ftMs_SpecialN_80136DB4(HSD_GObj* gobj)
     Fighter* fp = gobj->user_data;
 
     ftCommon_8007D5D4(gobj->user_data);
-    Fighter_ChangeMotionState(gobj, 0x15A, 0x0C4C5A86, 0, fp->cur_anim_frame,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x15A, 0x0C4C5A86, fp->cur_anim_frame,
+                              1.0f, 0.0f, 0);
 }
 
 // 80136E14 001339F4
@@ -285,22 +285,22 @@ void ftMs_SpecialN_80136E14(HSD_GObj* gobj)
     Fighter* fp = gobj->user_data;
 
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, 0x156, 0x0C4C5A86, 0, fp->cur_anim_frame,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x156, 0x0C4C5A86, fp->cur_anim_frame,
+                              1.0f, 0.0f, 0);
 }
 
 // 80136E74 00133A54
 // https://decomp.me/scratch/M7HBN
 void ftMs_SpecialN_80136E74(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, 0x156, 0x1200, 0, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x156, 0x1200, 0.0f, 1.0f, 0.0f, 0);
 }
 
 // 80136EAC 00133A8C
 // https://decomp.me/scratch/RkI7l
 void ftMs_SpecialN_80136EAC(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, 0x15A, 0x1200, 0, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x15A, 0x1200, 0.0f, 1.0f, 0.0f, 0);
 }
 
 // 80136EE4 00133AC4
@@ -475,8 +475,8 @@ void ftMs_SpecialN_801371FC(HSD_GObj* gobj)
     // Air_StoreBool_LoseGroundJump_NoECBfor10Frames
     ftCommon_8007D5D4(fp);
     // MotionStateChange
-    Fighter_ChangeMotionState(gobj, thing, 0x0C4C508E, 0, fp->cur_anim_frame,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, thing, 0x0C4C508E, fp->cur_anim_frame,
+                              1.0f, 0.0f, 0);
 
     if (fp->x2219_b0 == 1) {
         fp->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
@@ -501,8 +501,8 @@ void ftMs_SpecialN_801372A8(HSD_GObj* gobj)
     // Air_SetAsGrounded2
     ftCommon_8007D7FC(fp);
     // MotionStateChange
-    Fighter_ChangeMotionState(gobj, thing, 0x0C4C508E, 0, fp->cur_anim_frame,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, thing, 0x0C4C508E, fp->cur_anim_frame,
+                              1.0f, 0.0f, 0);
 
     if (fp->x2219_b0 == 1) {
         fp->cb.x21D4_callback_EnterHitlag = &efLib_PauseAll;
@@ -524,7 +524,7 @@ void ftMs_SpecialN_80137354(HSD_GObj* gobj)
         thing = 0x158;
     }
 
-    Fighter_ChangeMotionState(gobj, thing, 0, 0, 1.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, thing, 0, 1.0f, 1.0f, 0.0f, 0);
     fp->cb.x21BC_callback_Accessory4 = &ftMs_SpecialN_801365A8;
 }
 
@@ -541,6 +541,6 @@ void ftMs_SpecialN_801373B8(HSD_GObj* gobj)
         thing = 0x15C;
     }
 
-    Fighter_ChangeMotionState(gobj, thing, 0, 0, 1.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, thing, 0, 1.0f, 1.0f, 0.0f, 0);
     fp->cb.x21BC_callback_Accessory4 = &ftMs_SpecialN_8013666C;
 }

--- a/src/melee/ft/chara/ftMars/ftMs_SpecialS.c
+++ b/src/melee/ft/chara/ftMars/ftMs_SpecialS.c
@@ -33,7 +33,7 @@ void ftMs_SpecialS_Enter(HSD_GObj* gobj)
                 msid = 358;
             }
 
-            Fighter_ChangeMotionState(gobj, msid, 0, 0, 0, 1, 0);
+            Fighter_ChangeMotionState(gobj, msid, 0, 0, 1, 0, 0);
         }
     }
 
@@ -67,7 +67,7 @@ void ftMs_SpecialAirS_Enter(HSD_GObj* gobj)
                 msid = 358;
             }
 
-            Fighter_ChangeMotionState(gobj, msid, 0, 0, 0, 1, 0);
+            Fighter_ChangeMotionState(gobj, msid, 0, 0, 1, 0, 0);
         }
     }
 
@@ -153,8 +153,8 @@ void ftMs_SpecialS_801376E8(HSD_GObj* gobj)
     // Air_StoreBool_LoseGroundJump_NoECBfor10Frames
     ftCommon_8007D5D4(fp);
 
-    Fighter_ChangeMotionState(gobj, 358, transition_flags, 0,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, 358, transition_flags, fp->cur_anim_frame,
+                              1, 0, 0);
 }
 
 void ftMs_SpecialS_80137748(HSD_GObj* gobj)
@@ -165,8 +165,8 @@ void ftMs_SpecialS_80137748(HSD_GObj* gobj)
     // Air_SetAsGrounded2
     ftCommon_8007D7FC(fp);
 
-    Fighter_ChangeMotionState(gobj, 349, transition_flags, 0,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, 349, transition_flags, fp->cur_anim_frame,
+                              1, 0, 0);
 }
 
 void ftMs_SpecialS2_Anim(HSD_GObj* gobj)
@@ -256,8 +256,8 @@ void ftMs_SpecialS_80137940(HSD_GObj* gobj)
 #endif
     }
 
-    Fighter_ChangeMotionState(gobj, msid, transition_flags, 0,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, transition_flags, fp->cur_anim_frame,
+                              1, 0, 0);
 }
 
 void ftMs_SpecialS_801379D0(HSD_GObj* gobj)
@@ -281,8 +281,8 @@ void ftMs_SpecialS_801379D0(HSD_GObj* gobj)
 #endif
     }
 
-    Fighter_ChangeMotionState(gobj, msid, transition_flags, 0,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, transition_flags, fp->cur_anim_frame,
+                              1, 0, 0);
 }
 
 void ftMs_SpecialS_80137A68(HSD_GObj* gobj)
@@ -313,7 +313,7 @@ void ftMs_SpecialS_80137A9C(HSD_GObj* gobj)
             msid = 360;
         }
     }
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_SkipAttackCount, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_SkipAttackCount, 0, 1, 0, 0);
 }
 
 void ftMs_SpecialS3_Anim(HSD_GObj* gobj)
@@ -407,8 +407,8 @@ void ftMs_SpecialS_80137CBC(HSD_GObj* gobj)
 #endif
     }
 
-    Fighter_ChangeMotionState(gobj, msid, transition_flags, 0,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, transition_flags, fp->cur_anim_frame,
+                              1, 0, 0);
 }
 
 void ftMs_SpecialS_80137D60(HSD_GObj* gobj)
@@ -432,8 +432,8 @@ void ftMs_SpecialS_80137D60(HSD_GObj* gobj)
         break;
     }
 
-    Fighter_ChangeMotionState(gobj, msid, transition_flags, 0,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, transition_flags, fp->cur_anim_frame,
+                              1, 0, 0);
 }
 
 void ftMs_SpecialS_80137E0C(HSD_GObj* gobj)
@@ -467,7 +467,7 @@ void ftMs_SpecialS_80137E0C(HSD_GObj* gobj)
         }
     }
 
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_SkipAttackCount, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_SkipAttackCount, 0, 1, 0, 0);
 }
 
 void ftMs_SpecialS4_Anim(HSD_GObj* gobj)
@@ -547,8 +547,8 @@ void ftMs_SpecialS_80137FF8(HSD_GObj* gobj)
 #endif
     }
 
-    Fighter_ChangeMotionState(gobj, msid, transition_flags, 0,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, transition_flags, fp->cur_anim_frame,
+                              1, 0, 0);
 }
 
 void ftMs_SpecialS_8013809C(HSD_GObj* gobj)
@@ -577,8 +577,8 @@ void ftMs_SpecialS_8013809C(HSD_GObj* gobj)
 #endif
     }
 
-    Fighter_ChangeMotionState(gobj, msid, transition_flags, 0,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, transition_flags, fp->cur_anim_frame,
+                              1, 0, 0);
 }
 
 void ftMs_SpecialS_80138148(HSD_GObj* gobj)
@@ -611,5 +611,5 @@ void ftMs_SpecialS_80138148(HSD_GObj* gobj)
             }
         }
     }
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_SkipAttackCount, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_SkipAttackCount, 0, 1, 0, 0);
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_BackAirplane1.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_BackAirplane1.c
@@ -37,7 +37,7 @@ static void doAnim(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     ftMasterHand_SpecialAttrs* da = fp->ft_data->ext_attr;
 
-    Fighter_ChangeMotionState(gobj, ftMh_MS_BackAirplane2, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_BackAirplane2, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 
     {

--- a/src/melee/ft/chara/ftMasterHand/ftMh_BackAirplane2.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_BackAirplane2.c
@@ -27,7 +27,7 @@ void ftMh_MS_368_80153A64(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftMasterHand_SpecialAttrs* da = fp->ft_data->ext_attr;
-    Fighter_ChangeMotionState(gobj, ftMh_MS_BackAirplane3, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_BackAirplane3, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     fp->cur_pos.x = da->x60;
     fp->cur_pos.y = da->x64;

--- a/src/melee/ft/chara/ftMasterHand/ftMh_BackAirplane3.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_BackAirplane3.c
@@ -36,7 +36,7 @@ void ftMh_MS_369_80153B90(HSD_GObj* gobj)
     ftMasterHand_SpecialAttrs* da = fp->ft_data->ext_attr;
     Vec3 pos;
 
-    Fighter_ChangeMotionState(gobj, ftMh_MS_BackPunch, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_BackPunch, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     fp->mv.mh.unk0.x0 = da->x6C;
     ftBossLib_8015C208(gobj, &pos);

--- a/src/melee/ft/chara/ftMasterHand/ftMh_BackCrush_0.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_BackCrush_0.c
@@ -33,7 +33,7 @@ void ftMh_MS_370_80153D2C(HSD_GObj* gobj)
     u8 _[4];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftMh_MS_BackCrush, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_BackCrush, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     ftBossLib_8015C208(gobj, &pos);
     fp->cur_pos.x = pos.x;

--- a/src/melee/ft/chara/ftMasterHand/ftMh_BackCrush_1.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_BackCrush_1.c
@@ -10,7 +10,7 @@ void ftMh_BackCrush_Coll(HSD_GObj* gobj) {}
 void ftMh_MS_371_801541C8(HSD_GObj* gobj, HSD_GObjEvent arg1)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    Fighter_ChangeMotionState(gobj, ftMh_MS_BackDisappear, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_BackDisappear, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     fp->mv.mh.unk0.x4 = arg1;
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_BackDisappear.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_BackDisappear.c
@@ -40,8 +40,8 @@ void ftMh_MS_372_801542E0(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftMasterHand_SpecialAttrs* da = fp->ft_data->ext_attr;
-    Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_1, 0, 0, fp->cur_anim_frame,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_1, 0, fp->cur_anim_frame, 1,
+                              0, 0);
     ftAnim_SetAnimRate(gobj, da->x110_pos.y);
     fp->mv.mh.unk0.x8 = da->x110_pos.x;
 }
@@ -59,7 +59,7 @@ void ftMh_Wait1_1_Anim(HSD_GObj* gobj)
     }
 
     if (!ftAnim_IsFramesRemaining(gobj)) {
-        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_1, 0, 0, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_1, 0, 0, 1, 0, 0);
         ftAnim_8006EBA4(gobj);
     }
 }
@@ -140,7 +140,7 @@ void ftMh_Wait1_1_Coll(HSD_GObj* gobj) {}
 void ftMh_MS_373_801545A0(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    Fighter_ChangeMotionState(gobj, ftMh_MS_Grab, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_Grab, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     ftCommon_8007E2D0(fp, 128, ftMh_MS_375_80154A2C, 0, ftMh_MS_388_80155A58);
     fp->mv.mh.unk0.x20 = 0;
@@ -174,7 +174,7 @@ void ftMh_MS_374_801546D8(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftMasterHand_SpecialAttrs* da = fp->ft_data->ext_attr;
-    Fighter_ChangeMotionState(gobj, ftMh_MS_Fail, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_Fail, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     fp->mv.mh.unk0.xC.x = da->x30_pos2.x;
     fp->mv.mh.unk0.xC.y = da->x30_pos2.y;
@@ -211,7 +211,7 @@ void ftMh_MS_381_8015483C(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftMasterHand_SpecialAttrs* da = fp->ft_data->ext_attr;
-    Fighter_ChangeMotionState(gobj, ftMh_MS_Cancel, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_Cancel, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     fp->mv.mh.unk0.x24 = da->x120;
     fp->cmd_vars[0] = 1;

--- a/src/melee/ft/chara/ftMasterHand/ftMh_CaptureDamageMasterHand.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_CaptureDamageMasterHand.c
@@ -13,7 +13,7 @@ void ftMh_CaptureDamageMasterHand_Coll(HSD_GObj* gobj) {}
 void ftMh_CaptureDamageMasterHand_80155C94(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    Fighter_ChangeMotionState(gobj, ftCo_MS_CaptureWaitMasterHand, 0, 0, 0, 1,
+    Fighter_ChangeMotionState(gobj, ftCo_MS_CaptureWaitMasterHand, 0, 0, 1, 0,
                               0);
     fp->x221E_b0 = true;
     ftCommon_8007E2F4(fp, 511);

--- a/src/melee/ft/chara/ftMasterHand/ftMh_CaptureMasterHand.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_CaptureMasterHand.c
@@ -18,8 +18,8 @@ void ftMh_CaptureMasterHand_Coll(HSD_GObj* gobj) {}
 void ftMh_CaptureMasterHand_80155B80(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    Fighter_ChangeMotionState(gobj, ftCo_MS_CaptureDamageMasterHand, 0, 0, 0,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_CaptureDamageMasterHand, 0, 0, 1,
+                              0, 0);
     fp->x221E_b0 = true;
     fp->x2220_flag.bits.b3 = true;
     fp->cb.x21B0_callback_Accessory1 = ftCo_800DB464;

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Damage_0.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Damage_0.c
@@ -56,7 +56,7 @@ void ftMh_MS_343_80151484(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     fp->cmd_vars[0] = 0;
     func_80151484_inline1(gobj);
-    Fighter_ChangeMotionState(gobj, ftMh_MS_Damage, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_Damage, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     ft_800881D8(fp, 320023, 127, 64);
     ft_80088148(fp, 320024, 127, 64);
@@ -79,7 +79,7 @@ void ftMh_Damage_Anim(HSD_GObj* gobj)
         fp->cmd_vars[0] = 0;
     }
     if (fp->mv.mh.unk0.x8 > 0 && !ftAnim_IsFramesRemaining(gobj)) {
-        Fighter_ChangeMotionState(gobj, ftMh_MS_Damage2, 0, 0, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftMh_MS_Damage2, 0, 0, 1, 0, 0);
         ftAnim_8006EBA4(gobj);
     }
     if (--fp->mv.mh.unk0.x8 == 0) {
@@ -100,7 +100,7 @@ void ftMh_MS_345_Anim(HSD_GObj* gobj)
         fp->cmd_vars[0] = 0;
     }
     if (fp->mv.mh.unk0.x8 > 0 && !ftAnim_IsFramesRemaining(gobj)) {
-        Fighter_ChangeMotionState(gobj, ftMh_MS_Damage2, 0, 0, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftMh_MS_Damage2, 0, 0, 1, 0, 0);
         ftAnim_8006EBA4(gobj);
     }
     if (--fp->mv.mh.unk0.x8 == 0) {

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Drill.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Drill.c
@@ -38,7 +38,7 @@ void ftMh_MS_352_801521DC(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftMh_MS_Drill, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_Drill, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     fp->mv.mh.unk0.x0 = 107;
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Entry.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Entry.c
@@ -16,7 +16,7 @@ void ftMh_MS_343_801510B0(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftMasterHand_SpecialAttrs* da = fp->ft_data->ext_attr;
-    Fighter_ChangeMotionState(gobj, ftMh_MS_Entry, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_Entry, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     fp->cur_pos.x = da->x30_pos2.x;
     fp->cur_pos.y = da->x30_pos2.y;

--- a/src/melee/ft/chara/ftMasterHand/ftMh_FingerBeam.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_FingerBeam.c
@@ -16,7 +16,7 @@ void ftMh_Poke1_Coll(HSD_GObj* gobj) {}
 void ftMh_MS_359_80152BCC(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    Fighter_ChangeMotionState(gobj, ftMh_MS_FingerBeamStart, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_FingerBeamStart, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     fp->mv.mh.unk0.x28 = -1;
     fp->mv.mh.unk0.x2C = -1;
@@ -48,7 +48,7 @@ void ftMh_FingerBeamStart_Coll(HSD_GObj* gobj) {}
 void ftMh_MS_361_80152CD8(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    Fighter_ChangeMotionState(gobj, ftMh_MS_FingerBeamLoop, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_FingerBeamLoop, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     fp->cb.x21BC_callback_Accessory4 = ftMh_MS_362_80152E28;
     fp->cmd_vars[0] = 1;
@@ -119,7 +119,7 @@ void ftMh_MS_362_80152E28(HSD_GObj* gobj)
 static void ftMh_MS_362_80152F80(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    Fighter_ChangeMotionState(gobj, ftMh_MS_FingerBeamEnd, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_FingerBeamEnd, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     lbAudioAx_800236B8(fp->mv.mh.unk0.x28);
     lbAudioAx_800236B8(fp->mv.mh.unk0.x2C);

--- a/src/melee/ft/chara/ftMasterHand/ftMh_FingerGun.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_FingerGun.c
@@ -44,7 +44,7 @@ void ftMh_MS_363_801530A4(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftMh_MS_FingerGun1, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_FingerGun1, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 
     {
@@ -168,7 +168,7 @@ void ftMh_MS_364_801533CC(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftMasterHand_SpecialAttrs* da = fp->ft_data->ext_attr;
-    Fighter_ChangeMotionState(gobj, ftMh_MS_FingerGun2, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_FingerGun2, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     if (ftLib_80087120(gobj) > da->xEC) {
         ftAnim_SetAnimRate(gobj, da->xF4);
@@ -182,7 +182,7 @@ static inline void lbl_8015346C_inline(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftMasterHand_SpecialAttrs* da = fp->ft_data->ext_attr;
-    Fighter_ChangeMotionState(gobj, ftMh_MS_FingerGun2, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_FingerGun2, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     if (ftLib_80087120(gobj) > da->xEC) {
         ftAnim_SetAnimRate(gobj, da->xF4);
@@ -272,6 +272,6 @@ void ftMh_MS_365_80153730(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftMh_MS_FingerGun3, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_FingerGun3, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_FingerGun3.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_FingerGun3.c
@@ -29,6 +29,6 @@ void ftMh_FingerGun3_Coll(HSD_GObj* gobj) {}
 
 void ftMh_MS_366_80153820(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, ftMh_MS_BackAirplane1, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_BackAirplane1, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_PaperCrush.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_PaperCrush.c
@@ -30,7 +30,7 @@ void ftMh_RockCrushDown_Coll(HSD_GObj* gobj) {}
 void ftMh_MS_357_801526D8(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    Fighter_ChangeMotionState(gobj, ftMh_MS_PaperCrush, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_PaperCrush, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     fp->mv.mh.unk0.x0 = 0;
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Poke.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Poke.c
@@ -22,7 +22,7 @@ void ftMh_MS_358_80152880(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftMh_MS_Poke1, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_Poke1, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     fp->mv.mh.unk13.x0 = da->x94 + HSD_Randi(da->x90 - da->x94);
     fp->mv.mh.unk13.x4 = 0;
@@ -41,7 +41,7 @@ void ftMh_Poke1_Anim(HSD_GObj* gobj)
 
             {
                 Fighter* fp = GET_FIGHTER(gobj);
-                Fighter_ChangeMotionState(gobj, ftMh_MS_Poke2, 0, 0, 0, 1, 0);
+                Fighter_ChangeMotionState(gobj, ftMh_MS_Poke2, 0, 0, 1, 0, 0);
                 ftAnim_8006EBA4(gobj);
                 ft_80088148(fp, 320007, 127, 64);
             }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_RockCrush.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_RockCrush.c
@@ -8,7 +8,7 @@ void ftMh_Drill_Coll(HSD_GObj* gobj) {}
 
 void ftMh_MS_354_80152370(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, ftMh_MS_RockCrushUp, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_RockCrushUp, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -39,7 +39,7 @@ void ftMh_RockCrushUp_Coll(HSD_GObj* gobj) {}
 
 void ftMh_MS_355_8015247C(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, ftMh_MS_RockCrushWait, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_RockCrushWait, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -50,7 +50,7 @@ void ftMh_RockCrushWait_Anim(HSD_GObj* gobj)
         ftMh_MS_356_801525E0(gobj);
     }
     if (!ftAnim_IsFramesRemaining(gobj)) {
-        Fighter_ChangeMotionState(gobj, ftMh_MS_RockCrushWait, 0, 0, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftMh_MS_RockCrushWait, 0, 0, 1, 0, 0);
         ftAnim_8006EBA4(gobj);
     }
 }
@@ -79,6 +79,6 @@ void ftMh_MS_356_801525E0(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     fp->self_vel.x = 0;
-    Fighter_ChangeMotionState(gobj, ftMh_MS_RockCrushDown, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_RockCrushDown, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Slam.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Slam.c
@@ -58,6 +58,6 @@ void ftMh_MS_380_80155194(HSD_GObj* gobj)
         ftCh_Init_8015A2B0(gobj1);
     }
     fp->x1A5C = gobj1;
-    Fighter_ChangeMotionState(gobj, ftMh_MS_TagCrush, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_TagCrush, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Slap.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Slap.c
@@ -31,7 +31,7 @@ void ftMh_MS_349_80151CA8(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftMasterHand_SpecialAttrs* da = fp->ft_data->ext_attr;
-    Fighter_ChangeMotionState(gobj, ftMh_MS_WalkShoot, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_WalkShoot, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 
     /// @todo The code matches, but is this right?

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Squeeze.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Squeeze.c
@@ -15,7 +15,7 @@ void ftMh_MS_378_80154A78(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     ftMasterHand_SpecialAttrs* da = fp->ft_data->ext_attr;
     fp->cmd_vars[1] = 0;
-    Fighter_ChangeMotionState(gobj, ftMh_MS_Squeeze, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_Squeeze, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     fp->x2222_b2 = true;
     ftCommon_8007E2F4(fp, 511);

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Squeezing.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Squeezing.c
@@ -48,7 +48,7 @@ void ftMh_Squeezing_Coll(HSD_GObj* gobj) {}
 void ftMh_MS_376_80154E78(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    Fighter_ChangeMotionState(gobj, ftMh_MS_Throw, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_Throw, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     fp->cmd_vars[0] = 0;
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Sweep.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Sweep.c
@@ -27,7 +27,7 @@ void ftMh_Damage_Coll(HSD_GObj* gobj) {}
 
 void ftMh_MS_344_80151828(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, ftMh_MS_WaitSweep, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_WaitSweep, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -60,7 +60,7 @@ void ftMh_MS_346_80151918(HSD_GObj* gobj)
     fp->mv.mh.unk0.xC.x = fp->cur_pos.x - da->x3C;
     fp->mv.mh.unk0.xC.y = da->x38;
     fp->mv.mh.unk0.xC.z = 0;
-    Fighter_ChangeMotionState(gobj, ftMh_MS_SweepLoop, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_SweepLoop, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -89,7 +89,7 @@ void ftMh_SweepLoop_Anim(HSD_GObj* gobj)
             fp->mv.mh.unk0.xC.y = da->x38;
             fp->mv.mh.unk0.xC.z = 0;
         }
-        Fighter_ChangeMotionState(gobj, ftMh_MS_SweepLoop, 0, 0, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftMh_MS_SweepLoop, 0, 0, 1, 0, 0);
         ftAnim_8006EBA4(gobj);
     }
 }
@@ -114,6 +114,6 @@ void ftMh_SweepLoop_Coll(HSD_GObj* gobj) {}
 
 static void ftMh_MS_347_80151AC8(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, ftMh_MS_SweepWait, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_SweepWait, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_SweepWait.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_SweepWait.c
@@ -34,6 +34,6 @@ void ftMh_MS_348_80151BB8(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftMh_MS_Slap, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_Slap, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_TagApplaud.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_TagApplaud.c
@@ -50,6 +50,6 @@ void ftMh_MS_383_80155484(HSD_GObj* gobj)
         ftCh_Init_8015A560(gobj1);
     }
     fp->x1A5C = gobj1;
-    Fighter_ChangeMotionState(gobj, ftMh_MS_TagRockPaper, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_TagRockPaper, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_TagCancel.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_TagCancel.c
@@ -28,7 +28,7 @@ void ftMh_MS_388_80155A58(HSD_GObj* gobj_1, HSD_GObj* gobj_2)
     ftCo_800DB368(ft_2, ft_1);
     ft_1->cb.x21B0_callback_Accessory1 = ftCo_800DB464;
     ftCommon_8007D5D4(ft_1);
-    Fighter_ChangeMotionState(gobj_1, ftCo_MS_CaptureMasterHand, 0, 0, 0, 1,
+    Fighter_ChangeMotionState(gobj_1, ftCo_MS_CaptureMasterHand, 0, 0, 1, 0,
                               0);
     ft_1->x221E_b0 = true;
     ft_1->x2220_flag.bits.b3 = true;

--- a/src/melee/ft/chara/ftMasterHand/ftMh_TagCrush.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_TagCrush.c
@@ -44,6 +44,6 @@ void ftMh_MS_382_801552F8(HSD_GObj* gobj)
         }
         fp->x1A5C = gobj_2;
     }
-    Fighter_ChangeMotionState(gobj, ftMh_MS_TagApplaud, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_TagApplaud, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_TagRockPaper.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_TagRockPaper.c
@@ -118,7 +118,7 @@ void ftMh_TagSqueeze_Coll(HSD_GObj* gobj) {}
 
 static void ftMh_MS_386_80155818(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, ftMh_MS_TagFail, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_TagFail, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 }
 

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Throw.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Throw.c
@@ -30,7 +30,7 @@ void ftMh_Throw_Coll(HSD_GObj* gobj) {}
 void ftMh_MS_379_80155014(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    Fighter_ChangeMotionState(gobj, ftMh_MS_Slam, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_Slam, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     fp->cmd_vars[0] = 0;
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_ThrownMasterHand.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_ThrownMasterHand.c
@@ -28,8 +28,8 @@ void ftMh_CaptureWaitMasterHand_80155D6C(HSD_GObj* gobj, s32 arg1)
 
     fp->facing_dir = victim_fp->facing_dir;
     fp->mv.mh.unk4.x0 = 0;
-    Fighter_ChangeMotionState(gobj, ftCo_MS_ThrownMasterHand, 0, 0, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_ThrownMasterHand, 0, 0.0f, 1.0f,
+                              0.0f, 0);
     fp->x221E_b0 = 0;
     fp->cb.x21B0_callback_Accessory1 = &ftCo_800DE508;
     ftCommon_8007E2F4(fp, 511);

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Wait1_0.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Wait1_0.c
@@ -53,10 +53,10 @@ static void ftMh_MS_341_8014FE5C(HSD_GObj* gobj)
         fp->fv.mh.x2240_pos = fp->cur_pos;
     }
     if (fp->fv.mh.x2258 == ftMh_MS_Wait1_2) {
-        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_0, 0, 0,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_0, 0, fp->cur_anim_frame,
+                                  1, 0, 0);
     } else {
-        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_0, 0, 0, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_0, 0, 0, 1, 0, 0);
     }
     fp->fv.mh.x2258 = ftMh_MS_Wait1_0;
 }
@@ -70,10 +70,10 @@ void ftMh_MS_341_8014FF1C(HSD_GObj* gobj)
         fp->fv.mh.x2240_pos = fp->cur_pos;
     }
     if (fp->fv.mh.x2258 == ftMh_MS_Wait2_1) {
-        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_0, 0, 0,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_0, 0, fp->cur_anim_frame,
+                                  1, 0, 0);
     } else {
-        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_0, 0, 0, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_0, 0, 0, 1, 0, 0);
     }
     fp->fv.mh.x2258 = ftMh_MS_Wait2_0;
 }
@@ -94,10 +94,10 @@ void ftMh_MS_341_8014FFDC(HSD_GObj* gobj)
             fp->fv.mh.x2240_pos = fp->cur_pos;
         }
         if (fp->fv.mh.x2258 == ftMh_MS_Wait2_1) {
-            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_0, 0, 0,
-                                      fp->cur_anim_frame, 1, 0);
+            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_0, 0,
+                                      fp->cur_anim_frame, 1, 0, 0);
         } else {
-            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_0, 0, 0, 0, 1, 0);
+            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_0, 0, 0, 1, 0, 0);
         }
         fp->fv.mh.x2258 = ftMh_MS_Wait2_0;
     } else {
@@ -109,10 +109,10 @@ void ftMh_MS_341_8014FFDC(HSD_GObj* gobj)
             fp->fv.mh.x2240_pos = fp->cur_pos;
         }
         if (fp->fv.mh.x2258 == ftMh_MS_Wait1_2) {
-            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_0, 0, 0,
-                                      fp->cur_anim_frame, 1, 0);
+            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_0, 0,
+                                      fp->cur_anim_frame, 1, 0, 0);
         } else {
-            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_0, 0, 0, 0, 1, 0);
+            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_0, 0, 0, 1, 0, 0);
         }
         fp->fv.mh.x2258 = ftMh_MS_Wait1_0;
     }
@@ -136,10 +136,10 @@ static void ifStage251(HSD_GObj* gobj)
             fp->fv.mh.x2240_pos = fp->cur_pos;
         }
         if (fp->fv.mh.x2258 == ftMh_MS_Wait1_2) {
-            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_0, 0, 0,
-                                      fp->cur_anim_frame, 1, 0);
+            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_0, 0,
+                                      fp->cur_anim_frame, 1, 0, 0);
         } else {
-            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_0, 0, 0, 0, 1, 0);
+            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_0, 0, 0, 1, 0, 0);
         }
         fp->fv.mh.x2258 = ftMh_MS_Wait1_0;
     }
@@ -178,10 +178,10 @@ inline void doAnim0(HSD_GObj* gobj)
         fp->fv.mh.x2240_pos = fp->cur_pos;
     }
     if (fp->fv.mh.x2258 == ftMh_MS_Wait2_1) {
-        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_0, 0, 0,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_0, 0, fp->cur_anim_frame,
+                                  1, 0, 0);
     } else {
-        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_0, 0, 0, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_0, 0, 0, 1, 0, 0);
     }
     fp->fv.mh.x2258 = ftMh_MS_Wait2_0;
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Wait1_1.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Wait1_1.c
@@ -8,7 +8,7 @@ void ftMh_MS_375_80154C78(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftMasterHand_SpecialAttrs* da = fp->ft_data->ext_attr;
-    Fighter_ChangeMotionState(gobj, ftMh_MS_Squeezing0, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_Squeezing0, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     fp->mv.mh.unk0.xC.x = da->x118_pos.x;
     fp->mv.mh.unk0.xC.y = da->x118_pos.y;
@@ -19,7 +19,7 @@ void ftMh_MS_378_80154CF8(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftMasterHand_SpecialAttrs* da = fp->ft_data->ext_attr;
-    Fighter_ChangeMotionState(gobj, ftMh_MS_Squeezing1, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_Squeezing1, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     fp->mv.mh.unk0.xC.x = da->x30_pos2.x;
     fp->mv.mh.unk0.xC.y = da->x30_pos2.y;

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Wait1_2.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Wait1_2.c
@@ -22,10 +22,10 @@ void ftMh_MS_389_80150C8C(HSD_GObj* gobj)
     if (fp->fv.mh.x2258 == ftMh_MS_Wait1_0 ||
         fp->fv.mh.x2258 == ftMh_MS_Wait1_2)
     {
-        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_2, 0, 0,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_2, 0, fp->cur_anim_frame,
+                                  1, 0, 0);
     } else {
-        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_2, 0, 0, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_2, 0, 0, 1, 0, 0);
         ftAnim_8006EBA4(gobj);
     }
     fp->fv.mh.x2258 = ftMh_MS_Wait1_2;
@@ -37,10 +37,10 @@ void ftMh_MS_389_80150D28(HSD_GObj* gobj)
     if (fp->fv.mh.x2258 == ftMh_MS_Wait2_0 ||
         fp->fv.mh.x2258 == ftMh_MS_Wait2_1)
     {
-        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_1, 0, 0,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_1, 0, fp->cur_anim_frame,
+                                  1, 0, 0);
     } else {
-        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_1, 0, 0, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_1, 0, 0, 1, 0, 0);
         ftAnim_8006EBA4(gobj);
     }
     fp->fv.mh.x2258 = ftMh_MS_Wait2_1;
@@ -60,10 +60,10 @@ void ftMh_MS_389_80150DC4(HSD_GObj* gobj, HSD_GObjEvent cb, Vec3* pos)
         if ((fp->fv.mh.x2258 == ftMh_MS_Wait2_0) ||
             (fp->fv.mh.x2258 == ftMh_MS_Wait2_1))
         {
-            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_1, 0, 0,
-                                      fp->cur_anim_frame, 1, 0);
+            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_1, 0,
+                                      fp->cur_anim_frame, 1, 0, 0);
         } else {
-            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_1, 0, 0, 0, 1, 0);
+            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait2_1, 0, 0, 1, 0, 0);
             ftAnim_8006EBA4(gobj);
         }
         fp->fv.mh.x2258 = ftMh_MS_Wait2_1;
@@ -71,10 +71,10 @@ void ftMh_MS_389_80150DC4(HSD_GObj* gobj, HSD_GObjEvent cb, Vec3* pos)
         if (fp->fv.mh.x2258 == ftMh_MS_Wait1_0 ||
             fp->fv.mh.x2258 == ftMh_MS_Wait1_2)
         {
-            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_2, 0, 0,
-                                      fp->cur_anim_frame, 1, 0);
+            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_2, 0,
+                                      fp->cur_anim_frame, 1, 0, 0);
         } else {
-            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_2, 0, 0, 0, 1, 0);
+            Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_2, 0, 0, 1, 0, 0);
             ftAnim_8006EBA4(gobj);
         }
         fp->fv.mh.x2258 = ftMh_MS_Wait1_2;
@@ -92,7 +92,7 @@ void ftMh_Wait1_2_Anim(HSD_GObj* gobj)
     if (!ftAnim_IsFramesRemaining(gobj)) {
         Fighter* fp = GET_FIGHTER(gobj);
         fp->fv.mh.x2258 = ftMh_MS_Wait1_2;
-        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_2, 0, 0, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftMh_MS_Wait1_2, 0, 0, 1, 0, 0);
         ftAnim_8006EBA4(gobj);
     }
 }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Walk.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Walk.c
@@ -36,7 +36,7 @@ void ftMh_WalkShoot_Coll(HSD_GObj* gobj) {}
 
 void ftMh_MS_353_80151DC4(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, ftMh_MS_Walk2, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_Walk2, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -64,7 +64,7 @@ void ftMh_Walk2_Coll(HSD_GObj* gobj) {}
 
 void ftMh_MS_350_80151EB4(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, ftMh_MS_WalkLoop, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_WalkLoop, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -126,7 +126,7 @@ void ftMh_WalkLoop_Anim(HSD_GObj* gobj)
     }
 
     if (!ftAnim_IsFramesRemaining(gobj)) {
-        Fighter_ChangeMotionState(gobj, ftMh_MS_WalkLoop, 0, 0, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftMh_MS_WalkLoop, 0, 0, 1, 0, 0);
         ftAnim_8006EBA4(gobj);
     }
 }
@@ -154,7 +154,7 @@ void ftMh_WalkLoop_Coll(HSD_GObj* gobj) {}
 void ftMh_MS_351_801520D8(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    Fighter_ChangeMotionState(gobj, ftMh_MS_WalkWait, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMh_MS_WalkWait, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
     fp->self_vel.x = 0;
 }

--- a/src/melee/ft/chara/ftMewtwo/ftMt_SpecialHi.c
+++ b/src/melee/ft/chara/ftMewtwo/ftMt_SpecialHi.c
@@ -81,7 +81,7 @@ void ftMt_SpecialHiStart_Enter(HSD_GObj* gobj)
         fp1->self_vel.x = 0;
     }
 
-    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialHiStart, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialHiStart, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 
     fp0->cmd_vars[0] = 0;
@@ -103,8 +103,8 @@ void ftMt_SpecialAirHiStart_Enter(HSD_GObj* gobj)
     fp->self_vel.x /= mewtwoAttrs->x40_MEWTWO_TELEPORT_VEL_DIV_X;
     fp->self_vel.y /= mewtwoAttrs->x44_MEWTWO_TELEPORT_VEL_DIV_Y;
 
-    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirHiStart, 0, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirHiStart, 0, 0, 1, 0,
+                              NULL);
     ftAnim_8006EBA4(gobj);
 
     fp->cmd_vars[0] = 0;
@@ -199,8 +199,8 @@ void ftMt_SpecialHiStart_GroundToAir(HSD_GObj* gobj)
     ftCommon_8007D60C(fp);
 
     Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirHiStart,
-                              transition_flags1, NULL, fp->cur_anim_frame, 1,
-                              0);
+                              transition_flags1, fp->cur_anim_frame, 1, 0,
+                              NULL);
 
     fp->cb.x21BC_callback_Accessory4 = ftMt_SpecialHi_CreateGFX;
 }
@@ -212,7 +212,7 @@ void ftMt_SpecialAirHiStart_AirToGround(HSD_GObj* gobj)
     ftCommon_8007D7FC(fp);
 
     Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialHiStart, transition_flags1,
-                              NULL, fp->cur_anim_frame, 1, 0);
+                              fp->cur_anim_frame, 1, 0, NULL);
 
     fp->cb.x21BC_callback_Accessory4 = ftMt_SpecialHi_CreateGFX;
 }
@@ -365,8 +365,8 @@ void ftMt_SpecialHi_GroundToAir(HSD_GObj* gobj)
 
     ftCommon_8007D60C(fp);
     Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirHiLost,
-                              transition_flags1, NULL, fp->cur_anim_frame, 0,
-                              0);
+                              transition_flags1, fp->cur_anim_frame, 0, 0,
+                              NULL);
 
     fp->x2223_flag.bits.b4 = true;
     fp->x221E_b0 = true;
@@ -379,7 +379,7 @@ void ftMt_SpecialAirHi_AirToGround(HSD_GObj* gobj)
 
     ftCommon_8007D7FC(fp);
     Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialHiLost, transition_flags1,
-                              NULL, fp->cur_anim_frame, 0, 0);
+                              fp->cur_anim_frame, 0, 0, NULL);
 
     fp->x221E_b0 = true;
 }
@@ -461,8 +461,8 @@ void ftMt_SpecialHi_Enter(HSD_GObj* gobj)
                   mewtwoAttrs->x60_MEWTWO_TELEPORT_MOMENTUM_ADD) *
                  cosf(vel));
 
-            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialHiLost, 0, NULL, 35,
-                                      1, 0);
+            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialHiLost, 0, 35, 1, 0,
+                                      NULL);
 
             ftAnim_8006EBA4(gobj);
 
@@ -536,8 +536,8 @@ void ftMt_SpecialAirHi_Enter(HSD_GObj* gobj)
                       mewtwoAttrs->x60_MEWTWO_TELEPORT_MOMENTUM_ADD) *
                      sinf(floatVar);
 
-    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirHiLost, 0, NULL, 35, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirHiLost, 0, 35, 1, 0,
+                              NULL);
 
     ftAnim_8006EBA4(gobj);
 
@@ -631,7 +631,7 @@ void ftMt_SpecialHiLost_GroundToAir(HSD_GObj* gobj)
 
     ftCommon_8007D60C(fp);
     Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirHi, transition_flags0,
-                              NULL, fp->cur_anim_frame, 1, 0);
+                              fp->cur_anim_frame, 1, 0, NULL);
 }
 
 static inline void ftMewtwo_SpecialHiLost_SetVars(HSD_GObj* gobj)
@@ -653,7 +653,7 @@ void ftMt_SpecialHiLost_Enter(HSD_GObj* gobj)
     Fighter* fp = getFighter(gobj);
     ftMewtwoAttributes* mewtwoAttrs = getFtSpecialAttrsD(fp);
 
-    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialHi, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialHi, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 
     ftMewtwo_SpecialHiLost_SetVars(gobj);
@@ -668,7 +668,7 @@ void ftMt_SpecialAirHiLost_Enter(HSD_GObj* gobj)
     Fighter* fp = getFighter(gobj);
     ftMewtwoAttributes* mewtwoAttrs = getFtSpecialAttrsD(fp);
 
-    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirHi, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirHi, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 
     ftMewtwo_SpecialHiLost_SetVars(gobj);

--- a/src/melee/ft/chara/ftMewtwo/ftMt_SpecialLw.c
+++ b/src/melee/ft/chara/ftMewtwo/ftMt_SpecialLw.c
@@ -51,8 +51,8 @@ void ftMt_SpecialLw_Enter(HSD_GObj* gobj)
     fp->cmd_vars[0] = 0;
     fp->fv.mt.x222C_disableGObj = NULL;
 
-    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialLw, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialLw, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
 
     fp->cb.x21BC_callback_Accessory4 = ftMt_SpecialLw_CreateDisable;
@@ -75,8 +75,8 @@ void ftMt_SpecialAirLw_Enter(HSD_GObj* gobj)
     fp->fv.mt.x222C_disableGObj = NULL;
     fp->self_vel.y = 0.0f;
 
-    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirLw, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirLw, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
 
     fp->cb.x21BC_callback_Accessory4 = ftMt_SpecialLw_CreateDisable;
@@ -161,8 +161,8 @@ void ftMt_SpecialLw_GroundToAir(HSD_GObj* gobj)
     fp->self_vel.y = 0.0f;
 
     Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirLw,
-                              FTMEWTWO_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+                              FTMEWTWO_SPECIALLW_COLL_FLAG, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
 
     fp->cb.x21BC_callback_Accessory4 = ftMt_SpecialLw_CreateDisable;
 
@@ -181,8 +181,8 @@ void ftMt_SpecialAirLw_AirToGround(HSD_GObj* gobj, float lag)
     ftCommon_8007D7FC(fp);
 
     Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialLw,
-                              FTMEWTWO_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+                              FTMEWTWO_SPECIALLW_COLL_FLAG, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
 
     fp->cb.x21BC_callback_Accessory4 = ftMt_SpecialLw_CreateDisable;
 

--- a/src/melee/ft/chara/ftMewtwo/ftMt_SpecialN.c
+++ b/src/melee/ft/chara/ftMewtwo/ftMt_SpecialN.c
@@ -387,8 +387,8 @@ inline void ftMewtwo_SpecialN_ChangeAction(HSD_GObj* gobj)
     ftMewtwoAttributes* mewtwoAttrs = getFtSpecialAttrsD(fp);
     s32 releaseLag;
 
-    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNStart, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNStart, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
 
     releaseLag = 0;
     fp->cmd_vars[3] = 0;
@@ -428,8 +428,8 @@ inline void ftMewtwo_SpecialAirN_ChangeAction(HSD_GObj* gobj)
     ftMewtwoAttributes* mewtwoAttrs = getFtSpecialAttrsD(fp);
     u32 releaseLag;
 
-    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNStart, 0, NULL, 0.0f,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNStart, 0, 0.0f, 1.0f,
+                              0.0f, NULL);
 
     releaseLag = 0;
 
@@ -502,11 +502,11 @@ void ftMt_SpecialNStart_Anim(HSD_GObj* gobj)
             ((f32) fp->fv.mt.x2234_shadowBallCharge ==
              mewtwoAttrs->x0_MEWTWO_SHADOWBALL_CHARGE_CYCLES))
         {
-            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNEnd, 0, NULL, 0.0f,
-                                      1.0f, 0.0f);
+            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNEnd, 0, 0.0f, 1.0f,
+                                      0.0f, NULL);
         } else {
-            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNLoop, 0, NULL,
-                                      0.0f, 1.0f, 0.0f);
+            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNLoop, 0, 0.0f,
+                                      1.0f, 0.0f, NULL);
             fp->mv.mt.SpecialN.x2348 = false;
         }
         ftMewtwo_SpecialN_SetCall(gobj);
@@ -573,8 +573,8 @@ void ftMt_SpecialNLoop_Anim(HSD_GObj* gobj)
                 {
                     Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNLoopFull,
                                               FTMEWTWO_SPECIALN_ACTION_FLAG,
-                                              NULL, fp->cur_anim_frame, 1.0f,
-                                              0.0f);
+                                              fp->cur_anim_frame, 1.0f, 0.0f,
+                                              NULL);
                     fp->fv.mt.x2234_shadowBallCharge =
                         (s32) mewtwoAttrs->x0_MEWTWO_SHADOWBALL_CHARGE_CYCLES;
                     fp->mv.mt.SpecialN.x2348 = true;
@@ -682,11 +682,11 @@ void ftMt_SpecialAirNStart_Anim(HSD_GObj* gobj)
             ((f32) fp->fv.mt.x2234_shadowBallCharge ==
              mewtwoAttrs->x0_MEWTWO_SHADOWBALL_CHARGE_CYCLES))
         {
-            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNEnd, 0, NULL,
-                                      0.0f, 1.0f, 0.0f);
+            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNEnd, 0, 0.0f,
+                                      1.0f, 0.0f, NULL);
         } else {
-            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNLoop, 0, NULL,
-                                      0.0f, 1.0f, 0.0f);
+            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNLoop, 0, 0.0f,
+                                      1.0f, 0.0f, NULL);
             fp->mv.mt.SpecialN.x2348 = false;
         }
         ftMewtwo_SpecialN_SetCall(gobj);
@@ -726,8 +726,8 @@ void ftMt_SpecialAirNLoop_Anim(HSD_GObj* gobj)
                 {
                     Fighter_ChangeMotionState(
                         gobj, ftMt_MS_SpecialAirNLoopFull,
-                        FTMEWTWO_SPECIALN_ACTION_FLAG, NULL,
-                        fp->cur_anim_frame, 1.0f, 0.0f);
+                        FTMEWTWO_SPECIALN_ACTION_FLAG, fp->cur_anim_frame,
+                        1.0f, 0.0f, NULL);
                     fp->fv.mt.x2234_shadowBallCharge =
                         (s32) mewtwoAttrs->x0_MEWTWO_SHADOWBALL_CHARGE_CYCLES;
                     fp->mv.mt.SpecialN.x2348 = 1;
@@ -817,20 +817,20 @@ void ftMt_SpecialNLoop_IASA(HSD_GObj* gobj)
         recentInput = fp->input.x668;
         if ((recentInput & HSD_PAD_A) && (fp->mv.mt.SpecialN.releaseLag <= 0))
         {
-            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNEnd, 0, NULL, 0.0f,
-                                      1.0f, 0.0f);
+            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNEnd, 0, 0.0f, 1.0f,
+                                      0.0f, NULL);
             ftMewtwo_SpecialN_SetCall(gobj);
             return;
         }
         if ((recentInput & HSD_PAD_B) != false) {
             if (fp->mv.mt.SpecialN.releaseLag <= 0) {
-                Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNEnd, 0, NULL,
-                                          0.0f, 1.0f, 0.0f);
+                Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNEnd, 0, 0.0f,
+                                          1.0f, 0.0f, NULL);
                 ftMewtwo_SpecialN_SetCall(gobj);
             }
         } else if ((recentInput & HSD_PAD_LR) != false) {
-            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNCancel, 0, NULL,
-                                      0.0f, 1.0f, 0.0f);
+            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNCancel, 0, 0.0f,
+                                      1.0f, 0.0f, NULL);
             ftMewtwo_SpecialN_RemoveShadowBall2(gobj);
             ftMewtwo_SpecialN_SetCall(gobj);
         }
@@ -855,18 +855,18 @@ void ftMt_SpecialNLoopFull_IASA(HSD_GObj* gobj)
     } else {
         recentInput = fp->input.x668;
         if ((recentInput & HSD_PAD_A) != false) {
-            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNEnd, 0, NULL, 0.0f,
-                                      1.0f, 0.0f);
+            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNEnd, 0, 0.0f, 1.0f,
+                                      0.0f, NULL);
             ftMewtwo_SpecialN_SetCall(gobj);
             return;
         }
         if ((recentInput & HSD_PAD_B) != false) {
-            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNEnd, 0, NULL, 0.0f,
-                                      1.0f, 0.0f);
+            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNEnd, 0, 0.0f, 1.0f,
+                                      0.0f, NULL);
             ftMewtwo_SpecialN_SetCall(gobj);
         } else if ((recentInput & HSD_PAD_LR) != false) {
-            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNCancel, 0, NULL,
-                                      0.0f, 1.0f, 0.0f);
+            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNCancel, 0, 0.0f,
+                                      1.0f, 0.0f, NULL);
             ftMewtwo_SpecialN_RemoveShadowBall2(gobj);
             ftMewtwo_SpecialN_SetCall(gobj);
         }
@@ -908,20 +908,20 @@ void ftMt_SpecialAirNLoop_IASA(HSD_GObj* gobj)
     if (((recentInput & HSD_PAD_A) != false) &&
         (fp->mv.mt.SpecialN.releaseLag <= 0))
     {
-        Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNEnd, 0, NULL, 0.0f,
-                                  1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNEnd, 0, 0.0f, 1.0f,
+                                  0.0f, NULL);
         ftMewtwo_SpecialN_SetCall(gobj);
         return;
     }
     if ((recentInput & HSD_PAD_B) != false) {
         if (fp->mv.mt.SpecialN.releaseLag <= 0) {
-            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNEnd, 0, NULL,
-                                      0.0f, 1.0f, 0.0f);
+            Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNEnd, 0, 0.0f,
+                                      1.0f, 0.0f, NULL);
             ftMewtwo_SpecialN_SetCall(gobj);
         }
     } else if ((recentInput & HSD_PAD_LR) != false) {
-        Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNCancel, 0, NULL,
-                                  0.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNCancel, 0, 0.0f,
+                                  1.0f, 0.0f, NULL);
         ftMewtwo_SpecialN_RemoveShadowBall2(gobj);
         ftMewtwo_SpecialN_SetCall(gobj);
     }
@@ -940,18 +940,18 @@ void ftMt_SpecialAirNLoopFull_IASA(HSD_GObj* gobj)
 
     recentInput = fp->input.x668;
     if ((recentInput & HSD_PAD_A) != false) {
-        Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNEnd, 0, NULL, 0.0f,
-                                  1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNEnd, 0, 0.0f, 1.0f,
+                                  0.0f, NULL);
         ftMewtwo_SpecialN_SetCall(gobj);
         return;
     }
     if ((recentInput & HSD_PAD_B) != false) {
-        Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNEnd, 0, NULL, 0.0f,
-                                  1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNEnd, 0, 0.0f, 1.0f,
+                                  0.0f, NULL);
         ftMewtwo_SpecialN_SetCall(gobj);
     } else if ((recentInput & HSD_PAD_LR) != false) {
-        Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNCancel, 0, NULL,
-                                  0.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNCancel, 0, 0.0f,
+                                  1.0f, 0.0f, NULL);
         ftMewtwo_SpecialN_RemoveShadowBall2(gobj);
         ftMewtwo_SpecialN_SetCall(gobj);
     }
@@ -1044,8 +1044,8 @@ void ftMt_SpecialNStart_Coll(HSD_GObj* gobj)
     if (ft_80082708(gobj) == false) {
         ftCommon_8007D5D4(fp);
         Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNStart,
-                                  FTMEWTWO_SPECIALN_COLL_FLAG, NULL,
-                                  fp->cur_anim_frame, 1.0f, 0.0f);
+                                  FTMEWTWO_SPECIALN_COLL_FLAG,
+                                  fp->cur_anim_frame, 1.0f, 0.0f, NULL);
         ftMewtwo_SpecialN_SetCall(gobj);
     }
 }
@@ -1064,8 +1064,8 @@ void ftMt_SpecialNLoop_Coll(HSD_GObj* gobj)
         ftCommon_8007D5D4(fp);
         Fighter_ChangeMotionState(
             gobj, ftMt_MS_SpecialAirNLoop,
-            (Ft_MF_KeepSfx | FTMEWTWO_SPECIALN_COLL_FLAG), NULL,
-            fp->cur_anim_frame, 1.0f, 0.0f);
+            (Ft_MF_KeepSfx | FTMEWTWO_SPECIALN_COLL_FLAG), fp->cur_anim_frame,
+            1.0f, 0.0f, NULL);
         ftMewtwo_SpecialN_SetCall(gobj);
     }
 }
@@ -1084,8 +1084,8 @@ void ftMt_SpecialNLoopFull_Coll(HSD_GObj* gobj)
         ftCommon_8007D5D4(fp);
         Fighter_ChangeMotionState(
             gobj, ftMt_MS_SpecialAirNLoopFull,
-            (Ft_MF_KeepSfx | FTMEWTWO_SPECIALN_COLL_FLAG), NULL,
-            fp->cur_anim_frame, 1.0f, 0.0f);
+            (Ft_MF_KeepSfx | FTMEWTWO_SPECIALN_COLL_FLAG), fp->cur_anim_frame,
+            1.0f, 0.0f, NULL);
         ftMewtwo_SpecialN_SetCall(gobj);
     }
 }
@@ -1103,8 +1103,8 @@ void ftMt_SpecialNCancel_Coll(HSD_GObj* gobj)
     if (ft_80082708(gobj) == false) {
         ftCommon_8007D5D4(fp);
         Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNCancel,
-                                  FTMEWTWO_SPECIALN_COLL_FLAG, NULL,
-                                  fp->cur_anim_frame, 1.0f, 0.0f);
+                                  FTMEWTWO_SPECIALN_COLL_FLAG,
+                                  fp->cur_anim_frame, 1.0f, 0.0f, NULL);
         ftMewtwo_SpecialN_SetCall(gobj);
     }
 }
@@ -1122,8 +1122,8 @@ void ftMt_SpecialNEnd_Coll(HSD_GObj* gobj)
     if (ft_80082708(gobj) == false) {
         ftCommon_8007D5D4(fp);
         Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirNEnd,
-                                  FTMEWTWO_SPECIALN_COLL_FLAG, NULL,
-                                  fp->cur_anim_frame, 1.0f, 0.0f);
+                                  FTMEWTWO_SPECIALN_COLL_FLAG,
+                                  fp->cur_anim_frame, 1.0f, 0.0f, NULL);
         ftMewtwo_SpecialN_SetCall(gobj);
     }
 }
@@ -1141,8 +1141,8 @@ void ftMt_SpecialAirNStart_Coll(HSD_GObj* gobj)
     if (ft_80081D0C(gobj) == true) {
         ftCommon_8007D7FC(fp);
         Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNStart,
-                                  FTMEWTWO_SPECIALN_COLL_FLAG, NULL,
-                                  fp->cur_anim_frame, 1.0f, 0.0f);
+                                  FTMEWTWO_SPECIALN_COLL_FLAG,
+                                  fp->cur_anim_frame, 1.0f, 0.0f, NULL);
         ftMewtwo_SpecialN_SetCall(gobj);
     }
 }
@@ -1161,8 +1161,8 @@ void ftMt_SpecialAirNLoop_Coll(HSD_GObj* gobj)
         ftCommon_8007D7FC(fp);
         Fighter_ChangeMotionState(
             gobj, ftMt_MS_SpecialNLoop,
-            (Ft_MF_KeepSfx | FTMEWTWO_SPECIALN_COLL_FLAG), NULL,
-            fp->cur_anim_frame, 1.0f, 0.0f);
+            (Ft_MF_KeepSfx | FTMEWTWO_SPECIALN_COLL_FLAG), fp->cur_anim_frame,
+            1.0f, 0.0f, NULL);
         ftMewtwo_SpecialN_SetCall(gobj);
     }
 }
@@ -1181,8 +1181,8 @@ void ftMt_SpecialAirNLoopFull_Coll(HSD_GObj* gobj)
         ftCommon_8007D7FC(fp);
         Fighter_ChangeMotionState(
             gobj, ftMt_MS_SpecialNLoopFull,
-            (Ft_MF_KeepSfx | FTMEWTWO_SPECIALN_COLL_FLAG), NULL,
-            fp->cur_anim_frame, 1.0f, 0.0f);
+            (Ft_MF_KeepSfx | FTMEWTWO_SPECIALN_COLL_FLAG), fp->cur_anim_frame,
+            1.0f, 0.0f, NULL);
         ftMewtwo_SpecialN_SetCall(gobj);
     }
 }
@@ -1200,8 +1200,8 @@ void ftMt_SpecialAirNCancel_Coll(HSD_GObj* gobj)
     if (ft_80081D0C(gobj) == true) {
         ftCommon_8007D7FC(fp);
         Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNCancel,
-                                  FTMEWTWO_SPECIALN_COLL_FLAG, NULL,
-                                  fp->cur_anim_frame, 1.0f, 0.0f);
+                                  FTMEWTWO_SPECIALN_COLL_FLAG,
+                                  fp->cur_anim_frame, 1.0f, 0.0f, NULL);
         ftMewtwo_SpecialN_SetCall(gobj);
     }
 }
@@ -1219,8 +1219,8 @@ void ftMt_SpecialAirNEnd_Coll(HSD_GObj* gobj)
     if (ft_80081D0C(gobj) == true) {
         ftCommon_8007D7FC(fp);
         Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialNEnd,
-                                  FTMEWTWO_SPECIALN_COLL_FLAG, NULL,
-                                  fp->cur_anim_frame, 1.0f, 0.0f);
+                                  FTMEWTWO_SPECIALN_COLL_FLAG,
+                                  fp->cur_anim_frame, 1.0f, 0.0f, NULL);
         ftMewtwo_SpecialN_SetCall(gobj);
     }
 }

--- a/src/melee/ft/chara/ftMewtwo/ftMt_SpecialS.c
+++ b/src/melee/ft/chara/ftMewtwo/ftMt_SpecialS.c
@@ -69,8 +69,8 @@ void ftMt_SpecialS_Enter(HSD_GObj* gobj)
     fp->cmd_vars[1] = 0;
     fp->mv.mt.SpecialS.isConfusionReflect = false;
 
-    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialS, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialS, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
 
     ftMewtwo_SpecialS_SetGrab(gobj);
@@ -113,8 +113,8 @@ void ftMt_SpecialAirS_Enter(HSD_GObj* gobj)
         fp->fv.mt.x223C_isConfusionBoost = true;
     }
 
-    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirS, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirS, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
 
     ftMewtwo_SpecialAirS_SetGrab(gobj);
@@ -211,8 +211,8 @@ void ftMt_SpecialS_GroundToAir(HSD_GObj* gobj)
     ftCommon_8007D5D4(fp);
 
     Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialAirS,
-                              FTMEWTWO_SPECIALS_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+                              FTMEWTWO_SPECIALS_COLL_FLAG, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
 
     ftCommon_8007D468(fp);
 
@@ -234,8 +234,8 @@ void ftMt_SpecialAirS_AirToGround(HSD_GObj* gobj, float lag)
     ftCommon_8007D7FC(fp);
 
     Fighter_ChangeMotionState(gobj, ftMt_MS_SpecialS,
-                              FTMEWTWO_SPECIALS_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+                              FTMEWTWO_SPECIALS_COLL_FLAG, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
 
     ftMewtwo_SpecialS_SetGrab(gobj);
 

--- a/src/melee/ft/chara/ftNess/ftNs_AttackHi4.c
+++ b/src/melee/ft/chara/ftNess/ftNs_AttackHi4.c
@@ -647,8 +647,8 @@ void ftNs_AttackHi4_Enter(HSD_GObj* gobj)
         fp->fv.ns.x223C = 0.0f;
     }
 
-    Fighter_ChangeMotionState(gobj, ftNs_MS_AttackHi4, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_AttackHi4, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
 
     ftAnim_8006EBA4(gobj);
     fp->x2222_b2 = 1;
@@ -908,7 +908,7 @@ void ftNs_AttackHi4Charge_Enter(
     Fighter* fp = GET_FIGHTER(gobj);
 
     Fighter_ChangeMotionState(gobj, ftNs_MS_AttackHi4Charge, Ft_MF_SkipItemVis,
-                              NULL, 12.0f, 1.0f, 0.0f);
+                              12.0f, 1.0f, 0.0f, NULL);
     ftAnim_8006EBA4(gobj);
     ftAnim_SetAnimRate(gobj, 0.0f);
     ftNs_AttackHi4_YoyoApplySmash(gobj);
@@ -1049,7 +1049,7 @@ void ftNs_AttackHi4Release_Enter(HSD_GObj* gobj)
 
     fp = GET_FIGHTER(gobj);
     Fighter_ChangeMotionState(gobj, ftNs_MS_AttackHi4Release,
-                              Ft_MF_SkipItemVis, NULL, 13.0f, 1.0f, 0.0f);
+                              Ft_MF_SkipItemVis, 13.0f, 1.0f, 0.0f, NULL);
     ftAnim_8006EBA4(gobj);
 
     fighter_data2 = getFighter(gobj);

--- a/src/melee/ft/chara/ftNess/ftNs_AttackLw4.c
+++ b/src/melee/ft/chara/ftNess/ftNs_AttackLw4.c
@@ -19,8 +19,8 @@ void ftNs_AttackLw4_Enter(
     fp->allow_interrupt = 0;
     fp->mv.ns.attacklw4.isChargeDisable = false;
     ftNs_AttackHi4_YoyoSetVarAll(gobj);
-    Fighter_ChangeMotionState(gobj, ftNs_MS_AttackLw4, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_AttackLw4, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     fp->x2222_b2 = 1;
     fp->cb.x21C0_callback_OnGiveDamage = ftNs_AttackHi4_YoyoStartTimedRehit;
@@ -147,7 +147,7 @@ void ftNs_AttackLw4Charge_Enter(
     Fighter* fp = GET_FIGHTER(gobj);
 
     Fighter_ChangeMotionState(gobj, ftNs_MS_AttackLw4Charge, Ft_MF_SkipItemVis,
-                              NULL, 12.0f, 1.0f, 0.0f);
+                              12.0f, 1.0f, 0.0f, NULL);
     ftAnim_8006EBA4(gobj);
     ftAnim_SetAnimRate(gobj, 0.0f);
     ftNs_AttackHi4_YoyoApplySmash(gobj);
@@ -236,7 +236,7 @@ void ftNs_AttackLw4Release_Enter(
     Fighter* fp = GET_FIGHTER(gobj);
 
     Fighter_ChangeMotionState(gobj, ftNs_MS_AttackLw4Release,
-                              Ft_MF_SkipItemVis, NULL, 13.0f, 1.0f, 0.0f);
+                              Ft_MF_SkipItemVis, 13.0f, 1.0f, 0.0f, NULL);
     ftAnim_8006EBA4(gobj);
     ftNs_AttackHi4_YoyoSetChargeDamage(gobj);
     fp->x2222_b2 = 1;

--- a/src/melee/ft/chara/ftNess/ftNs_AttackS4.c
+++ b/src/melee/ft/chara/ftNess/ftNs_AttackS4.c
@@ -34,8 +34,8 @@ void ftNs_AttackS4_Enter(HSD_GObj* gobj) // Ness's F-Smash Motion State handler
 
     fp->cmd_vars[0] = false;
 
-    Fighter_ChangeMotionState(gobj, ftNs_MS_AttackS4, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_AttackS4, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
 
     ftAnim_8006EBA4(gobj);
 

--- a/src/melee/ft/chara/ftNess/ftNs_SpecialHi.c
+++ b/src/melee/ft/chara/ftNess/ftNs_SpecialHi.c
@@ -427,8 +427,8 @@ void ftNs_SpecialHiStart_Enter(HSD_GObj* gobj) // Ness's grounded PK Thunder
     ftNessAttributes* temp_attr;
     f64 phi_f0;
 
-    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialHiStart, 0, NULL, 0.0f,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialHiStart, 0, 0.0f, 1.0f,
+                              0.0f, NULL);
     fp->cmd_vars[3] = 0;
     fp->cmd_vars[2] = 0;
     fp->cmd_vars[1] = 0;
@@ -508,8 +508,8 @@ void ftNs_SpecialAirHiStart_Enter(
 
     fp = GET_FIGHTER(gobj);
     ness_attr = fp->dat_attrs;
-    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiStart, 0, NULL, 0.0f,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiStart, 0, 0.0f, 1.0f,
+                              0.0f, NULL);
     fp->cmd_vars[3] = 0;
     fp->cmd_vars[2] = 0;
     fp->cmd_vars[1] = 0;
@@ -626,7 +626,7 @@ void ftNs_SpecialHi_Enter(
 #endif
 
                         Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialHi, 0,
-                                                  NULL, 0.0f, 1.0f, 0.0f);
+                                                  0.0f, 1.0f, 0.0f, NULL);
                         fp->gr_vel =
                             (f32) (ness_attr->x54_PK_THUNDER_2_MOMENTUM *
                                    fp->facing_dir);
@@ -734,8 +734,8 @@ void ftNs_SpecialAirHi_Enter(HSD_GObj* gobj)
 #endif
 
     NessFloatMath_PKThunder2(gobj);
-    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHi, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHi, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     fighter_data2 = GET_FIGHTER(gobj);
     temp_attr = getFtSpecialAttrs(fighter_data2);
     fighter_data2->mv.ns.specialhi.unkVar = temp_attr->x58_PK_THUNDER_2_UNK1;
@@ -763,8 +763,8 @@ void ftNs_SpecialHiStart_Anim(HSD_GObj* gobj)
     Fighter* fp = gobj->user_data;
 
     if (!ftAnim_IsFramesRemaining(gobj)) {
-        Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialHiHold, 0, NULL, 0.0f,
-                                  1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialHiHold, 0, 0.0f, 1.0f,
+                                  0.0f, NULL);
 
         {
             Fighter* fighter_data2 = gobj->user_data;
@@ -829,8 +829,8 @@ void ftNs_SpecialHiHold_Anim(HSD_GObj* gobj) // Ness's grounded PK Thunder
         if (((s32) fp->mv.ns.specialhi.thunderTimerLoop1 <= 0) &&
             ((s32) fp->mv.ns.specialhi.thunderTimerLoop2 <= 0))
         {
-            Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialHiEnd, 0, NULL,
-                                      0.0f, 1.0f, 0.0f);
+            Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialHiEnd, 0, 0.0f,
+                                      1.0f, 0.0f, NULL);
             fighter_data2 = gobj->user_data;
             msid = fighter_data2->motion_id;
             switch (msid) {
@@ -853,8 +853,8 @@ void ftNs_SpecialHiHold_Anim(HSD_GObj* gobj) // Ness's grounded PK Thunder
         }
     } else {
         fp->fv.ns.pkthunder_gobj = NULL;
-        Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialHiEnd, 0, NULL, 0.0f,
-                                  1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialHiEnd, 0, 0.0f, 1.0f,
+                                  0.0f, NULL);
         fighter_data3 = gobj->user_data;
         ASID2 = fighter_data3->motion_id;
         switch (ASID2) {
@@ -908,8 +908,8 @@ void ftNs_SpecialHi_Anim(HSD_GObj* gobj)
     }
 
     if (!ftAnim_IsFramesRemaining(gobj)) {
-        Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialHiEnd, 0, NULL, 0.0f,
-                                  1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialHiEnd, 0, 0.0f, 1.0f,
+                                  0.0f, NULL);
         {
             Fighter* fp = gobj->user_data;
             enum_t msid = fp->motion_id;
@@ -945,8 +945,8 @@ void ftNs_SpecialAirHiStart_Anim(HSD_GObj* gobj)
     Fighter* fp = gobj->user_data;
 
     if (!ftAnim_IsFramesRemaining(gobj)) {
-        Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiHold, 0, NULL,
-                                  0.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiHold, 0, 0.0f,
+                                  1.0f, 0.0f, NULL);
 
         {
             Fighter* fp2 = gobj->user_data;
@@ -1009,8 +1009,8 @@ void ftNs_SpecialAirHiHold_Anim(HSD_GObj* gobj)
         if (fp0->mv.ns.specialhi.thunderTimerLoop1 <= 0 &&
             fp0->mv.ns.specialhi.thunderTimerLoop2 <= 0)
         {
-            Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiEnd, 0, NULL,
-                                      0, 1, 0);
+            Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiEnd, 0, 0, 1,
+                                      0, NULL);
             {
                 Fighter* fp1 = gobj->user_data;
                 enum_t msid = fp1->motion_id;
@@ -1032,8 +1032,8 @@ void ftNs_SpecialAirHiHold_Anim(HSD_GObj* gobj)
     } else if (it_802AB568(fp0->fv.ns.pkthunder_gobj) == gobj) {
         if (ftNs_SpecialHi_ItemPKThunder_CheckNessCollide(gobj) == true) {
             NessFloatMath_PKThunder2(gobj);
-            Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHi, 0, NULL,
-                                      0.0f, 1.0f, 0.0f);
+            Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHi, 0, 0.0f,
+                                      1.0f, 0.0f, NULL);
 
             {
                 Fighter* fp1 = gobj->user_data;
@@ -1060,8 +1060,8 @@ void ftNs_SpecialAirHiHold_Anim(HSD_GObj* gobj)
         }
     } else {
         fp0->fv.ns.pkthunder_gobj = NULL;
-        Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiEnd, 0, NULL, 0.0f,
-                                  1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiEnd, 0, 0.0f, 1.0f,
+                                  0.0f, NULL);
         {
             Fighter* fp1 = gobj->user_data;
             enum_t msid = fp1->motion_id;
@@ -1517,8 +1517,8 @@ void ftNs_SpecialHiStart_Coll(
     if (ft_80082708(gobj) == false) {
         ftCommon_8007D60C(fp);
         Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiStart,
-                                  FTNESS_SPECIALHI_COLL_FLAG, NULL,
-                                  fp->cur_anim_frame, 1.0f, 0.0f);
+                                  FTNESS_SPECIALHI_COLL_FLAG,
+                                  fp->cur_anim_frame, 1.0f, 0.0f, NULL);
     }
 }
 
@@ -1533,8 +1533,8 @@ void ftNs_SpecialHiHold_Coll(HSD_GObj* gobj) // Ness's grounded PK Thunder
     if (ft_80082708(gobj) == false) {
         ftCommon_8007D60C(fp);
         Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiHold,
-                                  FTNESS_SPECIALHI_COLL_FLAG, NULL,
-                                  fp->cur_anim_frame, 1.0f, 0.0f);
+                                  FTNESS_SPECIALHI_COLL_FLAG,
+                                  fp->cur_anim_frame, 1.0f, 0.0f, NULL);
     }
 }
 
@@ -1549,8 +1549,8 @@ void ftNs_SpecialHiEnd_Coll(
     if (ft_80082708(gobj) == false) {
         ftCommon_8007D60C(fp);
         Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiEnd,
-                                  FTNESS_SPECIALHI_COLL_FLAG, NULL,
-                                  fp->cur_anim_frame, 1.0f, 0.0f);
+                                  FTNESS_SPECIALHI_COLL_FLAG,
+                                  fp->cur_anim_frame, 1.0f, 0.0f, NULL);
     }
 }
 
@@ -1592,15 +1592,15 @@ void ftNs_SpecialHi_Coll(HSD_GObj* gobj)
             }
 
             Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiEnd,
-                                      FTNESS_SPECIALHI_COLL_FLAG, NULL,
-                                      fp0->cur_anim_frame, 1, 0);
+                                      FTNESS_SPECIALHI_COLL_FLAG,
+                                      fp0->cur_anim_frame, 1, 0, NULL);
             return;
         }
 
         ftCommon_8007D60C(fp0);
         Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHi,
-                                  FTNESS_JIBAKU_COLL_FLAG, NULL,
-                                  fp0->cur_anim_frame, 1, 0);
+                                  FTNESS_JIBAKU_COLL_FLAG, fp0->cur_anim_frame,
+                                  1, 0, NULL);
         return;
     }
 
@@ -1680,8 +1680,8 @@ void ftNs_SpecialAirHiStart_Coll(
     if (ft_80081D0C(gobj) != false) {
         ftCommon_8007D7FC(fp);
         Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialHiStart,
-                                  FTNESS_SPECIALHI_COLL_FLAG, NULL,
-                                  fp->cur_anim_frame, 1.0f, 0.0f);
+                                  FTNESS_SPECIALHI_COLL_FLAG,
+                                  fp->cur_anim_frame, 1.0f, 0.0f, NULL);
     }
 }
 
@@ -1697,8 +1697,8 @@ void ftNs_SpecialAirHiHold_Coll(
     if (ft_80081D0C(gobj) != false) {
         ftCommon_8007D7FC(fp);
         Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialHiHold,
-                                  FTNESS_SPECIALHI_COLL_FLAG, NULL,
-                                  fp->cur_anim_frame, 1.0f, 0.0f);
+                                  FTNESS_SPECIALHI_COLL_FLAG,
+                                  fp->cur_anim_frame, 1.0f, 0.0f, NULL);
     }
 }
 
@@ -1713,8 +1713,8 @@ void ftNs_SpecialAirHiEnd_Coll(
     if (ft_80081D0C(gobj) != false) {
         ftCommon_8007D7FC(fp);
         Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialHiEnd,
-                                  FTNESS_SPECIALHI_COLL_FLAG, NULL,
-                                  fp->cur_anim_frame, 1.0f, 0.0f);
+                                  FTNESS_SPECIALHI_COLL_FLAG,
+                                  fp->cur_anim_frame, 1.0f, 0.0f, NULL);
     }
 }
 
@@ -1813,8 +1813,8 @@ void ftNs_SpecialAirHi_Coll(HSD_GObj* gobj)
 
         ftCommon_8007D7FC(fighter_r31);
         Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialHi,
-                                  FTNESS_JIBAKU_COLL_FLAG, NULL,
-                                  fighter_r31->cur_anim_frame, 1, 0);
+                                  FTNESS_JIBAKU_COLL_FLAG,
+                                  fighter_r31->cur_anim_frame, 1, 0, NULL);
         return;
     }
 
@@ -1851,7 +1851,7 @@ void ftNs_SpecialAirHi_Coll(HSD_GObj* gobj)
             new_var->facing_dir = phi_f0;
             ftNs_SpecialHiStopGFX(gobj);
             Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiRebound,
-                                      Ft_MF_KeepGfx, NULL, 0.0f, 1.0f, 0.0f);
+                                      Ft_MF_KeepGfx, 0.0f, 1.0f, 0.0f, NULL);
             ftAnim_8006EBA4(gobj);
             spC4.x = atan2f(-fighter_r31->coll_data.ceiling.normal.x,
                             fighter_r31->coll_data.ceiling.normal.y);
@@ -1886,8 +1886,8 @@ void ftNs_SpecialAirHi_Coll(HSD_GObj* gobj)
                 fighter_data4->facing_dir = phi_f0;
                 ftNs_SpecialHiStopGFX(gobj);
                 Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiRebound,
-                                          Ft_MF_KeepGfx, NULL, 0.0f, 1.0f,
-                                          0.0f);
+                                          Ft_MF_KeepGfx, 0.0f, 1.0f, 0.0f,
+                                          NULL);
                 ftAnim_8006EBA4(gobj);
                 spB8.x = atan2f(-fighter_r31->coll_data.right_wall.normal.x,
                                 fighter_r31->coll_data.right_wall.normal.y);
@@ -1924,8 +1924,8 @@ void ftNs_SpecialAirHi_Coll(HSD_GObj* gobj)
                 fighter_data5->facing_dir = phi_f0;
                 ftNs_SpecialHiStopGFX(gobj);
                 Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirHiRebound,
-                                          Ft_MF_KeepGfx, NULL, 0.0f, 1.0f,
-                                          0.0f);
+                                          Ft_MF_KeepGfx, 0.0f, 1.0f, 0.0f,
+                                          NULL);
                 ftAnim_8006EBA4(gobj);
                 spAC.x = atan2f(-fighter_r31->coll_data.left_wall.normal.x,
                                 fighter_r31->coll_data.left_wall.normal.y);

--- a/src/melee/ft/chara/ftNess/ftNs_SpecialLw.c
+++ b/src/melee/ft/chara/ftNess/ftNs_SpecialLw.c
@@ -45,7 +45,7 @@ void ftNs_SpecialLwStart_Enter(HSD_GObj* gobj) // Ness's grounded PSI Magnet
     temp_fp->mv.ns.speciallw.gravityDelay =
         (s32) ness_attr->x84_PSI_MAGNET_FRAMES_BEFORE_GRAVITY;
     temp_fp->mv.ns.speciallw.x10 = 0;
-    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialLwStart, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialLwStart, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -72,8 +72,8 @@ void ftNs_SpecialAirLwStart_Enter(
     temp_fp->mv.ns.speciallw.x10 = 0;
     temp_fp->self_vel.y = 0.0f;
     temp_fp->self_vel.x /= ness_attr->x88_PSI_MAGNET_MOMENTUM_PRESERVATION;
-    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirLwStart, 0, NULL, 0.0f,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirLwStart, 0, 0.0f, 1.0f,
+                              0.0f, NULL);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -222,8 +222,8 @@ void ftNs_SpecialLwStart_GroundToAir(
     fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
     Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirLwStart,
-                              FTNESS_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+                              FTNESS_SPECIALLW_COLL_FLAG, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
 }
 
 // 0x8011A240
@@ -237,8 +237,8 @@ void ftNs_SpecialAirLwStart_AirToGround(
     fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
     Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialLwStart,
-                              FTNESS_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+                              FTNESS_SPECIALLW_COLL_FLAG, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
     ftCommon_8007D468(fp);
 }
 
@@ -405,8 +405,8 @@ void ftNs_SpecialLwHold_GroundToAir(
     fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
     Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirLwHold,
-                              FTNESS_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+                              FTNESS_SPECIALLW_COLL_FLAG, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
     fp = GET_FIGHTER(gobj);
     ness_attr = fp->dat_attrs;
     ftColl_CreateAbsorbHit(gobj, &ness_attr->x98_PSI_MAGNET_ABSORPTION);
@@ -429,8 +429,8 @@ void ftNs_SpecialAirLwHold_AirToGround(
     fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
     Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialLwHold,
-                              FTNESS_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+                              FTNESS_SPECIALLW_COLL_FLAG, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
     ftCommon_8007D468(fp);
     fp = GET_FIGHTER(gobj);
     ness_attr = fp->dat_attrs;
@@ -450,8 +450,8 @@ void ftNs_SpecialLwHold_Enter(
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialLwHold, Ft_MF_KeepGfx, NULL,
-                              0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialLwHold, Ft_MF_KeepGfx, 0.0f,
+                              1.0f, 0.0f, NULL);
     fp = GET_FIGHTER(gobj);
     ness_attr = fp->dat_attrs;
     ftColl_CreateAbsorbHit(gobj, &ness_attr->x98_PSI_MAGNET_ABSORPTION);
@@ -471,7 +471,7 @@ void ftNs_SpecialAirLwHold_Enter(
 #endif
 
     Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirLwHold, Ft_MF_KeepGfx,
-                              NULL, 0.0f, 1.0f, 0.0f);
+                              0.0f, 1.0f, 0.0f, NULL);
     fp = GET_FIGHTER(gobj);
     ness_attr = fp->dat_attrs;
     ftColl_CreateAbsorbHit(gobj, &ness_attr->x98_PSI_MAGNET_ABSORPTION);
@@ -646,8 +646,8 @@ void ftNs_SpecialLwTurn_GroundToAir(
     fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
     Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirLwTurn,
-                              FTNESS_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+                              FTNESS_SPECIALLW_COLL_FLAG, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
 }
 
 // 0x8011AAA8
@@ -661,8 +661,8 @@ void ftNs_SpecialAirLwTurn_AirToGround(
     fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
     Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialLwTurn,
-                              FTNESS_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+                              FTNESS_SPECIALLW_COLL_FLAG, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
     ftCommon_8007D468(fp);
 }
 
@@ -689,7 +689,7 @@ bool ftNs_SpecialLwHold_GroundOrAir(
     }
     if ((s32) fp->ground_or_air == GA_Ground) {
         Fighter_ChangeMotionState(arg0, ftNs_MS_SpecialLwHold, Ft_MF_KeepGfx,
-                                  NULL, 0.0f, 1.0f, 0.0f);
+                                  0.0f, 1.0f, 0.0f, NULL);
 
         {
             Fighter* fp = GET_FIGHTER(arg0);
@@ -698,7 +698,7 @@ bool ftNs_SpecialLwHold_GroundOrAir(
         }
     } else {
         Fighter_ChangeMotionState(arg0, ftNs_MS_SpecialAirLwHold,
-                                  Ft_MF_KeepGfx, NULL, 0.0f, 1.0f, 0.0f);
+                                  Ft_MF_KeepGfx, 0.0f, 1.0f, 0.0f, NULL);
 
         {
             Fighter* fp = GET_FIGHTER(arg0);
@@ -763,16 +763,16 @@ void ftNs_SpecialLwHit_Anim(
         } else {
             if ((s32) temp_r3_2->ground_or_air == GA_Ground) {
                 Fighter_ChangeMotionState(arg0, ftNs_MS_SpecialLwHold,
-                                          Ft_MF_KeepGfx, NULL, 0.0f, 1.0f,
-                                          0.0f);
+                                          Ft_MF_KeepGfx, 0.0f, 1.0f, 0.0f,
+                                          NULL);
 
                 temp_e1 = arg0->user_data;
                 da = temp_e1->dat_attrs;
                 ftColl_CreateAbsorbHit(arg0, &da->x98_PSI_MAGNET_ABSORPTION);
             } else {
                 Fighter_ChangeMotionState(arg0, ftNs_MS_SpecialAirLwHold,
-                                          Ft_MF_KeepGfx, NULL, 0.0f, 1.0f,
-                                          0.0f);
+                                          Ft_MF_KeepGfx, 0.0f, 1.0f, 0.0f,
+                                          NULL);
                 temp_e2 = arg0->user_data;
                 da = temp_e2->dat_attrs;
                 ftColl_CreateAbsorbHit(arg0, &da->x98_PSI_MAGNET_ABSORPTION);
@@ -927,8 +927,8 @@ void ftNs_SpecialLwHit_GroundToAir(
     fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
     Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirLwHit,
-                              FTNESS_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+                              FTNESS_SPECIALLW_COLL_FLAG, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
     fp = GET_FIGHTER(gobj);
     ness_attr = fp->dat_attrs;
     ftColl_CreateAbsorbHit(gobj, &ness_attr->x98_PSI_MAGNET_ABSORPTION);
@@ -951,8 +951,8 @@ void ftNs_SpecialAirLwHit_AirToGround(
     fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
     Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialLwHit,
-                              FTNESS_SPECIALLW_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+                              FTNESS_SPECIALLW_COLL_FLAG, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
     ftCommon_8007D468(fp);
     fp = GET_FIGHTER(gobj);
     ness_attr = fp->dat_attrs;
@@ -1006,7 +1006,7 @@ void ftNs_AbsorbThink_DecideAction(
             msid = ftNs_MS_SpecialAirLwHit;
         }
 
-        Fighter_ChangeMotionState(gobj, msid, 2, NULL, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, msid, 2, 0, 1, 0, NULL);
         ftColl_CreateAbsorbHit(gobj, &sa->x98_PSI_MAGNET_ABSORPTION);
     }
 }
@@ -1121,8 +1121,8 @@ void ftNs_SpecialLwEnd_GroundToAir(
     fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
     Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirLwEnd,
-                              FTNESS_SPECIALLW_END_FLAG, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+                              FTNESS_SPECIALLW_END_FLAG, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
 }
 
 // 0x8011B444
@@ -1136,8 +1136,8 @@ void ftNs_SpecialAirLwEnd_AirToGround(
     temp_r31 = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(temp_r31);
     Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialLwEnd,
-                              FTNESS_SPECIALLW_END_FLAG, NULL,
-                              temp_r31->cur_anim_frame, 1.0f, 0.0f);
+                              FTNESS_SPECIALLW_END_FLAG,
+                              temp_r31->cur_anim_frame, 1.0f, 0.0f, NULL);
     ftCommon_8007D468(temp_r31);
 }
 
@@ -1146,8 +1146,8 @@ void ftNs_SpecialAirLwEnd_AirToGround(
 void ftNs_SpecialLwEnd_Enter(
     HSD_GObj* gobj) // Ness's grounded PSI Magnet End Motion State handler
 {
-    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialLwEnd, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialLwEnd, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
 }
 
 // 0x8011B4E4
@@ -1155,6 +1155,6 @@ void ftNs_SpecialLwEnd_Enter(
 void ftNs_SpecialAirLwEnd_Enter(
     HSD_GObj* gobj) // Ness's aerial PSI Magnet End Motion State handler
 {
-    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirLwEnd, 0, NULL, 0.0f,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirLwEnd, 0, 0.0f, 1.0f,
+                              0.0f, NULL);
 }

--- a/src/melee/ft/chara/ftNess/ftNs_SpecialN.c
+++ b/src/melee/ft/chara/ftNess/ftNs_SpecialN.c
@@ -113,8 +113,8 @@ void ftNs_SpecialNStart_Enter(HSD_GObj* gobj)
         Fighter* fp0;
         fp0 = GET_FIGHTER(gobj);
 
-        Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialNStart, 0, NULL, 0, 1,
-                                  0);
+        Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialNStart, 0, 0, 1, 0,
+                                  NULL);
 
         fp0->cmd_vars[3] = 0;
         fp0->cmd_vars[2] = 0;
@@ -149,8 +149,8 @@ void ftNs_SpecialAirNStart_Enter(HSD_GObj* gobj)
 
     Fighter* fp = GET_FIGHTER(gobj);
 
-    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirNStart, 0, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirNStart, 0, 0, 1, 0,
+                              NULL);
 
     fp->cmd_vars[3] = 0;
     fp->cmd_vars[2] = 0;
@@ -190,7 +190,7 @@ void ftNs_SpecialNStart_Anim(HSD_GObj* gobj)
         return;
     }
 
-    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialNHold, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialNHold, 0, 0, 1, 0, NULL);
 
     {
         Fighter* fp = GET_FIGHTER(gobj);
@@ -243,15 +243,15 @@ void ftNs_SpecialNRelease_Anim(HSD_GObj* gobj)
         if (fp->mv.ns.specialn.flashTimerLoop1 <= 0 &&
             fp->mv.ns.specialn.flashTimerLoop2 <= 0)
         {
-            Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialNEnd, 0, NULL, 0, 1,
-                                      0);
+            Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialNEnd, 0, 0, 1, 0,
+                                      NULL);
 
             return;
         }
 
         if (fp->motion_id != ftNs_MS_SpecialNRelease) {
-            Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialNRelease, 0, NULL,
-                                      fp->cur_anim_frame, 1, 0);
+            Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialNRelease, 0,
+                                      fp->cur_anim_frame, 1, 0, NULL);
         }
 
         return;
@@ -265,8 +265,8 @@ void ftNs_SpecialNRelease_Anim(HSD_GObj* gobj)
     if (it_802AA7F0(fp->fv.ns.pkflash_gobj) == true &&
         fp->motion_id != ftNs_MS_SpecialNRelease)
     {
-        Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialNRelease, 0, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialNRelease, 0,
+                                  fp->cur_anim_frame, 1, 0, NULL);
     }
 }
 
@@ -313,8 +313,8 @@ void ftNs_SpecialAirNStart_Anim(HSD_GObj* gobj)
     }
 
     {
-        Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirNHold, 0, NULL, 0, 1,
-                                  0);
+        Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirNHold, 0, 0, 1, 0,
+                                  NULL);
         {
             Fighter* fighter_data2 = GET_FIGHTER(gobj);
 
@@ -369,14 +369,14 @@ void ftNs_SpecialAirNRelease_Anim(HSD_GObj* gobj)
         if (fp->mv.ns.specialn.flashTimerLoop1 <= 0 &&
             fp->mv.ns.specialn.flashTimerLoop2 <= 0)
         {
-            Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirNEnd, 0, NULL, 0,
-                                      1, 0);
+            Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirNEnd, 0, 0, 1, 0,
+                                      NULL);
             return;
         }
 
         if (fp->motion_id != ftNs_MS_SpecialAirNRelease) {
             Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirNRelease, 0,
-                                      NULL, fp->cur_anim_frame, 1, 0);
+                                      fp->cur_anim_frame, 1, 0, NULL);
         }
     } else {
         if (it_802AA7E4(fp->fv.ns.pkflash_gobj) != gobj) {
@@ -388,7 +388,7 @@ void ftNs_SpecialAirNRelease_Anim(HSD_GObj* gobj)
             fp->motion_id != ftNs_MS_SpecialAirNRelease)
         {
             Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirNRelease, 0,
-                                      NULL, fp->cur_anim_frame, 1, 0);
+                                      fp->cur_anim_frame, 1, 0, NULL);
         }
     }
 }
@@ -642,8 +642,8 @@ void ftNs_SpecialNStart_Coll(HSD_GObj* gobj)
     ftCommon_8007D5D4(fp);
 
     Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirNStart,
-                              FTNESS_SPECIALN_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              FTNESS_SPECIALN_COLL_FLAG, fp->cur_anim_frame, 1,
+                              0, NULL);
 }
 
 /// Ness's grounded PK Flash Charge Collision callback
@@ -658,8 +658,8 @@ void ftNs_SpecialNRelease_Coll(HSD_GObj* gobj)
     ftCommon_8007D5D4(fp);
 
     Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirNHold,
-                              FTNESS_SPECIALN_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              FTNESS_SPECIALN_COLL_FLAG, fp->cur_anim_frame, 1,
+                              0, NULL);
 }
 
 /// Ness's grounded PK Flash Release Collision callback
@@ -674,8 +674,8 @@ void ftNs_SpecialNEnd_Coll(HSD_GObj* gobj)
     ftCommon_8007D5D4(fp);
 
     Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirNEnd,
-                              FTNESS_SPECIALN_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              FTNESS_SPECIALN_COLL_FLAG, fp->cur_anim_frame, 1,
+                              0, NULL);
 }
 
 /// Ness's aerial PK Flash Start Collision callback
@@ -690,8 +690,8 @@ void ftNs_SpecialAirNStart_Coll(HSD_GObj* gobj)
     ftCommon_8007D7FC(fp);
 
     Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialNStart,
-                              FTNESS_SPECIALN_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              FTNESS_SPECIALN_COLL_FLAG, fp->cur_anim_frame, 1,
+                              0, NULL);
 }
 
 /// Ness's aerial PK Flash Charge Collision callback
@@ -706,8 +706,8 @@ void ftNs_SpecialAirNRelease_Coll(HSD_GObj* gobj)
     ftCommon_8007D7FC(fp);
 
     Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialNHold,
-                              FTNESS_SPECIALN_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              FTNESS_SPECIALN_COLL_FLAG, fp->cur_anim_frame, 1,
+                              0, NULL);
 }
 
 /// Ness's aerial PK Flash Release Collision callback
@@ -722,6 +722,6 @@ void ftNs_SpecialAirNEnd_Coll(HSD_GObj* gobj)
     ftCommon_8007D7FC(fp);
 
     Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialNEnd,
-                              FTNESS_SPECIALN_COLL_FLAG, NULL,
-                              fp->cur_anim_frame, 1, 0);
+                              FTNESS_SPECIALN_COLL_FLAG, fp->cur_anim_frame, 1,
+                              0, NULL);
 }

--- a/src/melee/ft/chara/ftNess/ftNs_SpecialS.c
+++ b/src/melee/ft/chara/ftNess/ftNs_SpecialS.c
@@ -78,8 +78,8 @@ void ftNs_SpecialS_Enter(
     fp = GET_FIGHTER(gobj);
     fp->throw_flags = 0; // Set projectile summon flag to 0
     fp->cmd_vars[0] = 0; // Set ftcmd flag0 to 0; _ in PK Fire?
-    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialS, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialS, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     fp->cb.x21BC_callback_Accessory4 =
         ftNs_SpecialS_ItemPKFireSpawn; // Store PK Fire spawn function
@@ -95,8 +95,8 @@ void ftNs_SpecialAirS_Enter(
     fp = GET_FIGHTER(gobj);
     fp->throw_flags = 0; // Set projectile summon flag to 0
     fp->cmd_vars[0] = 0; // Set ftcmd flag0 to 0; _ in PK Fire?
-    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirS, 0, NULL, 0.0f, 1.0f,
-                              0.0f);
+    Fighter_ChangeMotionState(gobj, ftNs_MS_SpecialAirS, 0, 0.0f, 1.0f, 0.0f,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     fp->cb.x21BC_callback_Accessory4 = ftNs_SpecialS_ItemPKFireSpawn;
 }

--- a/src/melee/ft/chara/ftPeach/ftPe_AttackS4.c
+++ b/src/melee/ft/chara/ftPeach/ftPe_AttackS4.c
@@ -25,7 +25,7 @@ void ftPe_AttackS4_Enter(HSD_GObj* gobj)
             msid = HSD_Randi(max - min + 1) + min;
         } while (msid == fp->fv.pe.attacks4_motion_id);
         fp->fv.pe.attacks4_motion_id = msid;
-        Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, 1, 0, NULL);
     }
     ftAnim_8006EBA4(gobj);
 }

--- a/src/melee/ft/chara/ftPeach/ftPe_Float.c
+++ b/src/melee/ft/chara/ftPeach/ftPe_Float.c
@@ -182,7 +182,7 @@ void ftPe_8011BB6C(HSD_GObj* gobj, bool arg1)
 #endif
     Fighter* fp = GET_FIGHTER(gobj);
     ftPe_DatAttrs* da = fp->dat_attrs;
-    Fighter_ChangeMotionState(gobj, ftPe_MS_Float, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_Float, 0, 0, 1, 0, NULL);
     fp->fv.pe.has_float = false;
     if (arg1) {
         fp->fv.pe.x4 = da->xC;
@@ -329,8 +329,8 @@ static void updateFloatDir(HSD_GObj* gobj)
     ftPeach_MotionState msid = getFloatDir(gobj);
     float anim_start = msid == ftPe_MS_FloatFallF ? da->floatfallf_anim_start
                                                   : da->floatfallb_anim_start;
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_KeepGfx, NULL,
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_KeepGfx,
                               anim_start - da->floatfall_anim_start_offset,
-                              lbl_804D97C8, lbl_804D97CC);
+                              lbl_804D97C8, lbl_804D97CC, NULL);
 }
 #endif

--- a/src/melee/ft/chara/ftPeach/ftPe_SpecialHi.c
+++ b/src/melee/ft/chara/ftPeach/ftPe_SpecialHi.c
@@ -175,8 +175,8 @@ void ftPe_SpecialHi_Enter(HSD_GObj* gobj)
 #ifdef MUST_MATCH
     u8 _[16];
 #endif
-    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialHiStart, FtMoveId_None,
-                              NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialHiStart, FtMoveId_None, 0,
+                              1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     doEnter(gobj);
 }
@@ -192,7 +192,7 @@ void ftPe_SpecialAirHi_Enter(HSD_GObj* gobj)
     fp->self_vel.y = 0;
     fp->self_vel.x *= da->x84;
     Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirHiStart, FtMoveId_None,
-                              NULL, 0, 1, 0);
+                              0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     doEnter(gobj);
 }

--- a/src/melee/ft/chara/ftPeach/ftPe_SpecialLw.c
+++ b/src/melee/ft/chara/ftPeach/ftPe_SpecialLw.c
@@ -210,8 +210,8 @@ void ftPe_SpecialLw_Enter(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     if (throwVegIfHeld(gobj, ftCo_MS_LightThrowF4) != true) {
         fp->throw_flags = 0;
-        Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialLw, Ft_MF_None, NULL, 0,
-                                  1, 0);
+        Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialLw, Ft_MF_None, 0, 1, 0,
+                                  NULL);
         ftAnim_8006EBA4(gobj);
         fp->cb.x21BC_callback_Accessory4 = spawnVeg;
     }
@@ -231,8 +231,8 @@ static void handleAirColl(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirLw, coll_mf, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirLw, coll_mf,
+                              fp->cur_anim_frame, 1, 0, NULL);
     fp->cb.x21BC_callback_Accessory4 = spawnVeg;
 }
 
@@ -241,8 +241,8 @@ static void handleColl(HSD_GObj* gobj, float lag)
     /// @todo #GET_FIGHTER
     Fighter* fp = gobj->user_data;
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialLw, coll_mf, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialLw, coll_mf,
+                              fp->cur_anim_frame, 1, 0, NULL);
     fp->cb.x21BC_callback_Accessory4 = spawnVeg;
 }
 

--- a/src/melee/ft/chara/ftPeach/ftPe_SpecialN.c
+++ b/src/melee/ft/chara/ftPeach/ftPe_SpecialN.c
@@ -158,8 +158,8 @@ void ftPe_SpecialN_Enter(HSD_GObj* gobj)
     u8 _[8];
 #endif
     GET_FIGHTER(gobj)->self_vel.y = 0;
-    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialN, Ft_MF_None, NULL, 0, 1,
-                              0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialN, Ft_MF_None, 0, 1, 0,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     reset(gobj);
 }
@@ -173,8 +173,8 @@ void ftPe_SpecialAirN_Enter(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     ftPe_DatAttrs* da = fp->dat_attrs;
     fp->self_vel.x /= da->specialairn_vel_x_div;
-    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirN, Ft_MF_None, NULL, 0,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirN, Ft_MF_None, 0, 1, 0,
+                              NULL);
     ftAnim_8006EBA4(gobj);
     reset(gobj);
 }
@@ -295,8 +295,8 @@ static void doColl(HSD_GObj* gobj)
 #endif
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirN, coll_mf, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirN, coll_mf,
+                              fp->cur_anim_frame, 1, 0, NULL);
     if (fp->cmd_vars[cmd_phys_state] == phys_state_1) {
         fp->cmd_vars[cmd_phys_state] = phys_state_2;
     }
@@ -312,8 +312,8 @@ static void doAirColl(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     fp->fv.pe.specialairn_used = false;
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialN, coll_mf, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialN, coll_mf,
+                              fp->cur_anim_frame, 1, 0, NULL);
     setupColl(gobj);
 }
 
@@ -378,8 +378,8 @@ static void doHitColl(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirNHit, coll_mf, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirNHit, coll_mf,
+                              fp->cur_anim_frame, 1, 0, NULL);
     setupHitColl(gobj);
 }
 
@@ -389,8 +389,8 @@ void doAirHitColl(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     fp->fv.pe.specialairn_used = false;
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialNHit, coll_mf, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialNHit, coll_mf,
+                              fp->cur_anim_frame, 1, 0, NULL);
     setupHitColl(gobj);
 }
 
@@ -416,7 +416,7 @@ static void onUnkHit(HSD_GObj* gobj)
     } else {
         msid = ftPe_MS_SpecialAirNHit;
     }
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 9, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 9, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     if (fp->fv.pe.toad_gobj != NULL) {
         it_802BE100(fp->fv.pe.toad_gobj);

--- a/src/melee/ft/chara/ftPeach/ftPe_SpecialS.c
+++ b/src/melee/ft/chara/ftPeach/ftPe_SpecialS.c
@@ -60,7 +60,7 @@ static inline void enter(HSD_GObj* gobj, FtMotionId msid)
     fp->cb.x21EC_callback = reset;
     fp->self_vel.y = 0;
     fp->gr_vel = da->x34 * fp->facing_dir;
-    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, msid, Ft_MF_None, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -75,8 +75,8 @@ void ftPe_SpecialS_Enter(HSD_GObj* gobj)
     fp->cb.x21EC_callback = reset;
     fp->self_vel.y = 0;
     fp->gr_vel = da->x34 * fp->facing_dir;
-    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialSStart, Ft_MF_None, NULL, 0,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialSStart, Ft_MF_None, 0, 1, 0,
+                              NULL);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -90,8 +90,8 @@ void ftPe_SpecialAirS_Enter(HSD_GObj* gobj)
     ftPe_DatAttrs* da = fp->dat_attrs;
     fp->cb.x21EC_callback = reset;
     fp->self_vel.y = da->x40;
-    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirSStart, Ft_MF_None, NULL,
-                              0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirSStart, Ft_MF_None, 0, 1,
+                              0, NULL);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -377,8 +377,8 @@ static void enterAirStart(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     fp->self_vel.x = 0;
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirSStart, start_mf, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirSStart, start_mf,
+                              fp->cur_anim_frame, 1, 0, NULL);
 }
 #endif
 
@@ -419,8 +419,8 @@ static void enterStart(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialSStart, start_mf, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialSStart, start_mf,
+                              fp->cur_anim_frame, 1, 0, NULL);
 }
 #endif
 
@@ -594,8 +594,8 @@ static void enterAirJump(HSD_GObj* gobj)
         fp->self_vel.x = da->specials_vel_x * fp->facing_dir;
     }
     fp->self_vel.y = da->specials_vel_y;
-    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirSJump, Ft_MF_None, NULL,
-                              0, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirSJump, Ft_MF_None, 0, 1,
+                              0, NULL);
     setCallbacks(gobj);
 }
 #endif
@@ -646,16 +646,16 @@ void enterAirEnd(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirSEnd_0, end_mf, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirSEnd_0, end_mf,
+                              fp->cur_anim_frame, 1, 0, NULL);
 }
 
 void enterEnd(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialSEnd, end_mf, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialSEnd, end_mf,
+                              fp->cur_anim_frame, 1, 0, NULL);
 }
 
 static void doPostEnd(HSD_GObj* gobj)
@@ -686,8 +686,8 @@ static void enterEndSmash(HSD_GObj* gobj)
 #ifdef MUST_MATCH
     u8 _[8];
 #endif
-    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialSEnd, Ft_MF_None, NULL, 0,
-                              1, 0);
+    Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialSEnd, Ft_MF_None, 0, 1, 0,
+                              NULL);
     doPostEnd(gobj);
 }
 
@@ -780,11 +780,11 @@ void enterAirEndSmash(HSD_GObj* gobj)
     fp->self_vel.x /= da->x68;
     fp->self_vel.y /= da->x6C;
     if (fp->cmd_vars[2] != 0U) {
-        Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirSEnd_1, 0, NULL,
-                                  0.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirSEnd_1, 0, 0.0f,
+                                  1.0f, 0.0f, NULL);
     } else {
-        Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirSEnd_0, 0, NULL,
-                                  0.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, ftPe_MS_SpecialAirSEnd_0, 0, 0.0f,
+                                  1.0f, 0.0f, NULL);
     }
     doPostEnd(gobj);
 }

--- a/src/melee/ft/chara/ftPikachu/ftPk_SpecialHi.c
+++ b/src/melee/ft/chara/ftPikachu/ftPk_SpecialHi.c
@@ -56,7 +56,7 @@ void ftPk_SpecialHi_Enter(HSD_GObj* gobj)
     fp->gr_vel = 0.0f;
     fp->self_vel.y = 0.0f;
     fp->self_vel.x = 0.0f;
-    Fighter_ChangeMotionState(gobj, 353, 0, 0, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 353, 0, 0.0f, 1.0f, 0.0f, 0);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -83,7 +83,7 @@ void ftPk_SpecialAirHi_Enter(HSD_GObj* gobj)
     fp->gr_vel = 0.0f;
     fp->self_vel.y = 0.0f;
     fp->self_vel.x = 0.0f;
-    Fighter_ChangeMotionState(gobj, 356, 0, 0, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 356, 0, 0.0f, 1.0f, 0.0f, 0);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -156,16 +156,16 @@ void ftPk_SpecialHi_ChangeMotion_Unk00(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D60C(fp);
-    Fighter_ChangeMotionState(gobj, 356, 206327940, 0, fp->cur_anim_frame,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 356, 206327940, fp->cur_anim_frame, 1.0f,
+                              0.0f, 0);
 }
 
 void ftPk_SpecialHi_ChangeMotion_Unk01(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, 353, 206327940, 0, fp->cur_anim_frame,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 353, 206327940, fp->cur_anim_frame, 1.0f,
+                              0.0f, 0);
 }
 
 void ftPk_SpecialHiStart1_Anim(HSD_GObj* gobj)
@@ -443,8 +443,8 @@ void ftPk_SpecialHi_ChangeMotion_Unk02(HSD_GObj* gobj)
 #endif
 
     ftCommon_8007D60C(fp);
-    Fighter_ChangeMotionState(gobj, 357, 206327946, 0, fp->cur_anim_frame,
-                              0.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 357, 206327946, fp->cur_anim_frame, 0.0f,
+                              0.0f, 0);
     fp->x2223_flag.bits.b4 = true;
     ftPk_SpecialHi_8012642C(gobj);
 }
@@ -472,8 +472,8 @@ void ftPk_SpecialHi_ChangeMotion_Unk03(HSD_GObj* gobj)
 
     fighter2 = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fighter2);
-    Fighter_ChangeMotionState(gobj, 354, 206327946, 0,
-                              fighter2->cur_anim_frame, 0.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 354, 206327946, fighter2->cur_anim_frame,
+                              0.0f, 0.0f, 0);
 
     fp = GET_FIGHTER(gobj);
     collData = &fp->coll_data;
@@ -554,10 +554,10 @@ void ftPk_SpecialHi_80126C0C(HSD_GObj* gobj)
                 // multiply ground velocity by second_zip_decay
                 fp->gr_vel *= pika_attr->x98;
 
-                Fighter_ChangeMotionState(gobj, 354, 2, 0, 12.0f, 1.0f, 0.0f);
+                Fighter_ChangeMotionState(gobj, 354, 2, 12.0f, 1.0f, 0.0f, 0);
                 ftAnim_8006EBA4(gobj);
             }
-            Fighter_ChangeMotionState(gobj, 354, 10, 0, 13.0f, 1.0f, 0.0f);
+            Fighter_ChangeMotionState(gobj, 354, 10, 13.0f, 1.0f, 0.0f, 0);
             ftAnim_8006EBA4(gobj);
             ftAnim_SetAnimRate(gobj, 0.0f);
             fp->x2223_flag.bits.b4 = 1;
@@ -640,10 +640,10 @@ void ftPk_SpecialHi_80126E1C(HSD_GObj* gobj)
         fp->self_vel.x *= pika_attr->x98;
         fp->self_vel.y *= pika_attr->x98;
 
-        Fighter_ChangeMotionState(gobj, 357, 2, 0, 12.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, 357, 2, 12.0f, 1.0f, 0.0f, 0);
         ftAnim_8006EBA4(gobj);
     }
-    Fighter_ChangeMotionState(gobj, 357, 10, 0, 13.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 357, 10, 13.0f, 1.0f, 0.0f, 0);
     ftAnim_8006EBA4(gobj);
     ftAnim_SetAnimRate(gobj, 0.0f);
     fp->x2223_flag.bits.b4 = 1;
@@ -820,8 +820,8 @@ void ftPk_SpecialHi_ChangeMotion_Unk04(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D60C(fp);
-    Fighter_ChangeMotionState(gobj, 358, 206327946, 0, fp->cur_anim_frame,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 358, 206327946, fp->cur_anim_frame, 1.0f,
+                              0.0f, 0);
 }
 
 void ftPk_SpecialHi_MotionChangeUpdateVel_Unk0(HSD_GObj* gobj)
@@ -842,7 +842,7 @@ void ftPk_SpecialHi_MotionChangeUpdateVel_Unk0(HSD_GObj* gobj)
     fp->self_vel.x = 0.0f;
     fp->gr_vel = 0.0f;
     fp->gr_vel = fp->mv.pk.unk4.x24 * pika_attr->xA4;
-    Fighter_ChangeMotionState(gobj, 355, 2, 0, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 355, 2, 0.0f, 1.0f, 0.0f, 0);
     fp->cb.x21F8_callback = &ftPk_SpecialHi_UpdateVel;
 }
 
@@ -865,6 +865,6 @@ void ftPk_SpecialHi_MotionChangeUpdateVel_Unk1(HSD_GObj* gobj)
     fp->gr_vel = 0.0f;
     fp->self_vel.x = fp->mv.pk.unk4.x1C.x * pika_attr->xA4;
     fp->self_vel.y = fp->mv.pk.unk4.x1C.y * pika_attr->xA4;
-    Fighter_ChangeMotionState(gobj, 358, 2, 0, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 358, 2, 0.0f, 1.0f, 0.0f, 0);
     fp->cb.x21F8_callback = &ftPk_SpecialHi_UpdateVel;
 }

--- a/src/melee/ft/chara/ftPikachu/ftPk_SpecialLw.c
+++ b/src/melee/ft/chara/ftPikachu/ftPk_SpecialLw.c
@@ -158,7 +158,7 @@ void ftPk_SpecialLw_Enter(HSD_GObj* gobj)
     fp->throw_flags = 0;
     fp->mv.pk.unk4.x4 = 1;
     fp->mv.pk.unk4.x0 = 0;
-    Fighter_ChangeMotionState(gobj, 359, 0, 0, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 359, 0, 0.0f, 1.0f, 0.0f, 0);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -169,7 +169,7 @@ void ftPk_SpecialAirLw_Enter(HSD_GObj* gobj)
     fp->throw_flags = 0;
     fp->mv.pk.unk4.x4 = 1;
     fp->mv.pk.unk4.x0 = 0;
-    Fighter_ChangeMotionState(gobj, 363, 0, 0, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 363, 0, 0.0f, 1.0f, 0.0f, 0);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -178,16 +178,16 @@ void ftPk_SpecialLw_ChangeMotion_Unk00(HSD_GObj* gobj, float lag)
     /// @todo #GET_FIGHTER
     Fighter* fp = gobj->user_data;
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, 359, 206327942, 0, fp->cur_anim_frame,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 359, 206327942, fp->cur_anim_frame, 1.0f,
+                              0.0f, 0);
 }
 
 void ftPk_SpecialLw_ChangeMotion_Unk01(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, 363, 206327942, 0, fp->cur_anim_frame,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 363, 206327942, fp->cur_anim_frame, 1.0f,
+                              0.0f, 0);
     ftCommon_8007D468(fp);
 }
 
@@ -196,8 +196,8 @@ void ftPk_SpecialLw_ChangeMotion_Unk02(HSD_GObj* gobj, float lag)
     /// @todo #GET_FIGHTER
     Fighter* fp = gobj->user_data;
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, 360, 206329998, 0, fp->cur_anim_frame,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 360, 206329998, fp->cur_anim_frame, 1.0f,
+                              0.0f, 0);
     fp->cb.x21DC_callback_OnTakeDamage = &ftPk_SpecialLw_SetState_Unk1;
     fp->cb.x21BC_callback_Accessory4 = &ftPk_SpecialLw_SpawnEffect;
 }
@@ -206,8 +206,8 @@ void ftPk_SpecialLw_ChangeMotion_Unk03(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, 364, 206329998, 0, fp->cur_anim_frame,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 364, 206329998, fp->cur_anim_frame, 1.0f,
+                              0.0f, 0);
     fp->cb.x21DC_callback_OnTakeDamage = &ftPk_SpecialLw_SetState_Unk1;
     fp->cb.x21BC_callback_Accessory4 = &ftPk_SpecialLw_SpawnEffect;
     ftCommon_8007D468(fp);
@@ -218,16 +218,16 @@ void ftPk_SpecialLw_ChangeMotion_Unk04(HSD_GObj* gobj, float lag)
     /// @todo #GET_FIGHTER
     Fighter* fp = gobj->user_data;
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, 361, 206327950, 0, fp->cur_anim_frame,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 361, 206327950, fp->cur_anim_frame, 1.0f,
+                              0.0f, 0);
 }
 
 void ftPk_SpecialLw_ChangeMotion_Unk05(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, 365, 206327950, 0, fp->cur_anim_frame,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 365, 206327950, fp->cur_anim_frame, 1.0f,
+                              0.0f, 0);
     ftCommon_8007D468(fp);
 }
 
@@ -236,16 +236,16 @@ void ftPk_SpecialLw_ChangeMotion_Unk06(HSD_GObj* gobj, float lag)
     /// @todo #GET_FIGHTER
     Fighter* fp = gobj->user_data;
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, 362, 206327942, 0, fp->cur_anim_frame,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 362, 206327942, fp->cur_anim_frame, 1.0f,
+                              0.0f, 0);
 }
 
 void ftPk_SpecialLw_ChangeMotion_Unk07(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, 366, 206327942, 0, fp->cur_anim_frame,
-                              1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 366, 206327942, fp->cur_anim_frame, 1.0f,
+                              0.0f, 0);
     ftCommon_8007D468(fp);
 }
 
@@ -259,7 +259,7 @@ void ftPk_SpecialLwStart_Anim(HSD_GObj* gobj)
     if (!ftAnim_IsFramesRemaining(gobj)) {
         Fighter* fighter_copy;
         Fighter* fp = GET_FIGHTER(gobj);
-        Fighter_ChangeMotionState(gobj, 360, 2048, 0, 0.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, 360, 2048, 0.0f, 1.0f, 0.0f, 0);
         fighter_copy = GET_FIGHTER(gobj);
         fighter_copy->throw_flags = 0;
         fighter_copy->cb.x21DC_callback_OnTakeDamage =
@@ -278,7 +278,7 @@ void ftPk_SpecialAirLwStart_Anim(HSD_GObj* gobj)
     if (!ftAnim_IsFramesRemaining(gobj)) {
         Fighter* fighter_copy;
         Fighter* fp = GET_FIGHTER(gobj);
-        Fighter_ChangeMotionState(gobj, 364, 2048, 0, 0.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, 364, 2048, 0.0f, 1.0f, 0.0f, 0);
         fighter_copy = GET_FIGHTER(gobj);
         fighter_copy->throw_flags = 0;
         fighter_copy->cb.x21DC_callback_OnTakeDamage =
@@ -297,12 +297,12 @@ void ftPk_SpecialLwLoop0_Anim(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     if ((fp->mv.pk.unk4.x4 == 3) || fp->cmd_vars[0]) {
         fp->cb.x21DC_callback_OnTakeDamage = 0;
-        Fighter_ChangeMotionState(gobj, 362, 0, 0, 0.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, 362, 0, 0.0f, 1.0f, 0.0f, 0);
         return;
     }
     if (ftPk_SpecialLw_8012765C(gobj)) {
         Fighter* fighter_copy = GET_FIGHTER(gobj);
-        Fighter_ChangeMotionState(gobj, 361, 0, 0, 0.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, 361, 0, 0.0f, 1.0f, 0.0f, 0);
         fighter_copy->cmd_vars[0] = 0;
         fighter_copy->cb.x21DC_callback_OnTakeDamage = 0;
         fp = GET_FIGHTER(gobj);
@@ -321,13 +321,13 @@ void ftPk_SpecialAirLwLoop0_Anim(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     if ((fp->mv.pk.unk4.x4 == 3) || fp->cmd_vars[0]) {
         fp->cb.x21DC_callback_OnTakeDamage = 0;
-        Fighter_ChangeMotionState(gobj, 366, 0, 0, 0.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, 366, 0, 0.0f, 1.0f, 0.0f, 0);
         return;
     }
     if (ftPk_SpecialLw_8012765C(gobj)) {
         Fighter* fighter_copy = GET_FIGHTER(gobj);
         ftPikachuAttributes* pika_attr = fighter_copy->dat_attrs;
-        Fighter_ChangeMotionState(gobj, 365, 0, 0, 0.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, 365, 0, 0.0f, 1.0f, 0.0f, 0);
         fighter_copy->cmd_vars[0] = 0;
         fighter_copy->cb.x21DC_callback_OnTakeDamage = NULL;
         fighter_copy->self_vel.y = (f32) pika_attr->xB4;
@@ -342,7 +342,7 @@ void ftPk_SpecialLwLoop1_Anim(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     if (fp->cmd_vars[0]) {
         fp->cb.x21DC_callback_OnTakeDamage = 0;
-        Fighter_ChangeMotionState(gobj, 362, 0, 0, 0.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, 362, 0, 0.0f, 1.0f, 0.0f, 0);
     }
 }
 
@@ -351,7 +351,7 @@ void ftPk_SpecialAirLwLoop1_Anim(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     if (fp->cmd_vars[0]) {
         fp->cb.x21DC_callback_OnTakeDamage = 0;
-        Fighter_ChangeMotionState(gobj, 366, 0, 0, 0.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, 366, 0, 0.0f, 1.0f, 0.0f, 0);
     }
 }
 

--- a/src/melee/ft/chara/ftPikachu/ftPk_SpecialN.c
+++ b/src/melee/ft/chara/ftPikachu/ftPk_SpecialN.c
@@ -23,7 +23,7 @@
 void ftPk_SpecialN_Enter(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    Fighter_ChangeMotionState(gobj, 341, 0, 0, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 341, 0, 0.0f, 1.0f, 0.0f, 0);
     fp->cmd_vars[3] = 0;
     fp->cmd_vars[2] = 0;
     fp->cmd_vars[1] = 0;
@@ -34,7 +34,7 @@ void ftPk_SpecialN_Enter(HSD_GObj* gobj)
 void ftPk_SpecialAirN_Enter(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    Fighter_ChangeMotionState(gobj, 342, 0, 0, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 342, 0, 0.0f, 1.0f, 0.0f, 0);
     fp->cmd_vars[3] = 0;
     fp->cmd_vars[2] = 0;
     fp->cmd_vars[1] = 0;
@@ -140,8 +140,8 @@ void ftPk_SpecialN_Coll(HSD_GObj* gobj)
     if (!ft_80082708(gobj)) {
         fp = GET_FIGHTER(gobj);
         ftCommon_8007D5D4(fp);
-        Fighter_ChangeMotionState(gobj, 342, 206327938, 0, fp->cur_anim_frame,
-                                  1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, 342, 206327938, fp->cur_anim_frame,
+                                  1.0f, 0.0f, 0);
     }
 }
 
@@ -152,8 +152,8 @@ void ftPk_SpecialAirN_Coll(HSD_GObj* gobj)
         fp = GET_FIGHTER(gobj);
         ftCommon_8007D7FC(fp);
         fp->self_vel.y = 0.0f;
-        Fighter_ChangeMotionState(gobj, 341, 206327938, 0, fp->cur_anim_frame,
-                                  1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, 341, 206327938, fp->cur_anim_frame,
+                                  1.0f, 0.0f, 0);
     }
 }
 

--- a/src/melee/ft/chara/ftPikachu/ftPk_SpecialS.c
+++ b/src/melee/ft/chara/ftPikachu/ftPk_SpecialS.c
@@ -25,7 +25,7 @@ void ftPk_SpecialS_Enter(HSD_GObj* gobj)
     fp->cb.x21EC_callback = ftPk_SpecialN_80124DC8;
 
     fp->gr_vel /= sa->x30;
-    Fighter_ChangeMotionState(gobj, 343, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 343, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -43,7 +43,7 @@ void ftPk_SpecialAirS_Enter(HSD_GObj* gobj)
 
     fp->self_vel.x /= sa->x30;
     fp->self_vel.y = 0;
-    Fighter_ChangeMotionState(gobj, 348, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 348, 0, 0, 1, 0, 0);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -122,16 +122,16 @@ void ftPk_SpecialS_ChangeMotion_Unk00(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, 348, transition_flags0, 0,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, 348, transition_flags0, fp->cur_anim_frame,
+                              1, 0, 0);
 }
 
 void ftPk_SpecialS_ChangeMotion_Unk01(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, 343, transition_flags0, 0,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 343, transition_flags0, fp->cur_anim_frame,
+                              1.0f, 0.0f, 0);
 }
 
 void ftPk_SpecialSHold_Anim(HSD_GObj* gobj)
@@ -227,16 +227,16 @@ void ftPk_SpecialS_ChangeMotion_Unk02(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, 349, transition_flags1, 0,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, 349, transition_flags1, fp->cur_anim_frame,
+                              1, 0, 0);
 }
 
 void ftPk_SpecialS_ChangeMotion_Unk03(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, 344, transition_flags1, 0,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, 344, transition_flags1, fp->cur_anim_frame,
+                              1, 0, 0);
 }
 
 void ftPk_SpecialS_ChangeMotion_Unk04(HSD_GObj* gobj)
@@ -245,7 +245,7 @@ void ftPk_SpecialS_ChangeMotion_Unk04(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, 344, Ft_MF_KeepSfx, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 344, Ft_MF_KeepSfx, 0, 1, 0, 0);
 
     {
         Fighter* fp = GET_FIGHTER(gobj);
@@ -260,7 +260,7 @@ void ftPk_SpecialS_ChangeMotion_Unk05(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, 349, Ft_MF_KeepSfx, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 349, Ft_MF_KeepSfx, 0, 1, 0, 0);
 
     {
         Fighter* fp = GET_FIGHTER(gobj);
@@ -346,16 +346,16 @@ void ftPk_SpecialS_ChangeMotion_Unk06(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, 352, transition_flags2, 0,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, 352, transition_flags2, fp->cur_anim_frame,
+                              1, 0, 0);
 }
 
 void ftPk_SpecialS_ChangeMotion_Unk07(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, 347, transition_flags2, 0,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, 347, transition_flags2, fp->cur_anim_frame,
+                              1, 0, 0);
 }
 
 void ftPk_SpecialS_ChangeMotion_Unk08(HSD_GObj* gobj)
@@ -365,7 +365,7 @@ void ftPk_SpecialS_ChangeMotion_Unk08(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, 347, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 347, 0, 0, 1, 0, 0);
     {
         Fighter* fp = GET_FIGHTER(gobj);
         fp->cmd_vars[0] = 0;
@@ -381,7 +381,7 @@ void ftPk_SpecialS_ChangeMotion_Unk09(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, 352, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 352, 0, 0, 1, 0, 0);
 
     {
         Fighter* fp = GET_FIGHTER(gobj);
@@ -463,8 +463,8 @@ void ftPk_SpecialS_ChangeMotion_Unk10(HSD_GObj* gobj)
         fp->self_vel.y = 0.5f * sa->x44 + sa->x44 * temp;
     }
 
-    Fighter_ChangeMotionState(gobj, 350, transition_flags3, 0,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, 350, transition_flags3, fp->cur_anim_frame,
+                              1, 0, 0);
 
     fp->cb.x21F8_callback = &ftCommon_8007F76C;
     fp->cb.x21C0_callback_OnGiveDamage = &ftPk_SpecialS_ZeroVelocity;
@@ -543,7 +543,7 @@ void ftPk_SpecialS_ChangeMotion_Unk11(HSD_GObj* gobj)
     fp->cmd_vars[0] = 0;
     fp->gr_vel /= sa->x50;
 
-    Fighter_ChangeMotionState(gobj, 346, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 346, 0, 0, 1, 0, 0);
 }
 
 void ftPk_SpecialS_ChangeMotion_Unk12(HSD_GObj* gobj)
@@ -559,5 +559,5 @@ void ftPk_SpecialS_ChangeMotion_Unk12(HSD_GObj* gobj)
     fp->cmd_vars[0] = 0;
     fp->self_vel.x /= sa->x50;
 
-    Fighter_ChangeMotionState(gobj, 351, 0, 0, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 351, 0, 0, 1, 0, 0);
 }

--- a/src/melee/ft/chara/ftPopo/ftPp_Init.c
+++ b/src/melee/ft/chara/ftPopo/ftPp_Init.c
@@ -466,8 +466,8 @@ void ftPp_SpecialN_Enter(HSD_GObj* gobj)
     fp->cmd_vars[0] = 0;
     fp->fv.nn.x222C = 0;
 
-    Fighter_ChangeMotionState(gobj, 341, 0, NULL, ftPp_Init_804D9838,
-                              ftPp_Init_804D983C, ftPp_Init_804D9838);
+    Fighter_ChangeMotionState(gobj, 341, 0, ftPp_Init_804D9838,
+                              ftPp_Init_804D983C, ftPp_Init_804D9838, NULL);
 
     ftAnim_8006EBA4(gobj);
     fp->cb.x21BC_callback_Accessory4 = &ftPp_SpecialN_8011F500;
@@ -497,8 +497,8 @@ void ftPp_SpecialAirN_Enter(HSD_GObj* gobj)
         fp->fv.nn.x2250 = ftPp_Init_804D9840;
     }
 
-    Fighter_ChangeMotionState(gobj, 342, 0, NULL, ftPp_Init_804D9838,
-                              ftPp_Init_804D983C, ftPp_Init_804D9838);
+    Fighter_ChangeMotionState(gobj, 342, 0, ftPp_Init_804D9838,
+                              ftPp_Init_804D983C, ftPp_Init_804D9838, NULL);
 
     ftAnim_8006EBA4(gobj);
     fp->cb.x21BC_callback_Accessory4 = &ftPp_SpecialN_8011F500;

--- a/src/melee/ft/chara/ftPurin/ftPr_Init.c
+++ b/src/melee/ft/chara/ftPurin/ftPr_Init.c
@@ -657,11 +657,13 @@ inline void ftPurin_SpecialHi_SetActionFromFacingDirection(HSD_GObj* gobj,
     Fighter* fighter = getFighter(gobj);
 
     if (ftPr_Init_804D9C10 == fighter->facing_dir) {
-        Fighter_ChangeMotionState(gobj, left_id, 0, NULL, ftPr_Init_804D9C14,
-                                  ftPr_Init_804D9C18, ftPr_Init_804D9C14);
+        Fighter_ChangeMotionState(gobj, left_id, 0, ftPr_Init_804D9C14,
+                                  ftPr_Init_804D9C18, ftPr_Init_804D9C14,
+                                  NULL);
     } else {
-        Fighter_ChangeMotionState(gobj, right_id, 0, NULL, ftPr_Init_804D9C14,
-                                  ftPr_Init_804D9C18, ftPr_Init_804D9C14);
+        Fighter_ChangeMotionState(gobj, right_id, 0, ftPr_Init_804D9C14,
+                                  ftPr_Init_804D9C18, ftPr_Init_804D9C14,
+                                  NULL);
     }
 }
 
@@ -676,11 +678,13 @@ inline void startHi(HSD_GObj* gobj, int left_id, int right_id)
     fighter = (Fighter*) HSD_GObjGetUserData(gobj);
 
     if (ftPr_Init_804D9C10 == fighter->facing_dir) {
-        Fighter_ChangeMotionState(gobj, left_id, 0, NULL, ftPr_Init_804D9C14,
-                                  ftPr_Init_804D9C18, ftPr_Init_804D9C14);
+        Fighter_ChangeMotionState(gobj, left_id, 0, ftPr_Init_804D9C14,
+                                  ftPr_Init_804D9C18, ftPr_Init_804D9C14,
+                                  NULL);
     } else {
-        Fighter_ChangeMotionState(gobj, right_id, 0, NULL, ftPr_Init_804D9C14,
-                                  ftPr_Init_804D9C18, ftPr_Init_804D9C14);
+        Fighter_ChangeMotionState(gobj, right_id, 0, ftPr_Init_804D9C14,
+                                  ftPr_Init_804D9C18, ftPr_Init_804D9C14,
+                                  NULL);
     }
 }
 
@@ -885,13 +889,13 @@ void ftPr_SpecialHi_8013CD34(HSD_GObj* gobj)
     ftCommon_8007D5D4(fp);
 
     if (ftPr_Init_804D9C10 == fp->facing_dir) {
-        Fighter_ChangeMotionState(gobj, 366, 0x0C4C508A, NULL,
-                                  fp->cur_anim_frame, ftPr_Init_804D9C18,
-                                  ftPr_Init_804D9C14);
+        Fighter_ChangeMotionState(gobj, 366, 0x0C4C508A, fp->cur_anim_frame,
+                                  ftPr_Init_804D9C18, ftPr_Init_804D9C14,
+                                  NULL);
     } else {
-        Fighter_ChangeMotionState(gobj, 368, 0x0C4C508A, NULL,
-                                  fp->cur_anim_frame, ftPr_Init_804D9C18,
-                                  ftPr_Init_804D9C14);
+        Fighter_ChangeMotionState(gobj, 368, 0x0C4C508A, fp->cur_anim_frame,
+                                  ftPr_Init_804D9C18, ftPr_Init_804D9C14,
+                                  NULL);
     }
 
     fp->cb.x21BC_callback_Accessory4 = ftPr_Init_8013C94C;

--- a/src/melee/ft/chara/ftSamus/ftSs_SpecialHi.c
+++ b/src/melee/ft/chara/ftSamus/ftSs_SpecialHi.c
@@ -22,7 +22,7 @@ void ftSs_SpecialHi_Enter(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, 353, 0, NULL, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 353, 0, 0.0f, 1.0f, 0.0f, NULL);
     ftSamus_updateDamageDeathCBs(gobj);
     fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
     fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;
@@ -42,7 +42,7 @@ void ftSs_SpecialAirHi_Enter(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     ftSs_DatAttrs* samus_attr = fp->dat_attrs;
 
-    Fighter_ChangeMotionState(gobj, 354, 0, NULL, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 354, 0, 0.0f, 1.0f, 0.0f, NULL);
     ftSamus_updateDamageDeathCBs(gobj);
     fp->cb.x21D4_callback_EnterHitlag = efLib_PauseAll;
     fp->cb.x21D8_callback_ExitHitlag = efLib_ResumeAll;

--- a/src/melee/ft/chara/ftSamus/ftSs_SpecialLw_0.c
+++ b/src/melee/ft/chara/ftSamus/ftSs_SpecialLw_0.c
@@ -111,7 +111,7 @@ void ftSs_Init_80128B1C(HSD_GObj* gobj, f32 angle, f32 arg9, f32 argA)
     if (fp->ground_or_air == GA_Ground) {
         ftCommon_8007D5D4(fighter2);
     }
-    Fighter_ChangeMotionState(gobj, 0x156, 0, 0, arg9, argA, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x156, 0, arg9, argA, 0.0f, 0);
     ftAnim_8006EBA4(gobj);
 }
 
@@ -267,16 +267,16 @@ void ftSs_SpecialLw_80129048(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, 0x156, 0x10, 0, fp->cur_anim_frame,
-                              fp->frame_spd_mul, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x156, 0x10, fp->cur_anim_frame,
+                              fp->frame_spd_mul, 0.0f, 0);
 }
 
 void ftSs_SpecialLw_801290A4(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, 0x155, 0x10, 0, fp->cur_anim_frame,
-                              fp->frame_spd_mul, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x155, 0x10, fp->cur_anim_frame,
+                              fp->frame_spd_mul, 0.0f, 0);
 }
 
 int ftSs_SpecialLw_80129100(HSD_GObj* gobj, s32* arg1, s32* arg2)

--- a/src/melee/ft/chara/ftSamus/ftSs_SpecialLw_1.c
+++ b/src/melee/ft/chara/ftSamus/ftSs_SpecialLw_1.c
@@ -86,13 +86,13 @@ void ftSs_SpecialLw_Enter(HSD_GObj* gobj)
 
     fp->gr_vel *= samus_attr->x6C;
     if (fp->motion_id == 0x28) {
-        Fighter_ChangeMotionState(gobj, 0x163, 0, NULL, 3.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, 0x163, 0, 3.0f, 1.0f, 0.0f, NULL);
         ftSamus_SpecialLw_StartAction_inner(gobj);
         fp->cmd_vars[1] = 2;
         ftSs_SpecialLw_8012B5F0(gobj);
         return;
     }
-    Fighter_ChangeMotionState(gobj, 0x163, 0, NULL, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x163, 0, 0.0f, 1.0f, 0.0f, NULL);
     ftAnim_8006EBA4(gobj);
     ftSamus_SpecialLw_StartAction_inner(gobj);
 }
@@ -110,7 +110,7 @@ void ftSs_SpecialAirLw_Enter(HSD_GObj* gobj)
     fp->self_vel.x *= samus_attr->x70;
     fp->self_vel.y = samus_attr->x58;
 
-    Fighter_ChangeMotionState(gobj, 0x164, 0, NULL, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x164, 0, 0.0f, 1.0f, 0.0f, NULL);
     ftAnim_8006EBA4(gobj);
     ftSamus_SpecialLw_StartAction_inner(gobj);
 }
@@ -412,8 +412,8 @@ void ftSs_SpecialLw_8012B570(HSD_GObj* gobj)
 {
     Fighter* fp = getFighter(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, 0x164, 0x0C4C509C, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x164, 0x0C4C509C, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
     ftSamus_UnkSetStateAndCb(gobj);
 }
 
@@ -423,8 +423,8 @@ void ftSs_SpecialLw_8012B5F0(HSD_GObj* gobj)
     ftSs_DatAttrs* samus_attr = getFtSpecialAttrs(fp);
     fp->self_vel.y = samus_attr->x54;
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, 0x164, 0x0C4C509C, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x164, 0x0C4C509C, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
     fp->cb.x21BC_callback_Accessory4 = ftSs_SpecialLw_8012ADF0;
 }
 
@@ -432,7 +432,7 @@ void ftSs_SpecialLw_8012B668(HSD_GObj* gobj)
 {
     Fighter* fp = getFighter(gobj);
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, 0x163, 0x0C4C509C, NULL,
-                              fp->cur_anim_frame, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x163, 0x0C4C509C, fp->cur_anim_frame,
+                              1.0f, 0.0f, NULL);
     ftSamus_UnkSetStateAndCb(gobj);
 }

--- a/src/melee/ft/chara/ftSamus/ftSs_SpecialN.c
+++ b/src/melee/ft/chara/ftSamus/ftSs_SpecialN.c
@@ -149,7 +149,7 @@ void ftSs_SpecialN_Enter(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, 343, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 343, 0, 0, 1, 0, NULL);
     fp->cmd_vars[3] = 0;
     fp->cmd_vars[2] = 0;
     fp->cmd_vars[1] = 0;
@@ -173,7 +173,7 @@ void ftSs_SpecialAirN_Enter(HSD_GObj* gobj)
     u8 _[8];
 #endif
 
-    Fighter_ChangeMotionState(gobj, 347, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 347, 0, 0, 1, 0, NULL);
     fp->cmd_vars[3] = 0;
     fp->cmd_vars[2] = 0;
     fp->cmd_vars[1] = 0;
@@ -198,9 +198,9 @@ void ftSs_SpecialNStart_Anim(HSD_GObj* gobj)
     ftSs_SpecialN_801292E4(gobj);
     if (!ftAnim_IsFramesRemaining(gobj)) {
         if ((fp->mv.ss.unk3.x0 == 1) || (fp->fv.ss.x2230 == samus_attr->x18)) {
-            Fighter_ChangeMotionState(gobj, 346, 0, NULL, 0, 1, 0);
+            Fighter_ChangeMotionState(gobj, 346, 0, 0, 1, 0, NULL);
         } else {
-            Fighter_ChangeMotionState(gobj, 344, 0, NULL, 0, 1, 0);
+            Fighter_ChangeMotionState(gobj, 344, 0, 0, 1, 0, NULL);
             ftSamus_SetAttrx2334(gobj);
         }
         ftSamus_updateDamageDeathCBs(gobj);
@@ -247,7 +247,7 @@ void ftSs_SpecialNHold_Anim(HSD_GObj* gobj)
         if (fp->fv.ss.x2230 >= samus_attr->x18) {
             ftCo_800BFFD0(fp, 53, 0);
             fp->fv.ss.x2230 = samus_attr->x18;
-            Fighter_ChangeMotionState(gobj, 345, 0, 0, 0, 1, 0);
+            Fighter_ChangeMotionState(gobj, 345, 0, 0, 1, 0, 0);
             ftSamus_UnkAndDestroyAllEF(gobj);
             ftSamus_updateDamageDeathCBs(gobj);
         }
@@ -287,7 +287,7 @@ void ftSs_SpecialAirNStart_Anim(HSD_GObj* gobj)
     ftSs_SpecialN_801292E4(gobj);
     fp->mv.ss.unk3.x0 = 1;
     if (!ftAnim_IsFramesRemaining(gobj)) {
-        Fighter_ChangeMotionState(gobj, 348, 0, NULL, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, 348, 0, 0, 1, 0, NULL);
         ftSamus_updateDamageDeathCBs(gobj);
     }
 }
@@ -323,12 +323,12 @@ void ftSs_SpecialNHold_IASA(HSD_GObj* gobj)
         ftSamus_UnkAndDestroyAllEF(fighterObj2);
     } else {
         if ((fp->input.x668 & 512)) {
-            Fighter_ChangeMotionState(gobj, 346, 0, NULL, 0, 1, 0);
+            Fighter_ChangeMotionState(gobj, 346, 0, 0, 1, 0, NULL);
             ftSamus_updateDamageDeathCBs(gobj);
             return;
         }
         if ((fp->input.x668 & 0x80000000)) {
-            Fighter_ChangeMotionState(gobj, 345, 0, NULL, 0, 1, 0);
+            Fighter_ChangeMotionState(gobj, 345, 0, 0, 1, 0, NULL);
             ftSamus_UnkAndDestroyAllEF(gobj);
             ftSamus_updateDamageDeathCBs(gobj);
         }
@@ -379,8 +379,8 @@ void ftSs_SpecialNStart_Coll(HSD_GObj* gobj)
 
     if (!ft_80082708(gobj)) {
         ftCommon_8007D5D4(fp);
-        Fighter_ChangeMotionState(gobj, 347, 0x0C4C5080, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, 347, 0x0C4C5080, fp->cur_anim_frame, 1,
+                                  0, NULL);
         ftSamus_updateDamageDeathCBs(gobj);
     }
 }
@@ -391,8 +391,8 @@ void ftSs_SpecialNHold_Coll(HSD_GObj* gobj)
 
     if (!ft_80082708(gobj)) {
         ftCommon_8007D5D4(fp);
-        Fighter_ChangeMotionState(gobj, 348, 0x0C4C5080, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, 348, 0x0C4C5080, fp->cur_anim_frame, 1,
+                                  0, NULL);
         ftSamus_updateDamageDeathCBs(gobj);
         ft_80088148(fp, 260021, 127, 64);
         fp->cmd_vars[1] = 1;
@@ -404,8 +404,8 @@ void ftSs_SpecialNCancel_Coll(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     if (!ft_80082708(gobj)) {
         ftCommon_8007D5D4(fp);
-        Fighter_ChangeMotionState(gobj, 348, 0x0C4C5080, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, 348, 0x0C4C5080, fp->cur_anim_frame, 1,
+                                  0, NULL);
         ftSamus_updateDamageDeathCBs(gobj);
     }
 }
@@ -415,8 +415,8 @@ void ftSs_SpecialN_Coll(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     if (!ft_80082708(gobj)) {
         ftCommon_8007D5D4(fp);
-        Fighter_ChangeMotionState(gobj, 348, 0x0C4C5080, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, 348, 0x0C4C5080, fp->cur_anim_frame, 1,
+                                  0, NULL);
         ftSamus_updateDamageDeathCBs(gobj);
     }
 }
@@ -426,8 +426,8 @@ void ftSs_SpecialAirNStart_Coll(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     if (ft_80081D0C(gobj) == 1) {
         ftCommon_8007D7FC(fp);
-        Fighter_ChangeMotionState(gobj, 343, 0x0C4C5080, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, 343, 0x0C4C5080, fp->cur_anim_frame, 1,
+                                  0, NULL);
         ftSamus_updateDamageDeathCBs(gobj);
     }
 }
@@ -437,8 +437,8 @@ void ftSs_SpecialAirN_Coll(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     if (ft_80081D0C(gobj) == 1) {
         ftCommon_8007D7FC(fp);
-        Fighter_ChangeMotionState(gobj, 346, 0x0C4C5080, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, 346, 0x0C4C5080, fp->cur_anim_frame, 1,
+                                  0, NULL);
         ftSamus_updateDamageDeathCBs(gobj);
     }
 }

--- a/src/melee/ft/chara/ftSamus/ftSs_SpecialS.c
+++ b/src/melee/ft/chara/ftSamus/ftSs_SpecialS.c
@@ -24,10 +24,10 @@ void ftSs_SpecialS_Enter(HSD_GObj* gobj)
     fp->gr_vel /= samus_attr->x2C;
     fp->self_vel.y = 0.0f;
     if (fp->x673 < samus_attr->x28) {
-        Fighter_ChangeMotionState(gobj, 0x15E, 0, NULL, 0.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, 0x15E, 0, 0.0f, 1.0f, 0.0f, NULL);
         ftAnim_8006EBA4(gobj);
     } else {
-        Fighter_ChangeMotionState(gobj, 0x15D, 0, NULL, 0.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, 0x15D, 0, 0.0f, 1.0f, 0.0f, NULL);
         ftAnim_8006EBA4(gobj);
     }
     ftSamus_ClearThrowFlagsUnk(gobj);
@@ -39,10 +39,10 @@ void ftSs_SpecialAirS_Enter(HSD_GObj* gobj)
     ftSs_DatAttrs* samus_attr = getFtSpecialAttrs(fp);
     fp->self_vel.x /= samus_attr->x2C;
     if (fp->x673 < samus_attr->x28) {
-        Fighter_ChangeMotionState(gobj, 0x160, 0, NULL, 0.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, 0x160, 0, 0.0f, 1.0f, 0.0f, NULL);
         ftAnim_8006EBA4(gobj);
     } else {
-        Fighter_ChangeMotionState(gobj, 0x15F, 0, NULL, 0.0f, 1.0f, 0.0f);
+        Fighter_ChangeMotionState(gobj, 0x15F, 0, 0.0f, 1.0f, 0.0f, NULL);
         ftAnim_8006EBA4(gobj);
     }
     ftSamus_ClearThrowFlagsUnk(gobj);

--- a/src/melee/ft/chara/ftSandbag/ftSb_Init.c
+++ b/src/melee/ft/chara/ftSandbag/ftSb_Init.c
@@ -107,7 +107,7 @@ void ftSb_Init_8014FBA4(HSD_GObj* gobj)
         ftCommon_8007D7FC(fp);
     }
 
-    Fighter_ChangeMotionState(gobj, 0x155, 0, 0, 0.0f, 1.0f, 0.0f);
+    Fighter_ChangeMotionState(gobj, 0x155, 0, 0.0f, 1.0f, 0.0f, 0);
     ftCommon_8007EFC0(fp, p_ftCommonData->x5F0);
 }
 

--- a/src/melee/ft/chara/ftSeak/ftSk_SpecialS.c
+++ b/src/melee/ft/chara/ftSeak/ftSk_SpecialS.c
@@ -491,7 +491,7 @@ void ftSk_SpecialS_80110F70(HSD_GObj* gobj)
 
 void ftSk_SpecialS_Enter(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, 349, 0, NULL, 0.0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 349, 0, 0.0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     ftSk_SpecialS_80110F70(gobj);
 }
@@ -501,7 +501,7 @@ void ftSk_SpecialAirS_Enter(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     fp->self_vel.y = 0;
 
-    Fighter_ChangeMotionState(gobj, 352, 0, NULL, 0.0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 352, 0, 0.0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
     ftSk_SpecialS_80110F70(gobj);
 }
@@ -657,8 +657,8 @@ void ftSk_SpecialS_80111440(HSD_GObj* gobj)
 
     ftCommon_8007D5D4(fp);
     {
-        Fighter_ChangeMotionState(gobj, 352, transition_flags, NULL,
-                                  fp->cur_anim_frame, 1, 0);
+        Fighter_ChangeMotionState(gobj, 352, transition_flags,
+                                  fp->cur_anim_frame, 1, 0, NULL);
     }
 
     {
@@ -680,8 +680,8 @@ void ftSk_SpecialS_801114E4(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
 
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, 349, transition_flags, NULL,
-                              fp->cur_anim_frame, 1.0, 0.0);
+    Fighter_ChangeMotionState(gobj, 349, transition_flags, fp->cur_anim_frame,
+                              1.0, 0.0, NULL);
 
     {
         Fighter* fp2 = GET_FIGHTER(gobj);
@@ -819,7 +819,7 @@ void ftSk_SpecialS_80111830(HSD_GObj* gobj)
 
     Fighter* fp = gobj->user_data;
 
-    Fighter_ChangeMotionState(gobj, 350, 8, NULL, 0.0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 350, 8, 0.0, 1, 0, NULL);
     ftSk_SpecialS_80110610(gobj, 305, 0);
 
     fp2 = gobj->user_data;
@@ -864,7 +864,7 @@ void ftSk_SpecialS_80111830(HSD_GObj* gobj)
 
 void ftSk_SpecialS_80111988(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, 353, 8, NULL, 0.0, 1.0, 0.0);
+    Fighter_ChangeMotionState(gobj, 353, 8, 0.0, 1.0, 0.0, NULL);
     ftSk_SpecialS_80110610(gobj, 308, 0.0);
 
     {
@@ -1010,8 +1010,8 @@ void ftSk_SpecialS_80111CB0(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
 
-    Fighter_ChangeMotionState(gobj, 354, transition_flags, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, 354, transition_flags, fp->cur_anim_frame,
+                              1, 0, NULL);
 
     {
         Fighter* fp2 = gobj->user_data;
@@ -1033,8 +1033,8 @@ void ftSk_SpecialS_80111D54(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
 
-    Fighter_ChangeMotionState(gobj, 351, transition_flags, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, 351, transition_flags, fp->cur_anim_frame,
+                              1, 0, NULL);
 
     {
         Fighter* fp2 = GET_FIGHTER(gobj);
@@ -1052,7 +1052,7 @@ void ftSk_SpecialS_80111D54(HSD_GObj* gobj)
 
 void ftSk_SpecialS_80111DF8(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, 351, 8, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 351, 8, 0, 1, 0, NULL);
 
     {
         Fighter* fp = GET_FIGHTER(gobj);
@@ -1076,7 +1076,7 @@ void ftSk_SpecialS_80111DF8(HSD_GObj* gobj)
 
 void ftSk_SpecialS_80111EB4(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, 354, 8, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 354, 8, 0, 1, 0, NULL);
 
     {
         Fighter* fp = gobj->user_data;

--- a/src/melee/ft/chara/ftYoshi/ftYs_Guard.c
+++ b/src/melee/ft/chara/ftYoshi/ftYs_Guard.c
@@ -247,8 +247,8 @@ void ftYs_GuardHold_Coll(HSD_GObj* arg0)
 
 void ftYs_Shield_8012C49C(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, 343, 0, NULL, ftYs_Init_804D9A2C,
-                              ftYs_Init_804D9A28, ftYs_Init_804D9A2C);
+    Fighter_ChangeMotionState(gobj, 343, 0, ftYs_Init_804D9A2C,
+                              ftYs_Init_804D9A28, ftYs_Init_804D9A2C, NULL);
 
     {
         Fighter* fp0 = GET_FIGHTER(gobj);
@@ -483,8 +483,8 @@ void ftYs_Shield_8012C850(HSD_GObj* gobj)
     Fighter* fp;
 
     fp = getFighter(gobj);
-    Fighter_ChangeMotionState(gobj, 345, 16, NULL, fp->cur_anim_frame,
-                              ftYs_Init_804D9A28, ftYs_Init_804D9A2C);
+    Fighter_ChangeMotionState(gobj, 345, 16, fp->cur_anim_frame,
+                              ftYs_Init_804D9A28, ftYs_Init_804D9A2C, NULL);
     fp->x672_input_timer_counter = 254;
     fp->x221A_b7 = false;
     fp->x221B_b0 = false;

--- a/src/melee/ft/chara/ftZelda/ftZd_SpecialHi.c
+++ b/src/melee/ft/chara/ftZelda/ftZd_SpecialHi.c
@@ -100,7 +100,7 @@ void ftZd_SpecialHi_Enter(HSD_GObj* gobj)
     fp->self_vel.y = 0;
     fp->self_vel.x = 0;
 
-    Fighter_ChangeMotionState(gobj, 349, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 349, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 
     fp = getFighterPlus(gobj);
@@ -121,7 +121,7 @@ void ftZd_SpecialAirHi_Enter(HSD_GObj* gobj)
         fp->self_vel.x = fp->self_vel.x / attributes->x38;
         fp->self_vel.y = fp->self_vel.y / attributes->x3C;
 
-        Fighter_ChangeMotionState(gobj, 352, 0, NULL, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, 352, 0, 0, 1, 0, NULL);
         ftAnim_8006EBA4(gobj);
     }
 
@@ -224,8 +224,8 @@ void ftZd_SpecialHi_80139B44(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D60C(fp);
 
-    Fighter_ChangeMotionState(gobj, 352, transition_flags1, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, 352, transition_flags1, fp->cur_anim_frame,
+                              1, 0, NULL);
 
     fp->cb.x21BC_callback_Accessory4 = &ftZd_SpecialHi_801396AC;
 }
@@ -235,8 +235,8 @@ void ftZd_SpecialHi_80139BB0(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
 
-    Fighter_ChangeMotionState(gobj, 349, transition_flags1, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, 349, transition_flags1, fp->cur_anim_frame,
+                              1, 0, NULL);
 
     fp->cb.x21BC_callback_Accessory4 = &ftZd_SpecialHi_801396AC;
 }
@@ -389,8 +389,8 @@ void ftZd_SpecialHi_80139F6C(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D60C(fp);
 
-    Fighter_ChangeMotionState(gobj, 353, transition_flags1, NULL,
-                              fp->cur_anim_frame, 0, 0);
+    Fighter_ChangeMotionState(gobj, 353, transition_flags1, fp->cur_anim_frame,
+                              0, 0, NULL);
 
     fp->x2223_flag.bits.b4 = true;
     fp->x221E_b0 = true;
@@ -401,8 +401,8 @@ void ftZd_SpecialHi_80139FE8(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
 
-    Fighter_ChangeMotionState(gobj, 350, transition_flags1, NULL,
-                              fp->cur_anim_frame, 0, 0);
+    Fighter_ChangeMotionState(gobj, 350, transition_flags1, fp->cur_anim_frame,
+                              0, 0, NULL);
 
     fp->x221E_b0 = true;
 }
@@ -482,7 +482,7 @@ void ftZd_SpecialHi_8013A058(HSD_GObj* gobj)
                           cosf(temp_f5);
                 fp->gr_vel = fp->facing_dir * temp_f6;
 
-                Fighter_ChangeMotionState(gobj, 350, 0, NULL, 35.0, 1.0, 0);
+                Fighter_ChangeMotionState(gobj, 350, 0, 35.0, 1.0, 0, NULL);
                 ftAnim_8006EBA4(gobj);
                 ftAnim_SetAnimRate(gobj, 0);
 
@@ -577,7 +577,7 @@ void ftZd_SpecialHi_8013A244(HSD_GObj* gobj)
     fp->self_vel.y =
         ((attributes->x54 * var_f31) + attributes->x58) * sinf(var_f30);
 
-    Fighter_ChangeMotionState(gobj, 353, 0, NULL, 35.0, 1.0, 0);
+    Fighter_ChangeMotionState(gobj, 353, 0, 35.0, 1.0, 0, NULL);
     ftAnim_8006EBA4(gobj);
     ftAnim_SetAnimRate(gobj, 0);
 
@@ -691,8 +691,8 @@ void ftZd_SpecialHi_8013A648(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommon_8007D60C(fp);
-    Fighter_ChangeMotionState(gobj, 354, transition_flags0, NULL,
-                              fp->cur_anim_frame, 1, 0);
+    Fighter_ChangeMotionState(gobj, 354, transition_flags0, fp->cur_anim_frame,
+                              1, 0, NULL);
 }
 
 void ftZd_SpecialHi_8013A6A8(HSD_GObj* gobj)
@@ -700,7 +700,7 @@ void ftZd_SpecialHi_8013A6A8(HSD_GObj* gobj)
     Fighter* fp0 = GET_FIGHTER(gobj);
     ftZelda_DatAttrs* attributes = fp0->dat_attrs;
 
-    Fighter_ChangeMotionState(gobj, 351, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 351, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 
     {
@@ -723,7 +723,7 @@ void ftZd_SpecialHi_8013A764(HSD_GObj* gobj)
     Fighter* fp0 = GET_FIGHTER(gobj);
     ftZelda_DatAttrs* sa = fp0->dat_attrs;
 
-    Fighter_ChangeMotionState(gobj, 354, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 354, 0, 0, 1, 0, NULL);
     ftAnim_8006EBA4(gobj);
 
     {

--- a/src/melee/ft/chara/ftZelda/ftZd_SpecialLw.c
+++ b/src/melee/ft/chara/ftZelda/ftZd_SpecialLw.c
@@ -93,7 +93,7 @@ static void ftZelda_SpecialLw_StartAction_Helper(HSD_GObj* gobj)
 // https://decomp.me/scratch/Lw6fO (single function)
 void ftZd_SpecialLw_Enter(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, 355, 0, NULL, 0, 1, 0);
+    Fighter_ChangeMotionState(gobj, 355, 0, 0, 1, 0, NULL);
 
     ftAnim_8006EBA4(gobj);
 
@@ -106,7 +106,7 @@ void ftZd_SpecialLw_Enter(HSD_GObj* gobj)
 // https://decomp.me/scratch/8W7ZF (single function)
 void ftZd_SpecialAirLw_Enter(HSD_GObj* gobj)
 {
-    Fighter_ChangeMotionState(gobj, 357, 0, NULL, 0, 1.0, 0);
+    Fighter_ChangeMotionState(gobj, 357, 0, 0, 1.0, 0, NULL);
 
     ftAnim_8006EBA4(gobj);
 
@@ -197,8 +197,8 @@ void ftZd_SpecialLw_8013B1CC(HSD_GObj* gobj)
 
     fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, 357, 0x0C4C508E, NULL, fp->cur_anim_frame,
-                              1.0, 0);
+    Fighter_ChangeMotionState(gobj, 357, 0x0C4C508E, fp->cur_anim_frame, 1.0,
+                              0, NULL);
     fp->cb.x21BC_callback_Accessory4 = &ftZd_SpecialLw_8013ADB4;
 }
 
@@ -209,8 +209,8 @@ void ftZd_SpecialLw_8013B238(HSD_GObj* gobj)
 
     fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, 355, 0x0C4C508E, NULL, fp->cur_anim_frame,
-                              1.0, 0);
+    Fighter_ChangeMotionState(gobj, 355, 0x0C4C508E, fp->cur_anim_frame, 1.0,
+                              0, NULL);
     fp->cb.x21BC_callback_Accessory4 = &ftZd_SpecialLw_8013ADB4;
 }
 
@@ -290,8 +290,8 @@ void ftZd_SpecialLw_8013B400(HSD_GObj* gobj)
 
     fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, 358, 0x0C4C508E, NULL, fp->cur_anim_frame,
-                              1.0, 0);
+    Fighter_ChangeMotionState(gobj, 358, 0x0C4C508E, fp->cur_anim_frame, 1.0,
+                              0, NULL);
     fp->cb.x21BC_callback_Accessory4 = &ftZd_SpecialLw_8013AE30;
 }
 
@@ -303,8 +303,8 @@ void ftZd_SpecialLw_8013B46C(HSD_GObj* gobj)
 
     fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, 356, 0x0C4C508E, NULL, fp->cur_anim_frame,
-                              1.0, 0);
+    Fighter_ChangeMotionState(gobj, 356, 0x0C4C508E, fp->cur_anim_frame, 1.0,
+                              0, NULL);
     fp->cb.x21BC_callback_Accessory4 = &ftZd_SpecialLw_8013AE30;
 }
 
@@ -329,7 +329,7 @@ void ftZd_SpecialLw_8013B4D8(HSD_GObj* gobj)
             msid = 358;
         }
 
-        Fighter_ChangeMotionState(gobj, msid, 0, NULL, sa->x80, 1.0, 0);
+        Fighter_ChangeMotionState(gobj, msid, 0, sa->x80, 1.0, 0, NULL);
     }
     fp->cb.x21BC_callback_Accessory4 = &ftZd_SpecialLw_8013AE30;
 }

--- a/src/melee/ft/chara/ftZelda/ftZd_SpecialN.c
+++ b/src/melee/ft/chara/ftZelda/ftZd_SpecialN.c
@@ -62,7 +62,7 @@ void ftZd_SpecialN_Enter(HSD_GObj* gobj)
     temp_f1 = 0;
     fp = GET_FIGHTER(gobj);
 
-    Fighter_ChangeMotionState(gobj, 341, 0, NULL, temp_f1, 1.0, temp_f1);
+    Fighter_ChangeMotionState(gobj, 341, 0, temp_f1, 1.0, temp_f1, NULL);
     ftAnim_8006EBA4(gobj);
     startActionHelper(gobj);
     fp->cb.x21BC_callback_Accessory4 = &ftZd_SpecialN_8013A830;
@@ -81,7 +81,7 @@ void ftZd_SpecialAirN_Enter(HSD_GObj* gobj)
     fp->self_vel.y = 0;
     fp->self_vel.x = fp->self_vel.x / sa->x8;
 
-    Fighter_ChangeMotionState(gobj, 342, 0, NULL, 0, 1.0, 0);
+    Fighter_ChangeMotionState(gobj, 342, 0, 0, 1.0, 0, NULL);
     ftAnim_8006EBA4(gobj);
 
     startActionHelper(gobj);
@@ -220,8 +220,8 @@ void ftZd_SpecialN_8013AC88(HSD_GObj* gobj)
 
     fp = GET_FIGHTER(gobj);
     ftCommon_8007D5D4(fp);
-    Fighter_ChangeMotionState(gobj, 342, 0x0C4C508E, NULL, fp->cur_anim_frame,
-                              1.0, 0);
+    Fighter_ChangeMotionState(gobj, 342, 0x0C4C508E, fp->cur_anim_frame, 1.0,
+                              0, NULL);
 
     fighter2 = GET_FIGHTER(gobj);
     attributes = fighter2->dat_attrs;
@@ -246,8 +246,8 @@ void ftZd_SpecialN_8013AD1C(HSD_GObj* gobj)
 
     fp = GET_FIGHTER(gobj);
     ftCommon_8007D7FC(fp);
-    Fighter_ChangeMotionState(gobj, 341, 0x0C4C508E, NULL, fp->cur_anim_frame,
-                              1.0, 0);
+    Fighter_ChangeMotionState(gobj, 341, 0x0C4C508E, fp->cur_anim_frame, 1.0,
+                              0, NULL);
 
     fighter2 = GET_FIGHTER(gobj);
     attributes = fighter2->dat_attrs;

--- a/src/melee/ft/chara/ftZelda/ftZd_SpecialS.c
+++ b/src/melee/ft/chara/ftZelda/ftZd_SpecialS.c
@@ -32,7 +32,7 @@ void ftZd_SpecialS_Enter(HSD_GObj* gobj)
 
     temp_f1 = 0;
     fp = GET_FIGHTER(gobj);
-    Fighter_ChangeMotionState(gobj, 343, 0, NULL, temp_f1, 1.0, temp_f1);
+    Fighter_ChangeMotionState(gobj, 343, 0, temp_f1, 1.0, temp_f1, NULL);
     fp->cmd_vars[3] = 0;
     fp->cmd_vars[2] = 0;
     fp->cmd_vars[1] = 0;
@@ -65,7 +65,7 @@ void ftZd_SpecialAirS_Enter(HSD_GObj* gobj)
 
     temp_f1 = 0;
     fp = GET_FIGHTER(gobj);
-    Fighter_ChangeMotionState(gobj, 346, 0, NULL, temp_f1, 1.0, temp_f1);
+    Fighter_ChangeMotionState(gobj, 346, 0, temp_f1, 1.0, temp_f1, NULL);
     fp->cmd_vars[3] = 0;
     fp->cmd_vars[2] = 0;
     fp->cmd_vars[1] = 0;
@@ -123,7 +123,7 @@ void ftZd_SpecialSStart_Anim(HSD_GObj* gobj)
 
     if (!ftAnim_IsFramesRemaining(gobj)) {
         temp_f1 = 0;
-        Fighter_ChangeMotionState(gobj, 344, 0, NULL, temp_f1, 1.0, temp_f1);
+        Fighter_ChangeMotionState(gobj, 344, 0, temp_f1, 1.0, temp_f1, NULL);
         fp->x1968_jumpsUsed = fp->co_attrs.max_jumps;
     }
 }
@@ -179,8 +179,8 @@ void ftZd_SpecialSLoop_Anim(HSD_GObj* gobj)
     if (temp_r3_u32 == NULL) {
         if (fp->mv.zd.specials.x0 <= 0 && fp->mv.zd.specials.x4 <= 0) {
             temp_f1 = 0;
-            Fighter_ChangeMotionState(gobj, 345, 0, NULL, temp_f1, 1.0,
-                                      temp_f1);
+            Fighter_ChangeMotionState(gobj, 345, 0, temp_f1, 1.0, temp_f1,
+                                      NULL);
         }
     } else {
         temp_r3 = it_802C3AF0(fp->fv.zd.x222C);
@@ -257,7 +257,7 @@ void ftZd_SpecialAirSStart_Anim(HSD_GObj* gobj)
 
     if (!ftAnim_IsFramesRemaining(gobj)) {
         temp_f1 = 0;
-        Fighter_ChangeMotionState(gobj, 347, 0, NULL, temp_f1, 1.0, temp_f1);
+        Fighter_ChangeMotionState(gobj, 347, 0, temp_f1, 1.0, temp_f1, NULL);
         fp->x1968_jumpsUsed = fp->co_attrs.max_jumps;
     }
 }
@@ -311,8 +311,8 @@ void ftZd_SpecialAirSLoop_Anim(HSD_GObj* gobj)
     if (fp->fv.zd.x222C == 0U) {
         if (fp->mv.zd.specials.x0 <= 0 && fp->mv.zd.specials.x4 <= 0) {
             temp_f1 = 0;
-            Fighter_ChangeMotionState(gobj, 348, 0, NULL, temp_f1, 1.0,
-                                      temp_f1);
+            Fighter_ChangeMotionState(gobj, 348, 0, temp_f1, 1.0, temp_f1,
+                                      NULL);
         }
     } else {
         temp_r3 = it_802C3AF0(fp->fv.zd.x222C);
@@ -381,7 +381,7 @@ void ftZd_SpecialSLoop_IASA(HSD_GObj* gobj)
 
     if ((var_r0 == 1) && !(fp->input.held_inputs & 512)) {
         temp_f1 = 0;
-        Fighter_ChangeMotionState(gobj, 345, 0, NULL, temp_f1, 1.0, temp_f1);
+        Fighter_ChangeMotionState(gobj, 345, 0, temp_f1, 1.0, temp_f1, NULL);
     }
 }
 
@@ -409,7 +409,7 @@ void ftZd_SpecialAirSLoop_IASA(HSD_GObj* gobj)
 
     if (var_r0 == 1 && !(fp->input.held_inputs & 512)) {
         temp_f1 = 0;
-        Fighter_ChangeMotionState(gobj, 348, 0, NULL, temp_f1, 1.0, temp_f1);
+        Fighter_ChangeMotionState(gobj, 348, 0, temp_f1, 1.0, temp_f1, NULL);
     }
 }
 
@@ -546,8 +546,8 @@ void ftZd_SpecialSStart_Coll(HSD_GObj* gobj)
     fp = GET_FIGHTER(gobj);
     if (ft_80082708(gobj) == 0) {
         ftCommon_8007D5D4(fp);
-        Fighter_ChangeMotionState(gobj, 346, 0x0C4C5082, NULL,
-                                  fp->cur_anim_frame, 1.0, 0);
+        Fighter_ChangeMotionState(gobj, 346, 0x0C4C5082, fp->cur_anim_frame,
+                                  1.0, 0, NULL);
     }
 }
 
@@ -560,8 +560,8 @@ void ftZd_SpecialSLoop_Coll(HSD_GObj* gobj)
     fp = GET_FIGHTER(gobj);
     if (ft_80082708(gobj) == 0) {
         ftCommon_8007D5D4(fp);
-        Fighter_ChangeMotionState(gobj, 347, 0x0C4C5080, NULL,
-                                  fp->cur_anim_frame, 1.0, 0);
+        Fighter_ChangeMotionState(gobj, 347, 0x0C4C5080, fp->cur_anim_frame,
+                                  1.0, 0, NULL);
     }
 }
 
@@ -573,8 +573,8 @@ void ftZd_SpecialSEnd_Coll(HSD_GObj* gobj)
     fp = GET_FIGHTER(gobj);
     if (ft_80082708(gobj) == 0) {
         ftCommon_8007D5D4(fp);
-        Fighter_ChangeMotionState(gobj, 348, 0x0C4C5080, NULL,
-                                  fp->cur_anim_frame, 1.0, 0);
+        Fighter_ChangeMotionState(gobj, 348, 0x0C4C5080, fp->cur_anim_frame,
+                                  1.0, 0, NULL);
     }
 }
 
@@ -586,8 +586,8 @@ void ftZd_SpecialAirSStart_Coll(HSD_GObj* gobj)
     fp = GET_FIGHTER(gobj);
     if (ft_80081D0C(gobj) != 0) {
         ftCommon_8007D7FC(fp);
-        Fighter_ChangeMotionState(gobj, 343, 0x0C4C5082, NULL,
-                                  fp->cur_anim_frame, 1.0, 0);
+        Fighter_ChangeMotionState(gobj, 343, 0x0C4C5082, fp->cur_anim_frame,
+                                  1.0, 0, NULL);
     }
 }
 
@@ -599,8 +599,8 @@ void ftZd_SpecialAirSLoop_Coll(HSD_GObj* gobj)
     fp = GET_FIGHTER(gobj);
     if (ft_80081D0C(gobj) != 0) {
         ftCommon_8007D7FC(fp);
-        Fighter_ChangeMotionState(gobj, 344, 0x0C4C5080, NULL,
-                                  fp->cur_anim_frame, 1.0, 0);
+        Fighter_ChangeMotionState(gobj, 344, 0x0C4C5080, fp->cur_anim_frame,
+                                  1.0, 0, NULL);
     }
 }
 
@@ -612,7 +612,7 @@ void ftZd_SpecialAirSEnd_Coll(HSD_GObj* gobj)
     fp = GET_FIGHTER(gobj);
     if (ft_80081D0C(gobj) != 0) {
         ftCommon_8007D7FC(fp);
-        Fighter_ChangeMotionState(gobj, 345, 0x0C4C5080, NULL,
-                                  fp->cur_anim_frame, 1.0, 0);
+        Fighter_ChangeMotionState(gobj, 345, 0x0C4C5080, fp->cur_anim_frame,
+                                  1.0, 0, NULL);
     }
 }

--- a/src/melee/ft/fighter.c
+++ b/src/melee/ft/fighter.c
@@ -912,9 +912,9 @@ Fighter_GObj* Fighter_Create(struct S_TEMP1* input)
 }
 
 void Fighter_ChangeMotionState(Fighter_GObj* gobj, FtMotionId msid,
-                               MotionFlags flags, Fighter_GObj* arg3,
-                               float anim_start, float anim_speed,
-                               float anim_blend)
+                               MotionFlags flags, float anim_start,
+                               float anim_speed, float anim_blend,
+                               Fighter_GObj* arg3)
 {
     HSD_JObj* jobj = GET_JOBJ(gobj);
     Fighter* fp = GET_FIGHTER(gobj);

--- a/src/melee/ft/fighter.h
+++ b/src/melee/ft/fighter.h
@@ -75,9 +75,9 @@ u32 Fighter_NewSpawn_80068E40(void);
 void Fighter_80068E64(Fighter_GObj* gobj);
 Fighter_GObj* Fighter_Create(struct S_TEMP1* input);
 void Fighter_ChangeMotionState(Fighter_GObj* gobj, FtMotionId msid,
-                               MotionFlags flags, Fighter_GObj* arg3,
-                               float anim_start, float anim_speed,
-                               float anim_blend);
+                               MotionFlags flags, float anim_start,
+                               float anim_speed, float anim_blend,
+                               Fighter_GObj* arg3);
 void Fighter_8006A1BC(Fighter_GObj* gobj);
 void Fighter_8006A360(Fighter_GObj* gobj);
 void Fighter_8006ABA0(Fighter_GObj* gobj);

--- a/src/melee/ft/ftcliffcommon.c
+++ b/src/melee/ft/ftcliffcommon.c
@@ -68,7 +68,7 @@ void ftCliffCommon_80081370(ftCo_GObj* gobj)
         }
         ftCommon_8007D780(fp);
         ftCommon_8007D5D4(fp);
-        Fighter_ChangeMotionState(gobj, 252, 0, NULL, 0, 1, 0);
+        Fighter_ChangeMotionState(gobj, 252, 0, 0, 1, 0, NULL);
         ftAnim_8006EBA4(gobj);
         ftCommon_8007D5D4(fp);
         ftCommon_8007EFC0(fp, p_ftCommonData->x5F0);

--- a/src/melee/ft/ftwalkcommon.c
+++ b/src/melee/ft/ftwalkcommon.c
@@ -74,7 +74,7 @@ void ftWalkCommon_800DFCA4(Fighter_GObj* gobj, FtMotionId msid,
     {
         FtWalkType walk_type = ftWalkCommon_GetWalkType_800DFBF8_fake(gobj);
         ftCommon_MotionState new_msid = msid + walk_type;
-        Fighter_ChangeMotionState(gobj, new_msid, ms_flags, 0, anim_start, 1,
+        Fighter_ChangeMotionState(gobj, new_msid, ms_flags, anim_start, 1, 0,
                                   0);
         ftAnim_8006EBA4(gobj);
         fp->mv.co.walk.x0 = fp->gr_vel;


### PR DESCRIPTION
## Report of `src/melee/ft/chara/ftCommon/ftCo_Shouldered.c`
Function|Score|Max|%
-|-|-|-
**File**|`2164`|`28200`|`92.33%`
`ftCo_8009C744`|`1432`|`5900`|`75.73%`
`ftCo_Shouldered_Anim`|`732`|`11600`|`93.69%`
`ftCo_8009C640`|`0`|`6500`|`100.00%`
`ftCo_8009C5A4`|`0`|`3900`|`100.00%`
`ftCo_Shouldered_Coll`|`0`|`100`|`100.00%`
`ftCo_Shouldered_IASA`|`0`|`100`|`100.00%`
`ftCo_Shouldered_Phys`|`0`|`100`|`100.00%`

```py
#!/usr/bin/env python3

import re
from pathlib import Path

if __name__ == "__main__":
    call_re = re.compile(
        r"""\b(Fighter_ChangeMotionState)\s*
             \((.*?),(.*?),(.*?),(.*?),(.*?),(.*?),(.*?)\)
        """,
        re.X | re.DOTALL,
    )
    path = Path("src")
    for p in path.resolve().rglob("*.[ch]"):

        def repl(m: re.Match[str]) -> str:
            groups = list(map(lambda g: str(g).strip(), m.groups()))
            return f"{groups[0]}({groups[1]}, {groups[2]}, {groups[3]}, {groups[5]}, {groups[6]}, {groups[7]}, {groups[4]})"

        text = p.read_text()
        text = re.sub(call_re, repl, text)
        p.write_text(text)
```