### PR TITLE
Fix iref_INC to have a void type

### DIFF
--- a/src/sysdolphin/baselib/object.h
+++ b/src/sysdolphin/baselib/object.h
@@ -111,7 +111,7 @@ static inline void ref_INC(void* o)
     }
 }
 
-static inline iref_INC(void* o)
+static inline void iref_INC(void* o)
 {
     HSD_OBJ(o)->ref_count_individual++;
     if (!(HSD_OBJ(o)->ref_count_individual != 0)) {


### PR DESCRIPTION
Breaks context parsing on decomp.me without it.