### PR TITLE
Match `ft_8008521C` (148 bytes)

### DIFF
--- a/src/melee/ft/ft_0852.c
+++ b/src/melee/ft/ft_0852.c
@@ -1,1 +1,18 @@
+#include "ft/inlines.h"
+#include "ft/types.h"
 
+#include <placeholder.h>
+#include <baselib/gobj.h>
+#include <baselib/jobj.h>
+
+void ft_8008521C(HSD_GObj* gobj)
+{
+    Fighter* fp = GET_FIGHTER(gobj);
+    HSD_JObj* jobj = GET_JOBJ(gobj);
+    Vec3 pos;
+
+    HSD_JObjGetTranslation(jobj, &pos);
+    fp->self_vel.x = pos.x - fp->cur_pos.x;
+    fp->self_vel.y = pos.y - fp->cur_pos.y;
+    fp->self_vel.z = pos.z - fp->cur_pos.z;
+}


### PR DESCRIPTION
## Report of `melee/ft/ft_0852.c`
Function|Size|Score|Max|%
-|-|-|-|-
**File**|`836 bytes`|`16,800`|`20,500`|`18.05%`
`ft_8008521C`|`148 bytes`|`0`|`3,700`|`100.00%`