### PR TITLE
Match lbHeap report function

### DIFF
--- a/src/melee/lb/lbheap.c
+++ b/src/melee/lb/lbheap.c
@@ -248,7 +248,7 @@ void lbHeap_80015DF8(void)
         } else {
             OSReport("                         destroy");
         }
-        OSReport(" / %5d KB\n", p->size / 1024);
+        OSReport(" / %5d KB\n", p->size / 1024, p->size);
     }
 
     bytes = (u32) lbHeap_80431FA0.arena_hi - (u32) lbHeap_80431FA0.arena_lo;


### PR DESCRIPTION
## Summary

Matches `lbHeap_80015DF8`.

The original code passes `p->size` as an extra argument to the final `OSReport` call. The format string only consumes the divided KB value, but keeping the extra vararg matches the target codegen.

## Matching

`main/melee/lb/lbheap`

- `lbHeap_80015DF8`: 99.87654% -> 100.0%
- Function size remains 324/324 bytes

## Verification

- `ninja build/GALE01/src/melee/lb/lbheap.o`
- `objdiff-cli diff -p . -u main/melee/lb/lbheap`
- `DYLD_LIBRARY_PATH=/Library/Developer/CommandLineTools/usr/lib cargo run -p melee-issues`

`melee-issues` reports 117 existing issues elsewhere; none are from `src/melee/lb/lbheap.c`.
