### PR TITLE
Remove DEBUG/NDEBUG flags from build script

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -250,9 +250,7 @@ cflags_base = [
 # Debug flags
 if args.debug:
     # Or -sym dwarf-2 for Wii compilers
-    cflags_base.extend(["-sym on", "-DDEBUG=1"])
-else:
-    cflags_base.extend(["-sym off", "-DNDEBUG=1"])
+    cflags_base.append("-sym on")
 
 cflags_base.append(f"-maxerrors {args.max_errors}")
 if args.max_errors == 0:


### PR DESCRIPTION
They were only used by extern/dolphin/ and caused build failures when using --debug to get line number info in objdiff.