### PR TITLE
sobjlib: decompile SObj setup and render paths

### DIFF
--- a/extern/.clang-format
+++ b/extern/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: false

--- a/extern/dolphin/include/dolphin/gx/GXEnum.h
+++ b/extern/dolphin/include/dolphin/gx/GXEnum.h
@@ -164,14 +164,11 @@ typedef enum _GXTexFmt
     GX_CTF_Z16L = 0xC | _GX_TF_ZTF | _GX_TF_CTF,
 
     GX_TF_A8 = GX_CTF_A8,
-} GXTexFmt;
 
-typedef enum _GXCITexFmt
-{
     GX_TF_C4 = 0x8,
     GX_TF_C8 = 0x9,
     GX_TF_C14X2 = 0xA,
-} GXCITexFmt;
+} GXTexFmt;
 
 typedef enum _GXTexWrapMode
 {

--- a/extern/dolphin/include/dolphin/gx/GXTexture.h
+++ b/extern/dolphin/include/dolphin/gx/GXTexture.h
@@ -13,7 +13,7 @@ typedef GXTlutRegion *(*GXTlutRegionCallback)(u32 idx);
 
 u32 GXGetTexBufferSize(u16 width, u16 height, u32 format, u8 mipmap, u8 max_lod);
 void GXInitTexObj(GXTexObj *obj, void *image_ptr, u16 width, u16 height, GXTexFmt format, GXTexWrapMode wrap_s, GXTexWrapMode wrap_t, u8 mipmap);
-void GXInitTexObjCI(GXTexObj *obj, void *image_ptr, u16 width, u16 height, GXCITexFmt format, GXTexWrapMode wrap_s, GXTexWrapMode wrap_t, u8 mipmap, u32 tlut_name);
+void GXInitTexObjCI(GXTexObj *obj, void *image_ptr, u16 width, u16 height, GXTexFmt format, GXTexWrapMode wrap_s, GXTexWrapMode wrap_t, u8 mipmap, u32 tlut_name);
 void GXInitTexObjLOD(GXTexObj *obj, GXTexFilter min_filt, GXTexFilter mag_filt,
     f32 min_lod, f32 max_lod, f32 lod_bias, GXBool bias_clamp,
     GXBool do_edge_lod, GXAnisotropy max_aniso);

--- a/extern/dolphin/src/dolphin/gx/GXTexture.c
+++ b/extern/dolphin/src/dolphin/gx/GXTexture.c
@@ -257,7 +257,7 @@ void GXInitTexObj(GXTexObj *obj, void *image_ptr, u16 width, u16 height, GXTexFm
     t->flags |= 2;
 }
 
-void GXInitTexObjCI(GXTexObj *obj, void *image_ptr, u16 width, u16 height, GXCITexFmt format, GXTexWrapMode wrap_s, GXTexWrapMode wrap_t, u8 mipmap, u32 tlut_name)
+void GXInitTexObjCI(GXTexObj *obj, void *image_ptr, u16 width, u16 height, GXTexFmt format, GXTexWrapMode wrap_s, GXTexWrapMode wrap_t, u8 mipmap, u32 tlut_name)
 {
     __GXTexObjInt *t = (__GXTexObjInt *)obj;
 

--- a/src/sysdolphin/baselib/sobjlib.c
+++ b/src/sysdolphin/baselib/sobjlib.c
@@ -1,3 +1,4 @@
+#define SOBJLIB_INTERNAL
 #include "sobjlib.h"
 
 #include "cobj.h"
@@ -5,11 +6,14 @@
 #include "gobjgxlink.h"
 #include "gobjobject.h"
 #include "objalloc.h"
+#include "pobj.h"
 #include "state.h"
 #include "tev.h"
+#include "tobj.h"
 
 #include "dolphin/gx.h"
 
+#include <math.h>
 #include <dolphin/os.h>
 
 /* 004DB670 */ extern const s32 HSD_SObjLib_804DEA90;
@@ -17,6 +21,8 @@
 /* 004DB668 */ extern const s32 HSD_SObjLib_804DEA88;
 /* 004DB664 */ extern const s32 HSD_SObjLib_804DEA84;
 /* 004DB660 */ extern const s32 HSD_SObjLib_804DEA80;
+/* 004DB674 */ extern const f32 HSD_SObjLib_804DEA94;
+/* 004DB678 */ extern const f32 HSD_SObjLib_804DEA98;
 /* 004D4540 */ u8 HSD_SObjLib_804D7960;
 /* 004CDCC0 */ extern HSD_ObjAllocData HSD_SObjLib_804D10E0;
 
@@ -35,8 +41,6 @@ void HSD_SObjLib_803A44A4(void)
     HSD_ObjAllocInit(&HSD_SObjLib_804D10E0, 0x9C, 4);
 }
 
-/* @todo 99.56% match - needs register allocation fix (r4 vs r5 for cur) */
-/* @todo 99.56% match - needs register allocation fix (r4 vs r5 for cur) */
 void HSD_SObjLib_803A44D4(HSD_GObj* gobj, HSD_SObj* sobj, u8 priority)
 {
     HSD_SObj* cur;
@@ -146,7 +150,86 @@ void HSD_SObjLib_803A4740(HSD_SObj* sobj)
 
 static char filename[] = "sobjlib.c";
 
-/// #HSD_SObjLib_803A477C
+HSD_SObj* HSD_SObjLib_803A477C(HSD_GObj* gobj, HSD_SObjDesc* desc,
+                               GXTexWrapMode wrap_s, GXTexWrapMode wrap_t,
+                               u8 priority, u8 use_secondary)
+{
+    HSD_ImageDesc* image;
+    HSD_Tlut* tlut;
+    HSD_ImageDesc* image2;
+    HSD_SObj* sobj;
+    f32 inv_width;
+    f32 inv_height;
+
+    if (use_secondary) {
+        image = desc->image;
+        tlut = desc->tlut;
+        image2 = desc->image2;
+    } else {
+        image = desc->image;
+        image2 = NULL;
+        tlut = desc->tlut;
+    }
+
+    sobj = HSD_ObjAlloc(&HSD_SObjLib_804D10E0);
+    if (sobj == NULL) {
+        __assert(filename, 0x11F, "sobj");
+    }
+
+    if (tlut != NULL) {
+        GXInitTlutObj(&sobj->x70_tlutobj, tlut->lut, tlut->fmt,
+                      tlut->n_entries);
+        GXInitTexObjCI(&sobj->x50_texobj, image->image_ptr, image->width,
+                       image->height, image->format, wrap_s, wrap_t,
+                       (u8) image->mipmap, tlut->tlut_name);
+    } else {
+        GXInitTexObj(&sobj->x50_texobj, image->image_ptr, image->width,
+                     image->height, image->format, wrap_s, wrap_t,
+                     (u8) image->mipmap);
+    }
+
+    if (use_secondary) {
+        GXInitTexObj(&sobj->x7C_texobj, image2->image_ptr, image2->width,
+                     image2->height, image2->format, wrap_s, wrap_t,
+                     (u8) image2->mipmap);
+    }
+
+    sobj->x0 = NULL;
+    sobj->prev = NULL;
+    sobj->next = NULL;
+    sobj->x14 = 0.0F;
+    sobj->x10 = 0.0F;
+    sobj->x18 = 0.0F;
+    sobj->x20 = 1.0F;
+    sobj->x1C = 1.0F;
+    sobj->x3F = 0xFF;
+    sobj->x3E = 0xFF;
+    sobj->x3D = 0xFF;
+    sobj->x3C = 0xFF;
+    sobj->x3B = 0xFF;
+    sobj->x3A = 0xFF;
+    sobj->x39 = 0xFF;
+    sobj->x38 = 0xFF;
+    sobj->x40 = 0;
+    sobj->x48 = 0;
+    sobj->x4C_callback = NULL;
+    sobj->gobj = gobj;
+
+    if (use_secondary) {
+        sobj->x40 |= 4;
+    }
+
+    sobj->x34 = image->width;
+    sobj->x36 = image->height;
+    inv_width = 1.0F / (f32) GXGetTexObjWidth(&sobj->x50_texobj);
+    inv_height = 1.0F / (f32) GXGetTexObjHeight(&sobj->x50_texobj);
+    sobj->x24 = 0.0F;
+    sobj->x28 = 0.0F;
+    sobj->x2C = (f32) sobj->x34 * inv_width;
+    sobj->x30 = (f32) sobj->x36 * inv_height;
+    HSD_SObjLib_803A44D4(gobj, sobj, priority);
+    return sobj;
+}
 
 void HSD_SObjLib_803A49E0(HSD_GObj* gobj, int unused)
 {
@@ -168,9 +251,301 @@ void HSD_SObjLib_803A49E0(HSD_GObj* gobj, int unused)
     }
 }
 
-static u8 data_pad_jumptable[0x3C] = { 0 };
+void HSD_SObjLib_803A4A68(HSD_SObj* sobj)
+{
+    f32 x_cos;
+    f32 origin_x;
+    f32 origin_y;
+    f32 angle;
+    f32 center_width;
+    f32 center_height;
+    f32 sin_half;
+    f32 cos_val;
+    f32 cos_half;
+    f32 width;
+    f32 height;
+    f32 x_sin;
+    f32 y_sin;
+    f32 y_cos;
+    f32 tex_s;
+    f32 tex_t;
+    f32 tex_s_max;
+    f32 tex_t_max;
+    f32 left_x;
+    f32 left_y;
+    f32 right_x;
+    f32 right_y;
+    u16 obj_width;
+    u16 obj_height;
+    u8 tex_fmt;
+    GXColorS10 tev_color;
+    GXColor k_color;
 
-/// #HSD_SObjLib_803A4A68
+    PAD_STACK(0x20);
+
+    if (sobj->x40 & 1) {
+        return;
+    }
+
+    obj_width = sobj->x34;
+    obj_height = sobj->x36;
+    tex_fmt = GXGetTexObjFmt(&sobj->x50_texobj);
+
+    if (sobj->x40 & 2) {
+        origin_x = sobj->x10;
+        origin_y = sobj->x14;
+    } else {
+        center_width = (f32) obj_width * sobj->x1C;
+        center_height = (f32) obj_height * sobj->x20;
+        origin_x = (center_width * HSD_SObjLib_804DEA94) + sobj->x10;
+        origin_y = (center_height * HSD_SObjLib_804DEA94) + sobj->x14;
+    }
+
+    GXClearVtxDesc();
+    if (sobj->x40 & 4) {
+        GXSetZTexture(GX_ZT_REPLACE, GX_TF_Z24X8, 0);
+        if (sobj->x40 & 8) {
+            HSD_StateSetZMode(1, GX_LESS, 0);
+        } else {
+            HSD_StateSetZMode(1, GX_LESS, 1);
+        }
+        HSD_StateSetZCompLoc(0);
+        GXSetCullMode(GX_CULL_BACK);
+        GXSetNumTexGens(1);
+        GXSetNumTevStages(2);
+    } else {
+        HSD_StateSetZMode(1, GX_ALWAYS, 0);
+        GXSetCullMode(GX_CULL_BACK);
+        if (sobj->x40 & 0x10) {
+            GXSetNumTexGens(2);
+            GXSetNumTevStages(4);
+        } else {
+            GXSetNumTexGens(1);
+            GXSetNumTevStages(1);
+        }
+    }
+
+    if ((u8) (tex_fmt - GX_TF_C4) <= 1U) {
+        GXLoadTlut(&sobj->x70_tlutobj, GX_TLUT0);
+    }
+    if (!(sobj->x40 & 0x10)) {
+        GXLoadTexObj(&sobj->x50_texobj, GX_TEXMAP0);
+    }
+
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_POS, GX_POS_XY, GX_F32, 0);
+    GXSetVtxDesc(GX_VA_POS, GX_DIRECT);
+    GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_TEX0, GX_TEX_ST, GX_F32, 0);
+    GXSetVtxDesc(GX_VA_TEX0, GX_DIRECT);
+    GXSetColorUpdate(1);
+    GXSetAlphaUpdate(0);
+
+    if (sobj->x40 & 0x10) {
+        GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD1, GX_TEXMAP1, GX_COLOR_NULL);
+        GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_ZERO, GX_CC_TEXC, GX_CC_QUARTER,
+                        GX_CC_C0);
+        GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1,
+                        GX_FALSE, GX_TEVPREV);
+        GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_TEXA, GX_CA_ONE,
+                        GX_CA_A0);
+        GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_SUB, GX_TB_ZERO, GX_CS_SCALE_1,
+                        GX_FALSE, GX_TEVPREV);
+        GXSetTevKColorSel(GX_TEVSTAGE0, GX_TEV_KCSEL_K0);
+        GXSetTevKAlphaSel(GX_TEVSTAGE0, GX_TEV_KASEL_K0_A);
+        GXSetTevSwapMode(GX_TEVSTAGE0, GX_TEV_SWAP0, GX_TEV_SWAP0);
+
+        GXSetTevOrder(GX_TEVSTAGE1, GX_TEXCOORD1, GX_TEXMAP2, GX_COLOR_NULL);
+        GXSetTevColorIn(GX_TEVSTAGE1, GX_CC_ZERO, GX_CC_TEXC, GX_CC_QUARTER,
+                        GX_CC_CPREV);
+        GXSetTevColorOp(GX_TEVSTAGE1, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_2,
+                        GX_FALSE, GX_TEVPREV);
+        GXSetTevAlphaIn(GX_TEVSTAGE1, GX_CA_ZERO, GX_CA_TEXA, GX_CA_ONE,
+                        GX_CA_APREV);
+        GXSetTevAlphaOp(GX_TEVSTAGE1, GX_TEV_SUB, GX_TB_ZERO, GX_CS_SCALE_1,
+                        GX_FALSE, GX_TEVPREV);
+        GXSetTevKColorSel(GX_TEVSTAGE1, GX_TEV_KCSEL_K1);
+        GXSetTevKAlphaSel(GX_TEVSTAGE1, GX_TEV_KASEL_K1_A);
+        GXSetTevSwapMode(GX_TEVSTAGE1, GX_TEV_SWAP0, GX_TEV_SWAP0);
+
+        GXSetTevOrder(GX_TEVSTAGE2, GX_TEXCOORD0, GX_TEXMAP0, GX_COLOR_NULL);
+        GXSetTevColorIn(GX_TEVSTAGE2, GX_CC_ZERO, GX_CC_TEXC, GX_CC_ONE,
+                        GX_CC_CPREV);
+        GXSetTevColorOp(GX_TEVSTAGE2, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1,
+                        GX_TRUE, GX_TEVPREV);
+        GXSetTevAlphaIn(GX_TEVSTAGE2, GX_CA_TEXA, GX_CA_ZERO, GX_CA_ZERO,
+                        GX_CA_APREV);
+        GXSetTevAlphaOp(GX_TEVSTAGE2, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1,
+                        GX_TRUE, GX_TEVPREV);
+        GXSetTevSwapMode(GX_TEVSTAGE2, GX_TEV_SWAP0, GX_TEV_SWAP0);
+
+        GXSetTevOrder(GX_TEVSTAGE3, GX_TEXCOORD_NULL, GX_TEXMAP_NULL,
+                      GX_COLOR_NULL);
+        GXSetTevColorIn(GX_TEVSTAGE3, GX_CC_APREV, GX_CC_CPREV, GX_CC_QUARTER,
+                        GX_CC_ZERO);
+        GXSetTevColorOp(GX_TEVSTAGE3, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1,
+                        GX_TRUE, GX_TEVPREV);
+        GXSetTevAlphaIn(GX_TEVSTAGE3, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO,
+                        GX_CA_ZERO);
+        GXSetTevAlphaOp(GX_TEVSTAGE3, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1,
+                        GX_TRUE, GX_TEVPREV);
+        GXSetTevSwapMode(GX_TEVSTAGE3, GX_TEV_SWAP0, GX_TEV_SWAP0);
+        GXSetTevKColorSel(GX_TEVSTAGE3, GX_TEV_KCSEL_K2);
+
+        GXSetAlphaCompare(GX_ALWAYS, 0, GX_AOP_OR, GX_ALWAYS, 0);
+
+        ((u32*) &tev_color)[0] = HSD_SObjLib_804DEA80;
+        ((u32*) &tev_color)[1] = HSD_SObjLib_804DEA84;
+        GXSetTevColorS10(GX_TEVREG0, tev_color);
+
+        *(u32*) &k_color = HSD_SObjLib_804DEA88;
+        GXSetTevKColor(GX_KCOLOR0, k_color);
+        *(u32*) &k_color = HSD_SObjLib_804DEA8C;
+        GXSetTevKColor(GX_KCOLOR1, k_color);
+        *(u32*) &k_color = HSD_SObjLib_804DEA90;
+        GXSetTevKColor(GX_KCOLOR2, k_color);
+
+        GXSetTevSwapModeTable(GX_TEV_SWAP0, GX_CH_RED, GX_CH_GREEN, GX_CH_BLUE,
+                              GX_CH_ALPHA);
+        GXSetBlendMode(GX_BM_NONE, GX_BL_ONE, GX_BL_ZERO, GX_LO_CLEAR);
+    } else {
+        GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD0, GX_TEXMAP0, GX_COLOR0A0);
+        if (sobj->x40 & 4) {
+            GXLoadTexObj(&sobj->x7C_texobj, GX_TEXMAP1);
+            GXSetTevOrder(GX_TEVSTAGE1, GX_TEXCOORD0, GX_TEXMAP1, GX_COLOR0A0);
+        }
+        GXSetAlphaCompare(GX_ALWAYS, 0, GX_AOP_OR, GX_ALWAYS, 0);
+
+        if (sobj->x40 & 4) {
+            GXColor z_color = sobj->x3C_color;
+
+            GXSetTevColor(GX_TEVREG0, z_color);
+            GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_ZERO, GX_CC_TEXC, GX_CC_C0,
+                            GX_CC_ZERO);
+            GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO,
+                            GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+            GXSetTevColorIn(GX_TEVSTAGE1, GX_CC_ZERO, GX_CC_ZERO, GX_CC_ZERO,
+                            GX_CC_CPREV);
+            GXSetTevColorOp(GX_TEVSTAGE1, GX_TEV_ADD, GX_TB_ZERO,
+                            GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+            GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO,
+                            GX_CA_A0);
+            GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO,
+                            GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+            GXSetTevAlphaIn(GX_TEVSTAGE1, GX_CA_ZERO, GX_CA_ZERO, GX_CA_ZERO,
+                            GX_CA_A0);
+            GXSetTevAlphaOp(GX_TEVSTAGE1, GX_TEV_ADD, GX_TB_ZERO,
+                            GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+            GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA,
+                           GX_LO_CLEAR);
+        } else {
+            switch (tex_fmt) {
+            case GX_TF_I4:
+            case GX_TF_I8:
+                GXSetTevColor(GX_TEVREG0, sobj->x38_color);
+                GXSetTevColor(GX_TEVREG1, sobj->x3C_color);
+                GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_C0, GX_CC_C1, GX_CC_TEXC,
+                                GX_CC_ZERO);
+                GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO,
+                                GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+                GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_ZERO,
+                                GX_CA_ZERO, GX_CA_TEXA);
+                GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO,
+                                GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+                break;
+            case GX_TF_IA4:
+            case GX_TF_IA8:
+                GXSetTevColor(GX_TEVREG0, sobj->x38_color);
+                GXSetTevColor(GX_TEVREG1, sobj->x3C_color);
+                GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_C0, GX_CC_C1, GX_CC_TEXC,
+                                GX_CC_ZERO);
+                GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO,
+                                GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+                GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_ZERO,
+                                GX_CA_ZERO, GX_CA_TEXA);
+                GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO,
+                                GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+                break;
+            case GX_TF_RGB565:
+                GXSetTevColor(GX_TEVREG0, sobj->x3C_color);
+                GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_ZERO, GX_CC_TEXC, GX_CC_C0,
+                                GX_CC_ZERO);
+                GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO,
+                                GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+                GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_ZERO,
+                                GX_CA_ZERO, GX_CA_A0);
+                GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO,
+                                GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+                break;
+            case GX_TF_RGB5A3:
+            case GX_TF_RGBA8:
+            case GX_TF_C4:
+            case GX_TF_C8:
+            case GX_TF_C14X2:
+            case GX_TF_CMPR:
+                GXSetTevColor(GX_TEVREG0, sobj->x3C_color);
+                GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_ZERO, GX_CC_TEXC, GX_CC_C0,
+                                GX_CC_ZERO);
+                GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO,
+                                GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+                GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_TEXA, GX_CA_A0,
+                                GX_CA_ZERO);
+                GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO,
+                                GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+                break;
+            }
+            GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA,
+                           GX_LO_CLEAR);
+        }
+    }
+
+    sin_half = HSD_SObjLib_804DEA94 * sinf(sobj->x18);
+    angle = sobj->x18;
+    cos_val = cosf(angle);
+    cos_half = HSD_SObjLib_804DEA94 * -cos_val;
+    width = (f32) obj_width * sobj->x1C;
+    height = (f32) obj_height * sobj->x20;
+    x_sin = sin_half * width;
+    x_cos = cos_half * width;
+    y_sin = sin_half * height;
+    y_cos = cos_half * height;
+
+    GXBegin(GX_QUADS, GX_VTXFMT0, 4);
+    left_y = origin_y + y_cos;
+    right_x = origin_x + y_sin;
+    right_y = origin_y - y_cos;
+    GXPosition2f32(x_cos + right_x, -(left_y - x_sin));
+    left_x = origin_x - y_sin;
+    tex_t = sobj->x28;
+    tex_s = sobj->x24;
+    GXTexCoord2f32(tex_s, tex_t);
+
+    GXPosition2f32(right_x - x_cos, -(x_sin + left_y));
+    tex_s_max = sobj->x2C;
+    GXTexCoord2f32(tex_s_max, tex_t);
+
+    GXPosition2f32(left_x - x_cos, -(x_sin + right_y));
+    tex_t_max = sobj->x30;
+    GXTexCoord2f32(tex_s_max, tex_t_max);
+
+    GXPosition2f32(x_cos + left_x, -(right_y - x_sin));
+    GXTexCoord2f32(tex_s, tex_t_max);
+    GXEnd();
+
+    if (sobj->x40 & 4) {
+        GXSetZTexture(GX_ZT_DISABLE, GX_TF_Z24X8, 0);
+    }
+    HSD_StateInvalidate(-1);
+    HSD_StateInitTev();
+    HSD_ClearVtxDesc();
+    HSD_StateSetZMode(1, GX_LEQUAL, 1);
+}
+
+const s32 HSD_SObjLib_804DEA80 = 0xFFA60000;
+const s32 HSD_SObjLib_804DEA84 = 0xFF8E0087;
+const s32 HSD_SObjLib_804DEA88 = 0xE258;
+const s32 HSD_SObjLib_804DEA8C = 0xB30000B6;
+const s32 HSD_SObjLib_804DEA90 = 0xFF00FF80;
+const f32 HSD_SObjLib_804DEA94 = 0.5F;
+const f32 HSD_SObjLib_804DEA98 = 2.0F;
 
 static HSD_Chan lbl_8040C418 = {
     NULL,       GX_COLOR0,  0,          { 0 },         { 0xFF, 0xFF, 0xFF },
@@ -207,8 +582,6 @@ void HSD_SObjLib_803A54EC(HSD_GObj* gobj, int unused)
     HSD_StateSetZMode(1, 3, 1);
 }
 
-/* @todo 99.84% match - near_val variable forces 6 FPR saves but adds
- * 4 bytes to stack, shifting local offsets by 4 */
 void HSD_SObjLib_803A55DC(HSD_GObj* gobj, u16 width, u16 height, int priority)
 {
     HSD_CObj* cobj;
@@ -219,7 +592,7 @@ void HSD_SObjLib_803A55DC(HSD_GObj* gobj, u16 width, u16 height, int priority)
 
     f32 roll = 0.0F;
     f32 near_val = roll;
-    f32 far_val = 2.0f;
+    f32 far_val = *(volatile const f32*) &HSD_SObjLib_804DEA98;
     f32 top = roll;
     f32 bottom = -height;
     f32 left = roll;

--- a/src/sysdolphin/baselib/sobjlib.h
+++ b/src/sysdolphin/baselib/sobjlib.h
@@ -3,14 +3,19 @@
 
 #include <placeholder.h>
 
-#include "dolphin/gx/GXStruct.h"
-
 #include <sysdolphin/baselib/forward.h>
 
+#include <dolphin/gx/GXStruct.h>
 #include <sysdolphin/baselib/gobj.h>
 
 extern GObjFuncs HSD_SObjLib_8040C3A4;
 extern u8 HSD_SObjLib_804D7960;
+
+typedef struct HSD_SObjDesc {
+    /* 0x00 */ HSD_ImageDesc* image;
+    /* 0x04 */ struct _HSD_Tlut* tlut;
+    /* 0x08 */ HSD_ImageDesc* image2;
+} HSD_SObjDesc;
 
 struct HSD_SObj {
     /* 0x00 */ void* x0;
@@ -28,14 +33,24 @@ struct HSD_SObj {
     /* 0x30 */ f32 x30;
     /* 0x34 */ u16 x34;
     /* 0x36 */ u16 x36;
-    /* 0x38 */ u8 x38;
-    /* 0x39 */ u8 x39;
-    /* 0x3A */ u8 x3A;
-    /* 0x3B */ u8 x3B;
-    /* 0x3C */ u8 x3C;
-    /* 0x3D */ u8 x3D;
-    /* 0x3E */ u8 x3E;
-    /* 0x3F */ u8 x3F;
+    /* 0x38 */ union {
+        GXColor x38_color;
+        struct {
+            u8 x38;
+            u8 x39;
+            u8 x3A;
+            u8 x3B;
+        };
+    };
+    /* 0x3C */ union {
+        GXColor x3C_color;
+        struct {
+            u8 x3C;
+            u8 x3D;
+            u8 x3E;
+            u8 x3F;
+        };
+    };
     /* 0x40 */ u32 x40;
     /* 0x44 */ u8 x44;
     /* 0x48 */ u32 x48;
@@ -51,8 +66,14 @@ typedef HSD_SObj HSD_SObj_803A477C_t;
 /* 3A44D4 */ void HSD_SObjLib_803A44D4(HSD_GObj*, HSD_SObj*, u8);
 /* 3A466C */ void HSD_SObjLib_803A466C(HSD_SObj*);
 /* 3A4740 */ void HSD_SObjLib_803A4740(HSD_SObj*);
+#ifdef SOBJLIB_INTERNAL
+/* 3A477C */ HSD_SObj* HSD_SObjLib_803A477C(HSD_GObj*, HSD_SObjDesc*,
+                                            GXTexWrapMode, GXTexWrapMode, u8,
+                                            u8);
+#else
 /* 3A477C */ HSD_SObj* HSD_SObjLib_803A477C(HSD_GObj*, int, int, int, int,
                                             int);
+#endif
 /* 3A49E0 */ void HSD_SObjLib_803A49E0(HSD_GObj*, int);
 /* 3A4A68 */ void HSD_SObjLib_803A4A68(HSD_SObj*);
 /* 3A54EC */ void HSD_SObjLib_803A54EC(HSD_GObj*, int);

--- a/src/sysdolphin/baselib/tobj.c
+++ b/src/sysdolphin/baselib/tobj.c
@@ -1215,8 +1215,8 @@ void HSD_TObjSetup(HSD_TObj* tobj)
             }
 
             GXInitTexObjCI(&texobj, imagedesc->image_ptr, imagedesc->width,
-                           imagedesc->height, (GXCITexFmt) imagedesc->format,
-                           tobj->wrap_s, tobj->wrap_t,
+                           imagedesc->height, imagedesc->format, tobj->wrap_s,
+                           tobj->wrap_t,
                            imagedesc->mipmap ? GX_TRUE : GX_FALSE,
                            tlut->tlut_name);
             if (min_filter == GX_LIN_MIP_LIN) {


### PR DESCRIPTION
## Summary
- Decompile HSD_SObjLib_803A477C at 100%
- Decompile HSD_SObjLib_803A55DC at 100%
- Add a near-match for HSD_SObjLib_803A4A68 at 99.88707%
- Add SObj descriptor/color typing used by the new implementations

## Verification
- pre-commit run --files src/sysdolphin/baselib/sobjlib.c src/sysdolphin/baselib/sobjlib.h
- python configure.py && ninja (passed in the dev worktree using wibo)
- ninja build/GALE01/src/sysdolphin/baselib/sobjlib.o
- objdiff: 803A477C 100%, 803A4A68 99.88707%, 803A55DC 100%; .data/.sdata2 100%

Note: a clean upstream-branch full rebuild locally hit the known Wine server crash path after rebuilding hundreds of objects; the changed object and the full dev-worktree build both pass.