### PR TITLE
lb: improve lbsnap matching

### DIFF
--- a/src/melee/lb/lbsnap.c
+++ b/src/melee/lb/lbsnap.c
@@ -104,30 +104,35 @@ void lbSnap_8001D4A4(int chan, char* arg1)
     sprintf(arg1, "%u", time);
 }
 
+static inline void lbSnap_ClearText(char* text)
+{
+    int i;
+
+    for (i = 0; i < 0x21; i++) {
+        text[i] = '\0';
+    }
+}
+
 int lbSnap_8001D5FC(int chan, int index)
 {
     struct Unk80433380_48* ptr = &lbSnap_80433380.x48[chan];
     char text[0x21];
-    int i;
+    int ret;
     PAD_STACK(8);
 
     if (ptr->card_result == 0 && lbSnap_80433380.x54_stateChanged[chan] != 0) {
         ptr->card_result = 8;
     }
-    if (ptr->card_result == 0) {
+    ret = ptr->card_result;
+    if (ret == 0) {
         HSD_ASSERTMSG(410, index < lbSnap_80433380.x48[chan].num,
                       "index < _p(slot)[chan].num");
-        i = 0;
-        while (i < 0x21) {
-            text[i] = '\0';
-            i++;
-        }
+        lbSnap_ClearText(text);
         sprintf(text, "%u", lbSnap_80433380.x48[chan].entries[index].time);
         lbSnap_80433380.x48[chan].card_result = 8;
-        return lb_8001B99C(chan, text, 0);
-    } else {
-        return ptr->card_result;
+        ret = lb_8001B99C(chan, text, 0);
     }
+    return ret;
 }
 
 int lbSnap_8001D7B0(int chan, int index, int jndex)
@@ -136,35 +141,27 @@ int lbSnap_8001D7B0(int chan, int index, int jndex)
     char text1[0x21];
     char text2[0x21];
     char text3[0x21];
-    int i;
+    int ret;
     PAD_STACK(8);
 
     if (ptr->card_result == 0 && lbSnap_80433380.x54_stateChanged[chan] != 0) {
         ptr->card_result = 8;
     }
-    if (ptr->card_result == 0) {
+    ret = ptr->card_result;
+    if (ret == 0) {
         HSD_ASSERTMSG(410, index < lbSnap_80433380.x48[chan].num,
                       "index < _p(slot)[chan].num");
-        i = 0;
-        while (i < 0x21) {
-            text1[i] = '\0';
-            i++;
-        }
+        lbSnap_ClearText(text1);
         sprintf(text1, "%u", lbSnap_80433380.x48[chan].entries[index].time);
         HSD_ASSERTMSG(410, jndex < lbSnap_80433380.x48[chan].num,
                       "index < _p(slot)[chan].num");
-        i = 0;
-        while (i < 0x21) {
-            text2[i] = '\0';
-            i++;
-        }
+        lbSnap_ClearText(text2);
         sprintf(text2, "%u", lbSnap_80433380.x48[chan].entries[jndex].time);
         lbSnap_8001D4A4(chan, text3);
         lbSnap_80433380.x48[chan].card_result = 8;
-        return lb_8001C0F4(chan, text1, text2, text3, 0);
-    } else {
-        return ptr->card_result;
+        ret = lb_8001C0F4(chan, text1, text2, text3, 0);
     }
+    return ret;
 }
 
 /// RGB5A3:  A RRRRR GGGGG BBBBB
@@ -183,53 +180,53 @@ int lbSnap_8001D7B0(int chan, int index, int jndex)
     (((x) & RGB5A3_MASK_B) | (((x) >> 1) & (RGB5A3_MASK_R | RGB5A3_MASK_G)) | \
      RGB5A3_MASK_A)
 
+static inline int lbSnap_GetTiledRGBOffset(int x, int y, int tile_stride)
+{
+    return ((((x / 4) * tile_stride) + (y / 4)) << 5) + ((x % 4) * 8) +
+           ((y % 4) * 2);
+}
+
+static inline int lbSnap_GetTiledYOff(int tile_column, int y)
+{
+    return (((y / 4) + tile_column) << 5) + ((y % 4) * 2);
+}
+
 void lbSnap_8001DA5C(int arg0)
 {
-    int r4, r5, r6, r7, r9, r10, r25, r27, r28, ctr;
-    PAD_STACK(16);
+    u8* dst = (u8*) lbSnap_80433380.x44_LbMcSnap_MemSnapIconData[0];
+    int dst_x;
+    int ctr;
+    PAD_STACK(8);
 
-    r7 = 0;
-    for (r10 = 0; r10 < 32; r10++) {
-        r4 = r7 / 32;
-        r6 = r10 / 4 * 24;
-        r27 = (r4 + 138) / 4 * 160;
-        r5 = lbSnap_80433380.x44_LbMcSnap_MemSnapIconData[(r10 % 4) * 2];
-        r9 = 0;
-        r4 = 0;
+    for (dst_x = 0; dst_x < 32; dst_x++) {
+        int src_x = (dst_x * 204 / 32) + 138;
+        u8* dst_col = dst + ((dst_x % 4) * 8);
+        int tile_column = (dst_x / 4) * 24;
+        int dst_y = 0;
+        int src_y_accum = 0;
+        u16 pixel;
         for (ctr = 0; ctr < 32; ctr++) {
-            // converting r25 from RGB565 to RGB5A3
-            // keep B where it is
-            // rightshift R and G, discarding the bottom bit of G
-            // A is fixed fully opaque
+            pixel = *(u16*) &((u8*) arg0)[lbSnap_GetTiledRGBOffset(
+                src_x, src_y_accum / 64 + 96, 160)];
+            *(u16*) &dst_col[lbSnap_GetTiledYOff(tile_column, dst_y + 16)] =
+                RGB565_TO_RGB5A3(pixel);
+            src_y_accum += 448;
 
-            r28 = r4 / 64;
-            r25 = *(unsigned short*) (arg0 + (((((r28 + 96) / 4) + r27) << 5) +
-                                              (((r4 + 138) % 4) * 8) +
-                                              (((r28 + 96) % 4) * 2)));
-            *(unsigned short*) (r5 + (((((r9 + 16) / 4) + r6) << 5) +
-                                      (((r9 + 16) % 4) * 2))) =
-                RGB565_TO_RGB5A3(r25);
-            r4 += 448; // height in pixels?
+            pixel = *(u16*) &((u8*) arg0)[lbSnap_GetTiledRGBOffset(
+                src_x, src_y_accum / 64 + 96, 160)];
+            *(u16*) &dst_col[lbSnap_GetTiledYOff(tile_column, dst_y + 17)] =
+                RGB565_TO_RGB5A3(pixel);
+            src_y_accum += 448;
 
-            r28 = r4 / 64;
-            r25 = *(unsigned short*) (arg0 + (((((r28 + 96) / 4) + r27) << 5) +
-                                              (((r4 + 138) % 4) * 8) +
-                                              (((r28 + 96) % 4) * 2)));
-            *(unsigned short*) (r5 + (((((r9 + 17) / 4) + r6) << 5) +
-                                      (((r9 + 17) % 4) * 2))) =
-                RGB565_TO_RGB5A3(r25);
-            r4 += 448;
-
-            r9 += 2;
+            dst_y += 2;
         }
-        r7 += 204;
     }
 }
 
 int lbSnap_8001DC0C(int arg0)
 {
     OSTime ticks;
-    OSTime seconds;
+    u32 seconds;
     OSCalendarTime time;
     u32 i;
     char* text;
@@ -252,8 +249,7 @@ int lbSnap_8001DC0C(int arg0)
     lbSnap_8001DA5C(arg0);
     ticks = OSGetTime();
     seconds = OSTicksToSeconds(ticks);
-    ticks = OSSecondsToTicks(seconds);
-    OSTicksToCalendarTime(ticks, &time);
+    OSTicksToCalendarTime(OSSecondsToTicks((u64) seconds), &time);
     for (i = 0; i < sizeof(lbSnap_80433380.x4_string); i++) {
         lbSnap_80433380.x4_string[i] = 0;
     }
@@ -282,14 +278,17 @@ int lbSnap_8001DE8C(void* arg0)
     return ret;
 }
 
+static inline int lbSnap_GetSaveDataOffset(struct Unk80433380_0* snap)
+{
+    return snap->xC + ((int) &snap->x38 - (int) snap);
+}
+
 int lbSnap_8001DF20(void)
 {
-    // This is probably an offsetof call, but I don't know what pointer is in
-    // xC
-    lbSnap_803BACC8.x14 =
-        lbSnap_80433380.x0->xC +
-        ((int) &lbSnap_80433380.x0->x38 - (int) &lbSnap_80433380.x0->x0);
-    lbSnap_803BACC8.x1C = lbSnap_80433380.x0;
+    struct Unk80433380_0* snap = lbSnap_80433380.x0;
+
+    lbSnap_803BACC8.x14 = lbSnap_GetSaveDataOffset(snap);
+    lbSnap_803BACC8.x1C = snap;
     return lb_8001C4A8(&lbSnap_803BACC8.x14, &lbSnap_803BACC8);
 }
 
@@ -298,22 +297,19 @@ int lbSnap_8001DF6C(int chan)
     struct Unk80433380_48* ptr = &lbSnap_80433380.x48[chan];
     char text[0x21];
     int ret;
-    PAD_STACK(8);
 
     if (ptr->card_result == 0 && lbSnap_80433380.x54_stateChanged[chan] != 0) {
         ptr->card_result = 8;
     }
     ret = ptr->card_result;
     if (ret == 0) {
+        struct Unk803BACC8* desc = &lbSnap_803BACC8;
+        int chan_arg = chan;
         lbSnap_80433380.x48[chan].card_result = 8;
-        lbSnap_8001D4A4(chan, text);
-        // This is probably an offsetof call, but I don't know what pointer is
-        // in xC
-        lbSnap_803BACC8.x14 =
-            lbSnap_80433380.x0->xC +
-            ((int) &lbSnap_80433380.x0->x38 - (int) &lbSnap_80433380.x0->x0);
-        lbSnap_803BACC8.x1C = lbSnap_80433380.x0;
-        ret = lb_8001BB48(chan, text, &lbSnap_803BACC8.x14, &lbSnap_803BACC8,
+        lbSnap_8001D4A4(chan_arg, text);
+        desc->x14 = lbSnap_GetSaveDataOffset(lbSnap_80433380.x0);
+        desc->x1C = lbSnap_80433380.x0;
+        ret = lb_8001BB48(chan, text, &desc->x14, desc,
                           lbSnap_80433380.x4_string,
                           lbSnap_80433380.x44_LbMcSnap_MemSnapIconData[0],
                           lbSnap_80433380.x44_LbMcSnap_MemSnapIconData[1], 0);
@@ -324,30 +320,26 @@ int lbSnap_8001DF6C(int chan)
 int lbSnap_8001E058(int chan, int index)
 {
     struct Unk80433380_48* ptr = &lbSnap_80433380.x48[chan];
-    int i;
+    int ret;
     char text[0x21];
     PAD_STACK(8);
 
     if (ptr->card_result == 0 && lbSnap_80433380.x54_stateChanged[chan] != 0) {
         ptr->card_result = 8;
     }
-    if (ptr->card_result == 0) {
+    ret = ptr->card_result;
+    if (ret == 0) {
         HSD_ASSERTMSG(410, index < lbSnap_80433380.x48[chan].num,
                       "index < _p(slot)[chan].num");
-        i = 0;
-        while (i < 0x21) {
-            text[i] = '\0';
-            i++;
-        }
+        lbSnap_ClearText(text);
         sprintf(text, "%u", lbSnap_80433380.x48[chan].entries[index].time);
         lbSnap_803BACC8.x1C = lbSnap_80433380.x0;
-        return lb_8001BF04(chan, text, &lbSnap_803BACC8.x14,
-                           lbSnap_80433380.x4_string,
-                           lbSnap_80433380.x44_LbMcSnap_MemSnapIconData[0],
-                           lbSnap_80433380.x44_LbMcSnap_MemSnapIconData[1], 0);
-    } else {
-        return ptr->card_result;
+        ret = lb_8001BF04(chan, text, &lbSnap_803BACC8.x14,
+                          lbSnap_80433380.x4_string,
+                          lbSnap_80433380.x44_LbMcSnap_MemSnapIconData[0],
+                          lbSnap_80433380.x44_LbMcSnap_MemSnapIconData[1], 0);
     }
+    return ret;
 }
 
 int lbSnap_8001E204(void)

--- a/src/melee/lb/lbsnap.h
+++ b/src/melee/lb/lbsnap.h
@@ -26,7 +26,7 @@
 /* 01E204 */ int lbSnap_8001E204(void);
 /* 01E210 */ int lbSnap_8001E210(void);
 /* 01E218 */ void lbSnap_8001E218(void* arg0, Unk80433380_48* arg1);
-/* 01E27C */ UNK_RET lbSnap_8001E27C(UNK_PARAMS);
+/* 01E27C */ void lbSnap_8001E27C(void);
 /* 01E290 */ void lbSnap_8001E290(void);
 
 #endif


### PR DESCRIPTION
Improves `src/melee/lb/lbsnap.c` by replacing several placeholder signatures and lowering the remaining unmatched surface in `lbsnap` to two functions.

Verification:
- `python configure.py && ninja`
- `main/melee/lb/lbsnap`: 20/22 functions at 100%

Remaining blockers:
- `lbSnap_8001DA5C`: 55.87963%
- `lbSnap_8001DF20`: 98.15790% (register allocation only)