### PR TITLE
ft: decompile 9 fighter functions

### DIFF
--- a/src/melee/ft/chara/ftCrazyHand/ftCh_Init.c
+++ b/src/melee/ft/chara/ftCrazyHand/ftCh_Init.c
@@ -9,6 +9,7 @@
 #include "baselib/forward.h"
 
 #include "cm/camera.h"
+#include "ft/chara/ftCommon/ftCo_Attack100.h"
 #include "ft/chara/ftCommon/ftCo_CaptureCut.h"
 #include "ft/chara/ftCommon/ftCo_Throw.h"
 #include "ft/chara/ftCommon/ftCo_Thrown.h"
@@ -105,6 +106,10 @@ extern f32 ftCh_Init_804DA0E0;
 extern f32 ftCh_Init_804DA0E4;
 extern f32 ftCh_Init_804DA178;
 extern f32 ftCh_Init_804DA17C;
+extern f32 ftCh_Init_804DA180;
+extern f32 ftCh_Init_804DA184;
+extern f32 ftCh_Init_804DA1D8;
+extern f32 ftCh_Init_804DA1DC;
 
 /* static */ void ftCh_Init_801566B4(void);
 /* static */ void ftCh_Init_80156A5C(void);
@@ -2291,7 +2296,18 @@ void ftCh_Throw_Phys(HSD_GObj* gobj)
 
 void ftCh_Throw_Coll(HSD_GObj* gobj) {}
 
-/// #ftCh_Slam_Anim
+void ftCh_Slam_Anim(HSD_GObj* gobj)
+{
+    if (ftBossLib_8015C2E0() || ftBossLib_8015C358() ||
+        !ftAnim_IsFramesRemaining(gobj))
+    {
+        Fighter* fp = GET_FIGHTER(gobj);
+        fp->self_vel.x = fp->self_vel.y = fp->self_vel.z = ftCh_Init_804DA178;
+        Fighter_UnkSetFlag_8006CFBC(gobj);
+        fp->x1A5C = 0;
+        ftCh_GrabUnk1_8015A888(gobj);
+    }
+}
 
 void ftCh_Slam_IASA(HSD_GObj* gobj)
 {
@@ -2408,7 +2424,18 @@ void fn_8015AAC8(Fighter_GObj* gobj)
                               NULL);
 }
 
-/// #ftCh_TagRockPaper_Anim
+void ftCh_TagRockPaper_Anim(HSD_GObj* gobj)
+{
+    if (ftBossLib_8015C2E0() || ftBossLib_8015C358()) {
+        ftCh_GrabUnk1_8015BC88(gobj);
+    }
+    if (!ftAnim_IsFramesRemaining(gobj)) {
+        Fighter_ChangeMotionState(gobj, 0x180, 0, ftCh_Init_804DA184,
+                                  ftCh_Init_804DA180, ftCh_Init_804DA184,
+                                  NULL);
+        ftAnim_8006EBA4(gobj);
+    }
+}
 
 void ftCh_TagRockPaper_IASA(HSD_GObj* gobj)
 {
@@ -2747,7 +2774,17 @@ void ftCo_CaptureCrazyHand_Phys(HSD_GObj* gobj) {}
 
 void ftCo_CaptureCrazyHand_Coll(HSD_GObj* gobj) {}
 
-/// #ftCh_GrabUnk1_8015B670
+void ftCh_GrabUnk1_8015B670(HSD_GObj* gobj)
+{
+    Fighter* fp = GET_FIGHTER(gobj);
+    Fighter_ChangeMotionState(gobj, 0x151, 0, ftCh_Init_804DA1D8,
+                              ftCh_Init_804DA1DC, ftCh_Init_804DA1D8, NULL);
+    fp->invisible = true;
+    fp->accessory1_cb = ftCo_800DB464;
+    ftCommon_8007E2F4(fp, 0x1FF);
+    fp->x2220_b3 = true;
+    ftAnim_8006EBA4(gobj);
+}
 
 #pragma dont_inline on
 void ftCo_CaptureDamageCrazyHand_Anim(HSD_GObj* gobj)

--- a/src/melee/ft/chara/ftPopo/ftPp_SpecialS.c
+++ b/src/melee/ft/chara/ftPopo/ftPp_SpecialS.c
@@ -823,9 +823,35 @@ void ftPp_SpecialHi_Enter(Fighter_GObj* gobj)
 
 /// #ftPp_SpecialAirHiStart_0_Anim
 
-/// #ftPp_SpecialHiStart_0_IASA
+void ftPp_SpecialHiStart_0_IASA(Fighter_GObj* gobj)
+{
+    Fighter* fp = gobj->user_data;
+    ftIceClimberAttributes* da = fp->dat_attrs;
+    PAD_STACK(16);
+    if (fp->cmd_vars[0] != 0) {
+        fp->cmd_vars[0] = 0;
+        if (ABS(fp->input.lstick.x) > da->x80) {
+            ftCommon_UpdateFacing(fp);
+            ftPartSetRotY(fp, 0,
+                          (float)(M_PI_2 * fp->facing_dir));
+        }
+    }
+}
 
-/// #ftPp_SpecialAirHiStart_0_IASA
+void ftPp_SpecialAirHiStart_0_IASA(Fighter_GObj* gobj)
+{
+    Fighter* fp = gobj->user_data;
+    ftIceClimberAttributes* da = fp->dat_attrs;
+    PAD_STACK(16);
+    if (fp->cmd_vars[0] != 0) {
+        fp->cmd_vars[0] = 0;
+        if (ABS(fp->input.lstick.x) > da->x80) {
+            ftCommon_UpdateFacing(fp);
+            ftPartSetRotY(fp, 0,
+                          (float)(M_PI_2 * fp->facing_dir));
+        }
+    }
+}
 
 void ftPp_SpecialHiStart_0_Phys(Fighter_GObj* gobj)
 {
@@ -1270,13 +1296,56 @@ void ftPp_SpecialHi_80122898(Fighter_GObj* gobj)
     }
 }
 
-/// #ftPp_SpecialLw_Enter
+void ftPp_SpecialLw_Enter(Fighter_GObj* gobj)
+{
+    Fighter* fp = gobj->user_data;
+    PAD_STACK(8);
+    fp->throw_flags = 0;
+    fp->cmd_vars[0] = 0;
+    fp->cmd_vars[3] = 0;
+    fp->mv.pp.speciallw.x0 = 0;
+    fp->mv.pp.speciallw.x4_b0 = false;
+    Fighter_ChangeMotionState(gobj, ftPp_MS_SpecialLw, 0, 0.0f,
+                              1.0f, 0.0f, NULL);
+    ftAnim_8006EBA4(gobj);
+    fp->accessory4_cb = fn_80122D2C;
+}
 
 /// #ftPp_SpecialAirLw_Enter
 
-/// #ftPp_SpecialLw_Anim
+void ftPp_SpecialLw_Anim(Fighter_GObj* gobj)
+{
+    PAD_STACK(16);
+    if (!ftAnim_IsFramesRemaining(gobj)) {
+        Fighter* fp = gobj->user_data;
+        if (fp->fv.pp.x2230_b0) {
+            efLib_DestroyAll(gobj);
+            fp = gobj->user_data;
+            fp->fv.pp.x2230_b0 = false;
+            fp->death2_cb = NULL;
+            fp->take_dmg_cb = NULL;
+            ftPartSetRotX(gobj->user_data, 0, 0.0f);
+        }
+        ft_8008A2BC(gobj);
+    }
+}
 
-/// #ftPp_SpecialAirLw_Anim
+void ftPp_SpecialAirLw_Anim(Fighter_GObj* gobj)
+{
+    PAD_STACK(16);
+    if (!ftAnim_IsFramesRemaining(gobj)) {
+        Fighter* fp = gobj->user_data;
+        if (fp->fv.pp.x2230_b0) {
+            efLib_DestroyAll(gobj);
+            fp = gobj->user_data;
+            fp->fv.pp.x2230_b0 = false;
+            fp->death2_cb = NULL;
+            fp->take_dmg_cb = NULL;
+            ftPartSetRotX(gobj->user_data, 0, 0.0f);
+        }
+        ftCo_Fall_Enter(gobj);
+    }
+}
 
 void ftPp_SpecialLw_IASA(Fighter_GObj* gobj) {}
 

--- a/src/melee/ft/chara/ftPopo/ftPp_SpecialS.h
+++ b/src/melee/ft/chara/ftPopo/ftPp_SpecialS.h
@@ -61,6 +61,6 @@
 /* 122B54 */ void fn_80122B54(Fighter_GObj* gobj);
 /// ftPp_SpecialLw_Coll
 /* ??? */ void ftPp_SpecialAirLw_Coll(Fighter_GObj* gobj);
-/// fn_80122D2C
+/* 122D2C */ void fn_80122D2C(Fighter_GObj* gobj);
 
 #endif

--- a/src/melee/ft/chara/ftPopo/types.h
+++ b/src/melee/ft/chara/ftPopo/types.h
@@ -51,7 +51,8 @@ typedef struct ftIceClimberAttributes {
     float x70;
     float x74;
     float x78;
-    u8 _7C[0x84 - 0x7C];
+    u8 _7C[0x80 - 0x7C];
+    float x80;
     float x84;
     u8 _88[0x94 - 0x88];
     float x94;
@@ -98,6 +99,10 @@ union ftPp_MotionVars {
     struct {
         /* fp+2340 */ int x0;
     } unk_80123954;
+    struct {
+        /* fp+2340 */ int x0;
+        /* fp+2344:0 */ u8 x4_b0 : 1;
+    } speciallw;
 };
 
 #endif

--- a/src/melee/ft/ft_0D31.c
+++ b/src/melee/ft/ft_0D31.c
@@ -544,4 +544,14 @@ void fn_800D5A30(Fighter_GObj* gobj)
     ftColl_8007B7A4(gobj, p_ftCommonData->x5D8);
     ft_8008A2BC(gobj);
 }
-/// #ftCo_Rebirth_Cam
+void ftCo_Rebirth_Cam(Fighter_GObj* gobj)
+{
+    UnkFloat6_Camera spC;
+    Fighter* fp = GET_FIGHTER(gobj);
+    CmSubject* camera_box = fp->x890_cameraBox;
+    ftCamera_80076018(fp->ft_data->x3C, &spC, fp->x34_scale.y);
+    camera_box->x10.x = fp->mv.co.common.x4;
+    camera_box->x10.y = *(f32*) &fp->mv.co.common.x8 + spC.x0.x;
+    camera_box->x10.z = 0.0f;
+    ftLib_800866DC(gobj, &camera_box->x1C);
+}


### PR DESCRIPTION
## Summary
- Decompile `ftCh_TagRockPaper_Anim`, `ftCh_Slam_Anim`, `ftCh_GrabUnk1_8015B670` in ftCh_Init
- Decompile `ftCo_Rebirth_Cam` in ft_0D31
- Decompile 5 functions in ftPp_SpecialS

## Test plan
- [x] `ninja` builds successfully
- [x] `ninja diff` shows no regressions
- [x] All functions are 100% matches in objdiff

🤖 Generated with [Claude Code](https://claude.com/claude-code)