### PR TITLE
grmutecity: match 2 functions

### DIFF
--- a/src/melee/gr/grmutecity.c
+++ b/src/melee/gr/grmutecity.c
@@ -324,7 +324,12 @@ StageData grMc_803E33DC = {
 
 static struct {
     int x0;
+    void* x4;
+    DynamicsDesc* x8;
+    DynamicsDesc* xC;
 }* grMc_804D69D0;
+
+static s32 grMc_804D69D4;
 
 static f32 light_ref_br = 40000.0f;
 static f32 light_ref_dist = 0.99f;
@@ -686,6 +691,20 @@ void grMuteCity_801F2AB0(s32 arg0, HSD_JObj* arg1)
 
 /// #fn_801F2B58
 
-/// #grMuteCity_801F2BBC
+DynamicsDesc* grMuteCity_801F2BBC(enum_t arg0)
+{
+    if (grMc_804D69D4 == 1) {
+        if (arg0 == 0x31) {
+            return grMc_804D69D0->x8;
+        }
+        if (arg0 == 0x35) {
+            return grMc_804D69D0->x8;
+        }
+        if ((u32) (arg0 - 0x32) <= 2) {
+            return grMc_804D69D0->xC;
+        }
+    }
+    return NULL;
+}
 
 /// #grMuteCity_801F2C10

--- a/src/melee/gr/grmutecity.c
+++ b/src/melee/gr/grmutecity.c
@@ -689,7 +689,37 @@ void grMuteCity_801F2AB0(s32 arg0, HSD_JObj* arg1)
     }
 }
 
-/// #fn_801F2B58
+void fn_801F2B58(Ground* gp, s32 arg1, CollData* cd, s32 arg3,
+                 mpLib_GroundEnum arg4, f32 arg5)
+{
+    s32 b1234 = cd->x34_flags.b1234;
+
+    if (grMc_804D69D4 != 1) {
+        return;
+    }
+
+    if ((u32) (b1234 - 2) > 1 && b1234 != 5) {
+        return;
+    }
+
+    if (arg4 != mpLib_GroundEnum_Unk2) {
+        return;
+    }
+
+    if (cd->x0_gobj == NULL) {
+        return;
+    }
+
+    if (cd->x0_gobj->p_link != 9) {
+        return;
+    }
+
+    if (cd->x0_gobj == NULL) {
+        return;
+    }
+
+    cd->x34_flags.b7 = 1;
+}
 
 DynamicsDesc* grMuteCity_801F2BBC(enum_t arg0)
 {

--- a/src/melee/gr/grmutecity.h
+++ b/src/melee/gr/grmutecity.h
@@ -5,6 +5,7 @@
 
 #include "gr/forward.h"
 #include "lb/forward.h"
+#include "mp/forward.h"
 #include "sc/forward.h"
 #include <baselib/forward.h>
 
@@ -74,7 +75,8 @@
 /* 1F28A8 */ DynamicModelDesc* grMuteCity_801F28A8(void);
 /* 1F290C */ UNK_RET grMuteCity_801F290C(UNK_PARAMS);
 /* 1F2AB0 */ void grMuteCity_801F2AB0(s32, HSD_JObj*);
-/* 1F2B58 */ UNK_RET fn_801F2B58(UNK_PARAMS);
+/* 1F2B58 */ void fn_801F2B58(Ground*, s32, CollData*, s32, mpLib_GroundEnum,
+                             f32);
 /* 1F2BBC */ DynamicsDesc* grMuteCity_801F2BBC(enum_t);
 /* 1F2C10 */ bool grMuteCity_801F2C10(Vec3*, int arg, HSD_JObj* jobj);
 


### PR DESCRIPTION
## Summary
- Decompile `grMuteCity_801F2BBC`, `fn_801F2B58` — 100% match

## Verification
- `ninja` builds clean
- `fuzzy_match_percent: 100.0` for all functions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)