### PR TITLE
Fix LObj match being broken by someone's bugfix

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1341,7 +1341,7 @@ config.libs = [
             Object(NonMatching, "sysdolphin/baselib/tev.c"),
             Object(Matching, "sysdolphin/baselib/mobj.c"),
             Object(Matching, "sysdolphin/baselib/aobj.c"),
-            Object(NonMatching, "sysdolphin/baselib/lobj.c"),
+            Object(Matching, "sysdolphin/baselib/lobj.c"),
             Object(NonMatching, "sysdolphin/baselib/cobj.c"),
             Object(Matching, "sysdolphin/baselib/fobj.c"),
             Object(NonMatching, "sysdolphin/baselib/pobj.c"),

--- a/src/sysdolphin/baselib/lobj.c
+++ b/src/sysdolphin/baselib/lobj.c
@@ -719,9 +719,9 @@ HSD_LObj* HSD_LObjGetCurrentByType(u16 flags)
     return NULL;
 }
 
-s32 HSD_LightID2Index(GXLightID id)
+u32 HSD_LightID2Index(GXLightID id)
 {
-    s32 index;
+    u32 index;
     switch (id) {
     case GX_LIGHT0:
         index = 0;
@@ -751,10 +751,7 @@ s32 HSD_LightID2Index(GXLightID id)
         index = 8;
         break;
     default:
-        __assert(__FILE__, 1170, "0");
-
-        /// @todo Find a better fix for uninitialized @c var_r31
-        index = 0;
+        HSD_ASSERT(1170, 0);
         break;
     }
     return index;

--- a/src/sysdolphin/baselib/lobj.h
+++ b/src/sysdolphin/baselib/lobj.h
@@ -147,7 +147,7 @@ HSD_WObj* HSD_LObjGetInterestWObj(HSD_LObj* lobj);
 void HSD_LObjSetPositionWObj(HSD_LObj* lobj, HSD_WObj* wobj);
 void HSD_LObjSetInterestWObj(HSD_LObj* lobj, HSD_WObj* wobj);
 
-s32 HSD_LightID2Index(GXLightID);
+u32 HSD_LightID2Index(GXLightID);
 void HSD_LObjDeleteCurrent(HSD_LObj* lobj);
 s32 HSD_Index2LightID(u32);
 void HSD_LObjRemoveAll(HSD_LObj* lobj);


### PR DESCRIPTION
The index is uninitialized in the case of an invalid GXLightID - because it's going to assert.

The attempt to fix this was making the file non-matching.