### PR TITLE
Match progress

### DIFF
--- a/src/melee/gm/gm_1B03.c
+++ b/src/melee/gm/gm_1B03.c
@@ -692,43 +692,40 @@ void gm_801B0CF0(GameScene* arg0)
     }
 }
 
-typedef struct GmB03MatchData {
-    /* 0x0 */ u8 x0;
-    /* 0x1 */ s8 x1;
-    /* 0x2 */ s8 x2;
-    /* 0x3 */ s8 x3;
-    /* 0x4 */ s8 x4;
-    /* 0x5 */ u8 pad5[3];
-    /* 0x8 */ MatchEnd me;
-} GmB03MatchData;
-
 void gm_801B0DD0(GameScene* arg0)
 {
-    GmB03MatchData* data = gm_801A427C(arg0);
-    MatchEnd* me = &data->me;
-    s32 i;
+    u64 sfx_result = 0;
+    int i;
+    struct DebugResultsData* data = gm_801A427C(arg0);
+    MatchEnd* match_end = &data->match_end;
 
-    data->x0 = (data->x0 & ~0x80) | ((un_803FA258[0x178 / 4] << 7) & 0x80);
-    data->x0 = (data->x0 & ~0x40) | ((un_803FA258[0x17C / 4] << 6) & 0x40);
-    data->x1 = un_803FA258[0x168 / 4];
-    data->x2 = un_803FA258[0x16C / 4];
-    data->x3 = un_803FA258[0x170 / 4];
-    data->x4 = un_803FA258[0x174 / 4];
-    gm_80166A98(me, un_803FA258[0x180 / 4], un_803FA258[0x144 / 4],
-                un_803FA258[0x158 / 4] - 1, un_803FA258[0x148 / 4],
-                un_803FA258[0x15C / 4] - 1, un_803FA258[0x14C / 4],
-                un_803FA258[0x160 / 4] - 1, un_803FA258[0x150 / 4],
-                un_803FA258[0x164 / 4] - 1);
+    data->x0_0 = un_803FA258[0x5E];
+    data->x0_1 = un_803FA258[0x5F];
+    data->x1 = un_803FA258[0x5A];
+    data->x2 = un_803FA258[0x5B];
+    data->x3 = un_803FA258[0x5C];
+    data->x4 = un_803FA258[0x5D];
+
+    gm_80166A98(match_end, un_803FA258[0x60] & 0xFF, (s8) un_803FA258[0x51],
+                un_803FA258[0x56] - 1, (s8) un_803FA258[0x52],
+                un_803FA258[0x57] - 1, (s8) un_803FA258[0x53],
+                un_803FA258[0x58] - 1, (s8) un_803FA258[0x54],
+                un_803FA258[0x59] - 1);
+
     for (i = 0; i < 4; i++) {
-        if (me->player_standings[i].slot_type != 3 &&
-            me->player_standings[i].is_big_loser == 0) {
-            lbAudioAx_80026E84(me->player_standings[i].character_kind);
+        if (match_end->player_standings[i].slot_type != 3 &&
+            match_end->player_standings[i].is_big_loser == 0)
+        {
+            sfx_result |= lbAudioAx_80026E84(
+                match_end->player_standings[i].character_kind);
         }
     }
+
     lbAudioAx_80026F2C(0x14);
-    lbAudioAx_8002702C(4, 0);
+    lbAudioAx_8002702C(0x4, sfx_result);
     gm_80168FC4();
     gm_801701A0();
+    PAD_STACK(8);
 }
 
 void gm_801B0F1C(GameScene* arg0)

--- a/src/melee/gm/gm_1B03.static.h
+++ b/src/melee/gm/gm_1B03.static.h
@@ -5,7 +5,15 @@
 #include "gm/types.h"
 
 struct DebugResultsData {
-    u8 pad_x0[0x2284];
+    u8 x0_0 : 1;
+    u8 x0_1 : 1;
+    u8 x0_other : 6;
+    u8 x1;
+    u8 x2;
+    u8 x3;
+    u8 x4;
+    u8 pad_x5[3];
+    MatchEnd match_end;
 }; /// data used by gm_801B0DD0
 
 struct DebugMemcardData {


### PR DESCRIPTION
## Progress

**1** matched, **107** failed

### Matched
| File | Function | Status |
|------|----------|--------|
| `gm_1B03.c` | `gm_801B0DD0` | ✓ 100% |

### Failed
- `grPura_80212FC0` — best 10.3%)
10.3%
- `ftKb_SpecialN_800F11F0` — best ?%
- `gm_801B59AC` — best ?%
- `ftCo_800B6208` — best ?%
- `fn_8024FD40` — best 27.9%
- `gmClassic_801B3A34` — best ?%
- `ftKb_SpecialN_800EEC34` — best ?%
- `un_803067BC` — best ?%
- `un_80311960` — best %
- `grAnime_801C8578` — best %
- `fn_800DA8E4` — best %
- `fn_80165548` — best %
- `fn_80160DE8` — best %
- `un_80307470` — best %
- `un_802FF9DC` — best %
- `fn_80167638` — best %
- `grIceMt_801F993C` — best %
- `ifStatus_802F6EA4` — best %
- `gm_8016260C` — best %
- `fn_800D9CE8` — best %
- `gm_80168710` — best %
- `grPura_802120E0` — best %
- `fn_802192A4` — best %
- `grInishie1_801FC4A0` — best %
- `fn_80169A84` — best %
- `ftKb_SpecialLw1_Coll` — best %
- `fn_801F8E58` — best %
- `fn_801656A8` — best %
- `gm_8016AC44` — best %
- `gm_801A9DD0` — best %
- `grPura_80212CD4` — best %
- `grAnime_801C752C` — best %
- `fn_80162170` — best %
- `fn_8016588C` — best %
- `fn_80169000` — best %
- `fn_80165FA4` — best %
- `ftCo_800A4E8C` — best %
- `ftCo_800A4768` — best %
- `ftCo_800AEA8C` — best %
- `ftCo_800A648C` — best %
- `gm_801BCC9C` — best %
- `ftCo_800B04DC` — best %
- `un_8031D9F8` — best %
- `gm_801B1C24` — best %
- `ftCo_800A6A98` — best %
- `ftCo_800A6D2C` — best %
- `grHeal_8021F180` — best %
- `fn_80165AC0` — best %
- `ftCo_800A4BEC` — best %
- `grIceMt_801FA0BC` — best %
- `un_802FFF2C` — best %
- `ftCo_800A61D8` — best %
- `ftCo_800AECF0` — best %
- `gm_801BF128` — best %
- `ftCo_800A866C` — best %
- `ftCo_800AEFB8` — best %
- `ftCo_800B1EF0` — best %
- `ftCo_800B24B8` — best %
- `ftCo_800AE7AC` — best %
- `ftCo_800B17D0` — best %
- `ftCo_800B1AB8` — best %
- `ftCo_800B21C8` — best %
- `fn_80169C54` — best %
- `gm_801BB758` — best %
- `grZebesRoute_8020B548` — best %
- `ftKb_SpecialAirNCaptureWait_IASA` — best %
- `fn_800D9930` — best %
- `ftKb_SpecialAirLwStart_Coll` — best %
- `gm_801BBB64` — best %
- `ftCo_8009E7B4` — best %
- `grInishie1_801FC664` — best %
- `ftKb_SpecialAirLw_Coll` — best %
- `ftCo_800B2790` — best %
- `ftCo_800A6700` — best %
- `fn_80164B48` — best %
- `fn_80161C90` — best %
- `grAnime_801C7C1C` — best %
- `ftKb_EatWait_IASA` — best %
- `ftCo_800A8210` — best %
- `fn_8016A4C8` — best %
- `gm_80166CCC` — best %
- `gm_801BC00C` — best %
- `ftCo_800A229C` — best %
- `ftCo_800A8940` — best %
- `ftCo_800A2C80` — best %
- `ftCo_800A75DC` — best %
- `gm_801BDE94` — best %
- `ftCo_800AF290` — best %
- `ftCo_800B33B0` — best %
- `ftCo_800A6FC4` — best %
- `ftCo_800A7AAC` — best %
- `grPushOn_80218888` — best %
- `gm_80166378` — best %
- `ftCo_800A3908` — best %
- `ftCo_800A4038` — best %
- `ftCo_800B5AB0` — best %
- `ftCo_800ABBA8` — best %
- `ftCo_800B4AB0` — best %
- `ftCo_800B52AC` — best %
- `ftCo_800B2AFC` — best %
- `ftCo_800ADE48` — best %
- `gm_801BAD70` — best %
- `fn_80161154` — best %
- `grBigBlueRoute_8020CD20` — best %
- `ftCo_800B77E8` — best %
- `fn_8018B090` — best %
- `fn_80039618` — best %

## What these functions do
**gm_1B03.c** — Debug results screen — loads cached match parameters from the sound test/debug menu into the results scene, rebuilds the four-player standings, then plays the character-specific results victory fanfare.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)