### PR TITLE
Remove redundant declarations

### DIFF
--- a/src/dolphin/mtx.h
+++ b/src/dolphin/mtx.h
@@ -47,9 +47,7 @@ void C_MTXLookAt(Mtx m, Vec3* cam_pos, Vec3* up, Vec3* target);
 
 void PSMTXQuat(Mtx m, const Quaternion* q);
 void PSMTXReflect(Mtx m, const Vec3* p, const Vec3* n);
-void PSMTXTrans(Mtx m, f32 xT, f32 yT, f32 zT);
 void PSMTXTransApply(const Mtx src, Mtx dst, f32 xT, f32 yT, f32 zT);
-void PSMTXScale(Mtx m, f32 xS, f32 yS, f32 zS);
 void PSMTXScaleApply(const Mtx src, Mtx dst, f32 xS, f32 yS, f32 zS);
 void PSMTXRotRad(Mtx m, char axis, f32 rad);
 void PSMTXRotTrig(Mtx m, char axis, f32 sinA, f32 cosA);
@@ -70,10 +68,7 @@ void PSVECSubtract(Vec3 const* a, Vec3 const* b, Vec3* ab);
 void PSVECNormalize(Vec3* a, Vec3* b);
 
 void PSMTXIdentity(Mtx m);
-u32 PSMTXInverse(const Mtx src, Mtx inv);
-void PSMTXRotAxisRad(Mtx m, const Vec3* axis, f32 rad);
 void PSMTXTrans(Mtx m, f32 x_trans, f32 y_trans, f32 z_trans);
 void PSMTXScale(Mtx m, f32 x_scale, f32 y_scale, f32 z_scale);
-void PSMTXQuat(Mtx m, const Quaternion* q);
 
 #endif

--- a/src/melee/ft/fighter.h
+++ b/src/melee/ft/fighter.h
@@ -105,7 +105,4 @@ void Fighter_UnkCallCameraCallback_8006D9EC(Fighter_GObj* gobj);
 void Fighter_8006DA4C(Fighter_GObj* gobj);
 void Fighter_Unload_8006DABC(void* user_data);
 
-void Fighter_UnkProcessDeath_80068354(Fighter_GObj*);
-u32 Fighter_NewSpawn_80068E40(void);
-
 #endif

--- a/src/melee/ft/ft_08A4.h
+++ b/src/melee/ft/ft_08A4.h
@@ -365,7 +365,6 @@ void ftCo_800D5BF8(ftCo_GObj* gobj);
 void ftCo_800D5CB0(ftCo_GObj*, bool, float landing_lag);
 void ftCo_800D638C(ftCo_GObj* gobj);
 void ftCo_800D6B00(ftCo_GObj*, s32);
-void ftCo_800D6C60(ftCo_GObj*, HSD_GObjEvent);
 void ftCo_800D6C60(ftCo_GObj*, HSD_GObjEvent callback);
 void ftCo_800D71D8(ftCo_GObj* gobj);
 void ftCo_800D94D8(ftCo_GObj* gobj);

--- a/src/melee/ft/ftcamera.h
+++ b/src/melee/ft/ftcamera.h
@@ -5,10 +5,9 @@
 
 #include "ft/fighter.h"
 
-void ftCamera_80076064(Fighter*);
 void ftCamera_UpdateCameraBox(HSD_GObj* gobj);
 void ftCamera_80076018(UnkFloat6_Camera* in, UnkFloat6_Camera* out, f32 mul);
-void ftCamera_80076064(Fighter* fp);
+void ftCamera_80076064(Fighter*);
 void ftCamera_800762F4(HSD_GObj* gobj);
 void ftCamera_80076320(HSD_GObj* gobj);
 

--- a/src/melee/ft/ftcoll.h
+++ b/src/melee/ft/ftcoll.h
@@ -30,8 +30,6 @@ f32 ftColl_800765F0(Fighter* fp, Fighter_GObj* victim,
                     f32 unk_floatvar); // Unk knockback related ?
 bool ftColl_8007B868(Fighter_GObj* gobj);
 
-void ftColl_80076528(Fighter_GObj*);
-void ftColl_800765E0(void);
 void ftColl_80078754(Fighter_GObj*, Fighter_GObj*, bool);
 void ftColl_80078A2C(Fighter_GObj*);
 void ftColl_80078C70(Fighter_GObj*);

--- a/src/melee/ft/ftcommon.h
+++ b/src/melee/ft/ftcommon.h
@@ -42,6 +42,7 @@ void ftCommon_ClampFallSpeed(ftCo_Fighter*, float);
 void ftCommon_8007D508(ftCo_Fighter*, float, float);
 bool ftCommon_8007D528(ftCo_Fighter*);
 void ftCommon_8007D5BC(ftCo_Fighter*);
+void ftCommon_8007D5D4(ftCo_Fighter*);
 void ftCommon_8007D60C(ftCo_Fighter*);
 void ftCommon_8007D698(ftCo_Fighter*);
 void ftCommon_8007D6A4(ftCo_Fighter*);
@@ -103,7 +104,6 @@ void ftCommon_8007FA00(ftCo_GObj*);
 void ftCommon_8007FA58(ftCo_GObj*, ftCo_GObj*);
 void ftCommon_8007FC7C(ftCo_GObj*, float);
 void ftCommon_8007FDA0(ftCo_GObj*);
-void ftCommon_8007FE84(ftCo_GObj*, ftCo_GObj* gobj, s32, float);
 void ftCommon_8007FF74(ftCo_GObj*);
 bool ftCommon_8007FFD8(ftCo_Fighter*, float);
 bool ftCommon_80080144(ftCo_Fighter*);
@@ -114,43 +114,13 @@ void ftCommon_80080460(ftCo_Fighter*);
 void ftCommon_80080474(ftCo_Fighter*);
 void ftCommon_80080484(ftCo_Fighter*);
 void ftCommon_800804A0(ftCo_Fighter*, float);
-float ftCommon_800804EC(ftCo_Fighter*);
 void ftCommon_800804FC(ftCo_Fighter*);
-
-void ftCommon_8007CB74(ftCo_GObj*);
-void ftCommon_8007CC78(ftCo_Fighter*, float);
-void ftCommon_8007CCA0(ftCo_Fighter*, float);
-float ftCommon_8007CD6C(float value, float decrement);
-float ftCommon_8007CDA4(ftCo_Fighter*);
-float ftCommon_8007CDF8(ftCo_Fighter*);
-void ftCommon_8007CE4C(ftCo_Fighter*, float);
-void ftCommon_8007CE94(ftCo_Fighter*, float);
-bool ftCommon_8007CF58(ftCo_Fighter*);
-void ftCommon_8007D344(ftCo_Fighter*, float, float, float);
-void ftCommon_8007D4B8(ftCo_Fighter*);
-void ftCommon_8007D5D4(ftCo_Fighter*);
-void ftCommon_8007D6A4(ftCo_Fighter*);
-void ftCommon_8007D780(ftCo_Fighter*);
-void ftCommon_8007D7FC(ftCo_Fighter*);
-void ftCommon_8007D92C(ftCo_GObj*);
-void ftCommon_8007D9FC(ftCo_Fighter*);
 
 void ftCommon_8007E2D0(ftCo_Fighter*, s16, HSD_GObjEvent, HSD_GObjEvent,
                        void (*)(ftCo_GObj*, ftCo_GObj*));
 
-void ftCommon_8007E2FC(ftCo_GObj*);
-void ftCommon_8007E83C(ftCo_GObj*, s32, float div);
-s32 ftCo_GetParasolStatus(ftCo_GObj*);
-void ftCommon_8007EA90(ftCo_Fighter*, s32);
-void ftCommon_8007ED50(ftCo_Fighter*, s32);
-void ftCommon_8007EFC0(ftCo_Fighter*, u32);
-float ftCommon_GetModelScale(ftCo_Fighter*);
-void ftCommon_8007FC7C(ftCo_GObj*, float);
-
 /// @todo static
 void ftCommon_8007FE84(ftCo_GObj*, ftCo_GObj*, s32, float);
-
-bool ftCommon_8007FFD8(ftCo_Fighter*, float);
 
 /// @todo @c DataOffset_PlayerScale_MultiplyBySomething
 /// @returns <tt>fp->x40*fp->x34</tt>

--- a/src/melee/gr/grdynamicattr.h
+++ b/src/melee/gr/grdynamicattr.h
@@ -17,8 +17,6 @@ struct grDynamicAttr_UnkStruct {
 };
 
 int grDynamicAttr_801CA284(Vec3* v, int arg1);
-
-int grDynamicAttr_801CA284(Vec3* v, int arg1);
 void grDynamicAttr_801CA0B4(void);
 grDynamicAttr_UnkStruct*
 grDynamicAttr_801CA0F8(s32 arg0, Vec3* v, enum_t floor_id, f32 f, s32 arg3);

--- a/src/melee/gr/grlib.h
+++ b/src/melee/gr/grlib.h
@@ -27,8 +27,6 @@ HSD_GObj* grLib_801C9CEC(s32);
 s16 grLib_801C9E40(void);
 void grLib_801C9E50(s16);
 bool grLib_801C9E60(Vec3*);
-bool grLib_801C9EE8(void);
-Vec3* grLib_801C9A10(void);
 
 /// @remarks Only called from yorster and inishie1
 bool grLib_801C9EE8(void);

--- a/src/melee/it/it_266F.h
+++ b/src/melee/it/it_266F.h
@@ -47,16 +47,12 @@ void it_8027163C(HSD_GObj* gobj);
 void it_80271A58(HSD_GObj* gobj);
 void it_802721B8(HSD_GObj* gobj);
 void it_80272280(HSD_GObj* gobj);
-void it_8027163C(HSD_GObj* gobj);
-void it_80271A58(HSD_GObj* gobj);
-void it_802721B8(HSD_GObj* gobj);
 void it_80272298(HSD_GObj* gobj);
 void it_802722B0(HSD_GObj* gobj);
 void it_80272304(HSD_GObj* gobj);
 void it_80272460(itHit* hitbox, s32 damage, HSD_GObj* gobj);
 void it_802725D4(HSD_GObj*);
 void it_80272784(HSD_GObj* gobj);
-void it_802728C8(HSD_GObj* gobj);
 void it_80272A18(HSD_JObj* item_jobj);
 void it_80272A3C(HSD_JObj* item_jobj);
 
@@ -66,16 +62,8 @@ bool it_80272D1C(HSD_GObj* gobj);
 /// Check GObj entity class
 s32 it_80272D40(HSD_GObj* gobj);
 
-void it_80272F7C(HSD_JObj*, f32);
 void it_802728C8(HSD_GObj* gobj);
-void it_80273168(HSD_GObj* gobj);
-void it_802731A4(HSD_GObj*);
-void it_802731E0(HSD_GObj*);
-void it_8027327C(HSD_GObj* gobj, s32 ID1, s32 ID2);
-void it_8027346C(HSD_GObj* gobj);
-void it_80273484(HSD_GObj* gobj);
 void it_80272F7C(HSD_JObj*, f32);
-void it_802728C8(HSD_GObj* gobj);
 void it_80273168(HSD_GObj* gobj);
 void it_802731A4(HSD_GObj*);
 void it_802731E0(HSD_GObj*);
@@ -108,8 +96,6 @@ void it_80275158(HSD_GObj* gobj, f32 lifetime);
 void it_80275390(HSD_GObj*);
 void it_802753BC(HSD_GObj*, s16);
 void it_802753DC(HSD_GObj*);
-void it_80274740(HSD_GObj* gobj);
-void it_80274A64(HSD_GObj* gobj);
 
 /// Toggle several flags in 0xDCD off
 void it_80275474(HSD_GObj* gobj);

--- a/src/melee/it/item.h
+++ b/src/melee/it/item.h
@@ -188,8 +188,6 @@ void Item_8026A0FC(HSD_GObj* gobj);
 /// Item Think - Exit Hitlag
 void Item_8026A1E8(HSD_GObj* gobj);
 
-void Item_802693E4(HSD_GObj* gobj);
-
 /// Item Think - Check for Blast Zones
 bool Item_802696CC(HSD_GObj* gobj);
 

--- a/src/melee/lb/lb_00B0.h
+++ b/src/melee/lb/lb_00B0.h
@@ -51,9 +51,4 @@ HSD_LObj* lb_8000CDC0(HSD_LObj*);
 void lb_8000CE30(HSD_DObj*, HSD_DObj*);
 void lb_8000CE40(HSD_JObj*, HSD_DObj*);
 
-f32 lb_8000BDB4(HSD_JObj*);
-void lb_8000C1C0(HSD_JObj*, HSD_JObj*);
-void lb_8000C228(HSD_JObj*, HSD_JObj*);
-void lb_8000C420(HSD_JObj*, u32, f32);
-
 #endif

--- a/src/melee/lb/lbaudio_ax.h
+++ b/src/melee/lb/lbaudio_ax.h
@@ -25,7 +25,6 @@ void lbAudioAx_8002500C(s32);
 void lbAudioAx_80025038(s32);
 void lbAudioAx_8002838C(void);
 bool lbAudioAx_80023710(s32);
-bool lbAudioAx_80023710(s32);
 void lbAudioAx_80023870(unk_t, s32, s32, s32);
 s32 lbAudioAx_8002305C(s32, s32);
 void lbAudioAx_80026510(HSD_GObj*);

--- a/src/melee/lb/lbrefract.h
+++ b/src/melee/lb/lbrefract.h
@@ -55,7 +55,6 @@ extern RefractCallbackTypeA lbRefract_80021F34;
 extern RefractCallbackTypeA lbRefract_80021F70;
 
 extern RefractCallbackTypeB lbRefract_80021FB4;
-extern RefractCallbackTypeB lbRefract_80021FB4;
 
 extern RefractCallbackTypeC lbRefract_80021FF8;
 extern RefractCallbackTypeC lbRefract_8002206C;

--- a/src/melee/sc/scene.h
+++ b/src/melee/sc/scene.h
@@ -2,6 +2,7 @@
 #define MELEE_SC_SCENE_H
 
 #include <baselib/forward.h>
+#include <melee/sc/forward.h>
 
 /// Model with a single animation or no animation
 struct StaticModelDesc {

--- a/src/sysdolphin/baselib/class.h
+++ b/src/sysdolphin/baselib/class.h
@@ -79,16 +79,6 @@ void class_set_flags(HSD_ClassInfo* class_info, s32 set, s32 reset);
 void ForgetClassLibraryReal(HSD_ClassInfo* class_info);
 void DumpClassStat(HSD_ClassInfo* info, s32 level);
 void hsdDumpClassStat(HSD_ClassInfo* info, bool recursive, s32 level);
-HSD_MemoryEntry* GetMemoryEntry(s32 idx);
-HSD_Class* _hsdClassAlloc(HSD_ClassInfo* info);
-int _hsdClassInit(HSD_Class* arg0);
-void _hsdClassRelease(HSD_Class* cls);
-void _hsdClassDestroy(HSD_Class* cls);
-void _hsdClassAmnesia(HSD_ClassInfo* info);
-void class_set_flags(HSD_ClassInfo* class_info, s32 set, s32 reset);
-void ForgetClassLibraryReal(HSD_ClassInfo* class_info);
-void DumpClassStat(HSD_ClassInfo* info, s32 level);
-void hsdDumpClassStat(HSD_ClassInfo* info, bool recursive, s32 level);
 
 void ForgetClassLibraryChild(const char* library_name,
                              HSD_ClassInfo* class_info);

--- a/src/sysdolphin/baselib/cobj.h
+++ b/src/sysdolphin/baselib/cobj.h
@@ -115,7 +115,6 @@ void HSD_CObjEraseScreen(HSD_CObj* cobj, s32 enable_color, s32 enable_alpha,
 void HSD_CObjRemoveAnim(HSD_CObj* cobj);
 HSD_WObj* HSD_CObjGetEyePositionWObj(HSD_CObj* cobj);
 HSD_WObj* HSD_CObjGetInterestWObj(HSD_CObj* cobj);
-void HSD_CObjSetOrtho(HSD_CObj* cobj, f32, f32, f32, f32);
 void HSD_CObjSetInterest(HSD_CObj* cobj, Vec3*);
 void HSD_CObjSetEyePosition(HSD_CObj* cobj, Vec3*);
 bool HSD_CObjSetCurrent(HSD_CObj*, cobj_UnkCallback1);

--- a/src/sysdolphin/baselib/debug.h
+++ b/src/sysdolphin/baselib/debug.h
@@ -22,6 +22,5 @@ ATTRIBUTE_NORETURN void HSD_Panic(char*, u32, char*);
     ((cond) ? ((void) 0) : __assert((file), (line), (#msg)))
 
 int HSD_Debug_8038815C(s32 arg0, s32 arg1, s32* arg2, s32 arg3);
-int HSD_Debug_8038815C(s32 arg0, s32 arg1, s32* arg2, s32 arg3);
 
 #endif

--- a/src/sysdolphin/baselib/fog.h
+++ b/src/sysdolphin/baselib/fog.h
@@ -62,10 +62,5 @@ HSD_FogAdj* HSD_FogAdjAlloc(void);
 void HSD_Fog_8037DE7C(HSD_Fog* fog, HSD_AObjDesc* desc);
 void HSD_FogReqAnim(HSD_Fog* fog, f32 frame);
 void HSD_FogInterpretAnim(HSD_Fog* fog);
-HSD_Fog* HSD_FogAlloc(void);
-HSD_FogAdj* HSD_FogAdjAlloc(void);
-void HSD_Fog_8037DE7C(HSD_Fog* fog, HSD_AObjDesc* desc);
-void HSD_FogReqAnim(HSD_Fog* fog, f32 frame);
-void HSD_FogInterpretAnim(HSD_Fog* fog);
 
 #endif

--- a/src/sysdolphin/baselib/forward.h
+++ b/src/sysdolphin/baselib/forward.h
@@ -3,7 +3,6 @@
 
 #include <platform.h>
 
-typedef struct DynamicModelDesc DynamicModelDesc;
 typedef struct HSD_AnimJoint HSD_AnimJoint;
 typedef struct HSD_AObj HSD_AObj;
 typedef struct HSD_AObjDesc HSD_AObjDesc;
@@ -74,8 +73,6 @@ typedef struct HSD_WObjInfo HSD_WObjInfo;
 typedef struct PadLibData PadLibData;
 typedef struct RumbleCommand RumbleCommand;
 typedef struct RumbleInfo RumbleInfo;
-typedef struct SceneDesc SceneDesc;
-typedef struct StaticModelDesc StaticModelDesc;
 typedef struct Struct804C22E0 Struct804C22E0;
 typedef struct TextKerning TextKerning;
 typedef struct UnkGeneratorStruct UnkGeneratorStruct;

--- a/src/sysdolphin/baselib/gobj.h
+++ b/src/sysdolphin/baselib/gobj.h
@@ -130,7 +130,6 @@ void HSD_GObj_803911C0(HSD_Obj* obj);
 void HSD_GObj_80391260(struct _GObjUnkStruct* arg0);
 void HSD_GObj_803912E0(GObjFuncs* arg0);
 void HSD_GObj_80390ED0(HSD_GObj* gobj, u32 mask);
-void HSD_GObj_80390ED0(HSD_GObj* gobj, u32 mask);
 
 static inline any_t HSD_GObjGetUserData(HSD_GObj* gobj)
 {

--- a/src/sysdolphin/baselib/gobjplink.h
+++ b/src/sysdolphin/baselib/gobjplink.h
@@ -8,9 +8,7 @@
 void HSD_GObjPLink_80390228(HSD_GObj*);
 void HSD_GObjPLink_8039032C(u32 arg0, HSD_GObj* gobj, u8 p_link, u8 priority,
                             HSD_GObj* position);
-void HSD_GObjProc_8038FE24(HSD_GObjProc* gproc);
 
-void GObj_PReorder(HSD_GObj* gobj, HSD_GObj* hiprio_gobj);
 void GObj_PReorder(HSD_GObj* gobj, HSD_GObj* hiprio_gobj);
 
 HSD_GObj* CreateGObj(s32 where, u16 classifier, u8 p_link, u8 priority,

--- a/src/sysdolphin/baselib/gobjproc.h
+++ b/src/sysdolphin/baselib/gobjproc.h
@@ -24,7 +24,5 @@ void HSD_GObjProc_8038FC18(HSD_GObjProc* gproc);
 
 void HSD_GObjProc_8038FCE4(HSD_GObjProc* gproc);
 void HSD_GObjProc_8038FE24(HSD_GObjProc* gproc);
-void HSD_GObjProc_8038FCE4(HSD_GObjProc* gproc);
-void HSD_GObjProc_8038FE24(HSD_GObjProc* gproc);
 
 #endif

--- a/src/sysdolphin/baselib/id.h
+++ b/src/sysdolphin/baselib/id.h
@@ -22,6 +22,5 @@ void HSD_IDInsertToTable(HSD_IDTable* table, u32 id, void* data);
 void HSD_IDRemoveByIDFromTable(HSD_IDTable* table, u32 id);
 void* HSD_IDGetDataFromTable(HSD_IDTable* table, u32 id, s32* success);
 void _HSD_IDForgetMemory(any_t low, any_t high);
-void HSD_IDSetup(void);
 
 #endif

--- a/src/sysdolphin/baselib/initialize.h
+++ b/src/sysdolphin/baselib/initialize.h
@@ -45,6 +45,5 @@ void HSD_Init_803755A8(void);
 static void HSD_ObjInit(void);
 void HSD_ObjDumpStat(void);
 bool HSD_SetInitParameter(HSD_InitParam param, ...);
-OSHeapHandle HSD_GetHeap(void);
 
 #endif

--- a/src/sysdolphin/baselib/jobj.h
+++ b/src/sysdolphin/baselib/jobj.h
@@ -145,7 +145,6 @@ void HSD_JObjCheckDepend(HSD_JObj* jobj);
 u32 HSD_JObjGetFlags(HSD_JObj* jobj);
 void HSD_JObjReqAnimAll(HSD_JObj*, f32);
 void HSD_JObjResetRST(HSD_JObj* jobj, HSD_Joint* joint);
-void HSD_JObjReqAnimAll(HSD_JObj*, f32);
 void HSD_JObjSetupMatrixSub(HSD_JObj*);
 void HSD_JObjSetMtxDirtySub(HSD_JObj*);
 void HSD_JObjUnref(HSD_JObj* jobj);

--- a/src/sysdolphin/baselib/lobj.h
+++ b/src/sysdolphin/baselib/lobj.h
@@ -135,8 +135,6 @@ bool HSD_LObjGetInterest(HSD_LObj*, Vec3*);
 
 HSD_WObj* HSD_LObjGetPositionWObj(HSD_LObj* lobj);
 HSD_WObj* HSD_LObjGetInterestWObj(HSD_LObj* lobj);
-void HSD_LObjReqAnim(HSD_LObj* lobj, f32 startframe);
-void HSD_LObjReqAnimAll(HSD_LObj* lobj, f32 startframe);
 
 s32 HSD_LightID2Index(GXLightID);
 void HSD_LObjDeleteCurrent(HSD_LObj* lobj);

--- a/src/sysdolphin/baselib/shadow.h
+++ b/src/sysdolphin/baselib/shadow.h
@@ -44,8 +44,5 @@ void HSD_ShadowDeleteObject(HSD_Shadow*, bool);
 HSD_TObj* makeShadowTObj(void);
 void HSD_ShadowRemove(HSD_Shadow* shadow);
 void HSD_ShadowInit(HSD_Shadow* shadow);
-HSD_TObj* makeShadowTObj(void);
-void HSD_ShadowRemove(HSD_Shadow* shadow);
-void HSD_ShadowInit(HSD_Shadow* shadow);
 
 #endif

--- a/src/sysdolphin/baselib/sislib.h
+++ b/src/sysdolphin/baselib/sislib.h
@@ -47,7 +47,6 @@ void HSD_SisLib_803A84BC(void);
 void HSD_SisLib_803A8134(void);
 s32 HSD_SisLib_803A7F0C(unk_t, s32);
 void HSD_SisLib_803A7684(unk_t, u8, u8);
-void HSD_SisLib_803A7684(unk_t, u8, u8);
 void HSD_SisLib_803A7664(unk_t);
 void HSD_SisLib_803A75E0(unk_t, s32);
 void HSD_SisLib_803A7548(unk_t, f32, f32);
@@ -57,7 +56,6 @@ s32 HSD_SisLib_803A70A0(s32, unk_t, unk_t);
 u32 lbl_803A6FEC(s32, s32, bool);
 void HSD_SisLib_803A6B98(unk_t, u32, s32, s32, s32, s32, s32, s32, f64, f64,
                          f64, f64, f64, f64, f64, f64);
-s32 HSD_SisLib_803A67EC(unk_t, unk_t);
 s32 HSD_SisLib_803A67EC(unk_t, unk_t);
 unk_t HSD_SisLib_803A6754(void);
 void HSD_SisLib_803A660C(s32, s32, s32);
@@ -69,7 +67,5 @@ s32 HSD_SisLib_803A611C(s16, u32, s16, s8, s8, s8, s8, u32);
 void lbl_803A60EC(void);
 unk_t HSD_SisLib_803A5ACC(f32, f32, f32, f32, f32);
 void HSD_SisLib_803A594C(u8*);
-s32 HSD_SisLib_803A611C(s16 arg0, u32 arg1, s16 arg2, s8 arg3, s8 arg4,
-                        s8 arg5, s8 arg6, u32 arg7);
 
 #endif

--- a/src/sysdolphin/baselib/texp.h
+++ b/src/sysdolphin/baselib/texp.h
@@ -182,7 +182,5 @@ void HSD_TExpSetupTev(HSD_TExpTevDesc*, HSD_TExp*);
 
 void HSD_TExpRef(HSD_TExp* texp, u8 sel);
 void HSD_TExpUnref(HSD_TExp* texp, u8 sel);
-void HSD_TExpRef(HSD_TExp* texp, u8 sel);
-void HSD_TExpUnref(HSD_TExp* texp, u8 sel);
 
 #endif

--- a/src/sysdolphin/baselib/tobj.h
+++ b/src/sysdolphin/baselib/tobj.h
@@ -303,7 +303,6 @@ u32 HSD_TexMtx2Index(u32 texmtx);
 u32 HSD_Index2TexMtx(u32 index);
 u8 HSD_Index2TexMap(u32 index);
 u32 HSD_TexMap2Index(u8 mapid);
-struct _HSD_ImageDesc* HSD_ImageDescAlloc(void);
 HSD_TObj* allocShadowTObj(void);
 
 void HSD_TObjRemoveAnim(HSD_TObj* tobj);

--- a/src/sysdolphin/baselib/wobj.h
+++ b/src/sysdolphin/baselib/wobj.h
@@ -50,6 +50,5 @@ void HSD_WObjSetPositionZ(HSD_WObj*, f32);
 void HSD_WObjGetPosition(HSD_WObj*, Vec3*);
 HSD_WObj* HSD_WObjAlloc(void);
 void HSD_WObjSetDefaultClass(HSD_ClassInfo* info);
-void HSD_WObjSetDefaultClass(HSD_ClassInfo* info);
 
 #endif


### PR DESCRIPTION
Discovered using clang-tidy `readability-redundant-declaration`. More issues remain, especially in melee/ft/ft_08A4.h