### PR TITLE
Match 4 fighter functions

### DIFF
--- a/src/melee/ft/chara/ftCommon/ftCo_Attack100.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Attack100.c
@@ -2167,7 +2167,18 @@ bool fn_800DC044(Fighter_GObj* gobj)
     return false;
 }
 
-/// #fn_800DC070
+void fn_800DC070(Fighter_GObj* gobj)
+{
+    Fighter* fp = GET_FIGHTER(gobj);
+    Fighter_GObj* victim = fp->victim_gobj;
+    ftCommon_8007D5D4(fp);
+    fp->self_vel.x = -fp->facing_dir * p_ftCommonData->x374;
+    fp->self_vel.y = p_ftCommonData->x378;
+    fp->mv.co.buryjump.x0 = 0;
+    ftCo_800DC920(victim, gobj);
+    Fighter_ChangeMotionState(gobj, ftCo_MS_CaptureJump, 0, 0.0F, 1.0F,
+                              0.0F, NULL);
+}
 
 void ftCo_CaptureJump_Anim(Fighter_GObj* gobj)
 {

--- a/src/melee/ft/chara/ftCrazyHand/ftCh_Init.c
+++ b/src/melee/ft/chara/ftCrazyHand/ftCh_Init.c
@@ -918,7 +918,18 @@ void ftCh_Damage_Phys(HSD_GObj* gobj)
 
 void ftCh_Damage_Coll(HSD_GObj* gobj) {}
 
-/// #ftCh_Init_80157170
+void ftCh_Init_80157170(HSD_GObj* gobj)
+{
+    Fighter* fp = GET_FIGHTER(gobj);
+    ftCrazyHand_DatAttrs* attrs = fp->ft_data->ext_attr;
+    fp->mv.ch.unk0.xC.x = fp->cur_pos.x - attrs->x28;
+    fp->mv.ch.unk0.xC.y = attrs->x24;
+    Fighter_ChangeMotionState(gobj, ftMh_MS_Damage2, 0,
+                              fp->mv.ch.unk0.xC.z = ftCh_Init_804DA070,
+                              ftCh_Init_804DA074, ftCh_Init_804DA070, NULL);
+    ftAnim_8006EBA4(gobj);
+    ft_PlaySFX(fp, 0x4E207, 127, 64);
+}
 
 /// #ftCh_Damage2_Anim
 

--- a/src/melee/ft/chara/ftCrazyHand/types.h
+++ b/src/melee/ft/chara/ftCrazyHand/types.h
@@ -15,7 +15,7 @@ typedef struct _ftCrazyHandAttributes {
     float x18;
     float x1C;
     s32 x20;
-    s32 x24;
+    float x24;
     float x28;
     float x2C;
     Vec2 x30_pos2;

--- a/src/melee/ft/chara/ftKirby/ftKb_Init.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_Init.c
@@ -3916,7 +3916,36 @@ void ftKb_SpecialN_800F13F0(Fighter_GObj* gobj)
     ftKb_SpecialN_800EF69C(gobj, 0x16, ft_80459B88.hats[FTKIND_DRMARIO]);
 }
 
-/// #ftKb_SpecialN_800F1420
+void ftKb_SpecialN_800F1420(Fighter_GObj* gobj, u32* arg1)
+{
+    Fighter* fp = GET_FIGHTER(gobj);
+    FtPartsVisLookup* lookup = fp->x5AC.xC[4];
+    int i;
+
+    for (i = 0; i < lookup->x0; i++) {
+        TempS* entry = &lookup->x4[i];
+        u8* p = entry->x4;
+        int j;
+
+        for (j = 0; j < entry->x0; j++, p++) {
+            HSD_DObj* dobj = fp->fv.kb.hat.x14.data[*p];
+            HSD_MObj* mobj;
+
+            if (dobj != NULL) {
+                mobj = dobj->mobj;
+            } else {
+                mobj = NULL;
+            }
+
+            if (mobj != NULL) {
+                HSD_Material* mat = mobj->mat;
+                if (mat != NULL) {
+                    *(u32*) &mat->diffuse = *arg1;
+                }
+            }
+        }
+    }
+}
 
 /// #ftKb_SpecialN_800F14B4
 

--- a/src/melee/ft/ftcolanim.c
+++ b/src/melee/ft/ftcolanim.c
@@ -102,7 +102,28 @@ void ftCo_800C0074(Fighter* fp)
     lb_80014498(&fp->x408);
 }
 
-/// #ft_800C0098
+#pragma push
+#pragma auto_inline off
+#pragma global_optimizer off
+void ft_800C0098(Fighter* fp)
+{
+    lb_80014498(&fp->x508);
+    if (fp->x2226_b4) {
+        s32 arg1 = 0x80;
+        if (arg1 >= 0x7B) {
+            s32 temp = arg1 - 0x7B;
+            lb_800144C8(&fp->x508, Fighter_804D6538, temp, 0);
+        } else {
+            Fighter_804D653C_t* entry = &Fighter_804D653C[arg1];
+            if (entry->unk5 != 0) {
+                lb_800144C8(&fp->x488, Fighter_804D653C, arg1, 0);
+            } else {
+                lb_800144C8(&fp->x408, Fighter_804D653C, arg1, 0);
+            }
+        }
+    }
+}
+#pragma pop
 
 /// #ftCo_800C0134
 


### PR DESCRIPTION
## Summary
- `ftKb_SpecialN_800F1420` in ftKb_Init.c
- `ftCh_Init_80157170` in ftCh_Init.c
- `ft_800C0098` in ftcolanim.c
- `fn_800DC070` in ftCo_Attack100.c

## What these functions do

**Kirby's copy ability** — Updates the diffuse color on Kirby's copied character hat model, used when tinting the hat appearance.

**Crazy Hand** — Initiates Crazy Hand's heavy damage flinch animation when he takes a big hit in Boss mode.

**Fighter color overlays** — Clears a fighter's spycloak color animation and optionally re-applies it when the Cloaking Device effect is active.

**Grab escape** — When a grabbed fighter breaks free by jumping, sets the escape velocity and enters the CaptureJump animation.

## Verification
- `fuzzy_match_percent: 100.0` for all functions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)