### PR TITLE
Match mnCharSel_803F0A48 and mnCharSel_803F0DFC

### DIFF
--- a/src/melee/mn/forward.h
+++ b/src/melee/mn/forward.h
@@ -6,6 +6,14 @@ typedef struct PlayerInitData PlayerInitData;
 typedef struct StartMeleeData StartMeleeData;
 typedef struct StartMeleeRules StartMeleeRules;
 typedef struct VsModeData VsModeData;
+typedef struct CSSModeInfo CSSModeInfo;
+typedef struct CSSIcon CSSIcon;
+typedef struct CSSIconsData CSSIconsData;
+typedef struct CSSDoor CSSDoor;
+typedef struct CSSTagData CSSTagData;
+typedef struct CSSTag CSSTag;
+typedef struct CSSKOStar CSSKOStar;
+typedef struct CSSDoorsData CSSDoorsData;
 
 typedef enum _Mode {
     Mode_Time,

--- a/src/melee/mn/mncharsel.c
+++ b/src/melee/mn/mncharsel.c
@@ -3,11 +3,268 @@
 #include "gm/gmmain_lib.h"
 #include "lb/lblanguage.h"
 #include "mn/types.h"
+#include "ft/forward.h"
 
 #include <baselib/sislib.h>
 
 extern CSSData* mnCharSel_804D6CB0;
 extern SIS* HSD_SisLib_804D1124[];
+
+// Can't be enum bc float, but reused values
+#define ICONROWHT_TOP_TOP        20.0F
+#define ICONROWHT_MID_TOP        13.0F
+#define ICONROWHT_BTM_TOP        6.0F
+#define ICONROWHT_BTM_BTM        (-1.0F)
+
+// Can't be enum bc float, but reused values
+#define ICONBNDS_COL0_L        (-30.0F)
+#define ICONBNDS_COL1_L        (-24.399999618530273F)
+#define ICONBNDS_COL2_L        (-17.399999618530273F)
+#define ICONBNDS_COL3_L        (-10.399999618530273F)
+#define ICONBNDS_COL4_L        (-3.4000000953674316F)
+#define ICONBNDS_COL5_L        3.5999999046325684F
+#define ICONBNDS_COL6_L        10.600000381469727F
+#define ICONBNDS_COL7_L        17.600000381469727F
+#define ICONBNDS_COL8_L        24.399999618530273F
+#define ICONBNDS_COL8_R        30.200000762939453F
+
+CSSIconsData mnCharSel_803F0A48 = {
+    {
+        // GnW Name
+        0x82, 0x6C, 0x82, 0x92,             // 0x803F0A48
+        0x81, 0x44, 0x82, 0x66,             // 0x803F0A4C
+        0x82, 0x81, 0x82, 0x8D,             // 0x803F0A50
+        0x82, 0x85, 0x81, 0x95,             // 0x803F0A54
+        0x82, 0x76, 0x82, 0x81,             // 0x803F0A58
+        0x82, 0x94, 0x82, 0x83,             // 0x803F0A5C
+        0x82, 0x88, 0x00, 0x00              // 0x803F0A60
+    }, {
+        // Mode Info
+        { 0x0000, 0x0001, 0x00007535 },     // 0x803F0A64
+        { 0x0002, 0x000D, 0x0000753A },     // 0x803F0A6C
+        { 0x0003, 0x000E, 0x0000753B },     // 0x803F0A74
+        { 0x0004, 0x000F, 0x0000753C },     // 0x803F0A7C
+        { 0x0007, 0x0011, 0x0000753D },     // 0x803F0A84
+        { 0x0008, 0x0012, 0x0000753E },     // 0x803F0A8C
+        { 0x0009, 0x0013, 0x0000753F },     // 0x803F0A94
+        { 0x0006, 0x0010, 0x00007540 },     // 0x803F0A9C
+        { 0x000A, 0x0014, 0x00007541 },     // 0x803F0AA4
+        { 0x000B, 0x0015, 0x00007535 },     // 0x803F0AAC
+        { 0x000C, 0x0016, 0x00007535 },     // 0x803F0AB4
+        { 0x0000, 0x0000, 0x00007534 },     // 0x803F0ABC
+        { 0x0001, 0x0000, 0x00007534 },     // 0x803F0AC4
+        { 0x0002, 0x0000, 0x00007533 },     // 0x803F0ACC
+        { 0x0003, 0x0000, 0x00007534 },     // 0x803F0AD4
+        { 0x0004, 0x0000, 0x0007C864 },     // 0x803F0ADC
+        { 0x0005, 0x0000, 0x00007531 },     // 0x803F0AE4
+        { 0x0008, 0x0000, 0x00007534 },     // 0x803F0AEC
+        { 0x0009, 0x0000, 0x00007534 },     // 0x803F0AF4
+        { 0x000A, 0x0000, 0x00007534 },     // 0x803F0AFC
+        { 0x000B, 0x0000, 0x00007534 },     // 0x803F0B04
+        { 0x000C, 0x0000, 0x00007534 },     // 0x803F0B0C
+        { 0x000D, 0x0000, 0x00007534 },     // 0x803F0B14
+        { 0x0007, 0x0000, 0x00007532 }      // 0x803F0B1C
+    }, {
+        // -------- Icons Top Row --------
+
+        {
+            // Dr. Mario -                      0x803F0B24
+            ICONHUD_DRMARIO,        CKIND_DRMARIO,          ICONSTATE_UNLOCKED, 0x00,
+            ICONJOINT_DRMARIO,      ICONJOINT_DRMARIO,      0x000000C5,
+            ICONBNDS_COL0_L,        ICONBNDS_COL1_L,        ICONROWHT_TOP_TOP,  ICONROWHT_MID_TOP
+        }, {
+            // Mario -                          0x803F0B40
+            ICONHUD_MARIO,          CKIND_MARIO,            ICONSTATE_TEMP,     0x00,
+            ICONJOINT_MARIO,        ICONJOINT_MARIO,        0x000000CD,
+            ICONBNDS_COL1_L,        ICONBNDS_COL2_L,        ICONROWHT_TOP_TOP,  ICONROWHT_MID_TOP
+        }, {
+            // Luigi -                          0x803F0B5C
+            ICONHUD_LUIGI,          CKIND_LUIGI,            ICONSTATE_TEMP,     0x00,
+            ICONJOINT_LUIGI,        ICONJOINT_LUIGI,        0x000000CC,
+            ICONBNDS_COL2_L,        ICONBNDS_COL3_L,        ICONROWHT_TOP_TOP,  ICONROWHT_MID_TOP
+        }, {
+            // Bowser -                         0x803F0B78
+            ICONHUD_KOOPA,          CKIND_KOOPA,            ICONSTATE_TEMP,     0x00,
+            ICONJOINT_KOOPA,        ICONJOINT_KOOPA,        0x000000CA,
+            ICONBNDS_COL3_L,        ICONBNDS_COL4_L,        ICONROWHT_TOP_TOP,  ICONROWHT_MID_TOP
+        }, {
+            // Peach -                          0x803F0B94
+            ICONHUD_PEACH,          CKIND_PEACH,            ICONSTATE_TEMP,     0x00,
+            ICONJOINT_PEACH,        ICONJOINT_PEACH,        0x000000D1,
+            ICONBNDS_COL4_L,        ICONBNDS_COL5_L,        ICONROWHT_TOP_TOP,  ICONROWHT_MID_TOP
+        }, {
+            // Yoshi -                          0x803F0BB0
+            ICONHUD_YOSHI,          CKIND_YOSHI,            ICONSTATE_TEMP,     0x00,
+            ICONJOINT_YOSHI,        ICONJOINT_YOSHI,        0x000000D7,
+            ICONBNDS_COL5_L,        ICONBNDS_COL6_L,        ICONROWHT_TOP_TOP,  ICONROWHT_MID_TOP
+        }, {
+            // DK -                             0x803F0BCC
+            ICONHUD_DONKEY,         CKIND_DONKEY,           ICONSTATE_TEMP,     0x00,
+            ICONJOINT_DONKEY,       ICONJOINT_DONKEY,       0x000000C4,
+            ICONBNDS_COL6_L,        ICONBNDS_COL7_L,        ICONROWHT_TOP_TOP,  ICONROWHT_MID_TOP
+        }, {
+            // Captain Falcon -                 0x803F0BE8
+            ICONHUD_CAPTAIN,        CKIND_CAPTAIN,          ICONSTATE_TEMP,     0x00,
+            ICONJOINT_CAPTAIN,      ICONJOINT_CAPTAIN,      0x000000C2,
+            ICONBNDS_COL7_L,        ICONBNDS_COL8_L,        ICONROWHT_TOP_TOP,  ICONROWHT_MID_TOP
+        }, {
+            // Ganondorf -                      0x803F0C04
+            ICONHUD_GANON,          CKIND_GANON,            ICONSTATE_UNLOCKED, 0x00,
+            ICONJOINT_GANON,        ICONJOINT_GANON,        0x000000D9,
+            ICONBNDS_COL8_L,        ICONBNDS_COL8_R,        ICONROWHT_TOP_TOP,  ICONROWHT_MID_TOP
+        },
+
+        // -------- Icons Middle Row --------
+
+        {
+            // Falco -                          0x803F0C20
+            ICONHUD_FALCO,          CKIND_FALCO,            ICONSTATE_UNLOCKED, 0x00,
+            ICONJOINT_FALCO,        ICONJOINT_FALCO,        0x000000C6,
+            ICONBNDS_COL0_L,        ICONBNDS_COL1_L,        ICONROWHT_MID_TOP,  ICONROWHT_BTM_TOP
+        }, {
+            // Fox -                            0x803F0C3C
+            ICONHUD_FOX,            CKIND_FOX,              ICONSTATE_TEMP,     0x00,
+            ICONJOINT_FOX,          ICONJOINT_FOX,          0x000000C7,
+            ICONBNDS_COL1_L,        ICONBNDS_COL2_L,        ICONROWHT_MID_TOP,  ICONROWHT_BTM_TOP
+        }, {
+            // Ness -                           0x803F0C58
+            ICONHUD_NESS,           CKIND_NESS,             ICONSTATE_TEMP,     0x00,
+            ICONJOINT_NESS,         ICONJOINT_NESS,         0x000000D0,
+            ICONBNDS_COL2_L,        ICONBNDS_COL3_L,        ICONROWHT_MID_TOP,  ICONROWHT_BTM_TOP
+        }, {
+            // ICs -                            0x803F0C74
+            ICONHUD_POPONANA,       CKIND_POPONANA,         ICONSTATE_TEMP,     0x00,
+            ICONJOINT_POPONANA,     ICONJOINT_POPONANA,     0x000000C8,
+            ICONBNDS_COL3_L,        ICONBNDS_COL4_L,        ICONROWHT_MID_TOP,  ICONROWHT_BTM_TOP
+        }, {
+            // Kirby -                          0x803F0C90
+            ICONHUD_KIRBY,          CKIND_KIRBY,            ICONSTATE_TEMP,     0x00,
+            ICONJOINT_KIRBY,        ICONJOINT_KIRBY,        0x000000C9,
+            ICONBNDS_COL4_L,        ICONBNDS_COL5_L,        ICONROWHT_MID_TOP,  ICONROWHT_BTM_TOP
+        }, {
+            // Samus -                          0x803F0CAC
+            ICONHUD_SAMUS,          CKIND_SAMUS,            ICONSTATE_TEMP,     0x00,
+            ICONJOINT_SAMUS,        ICONJOINT_SAMUS,        0x000000D5,
+            ICONBNDS_COL5_L,        ICONBNDS_COL6_L,        ICONROWHT_MID_TOP,  ICONROWHT_BTM_TOP
+        }, {
+            // Zelda -                          0x803F0CC8
+            ICONHUD_ZELDA,          CKIND_ZELDA,            ICONSTATE_TEMP,     0x00,
+            ICONJOINT_ZELDA,        ICONJOINT_ZELDA,        0x000000D6,
+            ICONBNDS_COL6_L,        ICONBNDS_COL7_L,        ICONROWHT_MID_TOP,  ICONROWHT_BTM_TOP
+        }, {
+            // Link -                           0x803F0CE4
+            ICONHUD_LINK,           CKIND_LINK,             ICONSTATE_TEMP,     0x00,
+            ICONJOINT_LINK,         ICONJOINT_LINK,         0x000000CB,
+            ICONBNDS_COL7_L,        ICONBNDS_COL8_L,        ICONROWHT_MID_TOP,  ICONROWHT_BTM_TOP
+        }, {
+            // Young Link -                     0x803F0D00
+            ICONHUD_CLINK,          CKIND_CLINK,            ICONSTATE_UNLOCKED, 0x00,
+            ICONJOINT_CLINK,        ICONJOINT_CLINK,        0x000000C3,
+            ICONBNDS_COL8_L,        ICONBNDS_COL8_R,        ICONROWHT_MID_TOP,  ICONROWHT_BTM_TOP
+        },
+
+        // -------- Icons Bottom Row --------
+
+        {
+            // Pichu -                          0x803F0D1C
+            ICONHUD_PICHU,          CKIND_PICHU,            ICONSTATE_UNLOCKED, 0x00,
+            ICONJOINT_PICHU,        ICONJOINT_PICHU,        0x000000D2,
+            -23.399999618530273,    ICONBNDS_COL2_L,        ICONROWHT_BTM_TOP,  ICONROWHT_BTM_BTM
+        }, {
+            // Pikachu -                        0x803F0D38
+            ICONHUD_PIKACHU,        CKIND_PIKACHU,          ICONSTATE_TEMP,     0x00,
+            ICONJOINT_PIKACHU,      ICONJOINT_PIKACHU,      0x000000D3,
+            ICONBNDS_COL2_L,        ICONBNDS_COL3_L,        ICONROWHT_BTM_TOP,  ICONROWHT_BTM_BTM
+        }, {
+            // Jigglypuff -                     0x803F0D54
+            ICONHUD_PURIN,          CKIND_PURIN,            ICONSTATE_TEMP,     0x00,
+            ICONJOINT_PURIN,        ICONJOINT_PURIN,        0x000000D4,
+            ICONBNDS_COL3_L,        ICONBNDS_COL4_L,        ICONROWHT_BTM_TOP,  ICONROWHT_BTM_BTM
+        }, {
+            // Mewtwo -                         0x803F0D70
+            ICONHUD_MEWTWO,         CKIND_MEWTWO,           ICONSTATE_TEMP,     0x00,
+            ICONJOINT_MEWTWO,       ICONJOINT_MEWTWO,       0x000000CF,
+            ICONBNDS_COL4_L,        ICONBNDS_COL5_L,        ICONROWHT_BTM_TOP,  ICONROWHT_BTM_BTM
+        }, {
+            // Mr. Game & Watch -               0x803F0D8C
+            ICONHUD_GAMEWATCH,      CKIND_GAMEWATCH,        ICONSTATE_TEMP,     0x00,
+            ICONJOINT_GAMEWATCH,    ICONJOINT_GAMEWATCH,    0x000000D8,
+            ICONBNDS_COL5_L,        ICONBNDS_COL6_L,        ICONROWHT_BTM_TOP,  ICONROWHT_BTM_BTM
+        }, {
+            // Marth -                          0x803F0DA8
+            ICONHUD_MARS,           CKIND_MARS,             ICONSTATE_TEMP,     0x00,
+            ICONJOINT_MARS,         ICONJOINT_MARS,         0x000000CE,
+            ICONBNDS_COL6_L,        ICONBNDS_COL7_L,        ICONROWHT_BTM_TOP,  ICONROWHT_BTM_BTM
+        }, {
+            // Roy -                            0x803F0DC4
+            ICONHUD_EMBLEM,         CKIND_EMBLEM,           ICONSTATE_UNLOCKED, 0x00,
+            ICONJOINT_EMBLEM,       ICONJOINT_EMBLEM,       0x000000DA,
+            ICONBNDS_COL7_L,        23.600000381469727,     ICONROWHT_BTM_TOP,  ICONROWHT_BTM_BTM
+        }
+    }
+};
+
+CSSDoorsData mnCharSel_803F0DFC = {
+    {
+        {
+            0x2E, 0x33, 0x38, 0x85, 0x29, 0xA6, 0x3D, 0x41, 0x40, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            -35.599998474121094F, -28.600000381469727F, -26.799999237060547F, -21.0F
+        }, {
+            0x2F, 0x34, 0x39, 0x8D, 0x2A, 0xA8, 0x43, 0x47, 0x46, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            -19.399999618530273F, -13.399999618530273F, -11.399999618530273F, -6.0F
+        }, {
+            0x30, 0x35, 0x3A, 0x95, 0x2B, 0xAA, 0x49, 0x4D, 0x4C, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            -4.199999809265137F, 2.200000047683716F, 3.5F, 9.399999618530273F
+        }, {
+            0x31, 0x36, 0x3B, 0x9D, 0x2C, 0xAC, 0x4F, 0x53, 0x52, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            11.0F, 17.0F, 19.0F, 24.600000381469727F
+        }
+    }, {
+        { NULL, 0x70, 0x73, 0x74, 0x72, 0x71, 0x00, 0x00, 0x00 },
+        { NULL, 0x75, 0x78, 0x79, 0x77, 0x76, 0x00, 0x00, 0x00 },
+        { NULL, 0x7A, 0x7D, 0x7E, 0x7C, 0x7B, 0x00, 0x00, 0x00 },
+        { NULL, 0x7F, 0x82, 0x83, 0x81, 0x80, 0x00, 0x00, 0x00 }
+    }, 0x00, 0x00, 0x00, 0x00, 0x4A, 0x4D, 0x4E, 0x4C, 0x4B, 0x00, 0x00, 0x00, 0x2F, 0x01,
+    0x00000000, 0x00000000,
+    0.0F, -10.899999618530273F, -4.199999809265137F, 12.5F, 19.600000381469727F,
+    -6.800000190734863F, -12.100000381469727F,
+    { 0x35, 0x39, 0x36, 0x38, 0x37 },
+    -2.200000047683716F, 3.700000047683716F, 13.699999809265137F, 19.299999237060547F,
+    -12.399999618530273F, -16.600000381469727F,
+    {
+        {
+            NULL, -22.5F, 0x57,
+            0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000
+        }, {
+            NULL, -7.099999904632568, 0x5D,
+            0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000
+        }, {
+            NULL, 8.300000190734863, 0x63,
+            0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000
+        }, {
+            NULL, 23.700000762939453, 0x69,
+            0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000
+        },
+    }, {
+                                0x25, 0x30, 0x32, 0x64,
+        0x3A, 0x25, 0x30, 0x32, 0x64, 0x00, 0x00, 0x00,
+
+        0x25, 0x64, 0x3A, 0x25, 0x30, 0x32, 0x64, 0x3A,
+        0x25, 0x30, 0x32, 0x64, 0x00, 0x00, 0x00, 0x00,
+
+        0x39, 0x39, 0x3A, 0x35, 0x39, 0x3A, 0x35, 0x39,
+        0x00, 0x00, 0x00, 0x00, 0x25, 0x64, 0x20, 0x90,
+
+        0x6C, 0x94, 0xB2, 0x82, 0xAB, 0x00, 0x00, 0x00,
+        0x25, 0x64, 0x20, 0x82, 0x6A, 0x82, 0x6E, 0x82,
+
+        0x93, 0x00, 0x00, 0x00
+    }
+};
 
 TextKerning* mnCharSel_8025BC20(TextKerning* arg0, u32 arg1)
 {

--- a/src/melee/mn/types.h
+++ b/src/melee/mn/types.h
@@ -4,6 +4,7 @@
 #include "mn/forward.h" // IWYU pragma: export
 
 #include <placeholder.h>
+#include <baselib/sislib.h>
 
 struct PlayerInitData {
     /*0x00*/ u8 character_kind;
@@ -134,6 +135,197 @@ struct CSSData {
     u8 pending_scene_change;
     u8* ko_star_counts;
     VsModeData data;
+};
+
+struct CSSModeInfo {
+    u16 mode_ffa_frame;         // 0x00 - Anim frame used for top-left mode texture
+    u16 mode_teams_frame;       // 0x02 - Anim frame used for top-left mode texture
+    int enter_sfx;              // 0x04 - Announcer sfx when entering CSS
+};
+
+// Not same as CharacterKind bc not as many characters as icons (missing Sheik, Master Hand, etc)
+typedef enum CSSIconHud {
+    ICONHUD_CAPTAIN =   0x00,
+    ICONHUD_DONKEY =    0x01,
+    ICONHUD_FOX =       0x02,
+    ICONHUD_GAMEWATCH = 0x03,
+    ICONHUD_KIRBY =     0x04,
+    ICONHUD_KOOPA =     0x05,
+    ICONHUD_LINK =      0x06,
+    ICONHUD_LUIGI =     0x07,
+    ICONHUD_MARIO =     0x08,
+    ICONHUD_MARS =      0x09,
+    ICONHUD_MEWTWO =    0x0A,
+    ICONHUD_NESS =      0x0B,
+    ICONHUD_PEACH =     0x0C,
+    ICONHUD_PIKACHU =   0x0D,
+    ICONHUD_POPONANA =  0x0E,
+    ICONHUD_PURIN =     0x0F,
+    ICONHUD_SAMUS =     0x10,
+    ICONHUD_YOSHI =     0x11,
+    ICONHUD_ZELDA =     0x12,
+    ICONHUD_FALCO =     0x13,
+    ICONHUD_CLINK =     0x14,
+    ICONHUD_DRMARIO =   0x15,
+    ICONHUD_EMBLEM =    0x16,
+    ICONHUD_PICHU =     0x17,
+    ICONHUD_GANON =     0x18
+} CSSIconHud;
+
+typedef enum CSSIconState {
+    ICONSTATE_LOCKED,
+    ICONSTATE_TEMP,
+    ICONSTATE_UNLOCKED
+} CSSIconState;
+
+typedef enum CSSIconJointId {
+    ICONJOINT_DRMARIO =     0x04,
+    ICONJOINT_FALCO =       0x08,
+    ICONJOINT_GANON =       0x06,
+    ICONJOINT_CLINK =       0x0A,
+    ICONJOINT_PICHU =       0x0C,
+    ICONJOINT_EMBLEM =      0x0E,
+    ICONJOINT_MARIO =       0x10,
+    ICONJOINT_LUIGI =       0x11,
+    ICONJOINT_KOOPA =       0x12,
+    ICONJOINT_PEACH =       0x13,
+    ICONJOINT_YOSHI =       0x14,
+    ICONJOINT_DONKEY =      0x15,
+    ICONJOINT_CAPTAIN =     0x16,
+    ICONJOINT_FOX =         0x17,
+    ICONJOINT_NESS =        0x18,
+    ICONJOINT_POPONANA =    0x19,
+    ICONJOINT_KIRBY =       0x1A,
+    ICONJOINT_SAMUS =       0x1B,
+    ICONJOINT_ZELDA =       0x1C,
+    ICONJOINT_LINK =        0x1D,
+    ICONJOINT_PIKACHU =     0x1E,
+    ICONJOINT_PURIN =       0x1F,
+    ICONJOINT_MEWTWO =      0x20,
+    ICONJOINT_GAMEWATCH =   0x21,
+    ICONJOINT_MARS =        0x22
+} CSSIconJointId;
+
+struct CSSIcon {
+    u8 ft_hudindex;     // 0x00 - used for getting combo count @ 8025C0C4
+    u8 char_kind;       // 0x01 - icons external ID
+    u8 state;           // 0x02 - 0x0 Not Unlocked, 0x01 Unlocked, 0x02 Unlocked and disp
+    u8 anim_timer;      // 0x03 - 0xC when char is chosen
+    u8 joint_id_vs;     // 0x04 - Vs Icon Bg Jobj ID
+    u8 joint_id_1p;     // 0x05 - Vs Icon Bg Jobj ID
+    int sfx;            // 0x08
+    float bound_l;      // 0x0C
+    float bound_r;      // 0x10
+    float bound_u;      // 0x14
+    float bound_d;      // 0x18
+};
+
+struct CSSIconsData {
+    u8 gnw_name[0x1C];                  // 0x0
+    CSSModeInfo mode_info[24];          // 0x1c
+    CSSIcon icons[25 + 1];              // 0xDC
+};
+
+struct CSSDoor {
+    u8 emblem_joint;            // 0x00
+    u8 costume_joint;           // 0x01
+    u8 team_joint;              // 0x02
+    u8 door_joint;              // 0x03
+    u8 bg_joint;                // 0x04
+    u8 player_indicator_joint;  // 0x05 - Nametag window joint id (to scroll and choose a name)
+    u8 slidername_joint;        // 0x06 - Slider name joint
+    u8 cpuslider_joint;         // 0x07 - Used when only CPU is showing
+    u8 cpuslider2_joint;        // 0x08 - Used when handicap is also showing
+    u8 selected_since_load;     // 0x09 - Determines when player selected since the CSS loaded
+
+    u8 team;                    // 0x0A
+    u8 p_kind;                  // 0x0B - PlayerKind, 0x0 = HMN, 0x1 = CPU, 0x3 = Closed
+    u8 p_kind_prev;             // 0x0C
+    u8 costume;                 // 0x0D
+    u8 sel_icon;                // 0x0E - Icon this player has selected
+    u8 sel_icon_prev;           // 0x0F
+    u8 dooranim_timer;          // 0x10
+    u8 slideranim_timer;        // 0x11
+    u8 is_hold_cpu_slider;      // 0x12
+    u8 is_hold_handicap_slider; // 0x13
+
+    float togglebtn_left;       // 0x14 - HMN button bound
+    float togglebtn_right;      // 0x18 - HMN button bound
+    float teambtn_left;         // 0x1C - Team button bound
+    float teambtn_right;        // 0x20 - Team button bound
+};
+
+struct CSSTagData {
+    TextGlyphTexture *text;     // 0x00
+    TextGlyphTexture *name_ls;  // 0x04
+    float x8;                   // 0x08
+    float scroll_amt;           // 0x0C
+    float scroll_force;         // 0x10
+    int timer;                  // 0x14
+    u8 next_tag;                // 0x18
+    u8 port;                    // 0x19
+    u8 state;                   // 0x1A
+    u8 use_tag;                 // 0x1B
+};
+
+struct CSSTag {
+    CSSTagData *data;           // 0x00
+    u8 x4;                      // 0x04
+    u8 list_joint;              // 0x05
+    u8 name_jointl;             // 0x06
+    u8 x7;                      // 0x07
+    u8 kostar_text_joint;       // 0x08
+    u8 x9;                      // 0x09
+    u8 xa;                      // 0x0A
+    u8 xb;                      // 0x0B
+};
+
+struct CSSKOStar {
+    TextGlyphTexture *text;     // 0x00
+    float x4;                   // 0x04
+    u8 joint;                   // 0x08
+    int xc;                     // 0x0C
+    int x10;                    // 0x10
+    int x14;                    // 0x14
+    int x18;                    // 0x18
+    int x1c;                    // 0x1C
+};
+
+struct CSSDoorsData {
+    CSSDoor doors[4];           // 0x00
+    CSSTag tags[4];             // 0x90
+    u8 xc0;
+    u8 xc1;
+    u8 xc2;
+    u8 xc3;
+    u8 xc4;
+    u8 name_list_joint;
+    u8 tag_box_joint;
+    u8 xc7;
+    u8 xc8;
+    u8 xc9;
+    u8 xca;
+    u8 xcb;
+    u8 xcc;
+    u8 xcd;
+    u8 xce;
+    int xcf;
+    int xd3;
+    float xd7;
+    float xdb;
+    float xdf;
+    float xe3;
+    float xe7;
+    float xeb;
+    u8 xf1[5];
+    float xf8;
+    float xfc;
+    float x100;
+    float x104;
+    float x108;
+    float x10c;
+    CSSKOStar ko_stars[4];      // 0x110
+    u8 x190[64];                // 0x190
 };
 
 #endif


### PR DESCRIPTION
NOTE: This is my first time contributing to the decomp. So please don't hesitate to let me know if I've done anything "out of protocol" :)

## Justification

mnCharSel_803F0A48 is primarily concerned with icon and mode data while mnCharSel_803F0DFC is concerned with the doors at the bottom of the screen.

Both appear to be pieces of data heavily used by other functions in mncharsel, so matching this should accelerate the decompilation of the CSS.

These data structures are also well known and propagated among various mods, Gecko codes, tools, etc.

## Implementation

I created two data structs for each of the memory structures with as much info as I could find then filled in the defaults into a variable in .data (where objdiff says they're located).

## Testing

1. Objdiff shows 100% match for each and proper sizing
2. Through the use of static write mods, I have verified the different mappings to characters to ensure that the names used are accurate as well as offsets.