### PR TITLE
Remove explicit casts in some item code

### DIFF
--- a/src/melee/it/items/itegg.c
+++ b/src/melee/it/items/itegg.c
@@ -95,7 +95,7 @@ inline s32 attrRand(EggVars* attrs)
 
 bool it_80288DC4(Item_GObj* gobj)
 {
-    Item* ip = GET_ITEM((HSD_GObj*) gobj);
+    Item* ip = GET_ITEM(gobj);
     EggVars* attrs = ip->xC4_article_data->x4_specialAttributes;
     if (attrRand(attrs) == 0) {
         return true;

--- a/src/melee/it/items/itentei.c
+++ b/src/melee/it/items/itentei.c
@@ -75,9 +75,9 @@ bool it_802CF544(Item_GObj* gobj)
     if (it->xDB0_itcmd_var1) {
         it->xDB0_itcmd_var1 = 0;
         it->xDB4_itcmd_var2 = 0;
-        efLib_DestroyAll((HSD_GObj*) gobj);
+        efLib_DestroyAll(gobj);
     }
-    if (it_80272C6C((HSD_GObj*) gobj) == false) {
+    if (it_80272C6C(gobj) == false) {
         return true;
     }
     if (it->xDB4_itcmd_var2) {
@@ -104,7 +104,7 @@ bool it_802CF544(Item_GObj* gobj)
 
 void it_802CF640(Item_GObj* gobj)
 {
-    Item* it = GET_ITEM((HSD_GObj*) gobj);
+    Item* it = GET_ITEM(gobj);
     if (it->ground_or_air == GA_Air) {
         it_80272860(gobj, it->xCC_item_attr->x10_fall_speed,
                     it->xCC_item_attr->x14_fall_speed_max);
@@ -113,7 +113,7 @@ void it_802CF640(Item_GObj* gobj)
 
 bool it_802CF67C(Item_GObj* gobj)
 {
-    Item* it = GET_ITEM((HSD_GObj*) gobj);
+    Item* it = GET_ITEM(gobj);
     if (it->ground_or_air == GA_Air) {
         it_8026E248(gobj, it_802CF44C);
     } else {

--- a/src/melee/it/items/itmetalb.c
+++ b/src/melee/it/items/itmetalb.c
@@ -19,7 +19,7 @@ ItemStateTable it_803F62C0[] = {
 
 void it_802953C8(Item_GObj* gobj)
 {
-    Item* it = GET_ITEM((HSD_GObj*) gobj);
+    Item* it = GET_ITEM(gobj);
     it->xDCE_flag.bits.b7 = 0;
     it_80295498(gobj);
 }
@@ -107,14 +107,14 @@ bool it_802955AC(Item_GObj* gobj)
 
 bool it_802955E0(Item_GObj* gobj)
 {
-    Item* it = GET_ITEM((HSD_GObj*) gobj);
+    Item* it = GET_ITEM(gobj);
     HSD_GObj* go = it_8027236C(gobj);
     PAD_STACK(8);
 
     if (go != NULL) {
         if (go->classifier == HSD_GOBJ_CLASS_FIGHTER && it->xDCF_flag.bits.b6)
         {
-            ftLib_800871A8(go, (HSD_GObj*) gobj);
+            ftLib_800871A8(go, gobj);
             pl_8003E17C(ftLib_80086BE0(go) & 0xFF, ftLib_800874BC(go), gobj);
             return true;
         } else {

--- a/src/melee/it/items/itpippi.c
+++ b/src/melee/it/items/itpippi.c
@@ -120,7 +120,7 @@ bool it_802D34A4(Item_GObj* gobj)
 
 void it_802D3508(Item_GObj* gobj)
 {
-    Item* it = GET_ITEM((HSD_GObj*) gobj);
+    Item* it = GET_ITEM(gobj);
     if (it->ground_or_air == GA_Air) {
         it_80272860(gobj, it->xCC_item_attr->x10_fall_speed,
                     it->xCC_item_attr->x14_fall_speed_max);
@@ -129,7 +129,7 @@ void it_802D3508(Item_GObj* gobj)
 
 bool it_802D3544(Item_GObj* gobj)
 {
-    Item* it = GET_ITEM((HSD_GObj*) gobj);
+    Item* it = GET_ITEM(gobj);
     if (it->ground_or_air == GA_Air) {
         it_8026E15C(gobj, it_802D32D8);
     } else {

--- a/src/melee/it/items/itraikou.c
+++ b/src/melee/it/items/itraikou.c
@@ -75,9 +75,9 @@ bool it_802CF978(Item_GObj* gobj)
     if (it->xDB0_itcmd_var1) {
         it->xDB0_itcmd_var1 = 0;
         it->xDB4_itcmd_var2 = 0;
-        efLib_DestroyAll((HSD_GObj*) gobj);
+        efLib_DestroyAll(gobj);
     }
-    if (it_80272C6C((HSD_GObj*) gobj) == false) {
+    if (it_80272C6C(gobj) == false) {
         return true;
     }
     if (it->xDB4_itcmd_var2) {
@@ -104,7 +104,7 @@ bool it_802CF978(Item_GObj* gobj)
 
 void it_802CFA74(Item_GObj* gobj)
 {
-    Item* it = GET_ITEM((HSD_GObj*) gobj);
+    Item* it = GET_ITEM(gobj);
     if (it->ground_or_air == GA_Air) {
         it_80272860(gobj, it->xCC_item_attr->x10_fall_speed,
                     it->xCC_item_attr->x14_fall_speed_max);
@@ -113,7 +113,7 @@ void it_802CFA74(Item_GObj* gobj)
 
 bool it_802CFAB0(Item_GObj* gobj)
 {
-    Item* it = GET_ITEM((HSD_GObj*) gobj);
+    Item* it = GET_ITEM(gobj);
     if (it->ground_or_air == GA_Air) {
         it_8026E248(gobj, it_802CF880);
     } else {

--- a/src/melee/it/items/itsuikun.c
+++ b/src/melee/it/items/itsuikun.c
@@ -75,9 +75,9 @@ bool it_802CFDAC(Item_GObj* gobj)
     if (it->xDB0_itcmd_var1) {
         it->xDB0_itcmd_var1 = 0;
         it->xDB4_itcmd_var2 = 0;
-        efLib_DestroyAll((HSD_GObj*) gobj);
+        efLib_DestroyAll(gobj);
     }
-    if (it_80272C6C((HSD_GObj*) gobj) == false) {
+    if (it_80272C6C(gobj) == false) {
         return true;
     }
     if (it->xDB4_itcmd_var2) {
@@ -104,7 +104,7 @@ bool it_802CFDAC(Item_GObj* gobj)
 
 void it_802CFEA8(Item_GObj* gobj)
 {
-    Item* it = GET_ITEM((HSD_GObj*) gobj);
+    Item* it = GET_ITEM(gobj);
     if (it->ground_or_air == GA_Air) {
         it_80272860(gobj, it->xCC_item_attr->x10_fall_speed,
                     it->xCC_item_attr->x14_fall_speed_max);
@@ -113,7 +113,7 @@ void it_802CFEA8(Item_GObj* gobj)
 
 bool it_802CFEE4(Item_GObj* gobj)
 {
-    Item* it = GET_ITEM((HSD_GObj*) gobj);
+    Item* it = GET_ITEM(gobj);
     if (it->ground_or_air == GA_Air) {
         it_8026E248(gobj, it_802CFCB4);
     } else {

--- a/src/melee/it/items/itzrshell.c
+++ b/src/melee/it/items/itzrshell.c
@@ -52,7 +52,7 @@ void it_802E0368(Item_GObj* gobj)
 
 void it_802E0388(Item_GObj* gobj)
 {
-    grZakoGenerator_801CACB8((Ground_GObj*) gobj);
+    grZakoGenerator_801CACB8(gobj);
 }
 
 void it_802E03A8(Item_GObj* gobj)


### PR DESCRIPTION
Removes casts resulting from me copy-pasting from decomp.me, since it's been complaining about forward declarations.