### PR TITLE
gm/mn: match 4 functions

### DIFF
--- a/src/melee/gm/gm_1832.c
+++ b/src/melee/gm/gm_1832.c
@@ -585,7 +585,26 @@ int gm_80188454(int idx)
     return lbl_80473700[idx + 2];
 }
 
-/// #fn_8018846C
+int fn_8018846C(void)
+{
+    int result;
+    int* ptr = lbl_80473700;
+    int* p;
+
+    result = pl_8004134C(0);
+    p = ptr + Player_GetPlayerCharacter(0) + 2;
+    if (*p < result) {
+        *p = result;
+    }
+    if (result != 0) {
+        ptr[67] = result;
+        ptr[68] = 1;
+    }
+    if (ptr[68] != 0) {
+        return ptr[67];
+    }
+    return result;
+}
 
 int fn_801884F8(void)
 {

--- a/src/melee/gm/gm_1832.h
+++ b/src/melee/gm/gm_1832.h
@@ -52,7 +52,7 @@
 /* 1883C0 */ f32 gm_801883C0(void);
 /* 18841C */ bool gm_8018841C(void);
 /* 188454 */ int gm_80188454(int idx);
-/* 18846C */ UNK_RET fn_8018846C(UNK_PARAMS);
+/* 18846C */ int fn_8018846C(void);
 /* 1884F8 */ int fn_801884F8(void);
 /* 188550 */ UNK_RET fn_80188550(UNK_PARAMS);
 /* 188644 */ UNK_RET fn_80188644(UNK_PARAMS);

--- a/src/melee/mn/mnname.c
+++ b/src/melee/mn/mnname.c
@@ -102,13 +102,75 @@ void mnName_802385A0(HSD_GObj* gobj)
     mnName_80238754(gobj);
     mnName_8023A058(gobj);
 }
-/// #mnName_GetPageCount
+s32 mnName_GetPageCount(void)
+{
+    s32 count = 0;
+    s32 i;
+    s32 extra;
+    for (i = 0; i < 0x78; i++) {
+        if (IsNameValid((u8) i)) {
+            count++;
+        }
+    }
+    if (count % 24 != 0) {
+        extra = 1;
+    } else {
+        extra = 0;
+    }
+    return count / 24 + extra;
+}
 
-/// #mnName_GetColumnCount
+s32 mnName_GetColumnCount(void)
+{
+    s32 count;
+    s32 extra;
+    s32 i;
+    count = 0;
+    for (i = count; i < 0x78; i++) {
+        if (IsNameValid((u8) i)) {
+            count++;
+        }
+    }
+    if (count % 6 != 0) {
+        extra = 1;
+    } else {
+        extra = 0;
+    }
+    PAD_STACK(16);
+    return count / 6 + extra;
+}
 
 /// #mnName_80238754
 
-/// #mnName_802388D4
+HSD_JObj* mnName_802388D4(HSD_GObj* gobj, u8 index)
+{
+    u8* p = (u8*) gobj;
+    HSD_JObj* result;
+
+    if ((u8) index < 0x18) {
+        HSD_JObj* jobj = *(HSD_JObj**) (p + 0x30);
+        s32 i;
+
+        result = (jobj == NULL) ? NULL : jobj->child;
+
+        for (i = 0; i < (u8) index; i++) {
+            result = (result == NULL) ? NULL : result->next;
+        }
+
+        return result;
+    }
+
+    switch ((u8) index) {
+    case 0x18:
+        return *(HSD_JObj**) (p + 0x24);
+    case 0x19:
+        return *(HSD_JObj**) (p + 0x18);
+    case 0x1A:
+        return *(HSD_JObj**) (p + 0x1C);
+    }
+
+    return (HSD_JObj*) gobj;
+}
 
 f32 mnName_80238964(u8 index, u8 target, u8 flag)
 {

--- a/src/melee/mn/mnname.h
+++ b/src/melee/mn/mnname.h
@@ -32,10 +32,10 @@ typedef struct MnName_GObj {
 /* 23817C */ UNK_RET mnName_MainInput(HSD_GObj*);
 /* 238540 */ void fn_80238540(HSD_GObj* gobj);
 /* 2385A0 */ void mnName_802385A0(HSD_GObj* gobj);
-/* 2385D4 */ UNK_RET mnName_GetPageCount(UNK_PARAMS);
-/* 238698 */ UNK_RET mnName_GetColumnCount(UNK_PARAMS);
+/* 2385D4 */ s32 mnName_GetPageCount(void);
+/* 238698 */ s32 mnName_GetColumnCount(void);
 /* 238754 */ void mnName_80238754(HSD_GObj* gobj);
-/* 2388D4 */ UNK_RET mnName_802388D4(UNK_PARAMS);
+/* 2388D4 */ HSD_JObj* mnName_802388D4(HSD_GObj* gobj, u8 index);
 /* 238964 */ f32 mnName_80238964(u8 index, u8 target, u8 flag);
 /* 238A04 */ UNK_RET mnName_80238A04(UNK_PARAMS);
 /* 238AE0 */ UNK_RET mnName_80238AE0(UNK_PARAMS);

--- a/src/melee/mn/mnruleplus.c
+++ b/src/melee/mn/mnruleplus.c
@@ -56,11 +56,46 @@ static mn_803ED1D0_t mn_803ED1D0 = { { 3, 4, 5, 6, 7, 8, 9 },
                                          60.0f,
                                      } };
 
+AnimLoopSettings mn_803ED270[3] = {
+    { 0.0f, 0.0f, 0.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0.0f, 0.0f, 0.0f },
+};
+
+AnimLoopSettings mn_803ED294[7] = {
+    { 0.0f, 0.0f, 0.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0.0f, 0.0f, 0.0f },
+};
+
+u8 mn_803ED2E8[16][2] = { 0 };
+
 static s32 mn_804DBE48 = 0x02030506;
 
 /// #fn_8023201C
 
-/// #mn_80232458
+AnimLoopSettings* mn_80232458(u8 option, u8 value, u8 direction)
+{
+    u8 count;
+
+    if (option != 1 && option != 2 && option != 3 && option != 4) {
+        return NULL;
+    }
+
+    count = mn_803ED2E8[option][1];
+
+    if (direction != 0) {
+        if (value == 0) {
+            return &mn_803ED270[count];
+        }
+        return &mn_803ED270[value - 1];
+    }
+    return &mn_803ED294[count - value];
+}
 
 /// #mn_802324E4
 


### PR DESCRIPTION
## Summary
- `fn_8018846C`
- `mn_80232458`
- `mnName_GetPageCount`, `mnName_GetColumnCount`, `mnName_802388D4`

## Verification
- All functions verified 100% match via objdiff during overnight run
- `ninja` builds cleanly

## What these functions do
Menu and game-mode utilities. `fn_8018846C` is a game-state callback in the results/ranking screen flow. `mn_80232458` handles logic in the **Rules** menu screen. The three `mnName` functions support the **Name Entry** screen — `GetPageCount` and `GetColumnCount` calculate pagination for the 120-slot name list (pages of 24, columns of 6), and `802388D4` is a layout callback for rendering the scrollable name grid.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>