### PR TITLE
Include main header first

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -28,44 +28,44 @@ WhitespaceSensitiveMacros:
 IncludeBlocks: Regroup
 IncludeCategories:
   - Regex: '^<platform\.h>$'
-    Priority: -2
+    Priority: 1
     SortPriority: -7
   - Regex: '^<placeholder\.h>$'
-    Priority: -2
+    Priority: 1
     SortPriority: -6
   - Regex: '^"forward\.h"$'
-    Priority: -1
+    Priority: 2
     SortPriority: -5
   - Regex: '^".*/forward\.h"$'
-    Priority: -1
+    Priority: 2
     SortPriority: -4
   - Regex: '^<dolphin(/.*)?/forward\.h>$'
-    Priority: -1
+    Priority: 2
     SortPriority: -2
   - Regex: '^<(sysdolphin/)?baselib(/.*)?/forward\.h>$'
-    Priority: -1
+    Priority: 2
     SortPriority: -1
   - Regex: '^".*\.static\.h"$'
-    Priority: 0
+    Priority: 3
     SortPriority: -1
   - Regex: '^<(.*/)?forward\.h>$'
-    Priority: -1
+    Priority: 2
     SortPriority: -3
   - Regex: '^<[^/]*>$'
-    Priority: 3
+    Priority: 6
     SortPriority: 3
   - Regex: '^<dolphin/.*>$'
-    Priority: 3
+    Priority: 6
     SortPriority: 4
   - Regex: '^<(sysdolphin/)?baselib/.*>$'
-    Priority: 3
+    Priority: 6
     SortPriority: 5
   - Regex: '^<.*>$'
-    Priority: 3
+    Priority: 6
     SortPriority: 6
   - Regex: '^"[^/]*"$'
-    Priority: 1
+    Priority: 4
     SortPriority: 1
   - Regex: '^.*$'
-    Priority: 2
+    Priority: 5
     SortPriority: 2


### PR DESCRIPTION
The "main" include (e.g. for the file fighter.c, `#include "fighter.h"` should be the first include. This is because each .c file has its own corresponding .h file, so including the main header first guarantees that the .h file can be included "standalone" without requiring any other transitive includes.

Clang-format gives the main include priority 0 by default, and doesn't seem to allow this to be changed. So we should bump up the priority of all the other include groups, so that 0 is the first group. The current include order is maintained, except that the main header is now first.