### PR TITLE
Match hsd_80394314

### DIFF
--- a/src/sysdolphin/baselib/particle.static.h
+++ b/src/sysdolphin/baselib/particle.static.h
@@ -75,7 +75,7 @@ extern int psNumTexGroup[65];
 static HSD_PSFormGroup** psFormGroupArray[65];
 
 /* 4CF7E8 */ static struct ParticleConsoleState hsd_804CF7E8;
-/* 4CF810 */ static struct ParticleScreenState hsd_804CF810;
+/* 4CF810 */ struct ParticleScreenState hsd_804CF810;
 /* 4D0908 */ static void* hsd_804D0908[146];
 /* 4D0B50 */ static HSD_PSTexGroup** psTexGroupArray[65];
 /* 4D0C54 */ static HSD_PSCmdList** psCmdListArray[65];


### PR DESCRIPTION
﻿Matches $(@{timestampUtc=2026-05-15T05:55:28.2966206Z; symbol=hsd_80394314; head=c59a5c65166d9572c40ca2eebb7b85fa23227540; model=manual-hermes-reverify; status=accepted-exact-match; sourcePath=src/sysdolphin/baselib/particle.c; percent=99.61; approxLines=34; attemptDir=D:\decomp\melee\artifacts\ai-attempts\20260515-015523_hsd_80394314; promptPath=D:\decomp\melee\artifacts\ai-attempts\20260515-015523_hsd_80394314\prompt.md; responsePath=; generatedPatch=D:\decomp\melee\artifacts\ai-attempts\20260513-030819_hsd_80394314\accepted.patch; verifierExitCode=0; verifierStatus=accepted-exact-match; acceptedPatch=D:\decomp\melee\artifacts\ai-attempts\20260515-015523_hsd_80394314\accepted.patch; error=}.symbol).

Verification:
- Base: $UpstreamRepo@c59a5c65166d9572c40ca2eebb7b85fa23227540
- Exact build SHA1: $ExpectedSha1
- Candidate source: $(@{symbol=hsd_80394314; status=queued; sourcePath=src/sysdolphin/baselib/particle.c; line=1961; signature=void hsd_80394314(void); percent=99.61; approxLines=34; reason=.bss.0 relocation symbol instead of; unit=main/sysdolphin/baselib/particle; targetPath=build/GALE01/obj/sysdolphin/baselib/particle.o; basePath=build/GALE01/src/sysdolphin/baselib/particle.o; ctxPath=build/GALE01/src/sysdolphin/baselib/particle.ctx; scratch=; claim=}.sourcePath)
- Changed files:
- `src/sysdolphin/baselib/particle.static.h`
- Local model: $(@{timestampUtc=2026-05-15T05:55:28.2966206Z; symbol=hsd_80394314; head=c59a5c65166d9572c40ca2eebb7b85fa23227540; model=manual-hermes-reverify; status=accepted-exact-match; sourcePath=src/sysdolphin/baselib/particle.c; percent=99.61; approxLines=34; attemptDir=D:\decomp\melee\artifacts\ai-attempts\20260515-015523_hsd_80394314; promptPath=D:\decomp\melee\artifacts\ai-attempts\20260515-015523_hsd_80394314\prompt.md; responsePath=; generatedPatch=D:\decomp\melee\artifacts\ai-attempts\20260513-030819_hsd_80394314\accepted.patch; verifierExitCode=0; verifierStatus=accepted-exact-match; acceptedPatch=D:\decomp\melee\artifacts\ai-attempts\20260515-015523_hsd_80394314\accepted.patch; error=}.model)
- Local proof artifact: $(@{timestampUtc=2026-05-15T05:55:28.2966206Z; symbol=hsd_80394314; head=c59a5c65166d9572c40ca2eebb7b85fa23227540; model=manual-hermes-reverify; status=accepted-exact-match; sourcePath=src/sysdolphin/baselib/particle.c; percent=99.61; approxLines=34; attemptDir=D:\decomp\melee\artifacts\ai-attempts\20260515-015523_hsd_80394314; promptPath=D:\decomp\melee\artifacts\ai-attempts\20260515-015523_hsd_80394314\prompt.md; responsePath=; generatedPatch=D:\decomp\melee\artifacts\ai-attempts\20260513-030819_hsd_80394314\accepted.patch; verifierExitCode=0; verifierStatus=accepted-exact-match; acceptedPatch=D:\decomp\melee\artifacts\ai-attempts\20260515-015523_hsd_80394314\accepted.patch; error=}.attemptDir)

This draft was prepared by the HERMES local Melee worker after exact-match verification.
