### PR TITLE
gr: match grheal

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1023,7 +1023,7 @@ config.libs = [
             Object(Matching, "melee/gr/grbattle.c"),
             Object(Matching, "melee/gr/grlast.c"),
             Object(NonMatching, "melee/gr/grhomerun.c"),
-            Object(NonMatching, "melee/gr/grheal.c"),
+            Object(Matching, "melee/gr/grheal.c"),
             # Break the Targets stages
             Object(Matching, "melee/gr/grtmario.c"),
             Object(Matching, "melee/gr/grtcaptain.c"),

--- a/src/melee/gr/grheal.c
+++ b/src/melee/gr/grheal.c
@@ -19,17 +19,40 @@
 #include "gr/grzakogenerator.h"
 #include "gr/inlines.h"
 #include "gr/stage.h"
+#include "if/textlib.h"
 #include "it/it_26B1.h"
+#include "it/items/itcoin.h"
 #include "it/types.h"
 #include "lb/lb_00B0.h"
 #include "lb/lb_00F9.h"
+#include "mp/mplib.h"
 
-struct {
-    int x0;
-    int x4;
-}* yaku;
+typedef struct grHeal_UnkVec4 {
+    Vec3 pos;
+    s32 unused;
+} grHeal_UnkVec4;
 
-static s32 grHeal_803E83B8[0x27] = {
+typedef struct grHeal_DataBlock {
+    s16 player_model_joint_ids[0x1A];
+    s32 next_player_character_ids[0x1A];
+    StageCallbacks callbacks[5];
+    char stage_filename[0xC];
+    StageData stage_data;
+    char report_fmt_get_gobj[0x24];
+    char assert_filename[0xC];
+    char report_fmt_not_found_next_player[0x20];
+} grHeal_DataBlock;
+STATIC_ASSERT(sizeof(grHeal_DataBlock) == 0x190);
+
+typedef struct grHeal_StageData {
+    StageData stage_data;
+    char report_fmt_get_gobj[0x24];
+} grHeal_StageData;
+STATIC_ASSERT(sizeof(grHeal_StageData) == 0x58);
+
+const grHeal_UnkVec4 grHeal_803B84A8 = { { 0.0F, 40.0F, 0.0F }, 0 };
+
+s32 grHeal_803E83B8[0x27] = {
     0x1D001E, 0x1F0020, 0x210022, 0x230024, 0x250026, 0x270028, 0x29002A,
     0x2B002C, 0x2D002E, 0x2F0030, 0x310032, 0x330034, 0x350036, 0,
     0x15,     1,        0x16,     0x14,     2,        0x19,     3,
@@ -38,7 +61,7 @@ static s32 grHeal_803E83B8[0x27] = {
     0x11,     0x12,     0x17,     -1,
 };
 
-static StageCallbacks grHeal_803E8454[] = {
+StageCallbacks grHeal_803E8454[] = {
     {
         grHeal_8021F0D8,
         grHeal_8021F170,
@@ -76,37 +99,38 @@ static StageCallbacks grHeal_803E8454[] = {
     },
 };
 
-static StageData grHeal_803E84C4 = {
-    HEAL,
-    grHeal_803E8454,
-    "/GrHe.dat",
-    grHeal_8021EF3C,
-    grHeal_8021EF38,
-    grHeal_8021EFBC,
-    grHeal_8021EFC0,
-    grHeal_8021EFE4,
-    grHeal_8021F830,
-    grHeal_8021F838,
-    1,
-    0,
-    0,
+grHeal_StageData grHeal_803E84C4 = {
+    {
+        HEAL,
+        grHeal_803E8454,
+        "/GrHe.dat",
+        grHeal_8021EF3C,
+        grHeal_8021EF38,
+        grHeal_8021EFBC,
+        grHeal_8021EFC0,
+        grHeal_8021EFE4,
+        grHeal_8021F830,
+        grHeal_8021F838,
+        1,
+        0,
+        0,
+    },
+    "%s:%d: couldn t get gobj(id=%d)\n",
 };
 
-static char grHeal_803E851C[0x2C] = {
-    0x67, 0x72, 0x68, 0x65, 0x61, 0x6C, 0x2E, 0x63, 0,    0,    0,
-    0,    0x2A, 0x2A, 0x2A, 0x20, 0x4E, 0x6F, 0x74, 0x20, 0x66, 0x6F,
-    0x75, 0x6E, 0x64, 0x20, 0x4E, 0x65, 0x78, 0x74, 0x20, 0x50, 0x6C,
-    0x61, 0x79, 0x65, 0x72, 0x21, 0x28, 0x25, 0x64, 0x29, 0xA,  0,
-};
+char grHeal_803E851C[0x2C] =
+    "grheal.c\0\0\0\0*** Not found Next Player!(%d)\n";
 
-extern struct yaku* grHeal_804D6AF0;
-extern s16 grHeal_804D49D8[4];
+s16 grHeal_804D49D8[4] = { 7, 8, 9, 0 };
+SDATA char grHeal_804D49E0[] = "gobj";
+
+grHeal_UnkData* grHeal_804D6AF0[2];
 
 void grHeal_8021EF38(bool arg0) {}
 
 void grHeal_8021EF3C(void)
 {
-    grHeal_804D6AF0 = Ground_801C49F8();
+    grHeal_804D6AF0[0] = Ground_801C49F8();
     stage_info.unk8C.b4 = false;
     stage_info.unk8C.b5 = true;
 
@@ -133,7 +157,8 @@ bool grHeal_8021EFE4(void)
 Ground_GObj* grHeal_8021EFEC(u32 idx)
 {
     HSD_GObj* gobj;
-    StageCallbacks* callbacks = &grHeal_803E8454[idx];
+    StageCallbacks* callbacks =
+        (StageCallbacks*) ((char*) grHeal_803E83B8 + 0x9C) + idx;
 
     gobj = Ground_GetStageGObj(idx);
 
@@ -156,7 +181,8 @@ Ground_GObj* grHeal_8021EFEC(u32 idx)
         }
 
     } else {
-        OSReport("%s:%d: couldn t get gobj(id=%d)\n", __FILE__, 273, idx);
+        OSReport(grHeal_803E84C4.report_fmt_get_gobj, grHeal_803E851C, 273,
+                 idx);
     }
 
     return gobj;
@@ -169,7 +195,7 @@ void grHeal_8021F0D8(Ground_GObj* gobj)
 
     grAnime_801C8138(gobj, gp->map_id, 0);
 
-    for (i = 0; i < *(s32*) grHeal_804D6AF0; i++) {
+    for (i = 0; i < grHeal_804D6AF0[0]->x0; i++) {
         if ((int) gm_80473A18.x90[i] != 0) {
             grHeal_8021F79C(8, grHeal_804D49D8[i], i);
         }
@@ -185,7 +211,60 @@ void grHeal_8021F178(Ground_GObj* gobj) {}
 
 void grHeal_8021F17C(Ground_GObj* gobj) {}
 
-/// #grHeal_8021F180
+void grHeal_8021F180(Ground_GObj* gobj)
+{
+    grHeal_UnkVec4 coin_pos;
+    u8 next_players[4];
+    HSD_JObj* next_jobjs[3];
+    UNUSED HSD_JObj* reserved_next_jobj;
+    HSD_JObj* player_jobjs[0x1A];
+    UNUSED HSD_JObj* reserved_player_jobj;
+    s32 next_count;
+    s32 line_id;
+    s32 next_idx;
+    u32 i;
+    Ground* gp;
+
+    gp = GET_GROUND(gobj);
+    grAnime_801C8138(gobj, gp->map_id, 0);
+
+    if (gm_80473A18._94[0] % grHeal_804D6AF0[0]->x4 == 0) {
+        coin_pos.pos = grHeal_803B84A8.pos;
+        Ground_801C2D24(0xDC, &coin_pos.pos);
+        line_id = Ground_801C5840();
+        if (line_id != -1) {
+            it_802F2094(NULL, &coin_pos.pos, line_id, 0);
+            un_80304A58(line_id);
+        }
+    }
+
+    for (next_count = 0; next_count < (s32) gm_80473A18._94[1]; next_count++) {
+        next_players[next_count] = gm_80473A18._94[next_count + 2];
+    }
+
+    next_jobjs[0] = Ground_801C3FA4(gobj, 0x3A);
+    next_jobjs[1] = Ground_801C3FA4(gobj, 0x3B);
+    next_jobjs[2] = Ground_801C3FA4(gobj, 0x3C);
+
+    for (next_idx = 0; next_idx < next_count; next_idx++) {
+        grHeal_8021F4E8(grHeal_8021F70C(next_players[next_idx]),
+                        next_jobjs[next_idx]);
+    }
+
+    for (i = 0; i < 0x1A; i++) {
+        player_jobjs[i] = Ground_801C3FA4(gobj, ((s16*) grHeal_803E83B8)[i]);
+    }
+
+    for (i = 0; i < 0x1A; i++) {
+        u32 character_id = gm_80473A18.x76[i];
+        if ((s32) character_id != 0x21) {
+            grHeal_8021F628(grHeal_8021F70C(character_id), player_jobjs[i]);
+        }
+    }
+
+    mpJointSetCb1(0, gp, (mpLib_Callback) fn_8021F4C0);
+    gp->gv.flatzone2.xC4 = 0;
+}
 
 bool grHeal_8021F41C(Ground_GObj* gobj)
 {
@@ -212,7 +291,7 @@ void grHeal_8021F474(Ground_GObj* ground)
     Ground* gp;
 
     gp = ground->user_data;
-    Ground_801C3D44(fn_8021F424, 10.0f, 20.0f);
+    Ground_801C3D44(fn_8021F424, 10.0F, 20.0F);
     lb_800115F4();
     gp->gv.flatzone2.xC4 = 0;
 }
@@ -236,10 +315,10 @@ void grHeal_8021F4E8(s32 arg0, HSD_JObj* parent_jobj)
 
     ground = grHeal_8021EFEC(4U);
     if (ground == NULL) {
-        __assert(grHeal_803E851C, 0x1B8U, "gobj");
+        __assert(grHeal_803E851C, 0x1B8U, grHeal_804D49E0);
     }
     grAnime_801C8138(ground, 4, 0);
-    grAnime_801C7FF8(ground, 0, 7, 0, (f32) arg0, 0.0f);
+    grAnime_801C7FF8(ground, 0, 7, 0, (f32) arg0, 0.0F);
     jobj = GET_JOBJ(ground);
     child = HSD_JObjGetChild(jobj);
     HSD_JObjReparent(child, parent_jobj);
@@ -284,10 +363,10 @@ void grHeal_8021F628(s32 arg0, HSD_JObj* jobj_parent)
 
     ground = grHeal_8021EFEC(2U);
     if (ground == NULL) {
-        __assert(grHeal_803E851C, 0x201U, "gobj");
+        __assert(grHeal_803E851C, 0x201U, grHeal_804D49E0);
     }
     grAnime_801C8138(ground, 2, 0);
-    grAnime_801C7FF8(ground, 0, 7, 0, (f32) arg0, 0.0f);
+    grAnime_801C7FF8(ground, 0, 7, 0, (f32) arg0, 0.0F);
     jobj = GET_JOBJ(ground);
     child = HSD_JObjGetChild(jobj);
     HSD_JObjReparent(child, jobj_parent);
@@ -307,25 +386,43 @@ void grHeal_8021F708(Ground_GObj* gobj) {}
 
 u32 grHeal_8021F70C(u32 character_id)
 {
+    s32* base;
     s32* entry;
+    s32 value;
     int frame;
 
+    base = grHeal_803E83B8;
     frame = 0;
-    if ((s32) character_id == 0x13) {
-        character_id = 0x12;
+
+    if ((s32) character_id != 0x13) {
+        goto loop_start;
+    }
+    character_id = 0x12;
+    goto loop_start;
+
+loop_compare:
+    if ((s32) character_id == value) {
+        goto loop_done;
+    }
+    entry++;
+    frame++;
+loop_check:
+    value = *entry;
+    if (value != -1) {
+        goto loop_compare;
     }
 
-    entry = (s32*) &grHeal_803E851C[0xD];
-
-    while (entry[frame] != -1 && entry[frame] != character_id) {
-        frame++;
-    }
-
-    if (grHeal_803E83B8[frame] == -1) {
-        OSReport("*** Not found Next Player!(%d)\n", frame);
+loop_done:
+    if (base[frame + 0xD] == -1) {
+        OSReport(((grHeal_DataBlock*) base)->report_fmt_not_found_next_player,
+                 character_id);
         frame = 0;
     }
     return frame;
+
+loop_start:
+    entry = base + 0xD;
+    goto loop_check;
 }
 
 void grHeal_8021F79C(s32 arg0, s32 idx, s32 arg2)

--- a/src/melee/gr/grheal.h
+++ b/src/melee/gr/grheal.h
@@ -8,6 +8,11 @@
 #include "gr/forward.h"
 #include "lb/forward.h"
 
+typedef struct grHeal_UnkData {
+    s32 x0;
+    s32 x4;
+} grHeal_UnkData;
+
 /* 21EF38 */ void grHeal_8021EF38(bool);
 /* 21EF3C */ void grHeal_8021EF3C(void);
 /* 21EFBC */ void grHeal_8021EFBC(void);
@@ -42,5 +47,7 @@
 /* 21F79C */ void grHeal_8021F79C(s32, s32, s32);
 /* 21F830 */ DynamicsDesc* grHeal_8021F830(enum_t);
 /* 21F838 */ bool grHeal_8021F838(Vec3*, int, HSD_JObj*);
+
+/* 4D6AF0 */ extern grHeal_UnkData* grHeal_804D6AF0[2];
 
 #endif


### PR DESCRIPTION
Matches the remaining functions in `src/melee/gr/grheal.c` and moves the required data declarations into `src/melee/gr/grheal.h`.

Verification:
- `python configure.py && ninja`
- `main.dol: OK`
- `main/melee/gr/grheal`: 100.0% fuzzy, 34/34 matched