### PR TITLE
Fix include paths in `sysdolphin`

### DIFF
--- a/src/sysdolphin/baselib/axdriver.h
+++ b/src/sysdolphin/baselib/axdriver.h
@@ -2,7 +2,7 @@
 #define _AXDRIVER_H_
 
 #include <platform.h>
-#include <baselib/forward.h>
+#include "baselib/forward.h"
 
 #define SMSTATE_MASK 0xC0000000
 

--- a/src/sysdolphin/baselib/baselib_unknown_002.h
+++ b/src/sysdolphin/baselib/baselib_unknown_002.h
@@ -2,9 +2,9 @@
 #define SYSDOLPHIN_BASELIB_BASELIB_UNKNOWN_002_H
 
 #include <platform.h>
-#include <baselib/forward.h>
+#include "baselib/forward.h"
 
-#include <baselib/jobj.h>
+#include "baselib/jobj.h"
 
 bool hsd_803931A4(s32);
 void hsd_80393A54(bool);

--- a/src/sysdolphin/baselib/class.c
+++ b/src/sysdolphin/baselib/class.c
@@ -3,10 +3,10 @@
 #include <__mem.h>
 #include <string.h>
 #include <dolphin/os.h>
-#include <baselib/debug.h>
-#include <baselib/hash.h>
-#include <baselib/memory.h>
-#include <baselib/object.h>
+#include "debug.h"
+#include "hash.h"
+#include "memory.h"
+#include "object.h"
 
 void _hsdClassInfoInit(void);
 HSD_ClassInfo hsdClass = { _hsdClassInfoInit };

--- a/src/sysdolphin/baselib/cobj.c
+++ b/src/sysdolphin/baselib/cobj.c
@@ -8,16 +8,16 @@
 #include <dolphin/mtx/mtxvec.h>
 #include <dolphin/mtx/vec.h>
 #include <dolphin/vi/vi.h>
-#include <baselib/aobj.h>
-#include <baselib/class.h>
-#include <baselib/cobj.h>
-#include <baselib/debug.h>
-#include <baselib/displayfunc.h>
-#include <baselib/fobj.h>
-#include <baselib/initialize.h>
-#include <baselib/mtx.h>
-#include <baselib/video.h>
-#include <baselib/wobj.h>
+#include "aobj.h"
+#include "class.h"
+#include "cobj.h"
+#include "debug.h"
+#include "displayfunc.h"
+#include "fobj.h"
+#include "initialize.h"
+#include "mtx.h"
+#include "video.h"
+#include "wobj.h"
 #include <MetroTRK/intrinsics.h>
 #include <MSL/trigf.h>
 

--- a/src/sysdolphin/baselib/controller.c
+++ b/src/sysdolphin/baselib/controller.c
@@ -1,6 +1,6 @@
 #include <dolphin/os/OSInterrupt.h>
-#include <baselib/controller.h>
-#include <baselib/rumble.h>
+#include "controller.h"
+#include "rumble.h"
 
 extern PadLibData HSD_PadLibData;
 extern HSD_PadStatus HSD_PadMasterStatus[4];

--- a/src/sysdolphin/baselib/controller.h
+++ b/src/sysdolphin/baselib/controller.h
@@ -3,10 +3,10 @@
 
 #include <platform.h>
 #include <dolphin/pad/forward.h>
-#include <baselib/forward.h>
+#include "baselib/forward.h"
 
 #include <dolphin/pad/pad.h>
-#include <baselib/rumble.h>
+#include "baselib/rumble.h"
 
 typedef enum _HSD_FlushType {
     HSD_PAD_FLUSH_QUEUE_MERGE,

--- a/src/sysdolphin/baselib/devcom.c
+++ b/src/sysdolphin/baselib/devcom.c
@@ -1,4 +1,4 @@
-#include <baselib/devcom.h>
+#include "devcom.h"
 
 bool devComStatus[4];
 

--- a/src/sysdolphin/baselib/devcom.h
+++ b/src/sysdolphin/baselib/devcom.h
@@ -2,9 +2,9 @@
 #define SYSDOLPHIN_BASELIB_DEVCOM_H
 
 #include <platform.h>
-#include <baselib/forward.h>
+#include "baselib/forward.h"
 
-#include <baselib/archive.h>
+#include "baselib/archive.h"
 
 s32 HSD_DevComIsBusy(s32 idx);
 void HSD_DevComRequest(int, int, HSD_Archive*, int, int, int,

--- a/src/sysdolphin/baselib/displayfunc.c
+++ b/src/sysdolphin/baselib/displayfunc.c
@@ -1,10 +1,10 @@
 #include <dolphin/gx/GXAttr.h>
 #include <dolphin/gx/GXTransform.h>
-#include <baselib/displayfunc.h>
-#include <baselib/objalloc.h>
-#include <baselib/pobj.h>
-#include <baselib/state.h>
-#include <baselib/tev.h>
+#include "displayfunc.h"
+#include "objalloc.h"
+#include "pobj.h"
+#include "state.h"
+#include "tev.h"
 
 typedef struct _HSD_ZList {
     Mtx pmtx;

--- a/src/sysdolphin/baselib/displayfunc.h
+++ b/src/sysdolphin/baselib/displayfunc.h
@@ -3,10 +3,10 @@
 
 #include <platform.h>
 #include <dolphin/mtx/forward.h>
-#include <baselib/forward.h>
+#include "baselib/forward.h"
 
-#include <baselib/jobj.h>
-#include <baselib/objalloc.h>
+#include "baselib/jobj.h"
+#include "baselib/objalloc.h"
 
 void _HSD_DispForgetMemory(void* low, void* high);
 void HSD_ZListInitAllocData(void);

--- a/src/sysdolphin/baselib/fobj.c
+++ b/src/sysdolphin/baselib/fobj.c
@@ -1,8 +1,8 @@
 #include "fobj.h"
 
 #include <__mem.h>
-#include <baselib/debug.h>
-#include <baselib/spline.h>
+#include "debug.h"
+#include "spline.h"
 
 HSD_ObjAllocData fobj_alloc_data;
 

--- a/src/sysdolphin/baselib/gobj.c
+++ b/src/sysdolphin/baselib/gobj.c
@@ -1,12 +1,12 @@
-#include <baselib/class.h>
-#include <baselib/cobj.h>
-#include <baselib/fog.h>
-#include <baselib/gobj.h>
-#include <baselib/gobjplink.h>
-#include <baselib/gobjproc.h>
-#include <baselib/jobj.h>
-#include <baselib/lobj.h>
-#include <baselib/object.h>
+#include "class.h"
+#include "cobj.h"
+#include "fog.h"
+#include "gobj.h"
+#include "gobjplink.h"
+#include "gobjproc.h"
+#include "jobj.h"
+#include "lobj.h"
+#include "object.h"
 
 inline void GObj_SetFlag1_inline(HSD_GObjProc* proc, u8 value)
 {

--- a/src/sysdolphin/baselib/gobjgxlink.c
+++ b/src/sysdolphin/baselib/gobjgxlink.c
@@ -1,6 +1,6 @@
-#include <baselib/debug.h>
-#include <baselib/gobj.h>
-#include <baselib/gobjgxlink.h>
+#include "debug.h"
+#include "gobj.h"
+#include "gobjgxlink.h"
 
 #ifdef MUST_MATCH
 #pragma push

--- a/src/sysdolphin/baselib/gobjgxlink.h
+++ b/src/sysdolphin/baselib/gobjgxlink.h
@@ -2,9 +2,9 @@
 #define _gobjgxlink_h_
 
 #include <platform.h>
-#include <baselib/forward.h>
+#include "baselib/forward.h"
 
-#include <baselib/gobj.h>
+#include "baselib/gobj.h"
 
 void GObj_GXReorder(HSD_GObj* gobj, HSD_GObj* hiprio_gobj);
 void GObj_SetupGXLink(HSD_GObj* gobj, GObj_RenderFunc render_cb, u8 gx_link,

--- a/src/sysdolphin/baselib/gobjplink.c
+++ b/src/sysdolphin/baselib/gobjplink.c
@@ -1,11 +1,11 @@
-#include <baselib/debug.h>
-#include <baselib/gobj.h>
-#include <baselib/gobjgxlink.h>
-#include <baselib/gobjobject.h>
-#include <baselib/gobjplink.h>
-#include <baselib/gobjproc.h>
-#include <baselib/gobjuserdata.h>
-#include <baselib/objalloc.h>
+#include "debug.h"
+#include "gobj.h"
+#include "gobjgxlink.h"
+#include "gobjobject.h"
+#include "gobjplink.h"
+#include "gobjproc.h"
+#include "gobjuserdata.h"
+#include "objalloc.h"
 
 void GObj_PReorder(HSD_GObj* gobj, HSD_GObj* hiprio_gobj)
 {

--- a/src/sysdolphin/baselib/gobjplink.h
+++ b/src/sysdolphin/baselib/gobjplink.h
@@ -2,9 +2,9 @@
 #define SYSDOLPHIN_BASELIB_GOBJPLINK_H
 
 #include <platform.h>
-#include <baselib/forward.h>
+#include "baselib/forward.h"
 
-#include <baselib/gobj.h>
+#include "baselib/gobj.h"
 
 void HSD_GObjPLink_80390228(HSD_GObj*);
 void HSD_GObjPLink_8039032C(u32 arg0, HSD_GObj* gobj, u8 p_link, u8 priority,

--- a/src/sysdolphin/baselib/gobjproc.c
+++ b/src/sysdolphin/baselib/gobjproc.c
@@ -1,7 +1,7 @@
-#include <baselib/debug.h>
-#include <baselib/gobj.h>
-#include <baselib/gobjproc.h>
-#include <baselib/objalloc.h>
+#include "debug.h"
+#include "gobj.h"
+#include "gobjproc.h"
+#include "objalloc.h"
 
 extern HSD_ObjAllocData gobjproc_alloc_data;
 

--- a/src/sysdolphin/baselib/gobjproc.h
+++ b/src/sysdolphin/baselib/gobjproc.h
@@ -2,7 +2,7 @@
 #define SYSDOLPHIN_BASELIB_GOBJPROC_H
 
 #include <platform.h>
-#include <baselib/forward.h>
+#include "baselib/forward.h"
 
 struct HSD_GObjProc {
     /* 0x00 */ HSD_GObjProc* child;

--- a/src/sysdolphin/baselib/hash.h
+++ b/src/sysdolphin/baselib/hash.h
@@ -3,7 +3,7 @@
 
 #include <platform.h>
 
-#include <baselib/class.h>
+#include "baselib/class.h"
 
 #define hash(s) (s % 0x65)
 HSD_ClassInfo* HSD_HashSearch(u32, const char* class_name, int);

--- a/src/sysdolphin/baselib/hsd_3B33.c
+++ b/src/sysdolphin/baselib/hsd_3B33.c
@@ -1,7 +1,7 @@
 #include <__mem.h>
 #include <Gecko_setjmp.h>
-#include <baselib/__baselib.h>
-#include <baselib/hsd_3B33.h>
+#include "__baselib.h"
+#include "hsd_3B33.h"
 
 void hsd_803B3344(u8 byte)
 {

--- a/src/sysdolphin/baselib/hsd_3B34.h
+++ b/src/sysdolphin/baselib/hsd_3B34.h
@@ -1,6 +1,6 @@
 #ifndef SYSDOLPHIN_BASELIB_BASELIB_UNKNOWN_001_H
 #define SYSDOLPHIN_BASELIB_BASELIB_UNKNOWN_001_H
 
-#include <baselib/__baselib.h>
+#include "baselib/__baselib.h"
 
 #endif

--- a/src/sysdolphin/baselib/initialize.c
+++ b/src/sysdolphin/baselib/initialize.c
@@ -7,23 +7,23 @@
 #include <dolphin/os/OSArena.h>
 #include <dolphin/os/OSMemory.h>
 #include <dolphin/vi/vi.h>
-#include <baselib/aobj.h>
-#include <baselib/class.h>
-#include <baselib/debug.h>
-#include <baselib/displayfunc.h>
-#include <baselib/fobj.h>
-#include <baselib/id.h>
-#include <baselib/initialize.h>
-#include <baselib/list.h>
-#include <baselib/lobj.h>
-#include <baselib/mtx.h>
-#include <baselib/objalloc.h>
-#include <baselib/random.h>
-#include <baselib/robj.h>
-#include <baselib/shadow.h>
-#include <baselib/state.h>
-#include <baselib/tev.h>
-#include <baselib/video.h>
+#include "aobj.h"
+#include "class.h"
+#include "debug.h"
+#include "displayfunc.h"
+#include "fobj.h"
+#include "id.h"
+#include "initialize.h"
+#include "list.h"
+#include "lobj.h"
+#include "mtx.h"
+#include "objalloc.h"
+#include "random.h"
+#include "robj.h"
+#include "shadow.h"
+#include "state.h"
+#include "tev.h"
+#include "video.h"
 
 extern OSHeapHandle HSD_Synth_804D6018;
 extern GXRenderModeObj GXNtsc480IntDf;

--- a/src/sysdolphin/baselib/jobj.c
+++ b/src/sysdolphin/baselib/jobj.c
@@ -6,19 +6,19 @@
 #include <dolphin/mtx/mtxvec.h>
 #include <dolphin/mtx/vec.h>
 #include <dolphin/os.h>
-#include <baselib/aobj.h>
-#include <baselib/class.h>
-#include <baselib/cobj.h>
-#include <baselib/displayfunc.h>
-#include <baselib/dobj.h>
-#include <baselib/fobj.h>
-#include <baselib/id.h>
-#include <baselib/jobj.h>
-#include <baselib/mobj.h>
-#include <baselib/mtx.h>
-#include <baselib/pobj.h>
-#include <baselib/robj.h>
-#include <baselib/spline.h>
+#include "aobj.h"
+#include "class.h"
+#include "cobj.h"
+#include "displayfunc.h"
+#include "dobj.h"
+#include "fobj.h"
+#include "id.h"
+#include "jobj.h"
+#include "mobj.h"
+#include "mtx.h"
+#include "pobj.h"
+#include "robj.h"
+#include "spline.h"
 
 void JObjInfoInit(void);
 HSD_JObjInfo hsdJObj = { JObjInfoInit };

--- a/src/sysdolphin/baselib/mobj.c
+++ b/src/sysdolphin/baselib/mobj.c
@@ -3,13 +3,13 @@
 #include <__mem.h>
 #include <dolphin/gx/GXEnum.h>
 #include <dolphin/os.h>
-#include <baselib/aobj.h>
-#include <baselib/class.h>
-#include <baselib/debug.h>
-#include <baselib/fobj.h>
-#include <baselib/state.h>
-#include <baselib/tev.h>
-#include <baselib/texp.h>
+#include "aobj.h"
+#include "class.h"
+#include "debug.h"
+#include "fobj.h"
+#include "state.h"
+#include "tev.h"
+#include "texp.h"
 
 static HSD_ClassInfo* default_class;
 static HSD_MObj* current_mobj;

--- a/src/sysdolphin/baselib/mtx.c
+++ b/src/sysdolphin/baselib/mtx.c
@@ -4,8 +4,8 @@
 
 #include <dolphin/mtx.h>
 #include <dolphin/mtx/vec.h>
-#include <baselib/debug.h>
-#include <baselib/mtx.h>
+#include "debug.h"
+#include "mtx.h"
 #include <MSL/trigf.h>
 
 #define EPSILON 0.0000000001f

--- a/src/sysdolphin/baselib/mtx.h
+++ b/src/sysdolphin/baselib/mtx.h
@@ -6,7 +6,7 @@
 
 #include "lb/lbrefract.h"
 
-#include <baselib/objalloc.h>
+#include "baselib/objalloc.h"
 
 void HSD_MtxInverse(Mtx src, Mtx dest);
 void HSD_MtxInverseConcat(Mtx inv, Mtx src, Mtx dest);

--- a/src/sysdolphin/baselib/pobj.c
+++ b/src/sysdolphin/baselib/pobj.c
@@ -1,5 +1,5 @@
 #include <dolphin/gx/forward.h>
-#include <baselib/forward.h>
+#include "forward.h"
 
 #include <__mem.h>
 #include <math.h>
@@ -11,20 +11,20 @@
 #include <dolphin/gx/GXVert.h>
 #include <dolphin/mtx.h>
 #include <dolphin/os.h>
-#include <baselib/aobj.h>
-#include <baselib/class.h>
-#include <baselib/debug.h>
-#include <baselib/displayfunc.h>
-#include <baselib/fobj.h>
-#include <baselib/id.h>
-#include <baselib/jobj.h>
-#include <baselib/memory.h>
-#include <baselib/mtx.h>
-#include <baselib/perf.h>
-#include <baselib/pobj.h>
-#include <baselib/state.h>
-#include <baselib/tobj.h>
-#include <baselib/util.h>
+#include "aobj.h"
+#include "class.h"
+#include "debug.h"
+#include "displayfunc.h"
+#include "fobj.h"
+#include "id.h"
+#include "jobj.h"
+#include "memory.h"
+#include "mtx.h"
+#include "perf.h"
+#include "pobj.h"
+#include "state.h"
+#include "tobj.h"
+#include "util.h"
 
 static void PObjInfoInit(void);
 

--- a/src/sysdolphin/baselib/psappsrt.c
+++ b/src/sysdolphin/baselib/psappsrt.c
@@ -1,5 +1,5 @@
-#include <baselib/objalloc.h>
-#include <baselib/psappsrt.h>
+#include "objalloc.h"
+#include "psappsrt.h"
 
 /* 004D4538 */ extern u16 HSD_PSAppSrt_804D7958[4];
 /* 004CDC90 */ extern HSD_ObjAllocData HSD_PSAppSrt_804D10B0;

--- a/src/sysdolphin/baselib/psappsrt.h
+++ b/src/sysdolphin/baselib/psappsrt.h
@@ -2,7 +2,7 @@
 #define SYSDOLPHIN_BASELIB_PSAPPSRT_H
 
 #include <platform.h>
-#include <baselib/forward.h>
+#include "baselib/forward.h"
 
 #include <dolphin/mtx/types.h>
 

--- a/src/sysdolphin/baselib/psdisp.c
+++ b/src/sysdolphin/baselib/psdisp.c
@@ -1,4 +1,4 @@
-#include <baselib/psdisp.h>
+#include "psdisp.h"
 
 typedef struct {
     u8 filename[9];

--- a/src/sysdolphin/baselib/psdisp.h
+++ b/src/sysdolphin/baselib/psdisp.h
@@ -4,7 +4,7 @@
 #include <platform.h>
 #include <dolphin/gx/forward.h>
 
-#include <baselib/psstructs.h>
+#include "baselib/psstructs.h"
 
 void psDispParticles(s32, u32);
 unk_t particleSort(s32, u8, unk_t*, unk_t*);

--- a/src/sysdolphin/baselib/psdisptev.c
+++ b/src/sysdolphin/baselib/psdisptev.c
@@ -1,7 +1,5 @@
 #include <platform.h>
 
-#include <baselib/psdisptev.h>
-
 extern s32 prevTev[2];
 
 void psSetupTev(unk_t);

--- a/src/sysdolphin/baselib/psstructs.h
+++ b/src/sysdolphin/baselib/psstructs.h
@@ -3,13 +3,13 @@
 
 #include <platform.h>
 #include <dolphin/gx/forward.h>
-#include <baselib/forward.h>
+#include "baselib/forward.h"
 
 #include <dolphin/gx/GXEnum.h>
 #include <dolphin/gx/types.h>
 #include <dolphin/mtx/types.h>
-#include <baselib/archive.h>
-#include <baselib/jobj.h>
+#include "baselib/archive.h"
+#include "baselib/jobj.h"
 
 struct _psAppSRT;
 struct HSD_Fog;

--- a/src/sysdolphin/baselib/robj.c
+++ b/src/sysdolphin/baselib/robj.c
@@ -4,16 +4,16 @@
 #include <dolphin/mtx.h>
 #include <dolphin/mtx/vec.h>
 #include <dolphin/os.h>
-#include <baselib/aobj.h>
-#include <baselib/class.h>
-#include <baselib/debug.h>
-#include <baselib/fobj.h>
-#include <baselib/id.h>
-#include <baselib/jobj.h>
-#include <baselib/list.h>
-#include <baselib/mtx.h>
-#include <baselib/object.h>
-#include <baselib/robj.h>
+#include "aobj.h"
+#include "class.h"
+#include "debug.h"
+#include "fobj.h"
+#include "id.h"
+#include "jobj.h"
+#include "list.h"
+#include "mtx.h"
+#include "object.h"
+#include "robj.h"
 
 HSD_ObjAllocData robj_alloc_data;   // robj_alloc_data
 HSD_ObjAllocData rvalue_alloc_data; // rvalue_alloc_data

--- a/src/sysdolphin/baselib/rumble.c
+++ b/src/sysdolphin/baselib/rumble.c
@@ -2,8 +2,8 @@
 
 #include <dolphin/os/OSInterrupt.h>
 #include <dolphin/pad/pad.h>
-#include <baselib/controller.h>
-#include <baselib/rumble.h>
+#include "controller.h"
+#include "rumble.h"
 
 extern PadLibData HSD_PadLibData;
 

--- a/src/sysdolphin/baselib/rumble.h
+++ b/src/sysdolphin/baselib/rumble.h
@@ -2,7 +2,7 @@
 #define SYSDOLPHIN_BASELIB_RUMBLE_H
 
 #include <platform.h>
-#include <baselib/forward.h>
+#include "baselib/forward.h"
 
 #include <dolphin/pad/pad.h>
 

--- a/src/sysdolphin/baselib/shadow.c
+++ b/src/sysdolphin/baselib/shadow.c
@@ -5,11 +5,11 @@
 
 #include <__mem.h>
 #include <dolphin/gx/GXFrameBuf.h>
-#include <baselib/class.h>
-#include <baselib/cobj.h>
-#include <baselib/debug.h>
-#include <baselib/object.h>
-#include <baselib/tobj.h>
+#include "class.h"
+#include "cobj.h"
+#include "debug.h"
+#include "object.h"
+#include "tobj.h"
 
 extern HSD_ObjAllocData shadow_alloc_data;
 

--- a/src/sysdolphin/baselib/shadow.h
+++ b/src/sysdolphin/baselib/shadow.h
@@ -2,13 +2,13 @@
 #define _shadow_h_
 
 #include <platform.h>
-#include <baselib/forward.h>
+#include "baselib/forward.h"
 
 #include <dolphin/mtx/types.h>
-#include <baselib/cobj.h>
-#include <baselib/list.h>
-#include <baselib/objalloc.h>
-#include <baselib/tobj.h>
+#include "baselib/cobj.h"
+#include "baselib/list.h"
+#include "baselib/objalloc.h"
+#include "baselib/tobj.h"
 
 struct HSD_Shadow {
     HSD_SList* objects; // 0x0

--- a/src/sysdolphin/baselib/sislib.h
+++ b/src/sysdolphin/baselib/sislib.h
@@ -2,9 +2,9 @@
 #define SYSDOLPHIN_BASELIB_SISLIB_H
 
 #include <platform.h>
-#include <baselib/forward.h>
+#include "baselib/forward.h"
 
-#include <baselib/archive.h>
+#include "baselib/archive.h"
 
 typedef struct {
     unk_t x0;

--- a/src/sysdolphin/baselib/sobjlib.c
+++ b/src/sysdolphin/baselib/sobjlib.c
@@ -1,9 +1,9 @@
 #include <platform.h>
 #include <dolphin/mtx/forward.h>
-#include <baselib/forward.h>
+#include "forward.h"
 
-#include <baselib/objalloc.h>
-#include <baselib/sobjlib.h>
+#include "objalloc.h"
+#include "sobjlib.h"
 
 /* 004DB670 */ extern const s32 HSD_SObjLib_804DEA90;
 /* 004DB66C */ extern const s32 HSD_SObjLib_804DEA8C;

--- a/src/sysdolphin/baselib/tev.c
+++ b/src/sysdolphin/baselib/tev.c
@@ -7,8 +7,8 @@
 #include <dolphin/gx/GXLight.h>
 #include <dolphin/gx/GXTev.h>
 #include <dolphin/gx/types.h>
-#include <baselib/debug.h>
-#include <baselib/tev.h>
+#include "debug.h"
+#include "tev.h"
 
 static struct {
     GXColorS10 a;

--- a/src/sysdolphin/baselib/texp.c
+++ b/src/sysdolphin/baselib/texp.c
@@ -1,7 +1,7 @@
 #include <__mem.h>
 #include <placeholder.h>
-#include <baselib/debug.h>
-#include <baselib/texp.h>
+#include "debug.h"
+#include "texp.h"
 #include <sysdolphin/baselib/class.h>
 #include <sysdolphin/baselib/tev.h>
 #include <sysdolphin/baselib/texpdag.h>

--- a/src/sysdolphin/baselib/texpdag.h
+++ b/src/sysdolphin/baselib/texpdag.h
@@ -2,9 +2,9 @@
 #define _texpdag_h_
 
 #include <platform.h>
-#include <baselib/forward.h>
+#include "baselib/forward.h"
 
-#include <baselib/texp.h>
+#include "baselib/texp.h"
 
 typedef struct HSD_TExpDag {
     struct _HSD_TETev* tev;

--- a/src/sysdolphin/baselib/tobj.c
+++ b/src/sysdolphin/baselib/tobj.c
@@ -8,8 +8,8 @@
 #include <math.h>
 #include <dolphin/mtx.h>
 #include <dolphin/mtx/types.h>
-#include <baselib/debug.h>
-#include <baselib/fobj.h>
+#include "debug.h"
+#include "fobj.h"
 #include <MetroTRK/intrinsics.h>
 
 extern void TObjInfoInit(void);

--- a/src/sysdolphin/baselib/video.c
+++ b/src/sysdolphin/baselib/video.c
@@ -2,9 +2,9 @@
 #include <dolphin/gx/GXMisc.h>
 #include <dolphin/os/OSInterrupt.h>
 #include <dolphin/vi/vi.h>
-#include <baselib/debug.h>
-#include <baselib/state.h>
-#include <baselib/video.h>
+#include "debug.h"
+#include "state.h"
+#include "video.h"
 
 HSD_VIInfo HSD_VIData;
 static u8 garbage[HSD_ANTIALIAS_GARBAGE_SIZE] ATTRIBUTE_ALIGN(32);


### PR DESCRIPTION
Note that there is a bug in MWCC when using `-cwd source`. It will use the location of the current C file, not the header, therefore headers must be more specific in their paths.

For example, in `gobj.c`, `#include "gobj.h"` is fine because it resolves to `gobj.h` in the directory of `gobj.c`. But if you put `#include "jobj.h"` in `gobj.h`, and then `fighter.c` tries to include `gobj.h`, it will try to resolve `melee/ft/jobj.h` instead of the correct path.