### PR TITLE
Remove MUST_MATCH from lbfile due to new compiler

### DIFF
--- a/src/melee/lb/lbfile.c
+++ b/src/melee/lb/lbfile.c
@@ -25,34 +25,14 @@ void lbFile_8001615C(int r3, int r4, int r5, bool cancelflag)
     cancel = true;
 }
 
-#ifdef MUST_MATCH
-
 #pragma push
-asm bool lbFile_800161A0()
-{
-    // clang-format off
-    nofralloc
-/* 800161A0 00012D80  7C 08 02 A6 */	mflr r0
-/* 800161A4 00012D84  90 01 00 04 */	stw r0, 4(r1)
-/* 800161A8 00012D88  94 21 FF F8 */	stwu r1, -8(r1)
-/* 800161AC 00012D8C  48 00 34 25 */	bl lb_800195D0
-/* 800161B0 00012D90  80 6D AD 28 */	lwz r3, cancel(r13)
-/* 800161B4 00012D94  80 01 00 0C */	lwz r0, 0xc(r1)
-/* 800161B8 00012D98  38 21 00 08 */	addi r1, r1, 8
-/* 800161BC 00012D9C  7C 08 03 A6 */	mtlr r0
-/* 800161C0 00012DA0  4E 80 00 20 */	blr
-} // clang-format on
-#pragma pop
-
-#else
-
+#pragma dont_inline on
 bool lbFile_800161A0(void)
 {
     lb_800195D0();
     return cancel;
 }
-
-#endif
+#pragma pop
 
 void lbFile_800161C4(int arg0, int arg1, HSD_Archive* arg2, int arg3, int arg4,
                      int arg5)


### PR DESCRIPTION
Requires a dont_inline pragma as it'll inline the function into all the calls within the file.