### PR TITLE
Create `revert_asm.py` to unlink C files from `make`

### DIFF
--- a/tools/revert_asm.py
+++ b/tools/revert_asm.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import argparse
+import platform
+import subprocess
+from pathlib import Path
+
+
+def run_command(path: Path) -> None:
+    root = Path(__file__).parents[1]
+    path = path.resolve().relative_to(root / "src")
+    obj_path = root / "build/GALE01/obj" / path.with_suffix(".o")
+    src_path = "src" / path
+    asm_path = "asm" / path.with_suffix(".s")
+    dtk_path = Path("build/tools/dtk")
+
+    if platform.system() == "Windows":
+        dtk_path = dtk_path.with_suffix(".exe")
+
+    command = [
+        str(root.joinpath(e).resolve()) if isinstance(e, Path) else e
+        for e in [dtk_path, "elf", "disasm", obj_path, asm_path]
+    ]
+
+    subprocess.run(command, check=True)
+
+    mk_path = root / "obj_files.mk"
+    text = mk_path.read_text().replace(src_path.as_posix(), asm_path.as_posix())
+    mk_path.write_text(text)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="revert a C file to asm for make")
+    parser.add_argument("path", metavar="C_FILE",  type=Path, help="the source file to revert")
+
+    args = parser.parse_args()
+
+    run_command(args.path)


### PR DESCRIPTION
```
usage: revert_asm.py [-h] C_FILE

revert a C file to asm for make

positional arguments:
  C_FILE      the source file to revert

options:
  -h, --help  show this help message and exit
```