### PR TITLE
Fix various literals and frame sizes

### DIFF
--- a/src/melee/cm/camera.c
+++ b/src/melee/cm/camera.c
@@ -708,6 +708,7 @@ inline float get_max_bounds_length(CameraBounds* bounds)
 
 void Camera_80029CF8(CameraBounds* bounds, CameraTransformState* transform)
 {
+    u8 _padA[16];
     f32 len;
     Vec3 scroll_offset;
     Vec3 scroll_offset2;
@@ -729,7 +730,6 @@ void Camera_80029CF8(CameraBounds* bounds, CameraTransformState* transform)
     f32 pitch_angle;
     f32 temp_f30;
     f32 var_f3;
-    PAD_STACK(16);
 
     Stage_UnkSetVec3TCam_Offset(&scroll_offset);
     len = get_max_bounds_length(bounds);
@@ -1960,6 +1960,7 @@ void Camera_8002C5B4(Camera_x2D0* arg0)
     f32 pitch;
     f32 yaw;
     f32 limit;
+    PAD_STACK(16);
 
     cam = &cm_80452C68;
     params = arg0;
@@ -2049,6 +2050,7 @@ void Camera_8002C5B4(Camera_x2D0* arg0)
 
 void Camera_8002C908(void* arg0)
 {
+    u8 _padA[24];
     CameraBounds bounds;
     Vec3 sp1C;
     Vec3 sp10;
@@ -3075,7 +3077,6 @@ void Camera_8002DDC4(void* arg0)
     CameraTransformState* transform_copy;
     CameraUnkGlobals* globals;
     f32 smooth;
-    PAD_STACK(8);
 
     cam = &cm_80452C68;
     Camera_80030DF8();

--- a/src/melee/cm/camera.c
+++ b/src/melee/cm/camera.c
@@ -4042,14 +4042,14 @@ void Camera_8002F9E4(s8 arg0, s8 arg1)
         s8 slot = cm_80452C68.x304;
         cm_80452C68.x314.x = cm_80452C68.x314.y = cm_80452C68.x314.z = 0.0f;
         cm_80452C68.pause_eye_offset.x = 0.0f;
-        cm_80452C68.pause_eye_offset.y = 85.0f;
-        cm_80452C68.pause_eye_offset.z = 730.0f;
+        cm_80452C68.pause_eye_offset.y = 5.0f;
+        cm_80452C68.pause_eye_offset.z = 20.0f;
         cm_80452C68.pause_up.x = 0.0f;
         cm_80452C68.pause_up.y = 1.0f;
         cm_80452C68.pause_up.z = 0.0f;
 
         if (slot == 0xA) {
-            cm_80452C68.pause_eye_distance = 35.0f * scale;
+            cm_80452C68.pause_eye_distance = 3.0f * scale;
         } else {
             cm_80452C68.pause_eye_distance = scale;
         }

--- a/src/melee/ft/chara/ftCommon/ftCo_09F7.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_09F7.c
@@ -81,6 +81,7 @@ void ftCo_8009F834(Fighter_GObj* gobj, int arg1, enum Fighter_Part arg2,
     f32 var_f1;
     f32 var_f1_2;
     u8 temp_r3;
+    PAD_STACK(72);
 
     var_f1 = arg7;
     var_r27 = arg2;

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -1013,12 +1013,15 @@ bool ftCo_800A2718(mp_UnkStruct0* arg0)
 {
     PAD_STACK(4 * 4);
     if (arg0 == NULL) {
-        return 0;
+        return false;
     }
-    if (!inlineL0(arg0) && !inlineL1(arg0)) {
-        return 0;
+    if (!inlineL0(arg0)) {
+        if (inlineL1(arg0)) {
+            return true;
+        }
+        return false;
     }
-    return 1;
+    return false;
 }
 
 bool ftCo_800A28D0(Fighter* fp, float arg1)

--- a/src/melee/ft/chara/ftCommon/ftCo_Damage.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Damage.c
@@ -737,6 +737,7 @@ static bool inlineB0(Fighter_GObj* gobj)
 #pragma inline_depth(1)
 void ftCo_8008EB58(Fighter_GObj* gobj)
 {
+    PAD_STACK(8);
     if (inlineB0(gobj)) {
         ftCo_800C8D00(gobj);
         inlineF0(gobj);
@@ -785,6 +786,7 @@ void ftCo_8008EC90(Fighter_GObj* gobj)
     bool ret0 = false;
     Fighter* fp = gobj->user_data;
     float facing_dir = 0;
+    PAD_STACK(64);
     if (fp->x2220_b3 || fp->x2220_b4 || !fp->dmg.kb_applied) {
         inlineB2(gobj);
         goto ret_A8C;

--- a/src/melee/ft/chara/ftCommon/ftCo_DownBound.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_DownBound.c
@@ -119,6 +119,7 @@ void ftCo_8009794C(Fighter_GObj* gobj)
 {
     u8 _[12] = { 0 };
     Fighter* fp = gobj->user_data;
+    PAD_STACK(16);
     if (fp->ground_or_air == GA_Air) {
         ftCommon_8007D7FC(fp);
     }
@@ -147,6 +148,7 @@ void ftCo_80097AF4(Fighter_GObj* gobj)
     HSD_JObj* jobj = fp->parts[ftParts_GetBoneIndex(fp, FtPart_HipN)].joint;
     float rot0, rot1;
     HSD_JObjSetupMatrix(jobj);
+    PAD_STACK(40);
     if (fp->x2226_b0) {
         rot0 = jobj->mtx[0][2];
         rot1 = jobj->mtx[1][2];

--- a/src/melee/ft/chara/ftCommon/ftCo_Guard.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Guard.c
@@ -211,6 +211,7 @@ static inline void inlineD0(Fighter_GObj* gobj)
 void ftCo_80091E78(HSD_GObj* gobj, float arg1)
 {
     Fighter* fp = gobj->user_data;
+    PAD_STACK(8);
     if (fp->reflecting || fp->x221B_b0) {
         ftCo_80091BC4(fp);
         if (fp->mv.co.guard.x4) {
@@ -256,6 +257,7 @@ void ftCo_80092158(Fighter_GObj* gobj, int arg1, HSD_JObj* arg2)
 void ftCo_800921DC(HSD_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
+    PAD_STACK(8);
     ftCo_80092158(gobj, 1047, fp->parts[fp->ft_data->x8->x11].joint);
     fp->x2219_b0 = true;
     fp->mv.co.guard.xC = false;
@@ -583,6 +585,7 @@ void ftCo_80092F2C(HSD_GObj* gobj, bool arg1)
     Fighter* fp = gobj->user_data;
     Fighter_ChangeMotionState(gobj, ftCo_MS_GuardSetOff, Ft_MF_None, 0, 1, 0,
                               NULL);
+    PAD_STACK(8);
     fp->hitlag_cb = ftCo_80093240;
     fp->x670_timer_lstick_tilt_x = -2;
     fp->post_hitlag_cb = ftCo_800932DC;
@@ -658,6 +661,7 @@ void ftCo_800932DC(Fighter_GObj* gobj)
 void ftCo_GuardSetOff_Anim(HSD_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
+    PAD_STACK(8);
     ftCo_80093BC0(gobj);
     if (!ftAnim_IsFramesRemaining(gobj)) {
         if (fp->mv.co.guard.xC) {
@@ -820,6 +824,7 @@ void ftCo_80093BC0(Fighter_GObj* gobj)
 
 void ftCo_GuardReflect_Anim(HSD_GObj* gobj)
 {
+    PAD_STACK(16);
     ftCo_80093BC0(gobj);
     ftCo_GuardOn_Anim(gobj);
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_Shouldered.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Shouldered.c
@@ -91,6 +91,7 @@ static inline float inlineA0(Fighter_GObj* gobj)
 void ftCo_Shouldered_Anim(Fighter_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
+    PAD_STACK(16);
     fp->mv.co.shouldered.x4 = ftCommon_GrabMash(fp, inlineA0(fp->victim_gobj));
     if (fp->grab_timer <= 0) {
         HitCapsule* hit;

--- a/src/melee/ft/chara/ftCommon/ftCo_ThrownKirby.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_ThrownKirby.c
@@ -136,6 +136,7 @@ void ftCo_800BDB58(Fighter_GObj* gobj, Fighter_GObj* thrower_gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     Vec3 scale;
+    PAD_STACK(24);
     inlineB2(gobj, thrower_gobj, &scale, ftCo_MS_ThrownKirbyStar,
              ftKb_SpecialN_800F58AC, ftKb_SpecialN_800F5A88);
 
@@ -203,6 +204,7 @@ void ftCo_800BE000(Fighter_GObj* gobj, Fighter_GObj* thrower_gobj)
 {
     Vec3 scale;
     Fighter* fp = GET_FIGHTER(gobj);
+    PAD_STACK(8);
     inlineB2(gobj, thrower_gobj, &scale, ftCo_MS_ThrownCopyStar,
              ftKb_SpecialN_800F58D8, ftKb_SpecialN_800F5AB0);
 

--- a/src/melee/ft/chara/ftKirby/ftKb_SpecialN.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_SpecialN.c
@@ -806,6 +806,7 @@ void ftKb_SpecialHi_800F3570(Fighter_GObj* gobj)
     f32 var_f3;
     Fighter* fp = GET_FIGHTER(gobj);
     ftKb_DatAttrs* dat_attr = fp->dat_attrs;
+    PAD_STACK(24);
 
     fp->mv.kb.specialhi.x18 = fp->coll_data.floor.normal;
     fp->mv.kb.specialhi.xC4 =
@@ -875,6 +876,7 @@ void ftKb_SpecialHi_800F37EC(Fighter_GObj* gobj)
     s32 j;
     Fighter* fp = GET_FIGHTER(gobj);
     ftKb_DatAttrs* dat_attr = fp->dat_attrs;
+    PAD_STACK(8);
     fp->mv.kb.speciallw.x48 = fp->mv.kb.speciallw.x3C;
     fp->mv.kb.speciallw.x78 = fp->mv.kb.speciallw.x6C;
     fp->mv.kb.speciallw.x88[3] = fp->mv.kb.speciallw.x88[2];

--- a/src/melee/ft/chara/ftNana/ftNn_Init.c
+++ b/src/melee/ft/chara/ftNana/ftNn_Init.c
@@ -466,6 +466,7 @@ bool ftNn_Init_801230D0(Fighter_GObj* nana_gobj)
     Fighter_GObj* popo_gobj = Player_GetEntityAtIndex(nana_fp->player_id, 0);
     Vec popo_vec;
     Vec nana_vec;
+    PAD_STACK(16);
     if (popo_gobj != NULL) {
         Fighter* popo_fp = GET_FIGHTER(popo_gobj);
         if (popo_fp->motion_id < 347 || popo_fp->motion_id > 352) {
@@ -720,6 +721,7 @@ void ftNn_Init_801238E4(Fighter_GObj* gobj)
 bool ftNn_Init_80123954(Fighter_GObj* nana_gobj, GroundOrAir pp_ga)
 {
     bool ret;
+    PAD_STACK(24);
     if (nana_gobj != NULL) {
         Fighter* nana_fp = GET_FIGHTER(nana_gobj);
         Fighter* popo_fp =

--- a/src/melee/ft/ftaction.c
+++ b/src/melee/ft/ftaction.c
@@ -1350,6 +1350,7 @@ void ftAction_80073354(Fighter_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
     CommandInfo* cmd = (CommandInfo*) &fp->x3E4_fighterCmdScript;
+    PAD_STACK(8);
     fp->x3E4_fighterCmdScript.timer = fp->cur_anim_frame + fp->x898_unk;
     fp->throw_flags = 0;
     if (fp->x3E4_fighterCmdScript.u != NULL) {

--- a/src/melee/ft/ftcoll.c
+++ b/src/melee/ft/ftcoll.c
@@ -2127,6 +2127,7 @@ float ftColl_80079C70(Fighter* fp, Fighter* attacker, HitCapsule* hit,
     float w = weight * ftd->xF4;
     float decay;
     float result;
+    PAD_STACK(8);
 
     if (hit->x28 != 0) {
         float x24_f;

--- a/src/melee/ft/ftcoll.c
+++ b/src/melee/ft/ftcoll.c
@@ -1622,7 +1622,7 @@ void ftColl_80078C70(Fighter_GObj* this_gobj)
                                     if (this_fp->x221B_b0) {
                                         var_r3 = true;
                                         if (this_fp->x221B_b3) {
-                                            if (1.0F == this_fp->facing_dir) {
+                                            if (-1.0f == this_fp->facing_dir) {
                                                 if (this_fp->cur_pos .x < victim_fp->cur_pos .x) {
                                                     var_r3 = false;
                                                 }

--- a/src/melee/ft/ftdynamics.c
+++ b/src/melee/ft/ftdynamics.c
@@ -363,6 +363,7 @@ void ftCo_8009D704(Fighter* fp)
 void ftCo_8009D81C(Fighter* fp)
 {
     KirbyHatStruct* data = ft_80459B88.hats[FTKIND_YOSHI];
+    PAD_STACK(8);
     fp->dynamics_num = data->hat_dynamics[3]->dynamicsNum;
     if (fp->dynamics_num >= Ft_Dynamics_NumMax) {
         OSReport("fighter dynamics num over!\n");
@@ -566,6 +567,7 @@ void ftCo_8009DD94(Fighter_GObj* gobj, bool arg1)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ssize_t dynamics_num = fp->dynamics_num;
+    PAD_STACK(16);
     if (dynamics_num != 0 && stage_info.internal_stage_id == FLATZONE) {
         HSD_JObjSetupMatrix(GET_JOBJ(gobj));
     }

--- a/src/melee/ft/ftmaterial.c
+++ b/src/melee/ft/ftmaterial.c
@@ -198,6 +198,7 @@ void ftMaterial_800BF6BC(Fighter* fp, HSD_MObj* mobj, HSD_TExp* texp)
     ColorOverlay* overlay;
     s32 var_r5;
     char* base = (char*) &ftMObj;
+    PAD_STACK(160);
 
     if (!fp->x2223_b3) {
         overlay = ftCo_800C0658(fp);

--- a/src/melee/gm/gm_1601.c
+++ b/src/melee/gm/gm_1601.c
@@ -2624,6 +2624,7 @@ void gm_80167BC8(VsModeData* vs_data)
     struct gmm_x1CB0* prefs;
     s32 i;
     s8* handicap;
+    PAD_STACK(56);
 
     rules = gmMainLib_8015CC34();
     prefs = gmMainLib_8015CC58();

--- a/src/melee/gm/gm_16F1.c
+++ b/src/melee/gm/gm_16F1.c
@@ -1293,6 +1293,7 @@ void fn_80171B64(struct lbl_804D65A8_t* arg0)
 
 int fn_80171BA4(void* arg0)
 {
+    u8 _padA[8];
     int scores[6];
     int player;
     int ko_count;

--- a/src/melee/gm/gm_1832.c
+++ b/src/melee/gm/gm_1832.c
@@ -261,13 +261,13 @@ void fn_8018325C(HSD_GObj* arg0, int arg1)
 
 void fn_80184138(HSD_GObj* arg0, int arg1)
 {
+    u8 _padA[8];
     Vec3 pos;
     Vec3 scale;
     HSD_JObj* jobj = arg0->hsd_obj;
     HSD_JObj* src = lbl_804735A8.x4[1];
     f32 scl, xoff, yoff;
     int i;
-    PAD_STACK(8);
 
     HSD_JObjGetTranslation(src, &pos);
     HSD_JObjSetTranslate(jobj, &pos);
@@ -1063,6 +1063,7 @@ void fn_80186634(void* arg0)
     HSD_JObj* jobj;
     HSD_GObj* gobj4;
     const char* names[4];
+    PAD_STACK(8);
 
     lbArchive_80016DBC("GmIntEz.dat", &lbl_804D6604, "gmIntroEasyTable", 0);
     Camera_80028B9C(0xC);
@@ -1542,6 +1543,7 @@ void fn_80187AB4(HSD_GObj* gobj)
     int state = lbl_804736C0.x37.anim_state;
     DynamicModelDesc* desc;
     int anim_state;
+    PAD_STACK(8);
 
     switch (state) {
     case 0:
@@ -1735,6 +1737,7 @@ void gm_80187F48_OnEnter(void* arg0_)
     HSD_JObj* jobj2;
     DynamicModelDesc* desc;
     int anim_idx;
+    PAD_STACK(24);
 
     lbl_804736C0.x38 = arg0[0];
     lb_8000FCDC();

--- a/src/melee/gm/gm_18A5.c
+++ b/src/melee/gm/gm_18A5.c
@@ -785,7 +785,6 @@ void fn_8018DF68(void* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4, s32 arg5,
     s32 half;
     GXColor c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10;
 
-    PAD_STACK(8);
 
     c0 = (GXColor){ 255, 255, 0, 255 };
     c10 = (GXColor){ 255, 255, 0, 255 };
@@ -1806,10 +1805,10 @@ static inline int gm_801905F0_inline0(int c_kind)
 
 void gm_801905F0(StartMeleeData* arg0)
 {
+    u8 _padA[8];
     GameRules* temp_r31 = gmMainLib_8015CC34();
     int i;
     TmVsData sp18;
-    PAD_STACK(8);
 
     gm_80168FC4();
     gm_80167A64(&arg0->rules);

--- a/src/melee/gm/gmallstar.c
+++ b/src/melee/gm/gmallstar.c
@@ -392,8 +392,8 @@ void gm_801B5324(UnkAllstarData* arg0, u8 arg1)
     s32 slot_idx;
     u64 audio;
     s32 i;
+    PAD_STACK(16);
 
-    PAD_STACK(12);
     base = (u8*) gm_803DE930_MinorScenes;
     is_last_round = 0;
     count_processed = 0;
@@ -517,8 +517,8 @@ void gm_801B5624(MinorScene* arg0)
     s32 count;
     u16 round;
     u8 color;
+    PAD_STACK(8);
 
-    PAD_STACK(16);
     base = (u8*) gm_803DE930_MinorScenes;
     data = gm_801A427C(arg0);
     allstar = &gm_80473A18;

--- a/src/melee/gm/gmclassic.c
+++ b/src/melee/gm/gmclassic.c
@@ -569,6 +569,7 @@ void gmClassic_OnLoad(void)
     UnkAllstarData* data;
     gm_803DDEC8Struct* entry;
     s32 i;
+    PAD_STACK(40);
 
     for (entry = gmClassic_803DDEC8.x00; entry->x0 != 0x0D; entry++) {
         entry->xC = NULL;

--- a/src/melee/gm/gmmain_lib.c
+++ b/src/melee/gm/gmmain_lib.c
@@ -1197,6 +1197,7 @@ static u8 gmMainLib_804D3EE4;
 void gmMainLib_8015F600(int arg0, int arg1)
 {
     s32 i;
+    PAD_STACK(112);
 
     if (arg0 == 1) {
         s32 j = 0;

--- a/src/melee/gm/gmresult.c
+++ b/src/melee/gm/gmresult.c
@@ -1015,7 +1015,7 @@ grey_out:
                                   -30.0F, NULL, 0);
 
 end_common:
-    HSD_SisLib_803A7548(lbl_8046DBE8.player_data[slot].ko_time, var_r30, 0.09F,
+    HSD_SisLib_803A7548(lbl_8046DBE8.player_data[slot].ko_time, var_r30, 0.11f,
                         0.08F);
     spC = sp10;
     new_var = &spC;

--- a/src/melee/gm/gmresult.c
+++ b/src/melee/gm/gmresult.c
@@ -240,6 +240,7 @@ void fn_80174468(u8 slot, HSD_Text* text1, HSD_Text* text2, HSD_Text* text3,
     /* Float constants preloaded into registers */
     f32 const_zero = 0.0F;
     f32 const_neg30 = -30.0F;
+    PAD_STACK(8);
 
     label_id = -1;
     value_id = -1;
@@ -559,6 +560,7 @@ void fn_80174B4C(ResultsData* data, s32 slot)
     f32 pos_x, pos_y, pos_z;
     f32 offset;
     u32 start_entry;
+    PAD_STACK(64);
 
     pdata = &data->player_data[slot];
 
@@ -1031,6 +1033,7 @@ void fn_80175A94(s32 slot, Vec3* position)
     GXColor sp18;
     GXColor* color_ptr;
     Vec3 sp24;
+    PAD_STACK(16);
 
     me = lbl_8046DBE8.x94;
     if (me->x5 == 3) {
@@ -1145,6 +1148,7 @@ void fn_80175DC8(HSD_GObj* gobj)
     HSD_JObj* temp_jobj;
     s32 i;
     Vec3 pos;
+    PAD_STACK(264);
 
     me = lbl_8046DBE8.x94;
     desc = lbl_8046DBE8.pnlsce;
@@ -1278,6 +1282,7 @@ void fn_80176D3C(Vec3* positions)
     HSD_JObj* jobj;
     s32 winner;
     s32 i;
+    PAD_STACK(8);
 
     me = data->x94;
     p = me->player_standings;

--- a/src/melee/gm/gmresultplayer.c
+++ b/src/melee/gm/gmresultplayer.c
@@ -1094,8 +1094,8 @@ void fn_80179990(HSD_GObj* arg0, int arg1, int arg2)
     HSD_CObj* cobj;
     HSD_JObj* child_jobj;
     int lookup;
+    PAD_STACK(16);
 
-    PAD_STACK(8);
 
     fn_801795D4();
     fn_801796F0(arg2);

--- a/src/melee/gm/gmstaffroll.c
+++ b/src/melee/gm/gmstaffroll.c
@@ -447,7 +447,7 @@ void fn_801AB200(HSD_GObj* gobj)
     f32 offset1, offset2;
     StaffEntryData* tree_base;
     HSD_Text* tally_text;
-    PAD_STACK(0x60);
+    PAD_STACK(88);
 
     lb_80011E24(root, &cursor_jobj, 7, -1);
 

--- a/src/melee/gr/granime.c
+++ b/src/melee/gr/granime.c
@@ -237,6 +237,7 @@ void grAnime_801C6A54(HSD_JObj* jobj, HSD_AnimJoint* animjoint,
                       HSD_MatAnimJoint* matanimjoint,
                       HSD_ShapeAnimJoint* shapeanimjoint)
 {
+    PAD_STACK(16);
     if (jobj == NULL) {
         return;
     }
@@ -261,6 +262,7 @@ void grAnime_801C6C0C(HSD_JObj* jobj, HSD_AnimJoint* animjoint,
                       HSD_MatAnimJoint* matanimjoint,
                       HSD_ShapeAnimJoint* shapeanimjoint)
 {
+    PAD_STACK(16);
     if (jobj == NULL) {
         return;
     }
@@ -822,6 +824,7 @@ HSD_AObj* grAnime_801C8318(HSD_GObj* gobj, int arg1, u32 arg2)
 bool grAnime_801C83D0(HSD_GObj* gobj, bool arg1, enum_t arg2)
 {
     HSD_AObj* aobj = grAnime_801C8318(gobj, arg1, arg2);
+    PAD_STACK(8);
     if (HSD_AObjGetFlags(aobj) & 0x40000000) {
         return true;
     }

--- a/src/melee/gr/grbigblue.c
+++ b/src/melee/gr/grbigblue.c
@@ -384,6 +384,7 @@ void grBigBlue_801E6364(Ground_GObj* gobj)
     f32 rot_y;
 
     Ground_801C2ED0(jobj, gp->map_id);
+    PAD_STACK(8);
 
     scale.x = scale.y = scale.z = 1.0F;
     HSD_JObjSetScale(jobj, &scale);
@@ -2055,6 +2056,7 @@ bool grBigBlue_801EAB50(Vec3* pos, s32 flag, f32 rangeX, f32 rangeY)
 s32 grBigBlue_801EACE8(HSD_JObj* exclude, Vec3* point, f32* out_y,
                        f32 half_range_x, f32 half_range_y)
 {
+    u8 _padA[32];
     HSD_GObj* gobj;
     Ground* gp;
     HSD_JObj* jobj;
@@ -2068,7 +2070,6 @@ s32 grBigBlue_801EACE8(HSD_JObj* exclude, Vec3* point, f32* out_y,
     f32* p_left;
     f32* p_right;
     s32 i;
-    PAD_STACK(0x24);
 
     gobj = Ground_801C2BA4(32);
 
@@ -2545,6 +2546,7 @@ void grBigBlue_801EBAF8(Ground_GObj* gobj)
     f32 rot_z;
     f32 angular_vel;
     grBb_TrackEntry* entry;
+    PAD_STACK(16);
 
     center.x = 0.0F;
     center.z = 0.0F;
@@ -2972,6 +2974,7 @@ void grBigBlue_801ECB50(Ground_GObj* gobj)
     s32 free_count = 0;
     s32 reserved_count = 0;
     s32 active_count = 0;
+    PAD_STACK(8);
 
     /* Count free (0) and reserved (2) lanes - 5×6=30 total */
     {
@@ -3894,6 +3897,7 @@ s32 grBigBlue_801EDF44(Ground_GObj* gobj, s32 index)
     u8* gp;
     s32 result;
     s32 offset;
+    PAD_STACK(8);
 
     gp = (u8*) gobj->user_data;
     result = 0;
@@ -4069,6 +4073,7 @@ s32 grBigBlue_801EE398(Ground_GObj* gobj, s32 arg1, s32 arg2)
     s32 result = 0;
     Ground* gp = gobj->user_data;
     Vec3 pos;
+    PAD_STACK(32);
 
     switch (arg2) {
     case 1: {

--- a/src/melee/gr/grbigblue.c
+++ b/src/melee/gr/grbigblue.c
@@ -1291,9 +1291,9 @@ void grBigBlue_801E8A1C(int idx)
         spawn.x8_vec = platform->translate;
 
         if (spawn.x14 == 4) {
-            spawn.x8_vec.y += 15.0F;
+            spawn.x8_vec.y += 8.0f;
         } else {
-            spawn.x8_vec.y += 10.0F;
+            spawn.x8_vec.y += 5.0f;
         }
 
         spawn.x1C.b0 = 1;
@@ -3813,7 +3813,7 @@ void grBigBlue_801ED694(Ground_GObj* gobj, s32 lane)
     if ((gp[lane_offset + 0xD4] >> 1) & 1) {
         /* Grounded path */
         ground_y = grBigBlue_801EC58C((Vec3*) (gp + lane_offset + 0xE0),
-                                      &sp_vec, (f32) 1.5707963F);
+                                      &sp_vec, (f32) 500.0f);
 
         if (0.0F != ground_y && ground_y > rank_factor) {
             if (*(f32*) (gp + lane_offset + 0x10C) < 0.0F) {

--- a/src/melee/gr/grbigblueroute.c
+++ b/src/melee/gr/grbigblueroute.c
@@ -362,7 +362,6 @@ void grBigBlueRoute_8020BF38(Ground_GObj* gobj)
     int i;
     u8* car;
     HSD_JObj* jobj;
-    PAD_STACK(4);
 
     fighter = Ground_801C57A4();
     Ground_801C3D44(0, grBb_Route_804DB948, grBb_Route_804DB94C);
@@ -691,7 +690,6 @@ void grBigBlueRoute_8020DAB4(HSD_JObj** jobjs, f32 scale, int count)
     HSD_JObj** arr;
     HSD_JObj* jobj;
     HSD_GObj* gobj;
-    PAD_STACK(8);
 
     if (jobjs == NULL) {
         return;

--- a/src/melee/gr/grbigblueroute.c
+++ b/src/melee/gr/grbigblueroute.c
@@ -545,7 +545,7 @@ void grBigBlueRoute_8020C85C(Ground_GObj* gobj)
     s32 route_idx;
     PAD_STACK(8);
 
-    if ((f32) gp->gv.bigblueroute.x108 >= 0.5F + grBb_Route_804D6A68->x40) {
+    if ((f32) gp->gv.bigblueroute.x108 >= 1.0f + grBb_Route_804D6A68->x40) {
         return;
     }
 

--- a/src/melee/gr/grcastle.c
+++ b/src/melee/gr/grcastle.c
@@ -553,6 +553,7 @@ void grCastle_801CDC44(Ground_GObj* gobj)
 {
     Ground* gp = GET_GROUND(gobj);
     s32 i = 0;
+    PAD_STACK(8);
 
     do {
         struct grCastle_Platform* plat = &gp->gv.castle8.plat[i];

--- a/src/melee/gr/grflatzone.c
+++ b/src/melee/gr/grflatzone.c
@@ -753,6 +753,7 @@ loop_4:
 void grFlatzone_802181B4(void)
 {
     HSD_GObj* gobj = Ground_801C2BA4(5);
+    PAD_STACK(16);
     if (gobj != NULL) {
         Ground* gp = GET_GROUND(gobj);
         if (gp != NULL) {

--- a/src/melee/gr/grfourside.c
+++ b/src/melee/gr/grfourside.c
@@ -277,6 +277,7 @@ void grFourside_801F3274(Ground_GObj* gobj)
     float temp_fVar1;
     // Ground_801C2ED0(jobj,gp->map_id);
     // grAnime_801C7FF8(gobj,0,7,0,0.0f,0.0f);
+    PAD_STACK(24);
     switch (gp->gv.foursideCrane.x0) {
     case 0:
         if (gp->gv.foursideCrane.x4 <= 0) {

--- a/src/melee/gr/gricemt.c
+++ b/src/melee/gr/gricemt.c
@@ -144,6 +144,7 @@ void grIceMt_801F686C(void)
     f32 y_pos4;
     HSD_GObj* gobj;
     HSD_JObj* jobj;
+    PAD_STACK(16);
 
     grIm_804D69F4 = Ground_801C49F8();
     stage_info.unk8C.b4 = true;
@@ -521,6 +522,7 @@ bool grIceMt_801F796C(Ground_GObj* arg0)
 {
     Ground* gp = GET_GROUND(arg0);
     HSD_GObj* gobj;
+    PAD_STACK(8);
     if (gp->gv.icemt2.xC4 != NULL) {
         gobj = Ground_801C2BA4(gp->gv.icemt2.xC4);
         if (gobj == NULL) {
@@ -653,6 +655,7 @@ void grIceMt_801F7D94(Ground_GObj* arg0)
 {
     Ground* gp = GET_GROUND(arg0);
     Ground_801C2ED0(arg0->hsd_obj, gp->map_id);
+    PAD_STACK(8);
     grAnime_801C8138(arg0, gp->map_id, 0);
     grAnime_801C77FC(arg0, 0, 7);
     gp->gv.icemt2.xC8 = Ground_801C3FA4(arg0, 3);
@@ -703,6 +706,7 @@ void grIceMt_801F7F70(Ground_GObj* arg0)
     HSD_JObj* jobj;
     HSD_JObj* jobj2;
     Ground_801C2ED0(arg0->hsd_obj, gp->map_id);
+    PAD_STACK(8);
     grAnime_801C8138(arg0, gp->map_id, 0);
     grAnime_801C77FC(arg0, 0, 7);
     jobj = Ground_801C3FA4(arg0, 4);
@@ -757,6 +761,7 @@ void grIceMt_801F8208(Ground_GObj* arg0)
     HSD_JObj* jobj;
     HSD_JObj* jobj2;
     Ground_801C2ED0(arg0->hsd_obj, gp->map_id);
+    PAD_STACK(8);
     grAnime_801C8138(arg0, gp->map_id, 0);
     grAnime_801C77FC(arg0, 0, 7);
     gp->gv.icemt2.xC8 = Ground_801C3FA4(arg0, 5);
@@ -808,6 +813,7 @@ void grIceMt_801F83EC(Ground_GObj* arg0)
     HSD_JObj* jobj2;
     Ground_801C0498();
     Ground_801C2ED0(arg0->hsd_obj, gp->map_id);
+    PAD_STACK(16);
     grAnime_801C8138(arg0, gp->map_id, 0);
     grAnime_801C77FC(arg0, 0, 7);
     jobj = Ground_801C3FA4(arg0, 7);
@@ -863,6 +869,7 @@ void grIceMt_801F865C(Ground_GObj* arg0)
     HSD_JObj* jobj2;
     // Ground_801C0498();
     Ground_801C2ED0(arg0->hsd_obj, gp->map_id);
+    PAD_STACK(8);
     grAnime_801C8138(arg0, gp->map_id, 0);
     grAnime_801C77FC(arg0, 0, 7);
     // jobj = Ground_801C3FA4(arg0,7);
@@ -917,6 +924,7 @@ void grIceMt_801F8850(Ground_GObj* arg0)
     HSD_JObj* jobj2;
     // Ground_801C0498();
     Ground_801C2ED0(arg0->hsd_obj, gp->map_id);
+    PAD_STACK(8);
     grAnime_801C8138(arg0, gp->map_id, 0);
     grAnime_801C77FC(arg0, 0, 7);
     // jobj = Ground_801C3FA4(arg0,7);
@@ -986,6 +994,7 @@ void grIceMt_801F8B10(Ground_GObj* arg0)
     HSD_JObj* jobj;
     double dVar3;
     double dVar4;
+    PAD_STACK(16);
     dVar4 = 0.3;
     jobj = Ground_801C3FA4(arg0, 8);
     HSD_JObjGetTranslationY(jobj);
@@ -1240,6 +1249,7 @@ void grIceMt_801F9ACC(Ground_GObj* gobj, float y, HSD_GObjEvent ev,
     HSD_GObj* jobj;
     double dVar3;
     double dVar4;
+    PAD_STACK(96);
     dVar4 = 0.3;
 
     jobj = Ground_801C2BA4(4);
@@ -1330,6 +1340,7 @@ int grIceMt_801FA500(HSD_GObj* param1)
     int iVar1 = NULL;
     int iVar2;
     int iVar3;
+    PAD_STACK(8);
     iVar3 = 0;
     if (param1->hsd_obj == NULL) {
         __assert("gricemt.c", 2993, "jobj");

--- a/src/melee/gr/gricemt.c
+++ b/src/melee/gr/gricemt.c
@@ -532,7 +532,7 @@ bool grIceMt_801F796C(Ground_GObj* arg0)
     if (gp->gv.icemt.xCC != NULL) {
         gobj = Ground_801C2BA4(gp->gv.icemt2.xC4);
         if (gobj == NULL) {
-            __assert("gricemt.c", 0x4A7, "mgobj");
+            __assert("gricemt.c", 0x47A, "mgobj");
         }
     }
     //__assert("gricemt.c",0x475,"mgobj");
@@ -1204,7 +1204,7 @@ float grIceMt_801F96E0(Ground_GObj* gobj, float y)
     HSD_JObjAddTranslationY(jobj->hsd_obj, y);
     jobj = Ground_801C2BA4(7);
     if (jobj == NULL) {
-        __assert("gricemt.c", 2639, "mgobj");
+        __assert("gricemt.c", 2635, "mgobj");
     }
     if (jobj->hsd_obj == NULL) {
         __assert("gricemt.c", 2630, "jobj");
@@ -1343,7 +1343,7 @@ int grIceMt_801FA500(HSD_GObj* param1)
     PAD_STACK(8);
     iVar3 = 0;
     if (param1->hsd_obj == NULL) {
-        __assert("gricemt.c", 2993, "jobj");
+        __assert("gricemt.c", 2994, "jobj");
         iVar1 = 0;
         //} else {
         //	ivar1 = param1->hsd_obj

--- a/src/melee/gr/grinishie1.c
+++ b/src/melee/gr/grinishie1.c
@@ -507,6 +507,7 @@ void grInishie1_801FB3F0(HSD_GObj* gobj)
     struct grInishie1_GroundVars* vars = &gp->gv.inishie1;
     HSD_DObj* dobj;
     int i;
+    PAD_STACK(56);
 
     if (vars->xD8 > 0) {
         vars->xD8--;
@@ -685,6 +686,7 @@ void grInishie1_801FBCEC(HSD_GObj* gobj, u32 index)
     Ground* gp = gobj->user_data;
     Vec3 effect_pos;
     Vec3 item_spawn_offset;
+    PAD_STACK(8);
 
     gp->gv.inishie1.blocks[index].status = 0;
     gp->gv.inishie1.blocks[index].x20 =

--- a/src/melee/gr/grinishie2.c
+++ b/src/melee/gr/grinishie2.c
@@ -514,6 +514,7 @@ void grInishie2_801FD4F0(Ground_GObj* gobj)
     void* temp_r30;
     void* temp_r3;
     Ground* gp;
+    PAD_STACK(8);
 
     temp_r29 = GET_JOBJ(gobj);
     gp = GET_GROUND(gobj);
@@ -642,6 +643,7 @@ void grInishie2_801FD9EC(HSD_GObj* gobj)
     s16 temp_r0;
     HSD_JObj* jobj;
     Vec3* temp_vec;
+    PAD_STACK(72);
 
     gp = gobj->user_data;
 

--- a/src/melee/gr/grkinokoroute.c
+++ b/src/melee/gr/grkinokoroute.c
@@ -319,6 +319,7 @@ void grKinokoRoute_80207C88(Ground_GObj* gobj)
     HSD_GObj* fighter;
     HSD_GObj* ground_gobj;
     HSD_JObj* jobj;
+    PAD_STACK(32);
 
     scale = Ground_801C0498();
     fighter = Ground_801C57A4();

--- a/src/melee/gr/grkongo.c
+++ b/src/melee/gr/grkongo.c
@@ -1330,7 +1330,7 @@ HSD_GObj* grKongo_801D5340(s32 gobj_id)
             HSD_GObj_SetupProc(gobj, callbacks->callback2, 4);
         }
     } else {
-        OSReport("%s:%d: couldn t get gobj(id=%d)\n", "grstory.c", 220,
+        OSReport("%s:%d: couldn t get gobj(id=%d)\n", "grstory.c", 270,
                  gobj_id);
     }
     return gobj;

--- a/src/melee/gr/grkongo.c
+++ b/src/melee/gr/grkongo.c
@@ -3,6 +3,7 @@
 #include "grkongo.static.h"
 
 #include "grmaterial.h"
+#include "placeholder.h"
 #include "types.h"
 
 #include "ef/efsync.h"
@@ -175,6 +176,7 @@ void grKongo_801D55D8(Ground_GObj* arg0)
     Vec3 sp14;
     Ground* temp_r31;
     void* temp_r28;
+    PAD_STACK(8);
 
     temp_r31 = arg0->user_data;
     temp_r28 = arg0->hsd_obj;
@@ -276,6 +278,7 @@ void grKongo_801D577C(Ground_GObj* arg0)
     f32 var_f0;
     HSD_GObj* temp_r3_9;
     Vec3 vec;
+    PAD_STACK(32);
 
     switch (temp_r31->gv.kongo3.xC4) {
     default:
@@ -888,6 +891,7 @@ void grKongo_801D6AFC(void)
     _struct_grKg_803E188C_0x18* var_r6;
 
     s32 var_ctr = 3;
+    PAD_STACK(80);
     var_r5 = &sp44;
     var_r3 = var_r5;
     do {

--- a/src/melee/gr/grmutecity.c
+++ b/src/melee/gr/grmutecity.c
@@ -971,6 +971,7 @@ void grMuteCity_801F106C(s32 i)
     f32 var_f0;
     grMc_CarEntry* car = &grMc_8049F4B8[i];
     u16 flags16 = car->x20;
+    PAD_STACK(8);
 
     if (!car->x22_flags.b0) {
         if (flags16 & 1) {
@@ -1052,6 +1053,7 @@ void grMuteCity_801F1328(void)
 {
     s32* arr = grMc_8049F440;
     int i, j;
+    PAD_STACK(8);
 
     for (i = 1; i < 30; i++) {
         j = i;
@@ -1301,6 +1303,7 @@ void grMuteCity_801F1A34(HSD_GObj* arg0, Ground_GObj* arg1)
     HSD_Spline* spline;
 
     Ground_801C0498();
+    PAD_STACK(8);
     track_mid = 0.5f * (gp->gv.mutecity.xD4 + gp->gv.mutecity.xD8);
     Camera_GetTransformPosition(&spE8);
 

--- a/src/melee/gr/groldkongo.c
+++ b/src/melee/gr/groldkongo.c
@@ -296,6 +296,7 @@ void grOldKongo_8020F888(Ground_GObj* arg0)
     s32 var_r3_4;
     s32 var_r3_5;
     s32 var_r3_6;
+    PAD_STACK(8);
 
     temp_r31 = GET_GROUND(arg0);
     temp_r30 = Ground_801C3FA4(arg0, 1);

--- a/src/melee/gr/groldpupupu.c
+++ b/src/melee/gr/groldpupupu.c
@@ -514,6 +514,7 @@ bool fn_802112F4(Ground_GObj* gobj, HSD_GObj* fighter_gobj, Vec3* vel)
 void grOldPupupu_802113E0(Ground_GObj* gobj)
 {
     Ground* gp = gobj->user_data;
+    PAD_STACK(176);
 
     if (grOp_804D6A9C == 0) {
         gp->gv.oldpupupu.xE0 += 1;

--- a/src/melee/gr/groldyoshi.c
+++ b/src/melee/gr/groldyoshi.c
@@ -241,6 +241,7 @@ void grOldYoshi_8020EC10(Ground_GObj* arg)
     int i = 0;
     Ground* gp = arg->user_data;
     HSD_JObj* jobj = arg->user_data;
+    PAD_STACK(8);
     do {
         // int test = HSD_Randi(3);
         switch (gp->gv.oldyoshicloud.cloud[i].xC4_0123) {
@@ -379,6 +380,7 @@ void grOldYoshi_8020F088(Ground_GObj* arg)
     float dVar9;
     float dVar10;
     int local34[5];
+    PAD_STACK(8);
     if (gp->gv.oldyoshiguest.xC6 == -1) {
         sVar5 = gp->gv.oldyoshiguest.xC4;
         gp->gv.oldyoshiguest.xC4 = sVar5 - 1;

--- a/src/melee/gr/gronett.c
+++ b/src/melee/gr/gronett.c
@@ -769,6 +769,7 @@ void grOnett_801E5214(Ground_GObj* gobj)
 {
     Ground* gp = GET_GROUND(gobj);
     int i;
+    PAD_STACK(8);
     for (i = 0; i < 2; i++) {
         struct grOnett_AwningData* awn = &gp->gv.onett.awnings[i];
         f32 disp, vel, error, abs_ratio, accel, force;

--- a/src/melee/gr/grpstadium.c
+++ b/src/melee/gr/grpstadium.c
@@ -1729,6 +1729,7 @@ void grStadium_801D3BBC(Ground_GObj* arg0)
     TextWrapper* gp2;
     Ground* gp;
     HSD_GObj* text_gobj;
+    PAD_STACK(24);
 
     var_r30 = 0;
     gp = GET_GROUND(arg0);

--- a/src/melee/gr/grpura.c
+++ b/src/melee/gr/grpura.c
@@ -99,6 +99,7 @@ const f32 grPu_804DBA7C = -30.0;
 
 void grPura_80211D00(void)
 {
+    u8 _padA[8];
     Vec3 cam_offset;
     f32 fVar1;
 
@@ -270,6 +271,7 @@ void grPura_8021231C(Ground_GObj* arg0)
     HSD_JObjSetScale(jobj, vec);
 
     // HSD_JObjGetFlags(jobj);
+    PAD_STACK(40);
     if ((HSD_JObjGetFlags(gp->gv.pura2.xC8) & 0x10) &&
         ((HSD_JObjGetFlags(jobj) & 0x10) == NULL))
     {

--- a/src/melee/gr/grrcruise.c
+++ b/src/melee/gr/grrcruise.c
@@ -674,6 +674,7 @@ void grRCruise_8020071C(Ground_GObj* gobj)
     f32 abs_rot =
         gp->gv.rcruise.x14 < 0.0f ? -gp->gv.rcruise.x14 : gp->gv.rcruise.x14;
     f32 wrapped = abs_rot - (360.0f * (s32) (abs_rot / 360.0f));
+    PAD_STACK(8);
 
     switch (gp->gv.rcruise.x2C) {
     case 0:
@@ -754,6 +755,7 @@ void grRCruise_80200C04(Ground_GObj* gobj)
 {
     Ground* gp = gobj->user_data;
     s32 i;
+    PAD_STACK(8);
 
     for (i = 0; i < 17; i++) {
         struct grRCruise_Entry* entry = &gp->gv.rcruise.entries[i];
@@ -1021,6 +1023,7 @@ void grRCruise_80201588(Ground_GObj* gobj)
     s32 i;
 
     HSD_ASSERT(0x5D6, gp->u.map.vanish);
+    PAD_STACK(16);
     for (i = 0; i < 20; i++, desc++) {
         struct grRCruise_VanishEntry* vanish = &gp->gv.rcruise.vanish[i];
 

--- a/src/melee/gr/grshrineroute.c
+++ b/src/melee/gr/grshrineroute.c
@@ -926,6 +926,7 @@ void grShrineRoute_8020A21C(Ground_GObj* gobj)
     f32 dx;
     f32 dy;
     f32 dist_sq;
+    PAD_STACK(16);
 
     player = Ground_801C57A4();
     if (player != NULL) {
@@ -1294,6 +1295,7 @@ void grShrineRoute_8020AF38(HSD_GObj* gobj, s32 arg1)
     HSD_JObj* jobj;
     f32 scale;
     s32 ix = arg1 - 0xBD;
+    PAD_STACK(16);
 
     pgobj = Ground_801C57A4();
 

--- a/src/melee/gr/grvenom.c
+++ b/src/melee/gr/grvenom.c
@@ -98,6 +98,7 @@ void grVenom_80203B18(void)
     s32 flag;
     HSD_GObj* gobj;
     HSD_LObj* lobj;
+    PAD_STACK(8);
 
     data = (s32*) &grVe_803E5348;
     grVe_804D6A30 = Ground_801C49F8();
@@ -929,6 +930,7 @@ void grVenom_80206874(Ground_GObj* gobj)
     HSD_JObj* jobj2;
     f32 scl;
     void* attr;
+    PAD_STACK(8);
 
     gp = gobj->user_data;
     jobj = gobj->hsd_obj;

--- a/src/melee/gr/gryorster.c
+++ b/src/melee/gr/gryorster.c
@@ -277,6 +277,7 @@ void grYorster_8020266C(HSD_GObj* gobj)
 {
     Ground* gp = gobj->user_data;
     s32 i;
+    PAD_STACK(8);
 
     for (i = 0; i < 9; i++) {
         struct grYorster_TrackElement* entry = &gp->gv.yorster.elements[i];

--- a/src/melee/gr/grzebes.c
+++ b/src/melee/gr/grzebes.c
@@ -356,6 +356,7 @@ void grZebes_801D881C(HSD_GObj* gobj)
     Ground* gp = GET_GROUND(gobj);
     HSD_GObj* secondary_gobj = (HSD_GObj*) gp->gv.zebes5.xF0;
     u8 result = grZebes_801DA528(gobj, &gp->gv.zebes5.xC8, 1, 2);
+    PAD_STACK(8);
 
     if ((s32) gp->gv.zebes5.xEC != result) {
         gp->gv.zebes5.xEC = result;

--- a/src/melee/if/if_2F72.c
+++ b/src/melee/if/if_2F72.c
@@ -432,6 +432,7 @@ void if_802F7D08(s32 slot)
     void** entry;
     s32 ret = gm_8016AEC8();
     HSD_GObj* result;
+    PAD_STACK(8);
 
     if (ret == -2) {
         idx = (u8) slot << 1;

--- a/src/melee/if/if_2F72.c
+++ b/src/melee/if/if_2F72.c
@@ -333,7 +333,7 @@ void fn_802F7994(HSD_GObj* gobj)
     }
 
     if (slot >= 0) {
-        if (frame > 0.0f && base[slot * 2 + 2] == NULL) {
+        if (frame > 12.0f && base[slot * 2 + 2] == NULL) {
             s32 idx = (u8) slot << 3;
             void** entry = base + idx;
             base[idx + 2] = fn_802F77F8(*++entry, (u8) slot, 1);

--- a/src/melee/if/if_2FC93.c
+++ b/src/melee/if/if_2FC93.c
@@ -113,6 +113,7 @@ void fn_802FDA78(HSD_GObj* gobj)
     unsigned char* pslot = gobj->user_data;
     unsigned char slot = *pslot;
     HSD_JObjSetTranslateZ(jobj, 0.0);
+    PAD_STACK(24);
     jobj->child->u.dobj->mobj->mat->diffuse = un_804A1F10.x14[slot];
     jobj->child->u.dobj->next->mobj->mat->diffuse = un_804A1F10.x14[slot];
     jobj->child->u.dobj->next->next->mobj->mat->diffuse =

--- a/src/melee/if/ifcoget.c
+++ b/src/melee/if/ifcoget.c
@@ -163,6 +163,7 @@ void fn_802FF218(HSD_GObj* arg0)
 {
     int x;
     int y;
+    PAD_STACK(24);
     for (x = 0; x < 6; x++) {
         if (un_804A1F58[x].x8.x0 == arg0) {
             y = x;
@@ -240,6 +241,7 @@ void un_802FF498(void)
 void un_802FF4FC(void)
 {
     int i;
+    PAD_STACK(8);
     for (i = 0; i < 6; i++) {
         if (un_804A1F58[i].x8.x0) {
             HSD_GObjPLink_80390228(un_804A1F58[i].x8.x0);

--- a/src/melee/if/ifprize.c
+++ b/src/melee/if/ifprize.c
@@ -131,6 +131,7 @@ void un_802FE6A8(void)
     GXColor color = { 0x5A, 0x5A, 0x5A, 0xFF };
     HSD_Text* text;
     HSD_Text* text2;
+    PAD_STACK(24);
     gobj_camera = GObj_Create(HSD_GOBJ_CLASS_CAMERA, 20, 0);
     HSD_GObjObject_80390A70(gobj_camera, HSD_GObj_804D784B,
                             HSD_CObjLoadDesc(un_804D6D9C->cameras[0].desc));
@@ -205,6 +206,7 @@ void un_802FEBE0_OnEnter(void* arg0_)
     int i;
     unsigned short arg0x0;
     int arg0x4;
+    PAD_STACK(8);
 
     un_803124BC();
     un_803F9D48.x28 = arg0;

--- a/src/melee/if/ifstock.c
+++ b/src/melee/if/ifstock.c
@@ -39,6 +39,7 @@ int ifStock_802F7EFC(int arg0, int arg1)
 {
     Vec3 pos;
     int i, j;
+    PAD_STACK(24);
     if (Player_GetStocks(arg1) == 0) {
         return 1;
     }
@@ -100,6 +101,7 @@ void ifStock_802F8298(HSD_GObj* gobj)
     HSD_JObj* jobj2;
     int i;
     Vec3 vecA, vecB, vecC;
+    PAD_STACK(8);
     ifStock_804A1378.player[user_data->player].stocks =
         Player_GetStocks(user_data->player);
     if (ifStock_804A1378.player[user_data->player].stocks > 99) {
@@ -219,6 +221,7 @@ void ifStock_802F89F8(HSD_GObj* gobj)
     int coins2;
     int count;
     Player_GetCoins(player);
+    PAD_STACK(72);
     coins = Player_GetCoins(user_data->player);
     ifStock_804A1378.player[user_data->player].coins = coins;
     if (coins > 99999) {
@@ -447,6 +450,7 @@ void ifStock_802F98E8(unsigned char player, int b)
     struct ifStock_804A1378_per_player* r26;
     int i;
     lbl_8046B6A0_t* ae44;
+    PAD_STACK(8);
     if (ifStock_804A1378.x0 != NULL) {
         user_data = &ifStock_804A1378.x204[player];
         ifStock_804A1378.x204[player].x0[0] = player;

--- a/src/melee/if/textdraw.c
+++ b/src/melee/if/textdraw.c
@@ -224,7 +224,7 @@ void DevText_Draw(DevText* text)
     }
     if ((text->flags & DEVTEXT_FLAG_SHOWCURSOR) == 1) {
         text->unk++;
-        if (text->unk < 17) {
+        if (text->unk < 16) {
             if (8 < text->unk) {
                 GXColor color = { 0xFF, 0xFF, 0xFF, 0xC0 };
                 DrawRectangle(text->x + text->scale_x * text->cursor_x,

--- a/src/melee/if/textdraw.c
+++ b/src/melee/if/textdraw.c
@@ -193,6 +193,7 @@ void DevText_SetupCObj(void)
 
 void DevText_Draw(DevText* text)
 {
+    PAD_STACK(24);
     hsd_80391A04(text->scale_x, text->scale_y, text->line_width);
     if ((text->flags & DEVTEXT_FLAG_HIDEBACKGROUND) == 0) {
         DrawRectangle(text->x - 8, text->y - 8, text->scale_x * text->w + 8,

--- a/src/melee/if/textlib.c
+++ b/src/melee/if/textlib.c
@@ -242,6 +242,7 @@ inline void DevText_AdvanceLine(DevText* text)
 
 void DevText_Print(DevText* text, char* str)
 {
+    PAD_STACK(8);
     if (str) {
         while (*str) {
             if (*str != '\n') {
@@ -627,6 +628,7 @@ void un_80303AC4(struct un_80304138_objalloc_t* arg0)
     int trigger = HSD_PadCopyStatus[0].trigger;
     int stick = un_803039A4(0);
     int buttons = stick | trigger;
+    PAD_STACK(8);
     if (buttons & HSD_PAD_START) {
         struct un_80304138_objalloc_t_x8* x8 = &arg0->x8[arg0->x0];
         if (x8->x4 != NULL) {
@@ -768,6 +770,7 @@ void un_80303FD4(HSD_GObj* arg0, struct un_80304138_objalloc_t* arg1,
     int size;
     void* buf;
     struct un_80304138_objalloc_t* un;
+    PAD_STACK(8);
 
     arg1->x8 = arg2;
     arg1->x1 = 0;

--- a/src/melee/it/items/itlinkhookshot.c
+++ b/src/melee/it/items/itlinkhookshot.c
@@ -576,14 +576,13 @@ void itLinkhookshot_UnkMotion2_Phys(Item_GObj* arg0)
 void it_802A3254(Item_GObj* arg0)
 {
     Vec3 pos;
-    u8 _padA[4];
     Mtx m;
-    u8 _padB[8];
     Item* item = GET_ITEM(arg0);
     Fighter* fp = item->owner->user_data;
     itLinkHookshotAttributes* attr =
         item->xC4_article_data->x4_specialAttributes;
     ItemLink* item_link = item->xDD4_itemVar.linkhookshot.x4;
+    PAD_STACK(8);
 
     it_802A2EE4_inline((MtxPtr) &m, item_link, &pos);
 

--- a/src/melee/it/items/itmasterhandlaser.c
+++ b/src/melee/it/items/itmasterhandlaser.c
@@ -143,13 +143,13 @@ void it_802F063C(Item_GObj* gobj, Item_GObj* arg1)
     Fighter* fp;
     Item* ip;
     itMasterHandLaserAttributes* attrs;
-    u8 _padA[8];
 
     f32 x0, y0, x1, y1;
     Vec3 pos_0;     // 58, 5C, 60
     Vec3 pos_1;     // 4C, 50, 54
     Vec3 pos_2;     // 40, 44, 48
     Vec3 translate; // 34, 38, 3C
+    PAD_STACK(8);
 
     ip = GET_ITEM(gobj);
     fp = GET_FIGHTER(ip->owner);

--- a/src/melee/lb/lb_00F9.c
+++ b/src/melee/lb/lb_00F9.c
@@ -394,6 +394,7 @@ void lb_8001044C(DynamicsDesc* desc, void* colliders_raw, int num_colliders,
                  float pos_y, bool use_floor_fn, Fighter_Part part,
                  int first_active, bool ground_check)
 {
+    u8 _padA[152];
     Mtx parent_mtx, temp_mtx, bone_mtx, constrained_mtx, trans_mtx, scale_mtx;
     Vec3 natural_dir, current_dir, link_dir;
     Vec3 cross_vec, local_axis;

--- a/src/melee/lb/lbaudio_ax.c
+++ b/src/melee/lb/lbaudio_ax.c
@@ -404,6 +404,7 @@ s32 lbAudioAx_80023B24(s32 arg0)
     lbAudioAx_PoolAlloc* st = &lbl_80433710;
     s32 slot;
     s32 off;
+    PAD_STACK(8);
 
     if (arg0 >= 0 && arg0 < 0x83D60) {
         s32(*ranges)[2] = lbl_803BB8D4;
@@ -2599,6 +2600,7 @@ void lbAudioAx_80027DBC(void)
 
 void lbAudioAx_80027DF8(void)
 {
+    PAD_STACK(16);
     if (lbl_804D640C == 0) {
         lbl_804D6430--;
         if (lbl_804D6430 <= 0) {
@@ -2741,6 +2743,7 @@ void lbAudioAx_8002838C(void)
     ARInit(st->x514, 0x10);
     ARQInit();
     AIInit(NULL);
+    PAD_STACK(8);
 
     lbl_804D643C = offsets_arr_803BC4E4[0][0];
     lbl_804D6440 = offsets_arr_803BC4E4[0x33][0];

--- a/src/melee/lb/lbbgflash.c
+++ b/src/melee/lb/lbbgflash.c
@@ -149,8 +149,8 @@ void fn_8001FEC4(HSD_GObj* gobj, s32 code)
     BgFlashData* data = &lbl_80433658;
     s32 mode;
     s32 y;
+    PAD_STACK(24);
 
-    PAD_STACK(8);
 
     if (data->state.active) {
         return;

--- a/src/melee/lb/lbcollision.c
+++ b/src/melee/lb/lbcollision.c
@@ -329,6 +329,7 @@ inline bool end(Vec3* a, Vec3* b, float unk_sum)
 int lbColl_80006094(Vec3* arg0, Vec3* arg1, Vec3* arg2, Vec3* arg3, Vec3* arg4,
                     Vec3* arg5, float arg6, float arg7)
 {
+    PAD_STACK(64);
     {
         Vec3 vec4;
         float sp30;
@@ -664,6 +665,7 @@ bool lbColl_800067F8(Vec3* a, Vec3* b, Vec3* c, Vec3* d, Vec3* e, Vec3* f,
     float a_z;
     Vec3 a0;
     Vec3 a1;
+    PAD_STACK(16);
 
     a0.x = a->x;
     a0.y = a->y;
@@ -1089,6 +1091,7 @@ bool lbColl_80006E58(Vec3* arg0, Vec3* arg1, Vec3* arg2, Vec3* arg3,
     s32 var_r0_2;
     s32 var_r0_3;
     s32 var_r0_4;
+    PAD_STACK(144);
 
     temp_f3 = (arg10 * arg11) + scl;
     sp11C = arg0->x;
@@ -2292,6 +2295,7 @@ void lbColl_80009DD4(Vec3* v0, Vec3* v1, GXColor* clr)
 
     HSD_StateInvalidate(-1);
     HSD_StateInitTev();
+    PAD_STACK(32);
     lbColl_80008DA4(clr, clr);
     HSD_ClearVtxDesc();
     GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XYZ, GX_F32, 0);

--- a/src/melee/lb/lbsnap.c
+++ b/src/melee/lb/lbsnap.c
@@ -185,6 +185,7 @@ int lbSnap_8001D7B0(int chan, int index, int jndex)
 void lbSnap_8001DA5C(int arg0)
 {
     int r4, r5, r6, r7, r9, r10, r25, r27, r28, ctr;
+    PAD_STACK(16);
 
     r7 = 0;
     for (r10 = 0; r10 < 32; r10++) {

--- a/src/melee/mn/mncharsel.c
+++ b/src/melee/mn/mncharsel.c
@@ -1621,6 +1621,7 @@ void mnCharSel_8025FB50(u8 door, s32 arg1)
     HSD_JObj* sp18;
     s32 icon_idx;
     s8 player;
+    PAD_STACK(16);
 
     do {
         icon_idx = HSD_Randi(0x19);

--- a/src/melee/mn/mncount.c
+++ b/src/melee/mn/mncount.c
@@ -320,6 +320,7 @@ s32 mnCount_8025092C(s32 rank, u32 (*getVal)(s32), bool mode)
 {
     CountEntry entries[NUM_CHARACTERS];
     int i, j, min;
+    PAD_STACK(8);
     if (mnCount_8025092C_inline()) {
         return NUM_CHARACTERS;
     }
@@ -418,6 +419,7 @@ int mnCount_GetRowValue_Character(mnCount_row row)
 unsigned int mnCount_GetRowValue_Number(int row)
 {
     unsigned int ret;
+    PAD_STACK(8);
     switch (row) {
     case POWER_COUNT:
         ret = *(unsigned int*) gmMainLib_GetPowerCount();
@@ -636,6 +638,7 @@ void fn_802514D8(HSD_GObj* gobj)
 {
     MnCountData* userdata = GET_MNCOUNT(gobj);
     HSD_GObjProc* proc;
+    PAD_STACK(16);
     if (mn_804A04F0.cur_menu != MENU_KIND_RECORDS_MISC) {
         HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
         proc = HSD_GObj_SetupProc(gobj, fn_802514B8, 0);
@@ -693,6 +696,7 @@ void fn_80251640(HSD_GObj* gobj)
     int i;
     HSD_JObj* jobj;
     StaticModelDesc* md;
+    PAD_STACK(24);
 
     if (mn_804A04F0.cur_menu != MENU_KIND_RECORDS_MISC) {
         HSD_GObjProc_8038FE24(HSD_GObj_804D7838);

--- a/src/melee/mn/mndiagram.c
+++ b/src/melee/mn/mndiagram.c
@@ -666,6 +666,7 @@ void mnDiagram_8023FA6C(void)
     int i, j;
     u8* src = mnDiagram_803EE74C;
     u8* dst = mnDiagram_804A0750.sorted_fighters;
+    PAD_STACK(8);
 
     for (i = 0; i < 0x19; i++) {
         u32 total = 0;
@@ -783,6 +784,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
     HSD_GObjProc* proc;
     Diagram* data = mnDiagram_804D6C10->user_data;
     u64 input = Menu_GetAllInputs();
+    PAD_STACK(80);
 
     if ((u32) input & 0x10) {
         lbAudioAx_80024030(1);
@@ -968,6 +970,7 @@ void mnDiagram_80240D94(void* arg0, s32 arg1, s32 arg2, s32 arg3)
     u16 sd_count;
 
     HSD_Text* text = HSD_SisLib_803A6754(0, 1);
+    PAD_STACK(24);
     data->text[0] = text;
     lb_8000B1CC(data->jobjs[8], mnDiagram_803EE728, &pos);
     text->font_size.x = 0.0521f;
@@ -1410,6 +1413,7 @@ void mnDiagram_OnFrame(HSD_GObj* gobj)
     u8 col_idx;
     s32 row_idx;
     int count;
+    PAD_STACK(8);
 
     if ((mn_804A04F0.cur_menu != 0x1E) || (mn_804A04F0.x10 != 0)) {
         if (mn_804A04F0.cur_menu == 0x1E) {
@@ -1592,6 +1596,7 @@ void mnDiagram_8024227C(void* arg0, s32 arg1, s32 arg2, u8 arg3)
     u8* var_r17;
     u8* var_r17_2;
     u8* var_r17_3;
+    PAD_STACK(32);
 
     var_r30 = 0;
     do {
@@ -1891,6 +1896,7 @@ void mnDiagram_802427B4(void* arg0, s32 arg1, s32 arg2)
 
     // Column headers
     text = HSD_SisLib_803A6754(0, 1);
+    PAD_STACK(104);
     data->col_header_text = text;
     text->font_size.x = 0.02f;
     text->font_size.y = 0.03f;
@@ -1973,6 +1979,7 @@ void mnDiagram_80242C0C(void* arg0, int arg1, int arg2)
     u8 fighter_id;
     f32 x_spacing;
     f32 y_spacing;
+    PAD_STACK(80);
 
     joint_data = (void**) &mnDiagram_804A0834;
 
@@ -2033,6 +2040,7 @@ void mnDiagram_CursorProc(HSD_GObj* gobj)
     f32 y_spacing;
     f32 x_pos;
     f32 y_pos;
+    PAD_STACK(40);
 
     if ((mn_804A04F0.cur_menu != 0x1E) || (mn_804A04F0.x10 != 0)) {
         HSD_GObjPLink_80390228(gobj);
@@ -2091,6 +2099,7 @@ void mnDiagram_80243434(u8 arg0)
     u16 indices;
     u8 col_idx;
     u8 row_idx;
+    PAD_STACK(32);
 
     joint_data = (void**) &mnDiagram_804A0824;
     gobj = GObj_Create(6, 7, 0x80);
@@ -2185,6 +2194,7 @@ void mnDiagram_802437E8(s32 arg0, s32 arg1)
 {
     mnDiagram_Assets* assets = (mnDiagram_Assets*) &mnDiagram_804A0750;
     HSD_GObjProc* proc;
+    PAD_STACK(24);
 
     mn_804A04F0.prev_menu = mn_804A04F0.cur_menu;
     mn_804A04F0.cur_menu = 0x1E;

--- a/src/melee/mn/mndiagram2.c
+++ b/src/melee/mn/mndiagram2.c
@@ -609,6 +609,7 @@ void mnDiagram2_CreateStatRow(HSD_GObj* gobj, u8 is_name_mode, u8 stat_type,
     HSD_Text* text;
     f32 f31;
     f32 f30;
+    PAD_STACK(16);
 
     data = gobj->user_data;
     base = (char*) &mnDiagram2_803EEAD0;

--- a/src/melee/mn/mndiagram3.c
+++ b/src/melee/mn/mndiagram3.c
@@ -420,7 +420,7 @@ void mnDiagram3_8024714C(void* arg0)
     f32 row_spacing;
     f32 neg_spacing;
     int i;
-    PAD_STACK(56);
+    PAD_STACK(64);
 
     {
         MenuFlow* flow = &mn_804A04F0;

--- a/src/melee/mn/mnname.c
+++ b/src/melee/mn/mnname.c
@@ -266,6 +266,7 @@ s32 mnName_SortNames(HSD_GObj* arg0)
     u8* order = mnName_NameDisplayOrder;
     MnName_GObj* data = (MnName_GObj*) arg0->user_data;
     s32 result;
+    PAD_STACK(8);
 
     if ((u8) data->gobj.p_priority == 0) {
         s32 i;
@@ -1124,6 +1125,7 @@ void mnName_80239A24(HSD_GObj* gobj)
     s32 extra;
     s32 total_rows;
     u8 name_idx;
+    PAD_STACK(24);
 
     for (i = 0; i < 0x18; i++) {
         jobj = HSD_JObjLoadJoint(mnName_804A06C0.joint);
@@ -1420,7 +1422,7 @@ HSD_GObj* mnName_8023A59C(u8 arg0)
     f32 rows;
     f32 pos;
     HSD_Text* txt;
-    PAD_STACK(0x18);
+    PAD_STACK(16);
 
     gobj = GObj_Create(6U, 7U, 0x80U);
     mnName_804D6BF8 = gobj;
@@ -1575,6 +1577,7 @@ s32 mnName_8023AC40(void)
     s32 ctr;
     s32 val;
     HSD_GObjProc* proc;
+    PAD_STACK(8);
 
     lbArchive_LoadSections(archive,
                            (void**) ((char*) mnName_NameDisplayOrder + 0x98),

--- a/src/melee/mn/mnnamenew.c
+++ b/src/melee/mn/mnnamenew.c
@@ -1193,6 +1193,7 @@ void fn_8023D0F8(void* arg0)
 
 s32 mnNameNew_8023D130(GlyphVariantEntry* arg0, u8 arg1, u8 arg2, s32 arg3)
 {
+    u8 _padA[8];
     Vec3 sp30;
     GXColor sp2C;
     HSD_JObj* jobj14;
@@ -1211,7 +1212,6 @@ s32 mnNameNew_8023D130(GlyphVariantEntry* arg0, u8 arg1, u8 arg2, s32 arg3)
     GlyphRow* table_lower;
     GXColor* sp2C_ptr;
 
-    PAD_STACK(8);
 
     jobj14 = arg0->jobjs[4];
     text = HSD_SisLib_803A6754(0, (s32) mn_804D6BB4);

--- a/src/melee/mn/mnruleplus.c
+++ b/src/melee/mn/mnruleplus.c
@@ -309,6 +309,7 @@ void mn_802327A4(HSD_GObj* gobj, u32 arg1, u32 arg2)
     s32 visible;
     HSD_JObj** root_ptr;
     u16 selected;
+    PAD_STACK(24);
 
     jobj_map[0] = 0;
     jobj_map[1] = 1;
@@ -506,6 +507,7 @@ void mn_80232D4C(HSD_GObj* gobj, u32 arg1, u32 arg2)
     u8 confirmed;
     u8 desc_idx;
     HSD_Text* text;
+    PAD_STACK(8);
 
     if ((s32) arg1 != 0) {
         selection = mn_804A04F0.hovered_selection;
@@ -708,6 +710,7 @@ HSD_GObj* mn_80233218(MenuState state)
     f32* frame_ptr;
     u16* sub_count_ptr;
     GameRules* rules;
+    PAD_STACK(16);
 
     for (i = 0; i < 17; i++) {
         jobj_map[i] = (u16) i;

--- a/src/melee/mn/mnsnap.c
+++ b/src/melee/mn/mnsnap.c
@@ -411,6 +411,7 @@ s32 mnSnap_80253BE0(u64 buttons, s32* cursor, s32 count)
 {
     s32 cur = *cursor;
     s32 next = cur;
+    PAD_STACK(8);
 
     if (buttons & 1) {
         if ((next & 1) == 1) {
@@ -799,7 +800,7 @@ void fn_802545C4(void)
     HSD_JObj* jobj;
     HSD_JObj* jobj2;
     Vec3* translate;
-    PAD_STACK(336);
+    PAD_STACK(328);
     buttons = (mn_804A04F0.buttons = mn_80229624(4));
     HSD_JObjAnimAll(mnSnap_804A0A10.select_jobj);
     HSD_JObjAnimAll(mnSnap_804A0A10.move_jobj);

--- a/src/melee/mn/mnsound.c
+++ b/src/melee/mn/mnsound.c
@@ -78,6 +78,7 @@ void mnSound_802492CC(HSD_GObj* gobj)
 {
     Menu* menu = GET_MENU(mnSound_804D6C30);
     u64 events;
+    PAD_STACK(24);
     if (mn_804D6BC8.cooldown != 0) {
         Menu_DecrementAnimTimer();
         return;
@@ -161,6 +162,7 @@ void fn_80249A1C(HSD_GObj* arg0)
 
     HSD_JObj* jobj = arg0->hsd_obj;
     Menu* menu = GET_MENU(arg0);
+    PAD_STACK(16);
     if ((u8) mn_804A04F0.cur_menu != 0x14) {
         HSD_GObjPLink_80390228(arg0);
         HSD_SisLib_803A5CC4(menu->text);
@@ -206,6 +208,7 @@ void mnSound_80249C08(int unused)
     HSD_JObj* jobj;
     Menu* menu;
     HSD_GObjProc* proc;
+    PAD_STACK(24);
     mnSound_804D6C30 = gobj;
     jobj = HSD_JObjLoadJoint(mnSound_804A08A8.joint);
     HSD_GObjObject_80390A70((HSD_GObj*) gobj, (u8) HSD_GObj_804D7849, jobj);

--- a/src/melee/mn/mnsoundtest.c
+++ b/src/melee/mn/mnsoundtest.c
@@ -147,6 +147,7 @@ void mnSoundTest_8024A790(HSD_GObj* arg0)
                (1.0f - HSD_PadCopyStatus[1].nml_analogR) *
                (1.0f - HSD_PadCopyStatus[2].nml_analogR) *
                (1.0f - HSD_PadCopyStatus[3].nml_analogR);
+    PAD_STACK(24);
     if ((temp_f31 < 0.9f) || (temp_r31->unk8 < 1.0f)) {
         temp_f1 = temp_f31 * (f32) gm_801601C4(gmMainLib_8015ED74());
         temp_r30 = (s32) (temp_r31->unk8 * temp_f1);
@@ -181,6 +182,7 @@ void mnSoundTest_8024A958(Soundtest_GObj* arg0)
     HSD_Text* temp_r3_3;
     HSD_Text* temp_r3_4;
     soundtest_user_data* temp_r30;
+    PAD_STACK(16);
 
     temp_r30 = arg0->user_data;
     if (temp_r30->unk14 != NULL) {
@@ -212,6 +214,7 @@ f32 mn_8022F298(HSD_JObj*);
 
 void mnSoundTest_8024AA70(HSD_GObj* arg0, u8 arg1)
 {
+    u8 _padA[16];
     HSD_JObj* sp38;
     HSD_JObj* sp34;
     char string[3];
@@ -370,6 +373,7 @@ void fn_8024AED0(HSD_GObj* arg0)
     u64 events;
 
     soundtest_user_data* user_data = arg0->user_data;
+    PAD_STACK(88);
     if ((u16) mn_804D6BC8.cooldown != 0) {
         Menu_DecrementAnimTimer();
         return;

--- a/src/melee/mn/mnvibration.c
+++ b/src/melee/mn/mnvibration.c
@@ -171,6 +171,7 @@ void fn_80247510(HSD_GObj* gobj)
     s32 name_idx;
     u8 rumble_setting;
     HSD_JObj* jobj;
+    PAD_STACK(136);
 
     if (mn_804D6BC8.cooldown != 0) {
         Menu_DecrementAnimTimer();
@@ -908,9 +909,9 @@ void mnVibration_80248ED4(s32 arg0)
     HSD_Text* text;
     s32 i;
     MnVibrationData* data;
-    PAD_STACK(32);
 
     (void) arg0;
+    PAD_STACK(24);
     assets = &mnVibration_804A0898;
     gobj = GObj_Create(6, 7, 0x80);
     mnVibration_804D6C28 = gobj;

--- a/src/melee/mp/mplib.c
+++ b/src/melee/mp/mplib.c
@@ -830,6 +830,7 @@ void mpLib_8004ED5C(int line_id, float* x0_out, float* y0_out, float* x1_out,
     float x1_f2 = groundCollVtx[line_r11->v1_idx].pos.x;
     float y1_f3 = groundCollVtx[line_r11->v1_idx].pos.y;
     float distance;
+    PAD_STACK(8);
 
     if (mpLineGetPrev(line_id) != -1) {
         distance = sqrtf(SQ(x0_f0 - x1_f2) + SQ(y0_f1 - y1_f3));
@@ -4864,6 +4865,7 @@ int mpJointFromLine(int line_id)
 bool mpLib_80056C54(int line_id, Vec3* pos, int* line_id_out, Vec3* vec_out,
                     u32* flags_out, Vec3* normal_out, f32 var_f25, f32 arg7)
 {
+    u8 _padA[8];
     float sp64;
     Vec3 sp58;
     Vec3 sp4C;
@@ -5461,6 +5463,7 @@ void mpLib_80058614_Floor(void)
     int count_r30;
     int count_r29;
     int j;
+    PAD_STACK(8);
 
     joint_r7 = groundCollJoint;
     count_r8 = mpLib_804D64B4->joint_count;

--- a/src/melee/ty/toy.c
+++ b/src/melee/ty/toy.c
@@ -424,6 +424,7 @@ void Trophy_SetUnlockState(enum_t trophyId, bool addValue)
     u16* ptr;
     u16* statePtr;
     u16 temp;
+    PAD_STACK(8);
 
     if (gm_8016B498() || (u8) gm_801A4310() == 0xC) {
         table = toy->trophyTable;
@@ -1340,6 +1341,7 @@ HSD_LObj* un_80306EEC(void* list_arg, s32 hasAnim_arg)
     u8* posTable;
     u8* animFlag;
     s32 idx;
+    PAD_STACK(8);
 
     prev = NULL;
     idx = 0;
@@ -1443,6 +1445,7 @@ void un_8030715C(f32 cstick_x, f32 cstick_y)
     TyLightArray_* cur;
     s32 i;
     s8* flag_ptr;
+    PAD_STACK(96);
 
     data = (void*) un_804D6E68;
     data2 = un_804D6ED4;
@@ -1547,6 +1550,7 @@ void un_803075E8(s32 arg0)
     void* matanim;
     void* shapanim;
     ToyDataJObj* tdjobj;
+    PAD_STACK(88);
 
     data = un_803FDD18;
     td = un_804D6ED8;
@@ -1980,6 +1984,7 @@ void un_803084A0(s16 arg0)
     tyDispData* display;
     HSD_Text* text;
     s32 one;
+    PAD_STACK(72);
 
     display = un_804D6EE0;
     color = un_804DDCFC;
@@ -2142,6 +2147,7 @@ void un_80308F04(HSD_CObj* cobj)
     f32 right;
     f32 left;
     ToyJObjNode* jobj;
+    PAD_STACK(64);
 
     data = TOY_DATA;
     state = TOY_STATE;
@@ -2351,6 +2357,7 @@ extern f32 un_804DDCF0;
 
 void un_80310324(void)
 {
+    u8 _padA[8];
     char* toy;
     char* data;
     ToyGlobalsS_* tg;
@@ -2943,6 +2950,7 @@ void un_80312050(void)
     u8 color_ff;
     u8 color_00;
     f32 fz, fy, fx;
+    PAD_STACK(40);
 
     data = un_804D6E6C;
     cobj = HSD_CObjGetCurrent();

--- a/src/melee/ty/tydisplay.c
+++ b/src/melee/ty/tydisplay.c
@@ -249,11 +249,13 @@ inline void quicksort(TySortElem* base, s32 lo, s32 hi)
 
 void un_8031830C(TySortElem* base, s32 lo, s32 hi)
 {
+    PAD_STACK(16);
     quicksort(base, lo, hi);
 }
 
 void un_80318714(TySortElem* base, s32 lo, s32 hi)
 {
+    PAD_STACK(16);
     quicksort(base, lo, hi);
 }
 
@@ -892,8 +894,8 @@ void un_80319EF0(void)
     HSD_CObj* cobj;
     f32 range;
     f32 scale;
+    PAD_STACK(16);
 
-    PAD_STACK(0x18);
 
     cobj = (HSD_CObj*) cfg->x00->hsd_obj;
 
@@ -1480,7 +1482,7 @@ void un_8031B460_OnEnter(void* arg0)
     HSD_GObj* gobj;
     int i;
     char* strbase = (char*) un_803FEFF0;
-    PAD_STACK(16);
+    PAD_STACK(8);
 
     un_804D6F10 = HSD_MemAlloc(0x4B0);
     un_804D6F14 = HSD_MemAlloc(0x12E4);

--- a/src/melee/ty/tyfigupon.c
+++ b/src/melee/ty/tyfigupon.c
@@ -799,6 +799,7 @@ static const Vec3 un_803B8968 = { 0.0f, 1.0f, 0.0f };
 
 void fn_803168DC(HSD_GObj* arg0)
 {
+    u8 _padA[32];
     ToyAnimState* data = &un_804A2AA8;
     HSD_CObj* cobj = arg0->hsd_obj;
     Vec3 interest;
@@ -1159,6 +1160,7 @@ static const DigitInit un_803B8974 = { 0, 0, 0, 0 };
 
 void un_8031753C(void)
 {
+    u8 _padA[24];
     struct un_804D6EF4_t* ef4 = un_804D6EF4;
     HSD_Joint* joint;
     HSD_JObj* jobj;

--- a/src/melee/vi/vi0401.c
+++ b/src/melee/vi/vi0401.c
@@ -137,6 +137,7 @@ void un_8031D288_OnEnter(void* data)
 
     ViCharaDesc* desc = (ViCharaDesc*) data;
     u8 char_index = desc->p1_char_index;
+    PAD_STACK(8);
 
     lbAudioAx_800236DC();
     efLib_Init();

--- a/src/melee/vi/vi0502.c
+++ b/src/melee/vi/vi0502.c
@@ -63,6 +63,7 @@ void vi0502_8031E124(CharacterKind player_kind, int player_costume,
     VecMtxPtr pmtx;
 
     Camera_80028B9C(6);
+    PAD_STACK(32);
     lb_8000FCDC();
     mpColl_80041C78();
     Ground_801C0378(0x40);

--- a/src/sysdolphin/baselib/cobj.c
+++ b/src/sysdolphin/baselib/cobj.c
@@ -792,18 +792,21 @@ MtxPtr HSD_CObjGetInvViewingMtxPtrDirect(HSD_CObj* cobj)
 MtxPtr HSD_CObjGetViewingMtxPtr(HSD_CObj* cobj)
 {
     HSD_CObjSetupViewingMtx(cobj);
+    PAD_STACK(24);
     return HSD_CObjGetViewingMtxPtrDirect(cobj);
 }
 
 MtxPtr HSD_CObjGetInvViewingMtxPtr(HSD_CObj* cobj)
 {
     HSD_CObjSetupViewingMtx(cobj);
+    PAD_STACK(24);
     return HSD_CObjGetInvViewingMtxPtrDirect(cobj);
 }
 
 void HSD_CObjSetRoll(HSD_CObj* cobj, float roll)
 {
     Vec3 up;
+    PAD_STACK(8);
 
     if (!cobj) {
         return;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -147,6 +147,7 @@ f32 DrawASCII(int chr, float x, float y, GXColor* color)
     s32 i;
     u8 p0, p1;
     u8 r, g, b, a;
+    PAD_STACK(56);
 
     if (chr >= '0' && chr <= '9') {
         index = chr - '0';
@@ -716,6 +717,7 @@ static const u32 lbl_804DE8E0 = 0xFFFFFFFF;
 // @TODO: Currently 89.78% match - needs minor control flow and register fixes
 void hsd_8039254C(void)
 {
+    u8 _padA[8];
     GXColor bar_col;
     GXColor bg_col3;
     GXColor bg_col2;
@@ -2076,6 +2078,7 @@ extern u8 lbl_8040AB40[];
 void hsd_80394668(void)
 {
     struct ParticleScreenState* sp = &hsd_804CF810;
+    PAD_STACK(24);
 
     if ((u32) sp->x2C != 0) {
         /* Copy XFB data with brightness adjustment */
@@ -2714,6 +2717,7 @@ void hsd_803957C0(u8 input)
     u8 ch;
     void* saved;
     u8 saved_ch;
+    PAD_STACK(32);
 
     ch = input;
     saved_ch = ch;
@@ -3125,6 +3129,7 @@ s32 hsd_803962A8(void* data)
     s32 old;
     u8* addr;
     s32 i, j, k;
+    PAD_STACK(16);
 
     bit = 1;
     while (bit <= sp->xBC) {
@@ -3296,6 +3301,7 @@ void hsd_80396884(void)
     void* saved;
     s32 x_base;
     u8 ch;
+    PAD_STACK(24);
 
     x_base = (sp->x20 - 30) / 2;
     sprintf(buf, "| INPUT ADDRESS : 8%07lX |", lbl_8040BC3C.x10 & 0x0FFFFFFF);
@@ -3467,7 +3473,6 @@ void hsd_80396E40(s32 keycode)
     s32 j;
     char ch;
 
-    PAD_STACK(8);
     saved = *px50;
     row = sp->x1C - 1;
     *px50 = lbl_8040AB00;
@@ -3855,6 +3860,7 @@ void* fn_80397814(void* arg)
     void* ctx = arg;
     u32 retrace;
     u32* keybuf = &sp->xC0;
+    PAD_STACK(160);
 
     hsd_80393D2C(0);
     hsd_80394314();
@@ -4982,6 +4988,7 @@ void hsd_80398F8C(HSD_Particle* pp, f32 angle)
     f32 sin_angle, cos_angle;
     f32 sin_rand, cos_rand;
     f32 temp;
+    PAD_STACK(24);
 
     temp = vz;
     *(s32*) &temp &= 0x7FFFFFFF;

--- a/src/sysdolphin/baselib/sislib.c
+++ b/src/sysdolphin/baselib/sislib.c
@@ -1264,7 +1264,7 @@ void HSD_SisLib_803A8134(void* sis_data, HSD_Text* text, f32* out_width,
     u8 kern_enabled;
     u8* kern_data;
     u8* cursor;
-    PAD_STACK(8);
+    PAD_STACK(16);
 
     cursor = sis_data;
     saved_scale_x = text->x80.x;

--- a/src/sysdolphin/baselib/sobjlib.c
+++ b/src/sysdolphin/baselib/sobjlib.c
@@ -213,7 +213,7 @@ void HSD_SObjLib_803A55DC(HSD_GObj* gobj, int width, int height, int priority)
     Scissor scissor;
     f32 roll = 0.0F;
     f32 near_val = roll;
-    f32 far_val = 0.5F;
+    f32 far_val = 2.0f;
     f32 top = roll;
     f32 bottom = (f32) - (s32) (u16) height;
     f32 left = roll;

--- a/src/sysdolphin/baselib/texpdag.c
+++ b/src/sysdolphin/baselib/texpdag.c
@@ -76,6 +76,7 @@ void order_dag(int num, u32* dep, u32* full_dep, HSD_TExpDag* list, int depth,
     int i;
     int n;
     int rem;
+    PAD_STACK(8);
 
     new_scheduled = done_set | (1 << idx);
     new_available = ready_set & ~(1 << idx);


### PR DESCRIPTION
I made two scripts: one that finds and fixes incorrect literals, and one that fixes frame sizes by adding or removing padding. I ran them on all nonmatching functions, keeping only the results that improved total match score. (There were a handful of false positives.)
