### PR TITLE
fix windows build

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -329,7 +329,7 @@ def DolphinLib(
             "-enum int",
             "-warn pragmas",
             "-requireprotos",
-            "-pragma 'cats off'",
+            '-pragma "cats off"',
             "-I-",
             "-Iextern/dolphin/include",
             "-Iextern/dolphin/include/libc",


### PR DESCRIPTION
singlequotes don't work on windows