### PR TITLE
Remove itHit struct

### DIFF
--- a/src/melee/it/forward.h
+++ b/src/melee/it/forward.h
@@ -53,8 +53,6 @@ typedef struct ItemModStruct ItemModStruct;
 typedef struct ItemStateArray ItemStateArray;
 typedef struct ItemStateDesc ItemStateDesc;
 typedef struct ItemStateTable ItemStateTable;
-typedef struct itHit itHit;
-typedef struct itHurt itHurt;
 typedef struct SpawnItem SpawnItem;
 typedef struct UnkItemArticles3 UnkItemArticles3;
 

--- a/src/melee/it/it_266F.h
+++ b/src/melee/it/it_266F.h
@@ -54,7 +54,7 @@ void it_80272280(HSD_GObj* gobj);
 void it_80272298(HSD_GObj* gobj);
 void it_802722B0(HSD_GObj* gobj);
 void it_80272304(HSD_GObj* gobj);
-void it_80272460(itHit* hitbox, s32 damage, HSD_GObj* gobj);
+void it_80272460(HitCapsule* hitbox, s32 damage, HSD_GObj* gobj);
 void it_802725D4(HSD_GObj*);
 void it_80272784(HSD_GObj* gobj);
 void it_80272A18(HSD_JObj* item_jobj);

--- a/src/melee/it/it_26B1.c
+++ b/src/melee/it/it_26B1.c
@@ -38,10 +38,10 @@ static inline float _sqrtfItem(float x)
     return x;
 }
 
-/// Apply Item Damage -  may not be itHit* ???
-f32 it_8026B1D4(HSD_GObj* gobj, itHit* itemHitboxUnk)
+/// Apply Item Damage -  may not be HitCapsule* ???
+f32 it_8026B1D4(HSD_GObj* gobj, HitCapsule* itemHitboxUnk)
 {
-    f32 ret = itemHitboxUnk->xC_damage_staled;
+    f32 ret = itemHitboxUnk->damage;
     const Item* ip = gobj->user_data;
     if (ip->xDC8_word.flags.x14 != 0) {
         f32 itemSpeed = _sqrtfItem(ip->x40_vel.x * ip->x40_vel.x +

--- a/src/melee/it/it_26B1.h
+++ b/src/melee/it/it_26B1.h
@@ -15,7 +15,7 @@ enum_t it_8026B30C(Item_GObj* gobj);
 enum_t it_8026B320(Item_GObj* gobj);
 
 /// Apply Item Damage
-f32 it_8026B1D4(Item_GObj* gobj, itHit* itemHitboxUnk);
+f32 it_8026B1D4(Item_GObj* gobj, HitCapsule* itemHitboxUnk);
 
 /// Copy Item position vector
 void it_8026B294(Item_GObj* gobj, Vec3* pos);

--- a/src/melee/it/item.c
+++ b/src/melee/it/item.c
@@ -1657,15 +1657,15 @@ bool Item_80269F14(HSD_GObj* gobj)
         for (i = 0; i < 4; i++) // 4 here is the maximum amount of hitboxes
                                 // available in the vanilla Item struct
         {
-            if (temp_item->x5D4_hitboxes[i].x0_toggle) {
-                temp_f30 = temp_item->x5D4_hitboxes[i].xC_damage_staled *
+            if (temp_item->x5D4_hitboxes[i].hit.state != HitCapsule_Disabled) {
+                temp_f30 = temp_item->x5D4_hitboxes[i].hit.damage *
                                temp_item->xC6C +
                            0.99f;
                 var_r27 = temp_f30;
                 if (var_r27 > it_804D6D28->xD8) {
                     var_r27 = it_804D6D28->xD8;
                 }
-                it_80272460(&temp_item->x5D4_hitboxes[i], var_r27, gobj);
+                it_80272460(&temp_item->x5D4_hitboxes[i].hit, var_r27, gobj);
             }
         }
     }

--- a/src/melee/it/types.h
+++ b/src/melee/it/types.h
@@ -275,47 +275,6 @@ struct Article {
     ItemDynamics* x14_dynamics;
 };
 
-struct itHit {
-    bool x0_toggle; // Toggles hitbox on/off.
-    s32 x4_unk;
-    s32 x8_damage;        // Projected damage
-    f32 xC_damage_staled; // Staled damage, actually applied
-    Vec3 x10_offset;
-    f32 x1C_hitbox_size;
-    s32 x20_angle;
-    s32 x24_knockback_growth;
-    s32 x28_wdsk; // Weight-Dependent Set Knockback
-    s32 x2C_base_knockback;
-    s32 x30_element;       // Normal, fire, electric, etc.
-    s32 x34_shield_damage; // If hitbox damage + shield damage is less than 0
-                           // (negative), this will effectively restore shield
-                           // health
-    s32 x38_SFX_severity; // 0x38. hurtbox interaction. 0 = none, 1 = grounded,
-                          // 2 = aerial, 3 = both // What
-    s32 x3C_SFX_kind;
-    UnkFlagStruct x40_flags; // 0x20 -> check against aerial fighters; 0x10 ->
-                             // check against grounded fighters
-    UnkFlagStruct x41_flags; // 0x8/0x4/0x2 = timed rehit on
-                             // item/fighter/shield; 0x1 = can reflect
-    UnkFlagStruct x42_flags; // 0x80 = can absorb; 0x20 = hit only fighters
-                             // facing the item; 0x10 = can shield; 0x8 =
-                             // ignore reflect/absorb bubbles(?); 0x4 = ignore
-                             // hurtboxes; 0x2 = ignore ungrabbable hurtboxes
-    UnkFlagStruct x43_flags; // 0x80 = interact with items only; 0x20 =
-                             // interact with all?
-    s32 x44;
-    HSD_JObj* x48_jobj;
-    Vec3 pos;
-    Vec3 x58_posPrev;
-    Vec3 x64_posColl;      // 0x64   position of hurt collision
-    f32 x70_coll_distance; // 0x70   Distance From Collding HurtCapsule (Used
-                           // for phantom hit collision calculation)
-    HitVictim x74_tipLog[12];
-    HitVictim xD4_damageLog[12];
-    s32 x134;
-    s32 x138;
-};
-
 struct Item {
     void* x0;
 
@@ -415,7 +374,10 @@ struct Item {
     u8 x5CB;
     f32 x5CC_currentAnimFrame;
     f32 x5D0_animFrameSpeed;
-    itHit x5D4_hitboxes[4];
+    struct {
+        HitCapsule hit;
+        s32 x138;
+    } x5D4_hitboxes[4];
     s32 xAC4_ignoreItemID; // Cannot hit items with this index?
     s32 xAC8_hurtboxNum;   // Number of hurtboxes this item has
     HurtCapsule xACC_itemHurtbox[2];

--- a/src/melee/lb/lbcollision.h
+++ b/src/melee/lb/lbcollision.h
@@ -100,6 +100,7 @@ struct HitCapsule {
     HitVictim victims_1[12];
     /// @at{D4} @sz{60}
     HitVictim victims_2[12];
+    // @at{134}
     union {
         HSD_GObj* owner;
         u8 hit_grabbed_victim_only : 1;


### PR DESCRIPTION
A number of functions in itcoll pass `&Item->x5D4` to functions which expect a HitCapsule, and known areas of itHit/HitCapsule are identical, so we can merge the structs.