### PR TITLE
Impove jobj inlines

### DIFF
--- a/src/melee/ft/chara/ftPurin/ftPr_Init.c
+++ b/src/melee/ft/chara/ftPurin/ftPr_Init.c
@@ -504,21 +504,15 @@ void ftPr_Init_8013C494(HSD_GObj* gobj)
 
 void ftPr_Init_UnkMtxFunc0(HSD_GObj* gobj, int arg1, Mtx vmtx)
 {
-    /// @todo Unused stack.
-#ifdef MUST_MATCH
-    u8 _[8];
-#endif
-
     Fighter* fp = GET_FIGHTER(gobj);
 
     if (fp->fv.pr.x223C && fp->x2225_b2) {
-        Mtx* mtx;
+        MtxPtr mtx;
         HSD_JObj* jobj;
         HSD_JObj* bone_jobj = fp->parts[FtPart_LLegJA].joint;
-        HSD_JObjGetMtx(fp->parts[FtPart_LLegJA].joint);
-        mtx = (0, &bone_jobj->mtx);
+        mtx = HSD_JObjGetMtxPtr(fp->parts[FtPart_LLegJA].joint);
         jobj = fp->fv.pr.x223C;
-        HSD_JObjCopyMtx(fp->fv.pr.x223C, *mtx);
+        HSD_JObjCopyMtx(fp->fv.pr.x223C, mtx);
         jobj->flags |= (1 << 23) | (1 << 24) | (1 << 25);
         HSD_JObjSetMtxDirty(jobj);
 

--- a/src/melee/ft/fighter.c
+++ b/src/melee/ft/fighter.c
@@ -2412,15 +2412,8 @@ void Fighter_UnkApplyTransformation_8006C0F0(Fighter_GObj* gobj)
         Vec3 translation;
         Quaternion rotation;
 
-        /// @todo This usually implies an inline, but inlines reserve more
-        /// stack
-        ///       (usually in 8 byte increments) than a single allocation
-        ///       (removed) like this.
-        jobj = GET_JOBJ(gobj);
-
         HSD_JObjSetupMatrix(jobj);
-        HSD_JObjGetMtx(jobj);
-        HSD_MtxInverse(jobj->mtx, mtx1);
+        HSD_MtxInverse(HSD_JObjGetMtxPtr(jobj), mtx1);
         HSD_JObjGetScale(jobj, &scale);
 
         scale.x = ftCommon_GetModelScale(fp);

--- a/src/sysdolphin/baselib/jobj.h
+++ b/src/sysdolphin/baselib/jobj.h
@@ -189,11 +189,12 @@ static inline bool HSD_JObjMtxIsDirty(HSD_JObj* jobj)
     return result;
 }
 
-static inline void HSD_JObjSetupMatrix(HSD_JObj* jobj)
+inline void HSD_JObjSetupMatrix(HSD_JObj* jobj)
 {
-    if (jobj != NULL && HSD_JObjMtxIsDirty(jobj)) {
-        HSD_JObjSetupMatrixSub(jobj);
+    if (jobj == NULL || !HSD_JObjMtxIsDirty(jobj)) {
+        return;
     }
+    HSD_JObjSetupMatrixSub(jobj);
 }
 
 // Why does this seem to be a define while the others are inline functions?
@@ -390,14 +391,16 @@ static inline void HSD_JObjAddTranslationZ(HSD_JObj* jobj, float z)
     }
 }
 
-/// @todo This is misplaced or something; @c jobj.h must not include @c
-///       lbcollision.
+/// @todo This is inlined into lbcoll, and linker deduplication
+/// only kept that definition.
+/// Rename it back to HSD_JObjSetupMatrix once lbcoll is matched.
 void lbColl_JObjSetupMatrix(HSD_JObj*);
 
-static inline void HSD_JObjGetMtx(HSD_JObj* jobj)
+static inline MtxPtr HSD_JObjGetMtxPtr(HSD_JObj* jobj)
 {
     HSD_ASSERT(1144, jobj);
     lbColl_JObjSetupMatrix(jobj);
+    return jobj->mtx;
 }
 
 static inline void HSD_JObjCopyMtx(HSD_JObj* jobj, Mtx mtx)


### PR DESCRIPTION
HSD_JObjSetupMatrix failed to inline into lbcoll,
so trying to match that copy shows us that the definition must be modified.

HSD_JObjGetMtx is actually HSD_JObjGetMtxPtr, which improves some matches in melee/ft.