### PR TITLE
Fix colored output of tools on Windows

### DIFF
--- a/tools/decomp.py
+++ b/tools/decomp.py
@@ -7,9 +7,6 @@ from pathlib import Path
 from sys import stderr
 from typing import Optional, cast
 
-import colorama
-colorama.just_fix_windows_console()
-
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 
@@ -139,6 +136,11 @@ def main():
             pyperclip.copy(output)
         if args.print:
             if args.color:
+                try:
+                    import colorama
+                    colorama.just_fix_windows_console()
+                except ModuleNotFoundError:
+                    pass
                 from pygments import highlight
                 from pygments.formatters import TerminalFormatter
                 from pygments.lexers import CLexer

--- a/tools/decomp.py
+++ b/tools/decomp.py
@@ -7,6 +7,9 @@ from pathlib import Path
 from sys import stderr
 from typing import Optional, cast
 
+import colorama
+colorama.just_fix_windows_console()
+
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 

--- a/tools/m2ctx/m2ctx.py
+++ b/tools/m2ctx/m2ctx.py
@@ -6,9 +6,6 @@ import sys
 from pathlib import Path
 from typing import List
 
-import colorama
-colorama.just_fix_windows_console()
-
 here = Path(__file__).parent
 root = (here / "../../").resolve()
 src = root / "src"
@@ -197,6 +194,11 @@ def main():
 
     if not args.quiet:
         if args.colorize:
+            try:
+                import colorama
+                colorama.just_fix_windows_console()
+            except ModuleNotFoundError:
+                pass
             from pygments import highlight
             from pygments.formatters import TerminalFormatter
             from pygments.lexers import CLexer

--- a/tools/m2ctx/m2ctx.py
+++ b/tools/m2ctx/m2ctx.py
@@ -6,6 +6,9 @@ import sys
 from pathlib import Path
 from typing import List
 
+import colorama
+colorama.just_fix_windows_console()
+
 here = Path(__file__).parent
 root = (here / "../../").resolve()
 src = root / "src"


### PR DESCRIPTION
> If you’re on a recent version of Windows 10 or better, and your stdout/stderr are pointing to a Windows console, then this will flip the magic configuration switch to enable Windows’ built-in ANSI support.
> 
> If you’re on an older version of Windows, and your stdout/stderr are pointing to a Windows console, then this will wrap sys.stdout and/or sys.stderr in a magic file object that intercepts ANSI escape sequences and issues the appropriate Win32 calls to emulate them.
> 
> In all other circumstances, it does nothing whatsoever. Basically the idea is that this makes Windows act like Unix with respect to ANSI escape handling.

https://pypi.org/project/colorama/