### PR TITLE
Library, menu, and game system decompilation matches

### DIFF
--- a/src/melee/gm/gm_1601.c
+++ b/src/melee/gm/gm_1601.c
@@ -1799,7 +1799,40 @@ found:
     return false;
 }
 
-/// #gm_80164504
+int gm_80164504(u16 stage_id)
+{
+    u16* stage_unlock_mask;
+    u8 internal_id;
+    s32 i;
+    u8 unlock_idx;
+    u8 notify_val;
+
+    stage_unlock_mask = gmMainLib_8015EDA4();
+    internal_id = Stage_8022519C(stage_id);
+
+    for (i = 0; i < NUM_UNLOCKABLE_STAGES; i++) {
+        if ((s32) internal_id == (s32) lbl_803B790C[i][1]) {
+            unlock_idx = lbl_803B790C[i][0];
+            goto found_stage;
+        }
+    }
+    unlock_idx = NUM_UNLOCKABLE_STAGES;
+
+found_stage:
+    if (unlock_idx != NUM_UNLOCKABLE_STAGES) {
+        for (i = 0; i < NUM_UNLOCKABLE_STAGES; i++) {
+            if ((s32) unlock_idx == (s32) lbl_803B790C[i][0]) {
+                notify_val = lbl_803B790C[i][2];
+                goto found_notify;
+            }
+        }
+        notify_val = 0x42;
+
+    found_notify:
+        gmMainLib_8015D818(notify_val);
+        *stage_unlock_mask |= (1LL << (s32) unlock_idx);
+    }
+}
 
 /// Are all stages unlocked?
 bool gm_80164600(void)

--- a/src/melee/lb/lbarq.c
+++ b/src/melee/lb/lbarq.c
@@ -63,4 +63,25 @@ void lbArq_80014AC4(lbArqHandle* handle)
 
 /// #lbArq_80014BD0
 
-/// #lbArq_80014D2C
+void lbArq_80014D2C(void)
+{
+    lbArqGlobal* global = &lbArq_804316C0;
+    lbArqNode* nodes = (lbArqNode*)global;
+    lbArqNode* node;
+    int i;
+
+    global->list[0] = NULL;
+    global->list[1] = NULL;
+    global->list[2] = NULL;
+    global->list[0] = nodes;
+
+    for (i = 0; i < 9; i++) {
+        node = &nodes[i];
+        node->next = node + 1;
+        node->state = 0;
+    }
+    node->next = NULL;
+    node->state = 0;
+
+    PAD_STACK(8);
+}

--- a/src/melee/lb/lbaudio_ax.c
+++ b/src/melee/lb/lbaudio_ax.c
@@ -14,6 +14,7 @@
 #include <melee/gr/stage.h>
 #include <melee/it/it_26B1.h>
 #include <melee/lb/lbarchive.h>
+#include <melee/gm/gm_1601.h>
 #include <melee/lb/lblanguage.h>
 
 extern s8 flags_arr_803BB800[0x62];
@@ -515,7 +516,52 @@ int lbAudioAx_8002438C(int arg0)
 
 /// #lbAudioAx_800243F4
 
-/// #fn_800244F4
+void fn_800244F4(void)
+{
+    lbl_804D387C = 0x7F;
+    lbl_804D3884 = 0x7F;
+    lbl_804D388C = 0x7F;
+    lbl_804D3894 = 0x7F;
+    lbl_804D389C = 0x7F;
+    lbl_804D38A4 = 0x7F;
+    lbl_804D38D8 = 1;
+    lbl_804D38C0 = 1.0F;
+    lbl_804D38AC = 1.0F;
+    lbl_804D38B0 = 1.0F;
+    lbl_804D38B4 = 1.0F;
+    lbl_804D38B8 = 1.0F;
+    lbl_804D38BC = 1.0F;
+    lbl_804D640C = 0;
+    lbl_804D6410 = 0;
+    lbl_804D38E4 = 1.0F;
+    lbl_804D38E8 = 1.0F;
+    lbl_804D38EC = 1.0F;
+    lbl_804D6414 = 0;
+    lbl_804D6418 = 0;
+    lbl_804D6420 = 0;
+    lbl_804D6424 = 0;
+    lbl_804D6428 = 0;
+    lbl_804D642C = 0;
+    lbl_804D38F0 = -1;
+    lbl_804D38F4 = -1;
+    lbl_804D6430 = 0;
+    lbl_804D6434 = 0;
+    lbl_804D641C = 0;
+    lbl_804D63F4 = 0;
+    lbl_804D63F8 = 0;
+    lbl_804D63FC = 0;
+    lbl_804D6400 = 0;
+    lbl_804D6404 = 0;
+    lbl_804D3880 = 1.0F;
+    lbl_804D3888 = 0x7F;
+    lbl_804D3890 = 0x7F;
+    lbl_804D3898 = 0x7F;
+    lbl_804D38A0 = 0x7F;
+    lbl_804D38A8 = 0x7F;
+    lbl_804D63F0 = 0.0F;
+    lbl_804D38CC = 0x7F;
+    gm_801603B0();
+}
 
 void lbAudioAx_800245D4(int arg0)
 {

--- a/src/melee/lb/lbaudio_ax.h
+++ b/src/melee/lb/lbaudio_ax.h
@@ -40,7 +40,7 @@
 /* 024304 */ int lbAudioAx_80024304(int);
 /* 02438C */ int lbAudioAx_8002438C(int);
 /* 0243F4 */ UNK_RET lbAudioAx_800243F4(int);
-/* 0244F4 */ UNK_RET fn_800244F4(UNK_PARAMS);
+/* 0244F4 */ void fn_800244F4(void);
 /* 0245D4 */ void lbAudioAx_800245D4(int);
 /* 0245F4 */ int lbAudioAx_800245F4(int);
 /* 024614 */ void lbAudioAx_80024614(int);

--- a/src/melee/lb/lbaudio_ax.static.h
+++ b/src/melee/lb/lbaudio_ax.static.h
@@ -31,6 +31,7 @@ typedef struct lbAudioAx_UserData {
 
 extern f32 lbl_804D63F0;
 extern int lbl_804D63F4;
+extern int lbl_804D63F8;
 extern int lbl_804D63FC;
 extern int lbl_804D6400;
 extern int lbl_804D6404;
@@ -41,8 +42,12 @@ static f32 lbl_804D3880 = 1.0F; ///< synth volume
 static int lbl_804D3884 = 0x7F;
 static int lbl_804D3888 = 0x7F;
 static int lbl_804D388C = 0x7F;
+static int lbl_804D3890 = 0x7F;
+static int lbl_804D3894 = 0x7F;
 static int lbl_804D3898 = 0x7F;
+static int lbl_804D389C = 0x7F;
 static int lbl_804D38A0 = 0x7F;
+static int lbl_804D38A4 = 0x7F;
 static int lbl_804D38A8 = 0x7F;
 static f32 lbl_804D38AC = 1.0F;
 static f32 lbl_804D38B0 = 1.0F;

--- a/src/melee/lb/lbmthp.c
+++ b/src/melee/lb/lbmthp.c
@@ -1,8 +1,11 @@
 #include "lbmthp.static.h"
 
+#include "lb/lbfile.h"
+
 #include "baselib/memory.h"
 #include "baselib/video.h"
 
+#include <dolphin/dvd.h>
 #include <dolphin/gx/GXTexture.h>
 #include <sysdolphin/baselib/sobjlib.h>
 #include <melee/lb/lbanim.h>
@@ -10,7 +13,35 @@
 
 /// #fn_8001E910
 
-/// #fn_8001EB14
+s32 fn_8001EB14(THPDecComp* data, const char* path)
+{
+    THPInit();
+    data->unk_128 = DVDConvertPathToEntrynum(path);
+    lbFile_800161C4(data->unk_128, 0, (u32) data, 0x40, 0x21, 1);
+
+    data->unk_40 = data->unk_1C;
+    data->width = data->unk_10;
+    data->height = data->unk_14;
+    data->unk_100 = data->unk_0C;
+
+    if (data->unk_24 != 0) {
+        OSReport("Warning : frame offsets not supported\n");
+    }
+
+    if (data->unk_08 > 2) {
+        OSReport(
+            "Warning : file format is newer than player\n");
+    }
+
+    data->unk_11C = 1;
+    data->unk_6C = 1;
+    data->unk_110 = 0;
+    data->unk_70 = 1;
+    data->unk_134 = 0;
+    data->unk_130 = 0;
+
+    return 1;
+}
 
 #define ALIGN_32(x) (((x) + 0x1F) & ~0x1F)
 

--- a/src/melee/lb/lbmthp.h
+++ b/src/melee/lb/lbmthp.h
@@ -7,19 +7,30 @@
 #include "lb/forward.h"
 #include <baselib/forward.h>
 
-/* THPDec function declaration */
+/* THPDec function declarations */
+BOOL THPInit(void);
 s32 THPDec_8032FD40(void* arg0, u16 height);
 
 /* Struct used by fn_8001EBF0 for THP decode component init */
 typedef struct THPDecComp {
-    /* 0x00 */ u8 pad0[0x40];
+    /* 0x00 */ u8 pad0[0x08];
+    /* 0x08 */ u32 unk_08;
+    /* 0x0C */ u32 unk_0C;
+    /* 0x10 */ u32 unk_10;
+    /* 0x14 */ u32 unk_14;
+    /* 0x18 */ u8 pad18[0x1C - 0x18];
+    /* 0x1C */ u32 unk_1C;
+    /* 0x20 */ u8 pad20[0x24 - 0x20];
+    /* 0x24 */ u32 unk_24;
+    /* 0x28 */ u8 pad28[0x40 - 0x28];
     /* 0x40 */ u32 unk_40;
     /* 0x44 */ u32 width;
     /* 0x48 */ u32 height;
     /* 0x4C */ u8 pad4C[0x68 - 0x4C];
     /* 0x68 */ s32 unk_68;
     /* 0x6C */ s32 unk_6C;
-    /* 0x70 */ u8 pad70[0x78 - 0x70];
+    /* 0x70 */ s32 unk_70;
+    /* 0x74 */ u8 pad74[0x78 - 0x74];
     /* 0x78 */ u32 unk_78;
     /* 0x7C */ u32 unk_7C;
     /* 0x80 */ u32 unk_80;
@@ -42,10 +53,18 @@ typedef struct THPDecComp {
     /* 0x104 */ u32 unk_104;
     /* 0x108 */ s32 unk_108;
     /* 0x10C */ s32 unk_10C;
+    /* 0x110 */ s32 unk_110;
+    /* 0x114 */ u8 pad114[0x11C - 0x114];
+    /* 0x11C */ s32 unk_11C;
+    /* 0x120 */ u8 pad120[0x128 - 0x120];
+    /* 0x128 */ s32 unk_128;
+    /* 0x12C */ u8 pad12C[0x130 - 0x12C];
+    /* 0x130 */ s32 unk_130;
+    /* 0x134 */ s32 unk_134;
 } THPDecComp;
 
 /* 01E910 */ UNK_RET fn_8001E910(UNK_PARAMS);
-/* 01EB14 */ UNK_RET fn_8001EB14(UNK_PARAMS);
+/* 01EB14 */ s32 fn_8001EB14(THPDecComp* data, const char* path);
 /* 01EBF0 */ s32 fn_8001EBF0(THPDecComp* data);
 /* 01ECF4 */ UNK_RET fn_8001ECF4(UNK_PARAMS);
 /* 01EF5C */ UNK_RET fn_8001EF5C(UNK_PARAMS);

--- a/src/melee/mn/mndatadel.c
+++ b/src/melee/mn/mndatadel.c
@@ -13,6 +13,7 @@
 #include "lb/lb_00F9.h"
 #include "lb/lblanguage.h"
 #include "mn/mnmain.h"
+#include "mn/mnmainrule.h"
 #include "sc/types.h"
 
 /// #mnDataDel_8024E940
@@ -170,7 +171,37 @@ void fn_8024FBA4(HSD_GObj* gobj)
     }
 }
 
-/// #fn_8024FC48
+void fn_8024FC48(HSD_GObj* gobj)
+{
+    s32 i;
+    HSD_JObj* jobj;
+    struct MnDataDelData* data;
+    u8* user_data;
+
+    data = &mnDataDel_803EF870;
+    user_data = gobj->user_data;
+
+    if (mn_804A04F0.cur_menu != 0x18) {
+        HSD_GObjProc* proc;
+        HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
+        proc = HSD_GObj_SetupProc(gobj, fn_8024FBA4, 0);
+        proc->flags_3 = HSD_GObj_804D783C;
+        HSD_SisLib_803A5CC4(*(HSD_Text**)(user_data + 0xC));
+    } else {
+        for (i = 0; i < 6; i++) {
+            lb_80011E24(
+                (HSD_JObj*) mn_80231634(
+                    *(struct mn_80231634_t**)((u8*) gobj->user_data +
+                        ((s32*) ((u8*) &data->x3C))[i] * 4 + 0x10)),
+                &jobj, 1, -1);
+            if (user_data[0] == i) {
+                mn_8022EC18(jobj, &data->x18, (HSD_TypeMask) 0x400);
+            } else {
+                mn_8022EC18(jobj, &data->x24, (HSD_TypeMask) 0x400);
+            }
+        }
+    }
+}
 
 /// #fn_8024FD40
 

--- a/src/melee/mn/mnmainrule.c
+++ b/src/melee/mn/mnmainrule.c
@@ -49,7 +49,34 @@ extern StaticModelDesc MenMainCursorSs_Top;
 
 /// #mn_80230274
 
-/// #mn_802307F8
+extern u8 mn_804D4B96;
+extern u8 mn_803EC818[];
+
+void mn_802307F8(struct mn_802307F8_t* data, s32 mode, s32 index)
+{
+    HSD_Text* text;
+
+    if (data->text != NULL) {
+        HSD_SisLib_803A5CC4(data->text);
+        data->text = NULL;
+    }
+
+    if (mode == 1 && data->x2 == 1) {
+        index = mn_804D4B96;
+    } else if (mode == 1 || mode == 3 || (u32) (mode - 5) <= 1) {
+        index = mn_803EC818[mode * 5];
+    } else {
+        s32 off = mode * 5;
+        index = mn_803EC818[off + index];
+    }
+
+    text = HSD_SisLib_803A5ACC(0, 1, -9.5F, 8.0F, 17.0F, 364.68332F,
+                               76.77544F);
+    data->text = text;
+    text->font_size.x = 0.0521F;
+    text->font_size.y = 0.0521F;
+    HSD_SisLib_803A6368(text, (u8) index);
+}
 
 /// #mn_802308F0
 

--- a/src/melee/mn/mnmainrule.h
+++ b/src/melee/mn/mnmainrule.h
@@ -5,6 +5,14 @@
 
 #include <sysdolphin/baselib/forward.h>
 
+struct mn_802307F8_t {
+    /* 0x000 */ u8 x0;
+    /* 0x001 */ u8 x1;
+    /* 0x002 */ u8 x2;
+    /* 0x003 */ u8 pad_3[0x12D];
+    /* 0x130 */ HSD_Text* text;
+};
+
 struct mn_80231634_t {
     /*  +0 */ char pad_0[0x10];
     /* +10 */ int x10;
@@ -16,7 +24,7 @@ struct mn_80231634_t {
 /* 22FEC8 */ UNK_RET mn_8022FEC8(UNK_PARAMS);
 /* 230198 */ UNK_RET mn_80230198(UNK_PARAMS);
 /* 230274 */ UNK_RET mn_80230274(UNK_PARAMS);
-/* 2307F8 */ UNK_RET mn_802307F8(UNK_PARAMS);
+/* 2307F8 */ void mn_802307F8(struct mn_802307F8_t*, s32, s32);
 /* 2308F0 */ UNK_RET mn_802308F0(UNK_PARAMS);
 /* 2309F0 */ UNK_RET fn_802309F0(UNK_PARAMS);
 /* 230D18 */ UNK_RET mn_80230D18(UNK_PARAMS);

--- a/src/melee/mn/mnnamenew.c
+++ b/src/melee/mn/mnnamenew.c
@@ -1,17 +1,54 @@
 #include "mnnamenew.h"
 
+#include "gm/gm_18A5.h"
+#include "gm/gm_1A3F.h"
+#include "lb/lbcardgame.h"
 #include "lb/lblanguage.h"
+#include "mn/mncharsel.h"
 #include "mn/mnmain.h"
+#include "mn/mnname.h"
 #include "sysdolphin/baselib/memory.h"
 #include "sysdolphin/baselib/sislib.h"
 
 extern volatile char mnNameNew_NullCharacter;
 extern u8 mnNameNew_PortInUse;
 extern char mnNameNew_CurrentNameText[0x10];
+extern HSD_GObj* mnNameNew_804D6C08;
 
 /// #mnNameNew_8023B0F8
 
-/// #mnNameNew_8023B224
+void mnNameNew_8023B224(u8 arg0)
+{
+    HSD_GObj* gobj = mnNameNew_804D6C08;
+    u8* user_data = gobj->user_data;
+    u8 port = user_data[0x59];
+
+    if (arg0 != 0) {
+        lb_8001CE00();
+    }
+
+    if (gm_801A4310() == 0x1B) {
+        HSD_SisLib_803A5E70();
+        mn_8022EBDC();
+        if (arg0 != 0) {
+            gm_80190FE4(port);
+        } else {
+            gm_80190FE4(0x78);
+        }
+    } else if (gm_801A4310() == 0x01) {
+        mn_804D6BC8.cooldown = 5;
+        if (arg0 != 0 && GetNameCount() > 0x18) {
+            mnName_8023A9B4((u8)(user_data[0x59] / 6));
+        } else {
+            mnName_8023A9B4(0);
+        }
+    } else {
+        HSD_SisLib_803A5E70();
+        mn_8022EBDC();
+        mnCharSel_802640A0();
+    }
+    PAD_STACK(8);
+}
 
 /// #mnNameNew_8023B314
 

--- a/src/melee/mn/mnnamenew.h
+++ b/src/melee/mn/mnnamenew.h
@@ -6,7 +6,7 @@
 #include <baselib/forward.h>
 
 /* 23B0F8 */ UNK_RET mnNameNew_8023B0F8(UNK_PARAMS);
-/* 23B224 */ UNK_RET mnNameNew_8023B224(UNK_PARAMS);
+/* 23B224 */ void mnNameNew_8023B224(u8);
 /* 23B314 */ UNK_RET mnNameNew_8023B314(UNK_PARAMS);
 /* 23B3FC */ UNK_RET mnNameNew_KeySetup(UNK_PARAMS);
 /* 23BAA8 */ UNK_RET mnNameNew_8023BAA8(UNK_PARAMS);

--- a/src/melee/ty/toy.c
+++ b/src/melee/ty/toy.c
@@ -99,6 +99,11 @@ typedef struct TyCameraData_ {
     f32 x18;
     f32 x1C;
     f32 x20;
+    f32 x24;
+    f32 x28;
+    f32 x2C;
+    u8 pad30[0x58 - 0x30];
+    s32 x58;
 } TyCameraData_;
 
 typedef struct TyLightGObj_ {
@@ -260,6 +265,7 @@ extern void* un_804D6ED4;
 extern char un_803FE3B8[];
 extern char un_803FE3DC[];
 extern HSD_FogDesc un_803B8844;
+extern Vec3 un_803B8858;
 
 typedef struct PosArray {
     s32 xy[2];
@@ -1605,7 +1611,36 @@ void un_803075E8(s32 arg0)
     }
 }
 
-/// #un_80307828
+void un_80307828(int arg0)
+{
+    Vec3 interest;
+    TyCameraData_* data;
+    TyLightArray_* data2;
+    HSD_CObj* cobj;
+
+    data = (void*) un_804D6E68;
+    cobj = data->x8->x28;
+    data2 = un_804D6ED4;
+    interest = un_803B8858;
+
+    if (arg0 == 0) {
+        data->x18 = data->x1C = (f32)(data->x58 = 0);
+        data2->x18 = 0.0F;
+        data2->x14 = 0.0F;
+    } else {
+        data->x18 = 0.0F;
+        data2->x14 = 0.0F;
+    }
+
+    data->x20 = 38.0F;
+    data->x2C = 0.0F;
+    data->x28 = 0.0F;
+    data->x24 = 0.0F;
+
+    HSD_CObjSetInterest(cobj, &interest);
+
+    PAD_STACK(12);
+}
 
 /* 96.8% match */
 

--- a/src/melee/ty/toy.h
+++ b/src/melee/ty/toy.h
@@ -44,7 +44,7 @@
 /* 30715C */ void un_8030715C(f32, f32);
 /* 307470 */ void un_80307470(s32);
 /* 3075E8 */ void un_803075E8(s32 arg0);
-/* 307828 */ UNK_RET un_80307828(int);
+/* 307828 */ void un_80307828(int);
 /* 3078E4 */ void un_803078E4(void);
 /* 307BA0 */ HSD_JObj* un_80307BA0(HSD_JObj*, s16);
 /* 307E84 */ void fn_80307E84(HSD_GObj* gobj);


### PR DESCRIPTION
## Summary
- 8 matched functions across 7 library/menu/game/trophy files

## What these functions do

**toy.c — `un_80307828`** — Resets the trophy viewer camera to its default position and zoom level when switching trophies.

**lbmthp.c — `fn_8001EB14`** — Opens a THP movie file from disc and reads its header to prepare for video cutscene playback.

**lbaudio_ax.c — `fn_800244F4`** — Resets all audio volume, pitch, and sound effect state to defaults (full volume, normal speed, nothing playing).

**mnnamenew.c — `mnNameNew_8023B224`** — Exits the name entry screen, transitioning back to the appropriate parent menu depending on context.

**mnmainrule.c — `mn_802307F8`** — Updates a Rules menu text element by looking up the string for the current rule mode and value, then styling the display.

**mndatadel.c — `fn_8024FC48`** — Handles the Data Delete menu transition: starts exit animation when leaving, or highlights the selected delete option.

**lbarq.c — `lbArq_80014D2C`** — Initializes the asynchronous read queue (ARQ) system by clearing all lists and linking the node pool.

**gm_1601.c — `gm_80164504`** — Unlocks a hidden stage by setting its bit in the stage unlock mask and sending the unlock notification event.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)