### PR TITLE
Cut down on auto splits

### DIFF
--- a/config/GALE01/splits.txt
+++ b/config/GALE01/splits.txt
@@ -3471,6 +3471,11 @@ MSL/ansi_files.c:
 Runtime/__va_arg.c:
 	.text       start:0x80322620 end:0x80322714
 
+Runtime/global_destructor_chain.c:
+	.text       start:0x80322714 end:0x8032275C
+	.dtors      start:0x803B7268 end:0x803B726C
+	.sbss       start:0x804D7058 end:0x804D705C
+
 Runtime/Gecko_ExceptionPPC.c:
 	.text       start:0x8032275C end:0x803227CC
 	.bss        start:0x804A2F38 end:0x804A2F48

--- a/config/GALE01/splits.txt
+++ b/config/GALE01/splits.txt
@@ -4441,6 +4441,7 @@ sysdolphin/baselib/sislib.c:
 
 sysdolphin/baselib/hsd_40FF.c:
 	.data       start:0x8040FF80 end:0x80430B40
+	.sdata2     start:0x804DEB10 end:0x804DEC00
 
 sysdolphin/baselib/hsd_3A94.c:
 	.text       start:0x803A949C end:0x803AA790

--- a/config/GALE01/splits.txt
+++ b/config/GALE01/splits.txt
@@ -3482,6 +3482,12 @@ Runtime/runtime.c:
 	.text       start:0x803228C0 end:0x80322F20
 	.rodata     start:0x803B8B90 end:0x803B8BA8
 
+Runtime/__init_cpp_exceptions.c:
+	.text       start:0x80322F20 end:0x80322F9C
+	.ctors      start:0x803B7240 end:0x803B7244
+	.dtors      start:0x803B7260 end:0x803B7268
+	.sdata      start:0x804D5B40 end:0x804D5B44
+
 MSL/abort_exit.c:
 	.text       start:0x80322F9C end:0x803230A8
 	.bss        start:0x804A2F48 end:0x804A3148

--- a/src/Runtime/__init_cpp_exceptions.c
+++ b/src/Runtime/__init_cpp_exceptions.c
@@ -6,11 +6,7 @@
 
 static int fragmentID = -2;
 
-/**
- * @todo HACK: Should be @c _eti_init_info. We can't use the appropriate
- * name yet due to the linker not being able to generate it.
- */
-SECTION_INIT extern __eti_init_info _eti_init_info_[];
+SECTION_INIT extern __eti_init_info _eti_init_info[];
 
 #ifdef MWERKS_GEKKO
 static asm char* GetR2(void)
@@ -31,9 +27,13 @@ void __init_cpp_exceptions(void)
 {
 #ifdef MWERKS_GEKKO
     if (fragmentID == -2) {
-        fragmentID = __register_fragment(_eti_init_info_, GetR2());
+        fragmentID = __register_fragment(_eti_init_info, GetR2());
     }
 #else
     NOT_IMPLEMENTED;
 #endif
 }
+
+SECTION_CTORS void* const __init_cpp_exceptions_reference  = __init_cpp_exceptions;
+SECTION_DTORS void* const __destroy_global_chain_reference = __destroy_global_chain;
+SECTION_DTORS void* const __fini_cpp_exceptions_reference  = __fini_cpp_exceptions;

--- a/src/Runtime/__init_cpp_exceptions.h
+++ b/src/Runtime/__init_cpp_exceptions.h
@@ -5,5 +5,6 @@
 
 void __fini_cpp_exceptions(void);
 void __init_cpp_exceptions(void);
+void __destroy_global_chain(void);
 
 #endif

--- a/src/Runtime/global_destructor_chain.c
+++ b/src/Runtime/global_destructor_chain.c
@@ -16,3 +16,5 @@ void __destroy_global_chain(void)
         cur->destructor(cur->object, -1);
     }
 }
+
+SECTION_DTORS static void* const __destroy_global_chain_reference = __destroy_global_chain;

--- a/src/Runtime/platform.h
+++ b/src/Runtime/platform.h
@@ -41,6 +41,14 @@ typedef void (*Event)(void);
 #endif
 #endif
 
+#ifndef SECTION_DTORS
+#if defined(__MWERKS__) && !defined(M2CTX)
+#define SECTION_DTORS __declspec(section ".dtors")
+#else
+#define SECTION_DTORS
+#endif
+#endif
+
 #ifndef ATTRIBUTE_NORETURN
 #if defined(__clang__) || defined(__GNUC__)
 #define ATTRIBUTE_NORETURN __attribute__((noreturn))


### PR DESCRIPTION
Code/data not specified in splits.txt will be auto-generated by dtk. Some of these autogenerated objects were easily matchable, another was a missing sda2 segment. The only remaining auto-split is MetroTRK exception.s (which is written in assembly anyway, so we can probably ignore it).