### PR TITLE
Match psInitAppSRT, add/fix up psstructs

### DIFF
--- a/asm/sysdolphin/baselib/psappsrt.s
+++ b/asm/sysdolphin/baselib/psappsrt.s
@@ -2,26 +2,6 @@
 
 .section .text  # 0x80005940 - 0x803B7240
 
-# https://decomp.me/scratch/6K1oj // 405 (74.69%)
-.global psInitAppSRT
-psInitAppSRT:
-/* 803A4138 003A0D18  7C 08 02 A6 */	mflr r0
-/* 803A413C 003A0D1C  3C 60 80 4D */	lis r3, HSD_PSAppSrt_804D10B0@ha
-/* 803A4140 003A0D20  90 01 00 04 */	stw r0, 4(r1)
-/* 803A4144 003A0D24  38 00 00 00 */	li r0, 0
-/* 803A4148 003A0D28  38 63 10 B0 */	addi r3, r3, HSD_PSAppSrt_804D10B0@l
-/* 803A414C 003A0D2C  94 21 FF F8 */	stwu r1, -8(r1)
-/* 803A4150 003A0D30  38 A0 00 04 */	li r5, 4
-/* 803A4154 003A0D34  B0 0D C2 3E */	sth r0, hsd_804D78DE@sda21(r13)
-/* 803A4158 003A0D38  B0 0D C2 38 */	sth r0, hsd_804D78D8@sda21(r13)
-/* 803A415C 003A0D3C  B0 8D C2 B8 */	sth r4, HSD_PSAppSrt_804D7958@sda21(r13)
-/* 803A4160 003A0D40  4B FD 6B E9 */	bl HSD_ObjAllocInit
-/* 803A4164 003A0D44  38 60 00 00 */	li r3, 0
-/* 803A4168 003A0D48  80 01 00 0C */	lwz r0, 0xc(r1)
-/* 803A416C 003A0D4C  38 21 00 08 */	addi r1, r1, 8
-/* 803A4170 003A0D50  7C 08 03 A6 */	mtlr r0
-/* 803A4174 003A0D54  4E 80 00 20 */	blr
-
 # https://decomp.me/scratch/BtnBu
 .global psAddGeneratorAppSRT
 psAddGeneratorAppSRT:

--- a/src/sysdolphin/baselib/psappsrt.c
+++ b/src/sysdolphin/baselib/psappsrt.c
@@ -6,13 +6,14 @@
 
 /* 004D4538 */ extern u16 HSD_PSAppSrt_804D7958[4];
 /* 004CDC90 */ extern HSD_ObjAllocData HSD_PSAppSrt_804D10B0;
-/* 003A0FC8 */ extern u16 psRemoveGeneratorSRT(unk_t);
-/* 003A0F24 */ extern u16 psRemoveParticleAppSRT(unk_t);
-/* 003A0EE8 */ extern u16 psAttachGeneratorAppSRT(unk_t, unk_t);
-/* 003A0EAC */ extern u16 psAttachParticleAppSRT(unk_t, unk_t);
-/* 003A0E74 */ extern UnkGeneratorMember*
-psAddGeneratorAppSRT_begin(UnkGeneratorStruct*, s32);
-/* 003A0E3C */ extern void HSD_PSAppSrt_803A425C(unk_t, s32);
-/* 003A0D58 */ extern s32 psAddGeneratorAppSRT(s32, u16);
-/* 003A0D58 */ extern s32 psAddGeneratorAppSRT(s32, u16);
-/* 003A0D18 */ extern bool psInitAppSRT(u16);
+extern u16 hsd_804D78DE;
+extern u16 hsd_804D78D8;
+
+bool psInitAppSRT(int num, int size)
+{
+    hsd_804D78DE = 0;
+    hsd_804D78D8 = 0;
+    HSD_PSAppSrt_804D7958[0] = (u16) size;
+    HSD_ObjAllocInit(&HSD_PSAppSrt_804D10B0, size, 4U);
+    return 0;
+}

--- a/src/sysdolphin/baselib/psappsrt.h
+++ b/src/sysdolphin/baselib/psappsrt.h
@@ -30,6 +30,9 @@ struct UnkGeneratorStruct {
     UnkGeneratorMember* x54;
 };
 
+/* 003A0D18 */ bool psInitAppSRT(int, int);
+/* 003A0D58 */ s32 psAddGeneratorAppSRT(s32, u16);
+/* 003A0E3C */ void HSD_PSAppSrt_803A425C(unk_t, s32);
 u16 psRemoveGeneratorSRT(unk_t);
 u16 psRemoveParticleAppSRT(unk_t);
 UnkGeneratorMember* psAddGeneratorAppSRT_begin(UnkGeneratorStruct*, s32);

--- a/src/sysdolphin/baselib/psstructs.h
+++ b/src/sysdolphin/baselib/psstructs.h
@@ -7,11 +7,12 @@
 #include <baselib/archive.h>
 #include <baselib/jobj.h>
 
-typedef unk_t HSD_PSAppSRT;
-
-struct _generator;
-
 struct _psAppSRT;
+typedef struct _psAppSRT HSD_psAppSRT;
+struct _particle;
+typedef struct _particle HSD_Particle;
+struct _generator;
+typedef struct _generator HSD_Generator;
 
 enum HSD_ParticleKind {
     Tornado = 1 << 2,
@@ -84,7 +85,31 @@ typedef struct _HSD_PSCmdList {
 } HSD_PSCmdList;
 
 struct _particle;
-typedef struct _particle HSD_Particle;
+
+struct _psAppSRT {
+    struct _psAppSRT* next; /* 0x0 */
+
+    struct _generator* gp; /* 0x4 */
+
+    Vec3 tra;       /* 0x8 */
+    Quaternion rot; /* 0x14 */
+    Vec3 sca;       /* 0x24 */
+
+    u8 status; /* 0x30 */
+
+    u8 frameNum;   /* 0x31 */
+    u16 usedCount; /* 0x32 */
+
+    Mtx mmtx;  /* 0x34 */
+    float ssx; /* 0x64 */
+    float ssy; /* 0x68 */
+
+    void (*freefunc)(struct _psAppSRT* appSrt); /* 0x6C */
+
+    u16 idnum;    /* 0x70 */
+    u8 billboard; /* 0x72 */
+    u8 dummy;     /* 0x73 */
+};
 
 /* size: 0x9C */
 struct _particle {
@@ -181,31 +206,6 @@ struct _particle {
     int (*callback)(HSD_Particle* part); /* 0x98 */
 };
 
-struct _psAppSRT {
-    HSD_PSAppSRT* next; /* 0x0 */
-
-    struct _generator* gp; /* 0x4 */
-
-    Vec3 tra;       /* 0x8 */
-    Quaternion rot; /* 0x14 */
-    Vec3 sca;       /* 0x24 */
-
-    u8 status; /* 0x30 */
-
-    u8 frameNum;   /* 0x31 */
-    u16 usedCount; /* 0x32 */
-
-    Mtx mmtx;  /* 0x34 */
-    float ssx; /* 0x64 */
-    float ssy; /* 0x68 */
-
-    void (*freefunc)(HSD_PSAppSRT* appSrt); /* 0x6C */
-
-    u16 idnum;    /* 0x70 */
-    u8 billboard; /* 0x72 */
-    u8 dummy;     /* 0x73 */
-};
-
 /* size: 0xC */
 typedef struct _PSUserFunc {
     int (*hookCreate)(HSD_Particle* part); /* 0x0 */
@@ -213,6 +213,91 @@ typedef struct _PSUserFunc {
     int (*setUserData)(HSD_Particle* part, u8 unknown1,
                        float unknown2); /* 0x8 */
 } HSD_PSUserFunc;
+
+typedef struct _auxDisc {
+    f32 minAngle;
+    f32 maxAngle;
+} auxDisc;
+
+typedef struct _auxLine {
+    f32 x2;
+    f32 y2;
+    f32 z2;
+} auxLine;
+
+typedef struct _auxTornado {
+    f32 vel;
+} auxTornado;
+
+typedef struct _auxRect {
+    f32 x;
+    f32 y;
+    f32 z;
+    f32 xx;
+    f32 xy;
+    f32 xz;
+    f32 yx;
+    f32 yy;
+    f32 yz;
+    f32 zx;
+    f32 zy;
+    f32 zz;
+    u16 flag;
+} auxRect;
+
+typedef struct _auxCone {
+    f32 minAngle;
+    f32 maxAngle;
+    f32 height;
+} auxCone;
+
+typedef struct _auxSphere {
+    f32 speed;
+    f32 latMid;
+    f32 latRange;
+    f32 lonMid;
+    f32 lonRange;
+} auxSphere;
+
+typedef struct _generator {
+    HSD_Generator* next;
+    u32 kind;
+    f32 random;
+    f32 count;
+    HSD_JObj* jobj;
+    u16 genLife;
+    u16 type;
+    u8 bank;
+    u8 linkNo;
+    u8 texGroup;
+    u8 dummy;
+    u16 idnum;
+    u16 life;
+    u8* cmdList;
+    f32 x;
+    f32 y;
+    f32 z;
+    f32 vx;
+    f32 vy;
+    f32 vz;
+    f32 grav;
+    f32 fric;
+    f32 size;
+    f32 radius;
+    f32 angle;
+    u32 numChild;
+    HSD_psAppSRT* appsrt;
+    HSD_PSUserFunc userfunc;
+    int (*callback)(HSD_Generator* part);
+    union {
+        auxDisc disc;
+        auxLine line;
+        auxTornado tornado;
+        auxRect rect;
+        auxCone cone;
+        auxSphere sphere;
+    } aux;
+};
 
 extern u32* ptclref[64];
 


### PR DESCRIPTION
* Matches psInitAppSRT
* Removes erroneous `unk_t` typedef for an already defined struct
* Adds the `_generator` struct used in later psAppSRT code