### PR TITLE
ft/ftKirby: decompile 7 Kirby special N functions

### DIFF
--- a/src/melee/ft/chara/ftKirby/ftKb_Init.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_Init.c
@@ -34,6 +34,7 @@
 #include "ft/ftcommon.h"
 #include "ft/ftdata.h"
 #include "ft/ftdynamics.h"
+#include "ft/ftanim.h"
 #include "ft/ftparts.h"
 #include "ft/ftwalkcommon.h"
 #include "ft/inlines.h"
@@ -3320,7 +3321,33 @@ void ftKb_SpecialN_800EF040(Fighter_GObj* gobj, int arg1, KirbyHatStruct* hat)
 
 /// #ftKb_SpecialN_800EF0E4
 
-/// #ftKb_SpecialN_800EF35C
+void ftKb_SpecialN_800EF35C(Fighter_GObj* gobj, int arg1, u8* arg2)
+{
+    Fighter* fp = GET_FIGHTER(gobj);
+    struct {
+        HSD_Joint* joint;
+        HSD_MatAnimJoint* matanim;
+    }* costume_data = (void*) ftKb_Init_803C9FC8[arg1];
+    HSD_MatAnimJoint* matanimjoint =
+        costume_data[fp->x619_costume_id].matanim;
+    int idx = 0;
+    int i = 0;
+    while (matanimjoint != NULL) {
+        if (ftParts_8007506C(fp->kind, i) != 0) {
+            i++;
+            arg2++;
+        } else {
+            if (matanimjoint->matanim != NULL) {
+                HSD_DObjAddAnimAll(fp->fv.kb.hat.x14.data[*arg2],
+                                   matanimjoint->matanim, NULL);
+            }
+            i++;
+            arg2++;
+            ftAnim_GetNextMatAnimJointInTree(&matanimjoint, &idx);
+        }
+    }
+    PAD_STACK(8);
+}
 
 /// #ftKb_SpecialN_800EF438
 

--- a/src/melee/ft/chara/ftKirby/ftKb_Init.h
+++ b/src/melee/ft/chara/ftKirby/ftKb_Init.h
@@ -45,7 +45,7 @@
 /* 0EF028 */ HSD_JObj* ftKb_Init_UnkMotionStates6(Fighter_GObj* gobj);
 /* 0EF040 */ void ftKb_SpecialN_800EF040(Fighter_GObj*, int, KirbyHatStruct*);
 /* 0EF0E4 */ UNK_RET ftKb_SpecialN_800EF0E4(Fighter_GObj*, int, u8*);
-/* 0EF35C */ UNK_RET ftKb_SpecialN_800EF35C(Fighter_GObj*, int, u8*);
+/* 0EF35C */ void ftKb_SpecialN_800EF35C(Fighter_GObj*, int, u8*);
 /* 0EF438 */ UNK_RET ftKb_SpecialN_800EF438(Fighter_GObj*, KirbyHatStruct*);
 /* 0EF69C */ void ftKb_SpecialN_800EF69C(Fighter_GObj*, int, KirbyHatStruct*);
 /* 0EF87C */ void ftKb_UnkIntBoolFunc0(Fighter*, int, bool);

--- a/src/melee/ft/chara/ftKirby/ftKb_SpecialN.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_SpecialN.c
@@ -17,6 +17,7 @@
 #include "ft/ft_081B.h"
 #include "ft/ft_0877.h"
 #include "ft/ft_0892.h"
+#include "ft/ftanim.h"
 #include "ft/ftcliffcommon.h"
 #include "ft/ftcommon.h"
 #include "ft/ftdata.h"
@@ -2023,11 +2024,41 @@ void ftKb_SpecialAirNCaptured_Anim(Fighter_GObj* gobj)
 
 /// #ftKb_SpecialAirNSpit_Anim
 
-/// #ftKb_SpecialNDrink0_Anim
+void ftKb_SpecialNDrink0_Anim(Fighter_GObj* gobj)
+{
+    Fighter* fp = (0, GET_FIGHTER(gobj));
+    Item_GObj* item_gobj;
+    if (fp->cmd_vars[0] != 0 && (item_gobj = fp->target_item_gobj) != NULL) {
+        ftCommon_8007E2F4(fp, 0);
+        ft_PlaySFX(fp, 0x222F6, 0x7F, 0x40);
+        it_802F28C8(item_gobj, 0, 0.0F);
+        fp->x1A64 = NULL;
+        fp->target_item_gobj = NULL;
+        fp->cmd_vars[0] = 0;
+    }
+    if (!ftAnim_IsFramesRemaining(gobj)) {
+        ft_8008A2BC(gobj);
+    }
+}
 
 /// #ftKb_SpecialNDrink_Anim
 
-/// #ftKb_SpecialNDrink1_Anim
+void ftKb_SpecialNDrink1_Anim(Fighter_GObj* gobj)
+{
+    Fighter* fp = (0, GET_FIGHTER(gobj));
+    Item_GObj* item_gobj;
+    if (fp->cmd_vars[0] != 0 && (item_gobj = fp->target_item_gobj) != NULL) {
+        ftCommon_8007E2F4(fp, 0);
+        ft_PlaySFX(fp, 0x222F6, 0x7F, 0x40);
+        it_802F28C8(item_gobj, 0, 0.0F);
+        fp->x1A64 = NULL;
+        fp->target_item_gobj = NULL;
+        fp->cmd_vars[0] = 0;
+    }
+    if (!ftAnim_IsFramesRemaining(gobj)) {
+        ftCo_Fall_Enter(gobj);
+    }
+}
 
 /// #ftKb_SpecialAirNDrink_Anim
 

--- a/src/melee/ft/chara/ftKirby/ftKb_SpecialN.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_SpecialN.c
@@ -7,6 +7,8 @@
 #include "ef/efsync.h"
 #include "ft/chara/ftCommon/ftCo_Damage.h"
 #include "ft/chara/ftCommon/ftCo_FallSpecial.h"
+#include "ft/chara/ftCommon/ftCo_Throw.h"
+#include "ft/chara/ftCommon/ftCo_ThrownKirby.h"
 #include "ft/chara/ftCommon/ftCo_Jump.h"
 #include "ft/chara/ftCommon/ftCo_KneeBend.h"
 #include "ft/chara/ftCommon/ftCo_Wait.h"
@@ -2060,7 +2062,27 @@ void ftKb_SpecialNDrink1_Anim(Fighter_GObj* gobj)
     }
 }
 
-/// #ftKb_SpecialAirNDrink_Anim
+void ftKb_SpecialAirNDrink_Anim(Fighter_GObj* gobj)
+{
+    Fighter* fp2;
+    Fighter_GObj* victim_gobj;
+    Fighter* fp = getFighter(gobj);
+    if (fp->cmd_vars[0] != 0) {
+        if ((victim_gobj = fp->victim_gobj) != NULL) {
+            ftCommon_8007E2F4(fp, 0);
+            ftCo_800DE2CC(gobj, victim_gobj);
+            ftCo_800BE000(victim_gobj, gobj);
+            fp2 = getFighter(gobj);
+            fp2->fv.kb.xE0 = ftCo_800BD9E0(gobj, victim_gobj);
+            ftKb_SpecialN_800F1BAC(gobj, fp2->fv.kb.xE0, true);
+            fp->cmd_vars[0] = 0;
+        }
+    }
+    if (!ftAnim_IsFramesRemaining(gobj)) {
+        ftCo_Fall_Enter(gobj);
+    }
+    PAD_STACK(32);
+}
 
 void ftKb_EatTurn_Anim(Fighter_GObj* gobj)
 {

--- a/src/melee/ft/chara/ftKirby/ftKb_SpecialNNs.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_SpecialNNs.c
@@ -986,7 +986,29 @@ void ftKb_SpecialNPr_80101618(Fighter_GObj* gobj)
 
 /// #ftKb_PrSpecialNEnd_Anim
 
-/// #ftKb_PrSpecialAirNStart_Anim
+void ftKb_PrSpecialAirNStart_Anim(Fighter_GObj* gobj)
+{
+    static u32 const mf = (1 << 1) | (1 << 4) | (1 << 18);
+    Fighter* fp = GET_FIGHTER(gobj);
+    PAD_STACK(8);
+    fp->mv.pr.specialn.facing_dir = 0;
+    if (!ftAnim_IsFramesRemaining(gobj)) {
+        Fighter_ChangeMotionState(gobj, ftKb_MS_PrSpecialAirNFull, mf, 0,
+                                  0, 0, NULL);
+        {
+            Fighter* fp = GET_FIGHTER(gobj);
+            fp->death2_cb = ftKb_Init_800EE74C;
+            fp->take_dmg_cb = ftKb_Init_800EE7B8;
+            fp->deal_dmg_cb = fn_80100E0C;
+            fp->x21F8 = fn_80105978;
+        }
+        fp->cur_anim_frame = 0;
+        ftAnim_SetAnimRate(gobj, 0);
+        fp->self_vel.x = fp->facing_dir * 0.0001f;
+        fp->x74_anim_vel.x = 0;
+        ftPartSetRotY(fp, 0, M_PI_2);
+    }
+}
 
 /// #ftKb_PrSpecialAirNLoop_Anim
 

--- a/src/melee/ft/chara/ftKirby/ftKb_SpecialNZd.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_SpecialNZd.c
@@ -90,7 +90,6 @@ static void fn_801095DC(HSD_GObj*);
 static void fn_80109680(HSD_GObj*);
 static void fn_80109714(HSD_GObj*);
 static void fn_801097B8(HSD_GObj*);
-static void fn_80106DB0(HSD_GObj*);
 void fn_8010A930(Fighter_GObj*, Fighter_GObj*);
 
 inline void ftKirbyDmgInline(Fighter_GObj* gobj)

--- a/src/melee/ft/chara/ftKirby/ftKb_SpecialNZd.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_SpecialNZd.c
@@ -89,6 +89,7 @@ static void fn_801095DC(HSD_GObj*);
 static void fn_80109680(HSD_GObj*);
 static void fn_80109714(HSD_GObj*);
 static void fn_801097B8(HSD_GObj*);
+static void fn_80106DB0(HSD_GObj*);
 void fn_8010A930(Fighter_GObj*, Fighter_GObj*);
 
 inline void ftKirbyDmgInline(Fighter_GObj* gobj)
@@ -490,7 +491,21 @@ void ftKb_SkSpecialAirNEnd_Anim(Fighter_GObj* gobj)
 
 void ftKb_SkSpecialNStart_IASA(Fighter_GObj* gobj) {}
 
-/// #ftKb_SkSpecialNLoop_IASA
+void ftKb_SkSpecialNLoop_IASA(Fighter_GObj* gobj)
+{
+    Fighter* fp = GET_FIGHTER(gobj);
+    if (!(fp->input.held_inputs & HSD_PAD_B)) {
+        fp->mv.kb.specialhi.x0 = 0;
+        Fighter_ChangeMotionState(gobj, ftKb_MS_SkSpecialNEnd, Ft_MF_None,
+                                  0.0F, 1.0F, 0.0F, NULL);
+        ftKirbyDmgInline(gobj);
+        fp->accessory4_cb = fn_80106DB0;
+    } else if (fp->input.x668 & HSD_PAD_LR) {
+        Fighter_ChangeMotionState(gobj, ftKb_MS_SkSpecialNCancel, Ft_MF_None,
+                                  0.0F, 1.0F, 0.0F, NULL);
+        ftKirbyDmgInline(gobj);
+    }
+}
 
 void ftKb_SkSpecialNCancel_IASA(Fighter_GObj* gobj) {}
 

--- a/src/melee/ft/chara/ftKirby/ftKb_SpecialNZd.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_SpecialNZd.c
@@ -807,7 +807,48 @@ check:
 
 /// #ftKb_SpecialNMt_80107410
 
-/// #ftKb_SpecialNMt_80107568
+static inline void ftKb_SpecialNMt_ChangeAction(Fighter_GObj* gobj)
+{
+    Fighter* fp = getFighter(gobj);
+    ftKb_DatAttrs* da = fp->dat_attrs;
+    s32 timer;
+
+    Fighter_ChangeMotionState(gobj, ftKb_MS_MtSpecialNStart, 0, 0.0F, 1.0F,
+                              0.0F, NULL);
+
+    timer = 0;
+    fp->cmd_vars[3] = 0;
+    fp->cmd_vars[2] = 0;
+    fp->cmd_vars[1] = 0;
+    fp->cmd_vars[0] = 0;
+
+    ftCommon_8007D7FC(fp);
+
+    fp->self_vel.y = 0.0F;
+
+    {
+        Fighter* fp2 = gobj->user_data;
+        fp2->death2_cb = ftKb_Init_800EE74C;
+        fp2->take_dmg_cb = ftKb_Init_800EE7B8;
+    }
+
+    fp->mv.kb.specialhi.x0 = 0;
+    fp->mv.kb.specialhi.x4 = 0;
+
+    if (fp->fv.kb.x9C == 0) {
+        timer = da->specialn_mt_frames_to_transition;
+    }
+    fp->mv.kb.specialhi.xC = timer;
+    fp->mv.kb.specialhi.x10.f = 0.0F;
+
+    ftAnim_8006EBA4(gobj);
+}
+
+void ftKb_SpecialNMt_80107568(Fighter_GObj* gobj)
+{
+    ftKb_SpecialNMt_ChangeAction(gobj);
+    PAD_STACK(8);
+}
 
 void ftKb_SpecialNMt_80107638(Fighter_GObj* gobj)
 {

--- a/src/melee/ft/chara/ftKirby/ftKb_SpecialNZd.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_SpecialNZd.c
@@ -84,6 +84,7 @@ extern f32 ftKb_Init_804D9558;
 /// Forward declarations for functions called before definition
 void fn_80105AB0(Fighter_GObj*);
 void fn_80105A34(Fighter_GObj*);
+void fn_80106DB0(Fighter_GObj*);
 void fn_801090D4(Fighter_GObj*);
 static void fn_801095DC(HSD_GObj*);
 static void fn_80109680(HSD_GObj*);
@@ -513,7 +514,21 @@ void ftKb_SkSpecialNEnd_IASA(Fighter_GObj* gobj) {}
 
 void ftKb_SkSpecialAirNStart_IASA(Fighter_GObj* gobj) {}
 
-/// #ftKb_SkSpecialAirNLoop_IASA
+void ftKb_SkSpecialAirNLoop_IASA(Fighter_GObj* gobj)
+{
+    Fighter* fp = GET_FIGHTER(gobj);
+    if (!(fp->input.held_inputs & HSD_PAD_B)) {
+        fp->mv.kb.specialhi.x0 = 0;
+        Fighter_ChangeMotionState(gobj, ftKb_MS_SkSpecialAirNEnd, Ft_MF_None,
+                                  0, 1, 0, NULL);
+        ftKirbyDmgInline(gobj);
+        fp->accessory4_cb = fn_80106DB0;
+    } else if (fp->input.x668 & HSD_PAD_LR) {
+        Fighter_ChangeMotionState(gobj, ftKb_MS_SkSpecialAirNCancel,
+                                  Ft_MF_None, 0, 1, 0, NULL);
+        ftKirbyDmgInline(gobj);
+    }
+}
 
 void ftKb_SkSpecialAirNCancel_IASA(Fighter_GObj* gobj) {}
 


### PR DESCRIPTION
## Summary
- `ftKb_SpecialNDrink0_Anim`, `ftKb_SpecialNDrink1_Anim`, `ftKb_SpecialAirNDrink_Anim` in ftKb_SpecialN.c
- `ftKb_SpecialNMt_80107568`, `ftKb_SkSpecialNLoop_IASA`, `ftKb_SkSpecialAirNLoop_IASA` in ftKb_SpecialNZd.c
- `ftKb_SpecialN_800EF35C` in ftKb_Init.c
- `ftKb_PrSpecialAirNStart_Anim` in ftKb_SpecialNNs.c

## What these functions do

**Inhale swallowing animation** — `ftKb_SpecialNDrink0_Anim`, `Drink1_Anim`, and `SpecialAirNDrink_Anim` animate Kirby swallowing a captured opponent on the ground and in the air. On completion they transition to the "eat wait" (ground) or "eat fall" (air) states where Kirby holds the opponent in his stomach.

**Copied Sheik neutral B input** — `ftKb_SkSpecialNLoop_IASA` and `ftKb_SkSpecialAirNLoop_IASA` handle input checks during Kirby's copied Sheik Needle Storm loop. If B is released, Kirby fires the needles and transitions to the end state; if a shoulder button is pressed, the move is cancelled.

**Copied Mewtwo neutral B** — `ftKb_SpecialNMt_80107568` enters Kirby's copied Mewtwo Shadow Ball charge, initializing the motion state and charge variables.

**Hat model loading** — `ftKb_SpecialN_800EF35C` is part of the pipeline that loads the 3D hat model onto Kirby's head after copying a character's ability.

**Copied Jigglypuff neutral B** — `ftKb_PrSpecialAirNStart_Anim` handles the aerial startup animation for Kirby's copied Jigglypuff Rollout.

## Verification
- All 7 functions 100% match (verified by overnight script)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)