### PR TITLE
Fighter decompilation matches

### DIFF
--- a/src/melee/ft/chara/ftCommon/types.h
+++ b/src/melee/ft/chara/ftCommon/types.h
@@ -405,7 +405,10 @@ union ftCommon_MotionVars {
     struct {
         /* fp+2340 */ int x40;
         /* fp+2344 */ int x44;
-        /* fp+2348 */ u8 pad_x48[0x68 - 0x48];
+        /* fp+2348 */ u8 pad_x48[0x4C - 0x48];
+        /* fp+234C */ float x4C;
+        /* fp+2350 */ Vec3 x50;
+        /* fp+235C */ Vec3 x5C;
         /* fp+2368 */ int x68;
     } unk_deadup;
     struct {

--- a/src/melee/ft/chara/ftKirby/ftKb_Init.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_Init.c
@@ -4090,7 +4090,51 @@ void ftKb_SpecialN_800F190C(Fighter_GObj* gobj, FighterKind kind)
     fp->fv.kb.xDC = NULL;
 }
 
-/// #ftKb_SpecialN_800F19AC
+void ftKb_SpecialN_800F19AC(Fighter_GObj* gobj)
+{
+    Fighter* fp = GET_FIGHTER(gobj);
+    FighterKind kind = fp->fv.kb.hat.kind;
+
+    switch (kind) {
+    case FTKIND_POPO:
+        ftKb_SpecialNIc_80108D04(gobj);
+        break;
+    case FTKIND_PEACH:
+        ftKb_SpecialNPe_8010C3F4(gobj);
+        break;
+    case FTKIND_FOX:
+    case FTKIND_FALCO:
+        ftKb_SpecialNFx_800FDEE0(gobj);
+        break;
+    case FTKIND_LINK:
+    case FTKIND_CLINK:
+        ftKb_SpecialNLk800FB800(gobj);
+        ftKb_SpecialNLk800FB840(gobj);
+        break;
+    case FTKIND_MEWTWO:
+        ftKb_SpecialNMt_8010709C(gobj);
+        break;
+    case FTKIND_NESS:
+        ftKb_SpecialNNs_800FECE8(gobj);
+        break;
+    case FTKIND_SAMUS:
+        ftKb_SpecialNSs_800FCD60(gobj);
+        break;
+    case FTKIND_SEAK:
+        ftKb_SpecialNSk_8010603C(gobj);
+        break;
+    case FTKIND_YOSHI:
+        ftKb_SpecialNYs_801093B4(gobj);
+        ftKb_SpecialNYs_8010A8BC(gobj);
+        break;
+    case FTKIND_DONKEY:
+        ftKb_SpecialNPr_80100DE0(gobj);
+        break;
+    case FTKIND_GAMEWATCH:
+        ftKb_SpecialNGw_8010D0A8(gobj);
+        break;
+    }
+}
 
 /// #ftKb_SpecialN_800F1A8C
 

--- a/src/melee/ft/chara/ftKirby/ftKb_Init.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_Init.c
@@ -4136,7 +4136,51 @@ void ftKb_SpecialN_800F19AC(Fighter_GObj* gobj)
     }
 }
 
-/// #ftKb_SpecialN_800F1A8C
+void ftKb_SpecialN_800F1A8C(Fighter_GObj* gobj)
+{
+    Fighter* fp = GET_FIGHTER(gobj);
+    FighterKind kind = fp->fv.kb.hat.kind;
+
+    switch (kind) {
+    case FTKIND_POPO:
+        ftKb_SpecialNIc_80108D04(gobj);
+        break;
+    case FTKIND_PEACH:
+        ftKb_SpecialNPe_8010C3F4(gobj);
+        break;
+    case FTKIND_FOX:
+    case FTKIND_FALCO:
+        ftKb_SpecialNFx_800FDEE0(gobj);
+        break;
+    case FTKIND_LINK:
+    case FTKIND_CLINK:
+        ftKb_SpecialNLk800FB800(gobj);
+        ftKb_SpecialNLk800FB840(gobj);
+        break;
+    case FTKIND_MEWTWO:
+        ftKb_SpecialNMt_80107130(gobj);
+        break;
+    case FTKIND_NESS:
+        ftKb_SpecialNNs_800FECE8(gobj);
+        break;
+    case FTKIND_SAMUS:
+        ftKb_SpecialNSs_800FCD60(gobj);
+        break;
+    case FTKIND_SEAK:
+        ftKb_SpecialNSk_8010603C(gobj);
+        break;
+    case FTKIND_YOSHI:
+        ftKb_SpecialNYs_801093B4(gobj);
+        ftKb_SpecialNYs_8010A8BC(gobj);
+        break;
+    case FTKIND_DONKEY:
+        ftKb_SpecialNPr_80100DE0(gobj);
+        break;
+    case FTKIND_GAMEWATCH:
+        ftKb_SpecialNGw_8010D0A8(gobj);
+        break;
+    }
+}
 
 void ftKb_Init_UnkMotionStates3(Fighter_GObj* gobj)
 {

--- a/src/melee/ft/chara/ftKirby/ftKb_Init.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_Init.c
@@ -3936,7 +3936,32 @@ void ftKb_SpecialN_800F10A4(Fighter_GObj* gobj)
     ftKb_SpecialN_800EF69C(gobj, 3, ft_80459B88.hats[FTKIND_CAPTAIN]);
 }
 
-/// #ftKb_SpecialN_800F10D4
+#pragma push
+#pragma dont_inline on
+void ftKb_SpecialN_800F10D4(Fighter_GObj* gobj)
+{
+    u8 sp14[0x90];
+    Fighter* fp = fp = gobj->user_data;
+    KirbyHatStruct* temp_r28;
+    PAD_STACK(8);
+    if (fp->fv.kb.hat.x14.data != NULL) {
+        return;
+    }
+    temp_r28 = ft_80459B88.hats[14];
+    ftKb_SpecialN_800EF040(gobj, 0xF, temp_r28);
+    fp->fv.kb.hat.x14.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);
+    fp->fv.kb.hat.x1C.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);
+    ftKb_SpecialN_800EF0E4(gobj, 0xF, sp14);
+    ftKb_SpecialN_800EF35C(gobj, 0xF, sp14);
+    ftKb_SpecialN_800EF438(gobj, temp_r28);
+    ftParts_8007487C((FtPartsDesc*) temp_r28, &fp->fv.kb.hat.x24,
+                     fp->x619_costume_id, &fp->fv.kb.hat.x14,
+                     &fp->fv.kb.hat.x1C);
+    ftAnim_80070200(fp, (ftData_x8_x8*) &temp_r28->desc.vis_table,
+                    &fp->fv.kb.x44, &fp->fv.kb.hat.x14);
+    ftCo_8009D81C(fp);
+}
+#pragma pop
 
 void ftKb_SpecialN_800F11AC(Fighter_GObj* gobj)
 {

--- a/src/melee/ft/ft_0D31.c
+++ b/src/melee/ft/ft_0D31.c
@@ -50,6 +50,7 @@
 #include <melee/gm/gm_unsplit.h>
 #include <melee/gr/stage.h>
 #include <melee/it/item.h>
+#include <melee/mp/mpcoll.h>
 #include <melee/it/items/it_2E5A.h>
 #include <melee/it/items/itkinoko.h>
 #include <melee/pl/pl_040D.h>
@@ -552,7 +553,30 @@ void fn_800D55B4(Fighter_GObj* gobj)
         fp->cur_pos.y = other_fp->cur_pos.y;
     }
 }
-/// #ftCo_800D5600
+void ftCo_800D5600(Fighter_GObj* gobj)
+{
+    Fighter* fp = gobj->user_data;
+    mpColl_80043680(&fp->coll_data, &fp->cur_pos);
+    fp->self_vel.y = 0;
+    fp->mv.co.common.x0 = (int) p_ftCommonData->x5D4;
+    Fighter_ChangeMotionState(gobj, ftCo_MS_RebirthWait,
+                              Ft_MF_KeepGfx | Ft_MF_SkipColAnim |
+                                  Ft_MF_KeepAccessory |
+                                  Ft_MF_SkipNametagVis,
+                              0, 1, 0, NULL);
+    fp->x221E_b2 = 1;
+    fp->x2219_b1 = 1;
+    fp->x221E_b1 = 1;
+    fp->x221D_b5 = 1;
+    if (!fp->x221F_b4) {
+        fp->accessory1_cb = fn_800D54A4;
+    } else {
+        fp->accessory1_cb = fn_800D55B4;
+    }
+    if (fp->smash_attrs.x2135 != -1) {
+        mpColl_80043680(&fp->coll_data, &fp->cur_pos);
+    }
+}
 
 void ftCo_RebirthWait_Anim(Fighter_GObj* gobj)
 {

--- a/src/melee/ft/ft_0D31.c
+++ b/src/melee/ft/ft_0D31.c
@@ -10,11 +10,14 @@
 #include "ft/ft_081B.h"
 #include "ft/ft_0892.h"
 #include "ft/ft_0C88.h"
+#include "ft/ftanim.h"
 #include "ft/ftcoll.h"
 #include "ft/ftcommon.h"
 #include "ft/ftwaitanim.h"
 #include "ft/inlines.h"
 #include "ft/types.h"
+
+#include "lb/lbvector.h"
 
 #include "ftCommon/forward.h"
 
@@ -413,7 +416,39 @@ void ftCo_800D47B8(Fighter_GObj* gobj)
 
 /// #ftCo_DeadUpFall_Anim
 
-/// #ftCo_DeadUpFall_Phys
+void ftCo_DeadUpFall_Phys(Fighter_GObj* gobj)
+{
+    Fighter* fp = GET_FIGHTER(gobj);
+    u8* ca = (u8*) p_ftCommonData + 0x520;
+
+    switch (fp->mv.co.unk_deadup.x44) {
+    case 1:
+        if (fp->x2222_b6) {
+            if (!ftAnim_80070FD0(fp)) {
+                break;
+            }
+        }
+        lbVector_Lerp((Vec3*) (ca + 0x18), (Vec3*) (ca + 0x24),
+                      &fp->mv.co.unk_deadup.x50,
+                      fp->mv.co.unk_deadup.x4C);
+        break;
+    case 3:
+        ftCommon_Fall(fp, *(float*) (ca + 0x34),
+                      *(float*) (ca + 0x38));
+        lbVector_Add(&fp->mv.co.unk_deadup.x5C, &fp->self_vel);
+        if (fp->x2222_b6) {
+            if (!ftAnim_80070FD0(fp)) {
+                break;
+            }
+        }
+        lbVector_Add(&fp->mv.co.unk_deadup.x50,
+                     &fp->mv.co.unk_deadup.x5C);
+        fp->mv.co.unk_deadup.x5C.x = 0;
+        fp->mv.co.unk_deadup.x5C.y = 0;
+        fp->mv.co.unk_deadup.x5C.z = 0;
+        break;
+    }
+}
 
 void fn_800D4DD4(Fighter_GObj* gobj)
 {

--- a/src/melee/ft/ft_0D31.h
+++ b/src/melee/ft/ft_0D31.h
@@ -38,6 +38,7 @@
 /* 0D5358 */ void ftCo_Rebirth_IASA(Fighter_GObj* gobj);
 /* 0D535C */ void ftCo_Rebirth_Phys(Fighter_GObj* gobj);
 /* 0D5470 */ void ftCo_Rebirth_Coll(Fighter_GObj* gobj);
+/* 0D54A4 */ void fn_800D54A4(Fighter_GObj* gobj);
 /* 0D55B4 */ void fn_800D55B4(Fighter_GObj* gobj);
 /* 0D5600 */ void ftCo_800D5600(Fighter_GObj* gobj);
 /* 0D56EC */ void ftCo_RebirthWait_Anim(Fighter_GObj* gobj);


### PR DESCRIPTION
## Summary
- 5 matched functions across 2 fighter files

## What these functions do

**ftKb_Init.c — `ftKb_SpecialN_800F19AC`** — Cleans up copy ability projectiles/resources when Kirby loses a stock, dispatching to the appropriate handler for whichever ability Kirby has.

**ftKb_Init.c — `ftKb_SpecialN_800F1A8C`** — Same cleanup as above but triggered when Kirby respawns on a revival platform.

**ftKb_Init.c — `ftKb_SpecialN_800F10D4`** — Loads Yoshi's copy-ability hat onto Kirby when Kirby first copies Yoshi's Neutral Special (Egg Lay).

**ft_0D31.c — `ftCo_DeadUpFall_Phys`** — Applies physics during the falling portion of a star KO, interpolating position during the arc and applying gravity during freefall.

**ft_0D31.c — `ftCo_800D5600`** — Transitions a fighter from the Rebirth invincibility platform to RebirthWait, resetting collision and setting up the respawn platform callback.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)