### PR TITLE
Match Yoshi SpecialHi functions

### DIFF
--- a/src/melee/ft/chara/ftYoshi/ftYs_SpecialHi.c
+++ b/src/melee/ft/chara/ftYoshi/ftYs_SpecialHi.c
@@ -60,7 +60,11 @@ void ftYs_SpecialS_8012DF8C(Fighter_GObj* gobj, Vec3* arg1)
     float mag;
     {
         float temp = ABS(fp->input.lstick.x) / da->xEC;
-        mag = MAX(temp, 1.0f) * da->xF0;
+        mag = temp;
+        if (mag > 1.0f) {
+            mag = 1.0f;
+        }
+        mag *= da->xF0;
         if (mag < da->xF4) {
             mag = 0.0f;
         }
@@ -100,7 +104,6 @@ void fn_8012E110(Fighter_GObj* gobj)
 
     if (var_r0) {
         Vec3 sp30;
-        PAD_STACK(4);
         lb_8000B1CC(fp->parts[31].joint, NULL, &sp30);
         fp->x1984_heldItemSpec = fp->fv.ys.x2238 =
             it_802B2A10(gobj, &sp30, 0x1F, fp->facing_dir);
@@ -117,9 +120,11 @@ void fn_8012E110(Fighter_GObj* gobj)
         sp24.y = da->x108;
         sp24.z = 0.0F;
         ftYs_SpecialS_8012DF8C_outline(gobj, &sp18);
-        it_802B28C8(fp->fv.ys.x2238, &sp18, &sp24,
-                    fp->mv.ys.specialhi.x4 * da->x110 + da->x10C,
-                    fp->mv.ys.specialhi.x4);
+        {
+            float x4 = fp->mv.ys.specialhi.x4;
+            it_802B28C8(fp->fv.ys.x2238, &sp18, &sp24,
+                        x4 * da->x110 + da->x10C, x4);
+        }
         fp->fv.ys.x2238 = NULL;
         fp->take_dmg_cb = NULL;
         fp->death2_cb = NULL;


### PR DESCRIPTION
## Summary

This matches the two remaining functions in `main/melee/ft/chara/ftYoshi/ftYs_SpecialHi`:

| Function | Previous | New |
| --- | ---: | ---: |
| `ftYs_SpecialS_8012DF8C` | 97.22% | 100.00% |
| `fn_8012E110` | 94.02% | 100.00% |

The full translation unit is now 100% matched: 14/14 functions and 1836/1836 code bytes.

## Notes

`ftYs_SpecialS_8012DF8C` was very close, but the clamp around the stick-derived magnitude had the wrong source shape. The old `MAX(temp, 1.0f)` expression did not match the target control flow. Writing the cap explicitly as `if (mag > 1.0f) { mag = 1.0f; }` gives the target branch shape and preserves the intended cap-at-one behavior.

`fn_8012E110` had two remaining codegen issues. The egg throw frame counter was being converted to float twice for the `it_802B28C8` call, while the target converts it once and reuses that value. Introducing a scoped `x4` temporary matches that behavior. The function also had an extra `PAD_STACK(4)` before the first `Vec3`, which moved that stack slot from the target `r1+0x30` to `r1+0x34`; removing it restored the target stack layout.

## Verification

- `ninja progress`
  - `build/GALE01/main.dol: OK`
  - `ftYs_SpecialHi`: 100.0%, 14/14 functions, 1836/1836 code bytes
- `git diff --check`
- `DYLD_LIBRARY_PATH=/Library/Developer/CommandLineTools/usr/lib cargo run -p melee-issues`
  - reports 117 existing issues outside the touched file
