### PR TITLE
Match 87.77% of `dvderror` (344 bytes)

### DIFF
--- a/src/dolphin/dvd/dvderror.c
+++ b/src/dolphin/dvd/dvderror.c
@@ -1,0 +1,45 @@
+#include <platform.h>
+
+#include <dolphin/os/OSRtc.h>
+
+u32 ErrorTable[18] = { 0x00000000, 0x00023A00, 0x00062800, 0x00030200,
+                       0x00031100, 0x00052000, 0x00052001, 0x00052100,
+                       0x00052400, 0x00052401, 0x00052402, 0x000B5A01,
+                       0x00056300, 0x00020401, 0x00020400, 0x00040800 };
+
+static u8 ErrorCode2Num(u32 errorCode)
+{
+    size_t i;
+
+    for (i = 0; i < ARRAY_SIZE(ErrorTable); i++) {
+        if (errorCode == ErrorTable[i]) {
+            return i;
+        }
+    }
+
+    return 29;
+}
+
+void __DVDStoreErrorCode(u32 errCode)
+{
+    u8 storedCode;
+    u8* sramPtr;
+    u32 upperByte;
+
+    if (errCode == 0x1234567) {
+        storedCode = -1;
+    } else if (errCode == 0x1234568) {
+        storedCode = -2;
+    } else {
+        upperByte = errCode >> 24;
+        storedCode = ErrorCode2Num(errCode & 0xffffff);
+        if (errCode >> 24 >= 6) {
+            upperByte = 6;
+        }
+        storedCode += upperByte * 30;
+    }
+
+    sramPtr = (u8*) __OSLockSramEx();
+    sramPtr[36] = storedCode;
+    __OSUnlockSramEx(1);
+}


### PR DESCRIPTION
## Report of `dolphin/dvd/dvderror.c`
Function|Size|Score|Max|%
-|-|-|-|-
**File**|`344 bytes`|`1,052`|`8,600`|`87.77%`
`__DVDStoreErrorCode`|`344 bytes`|`1,052`|`8,600`|`87.77%`
