### PR TITLE
lb: improve lbheap matching

### DIFF
--- a/src/melee/lb/lbheap.c
+++ b/src/melee/lb/lbheap.c
@@ -9,15 +9,70 @@
 #include <baselib/memory.h>
 #include <melee/lb/lbmemory.h>
 
-struct {
+struct lbHeap_HeapDesc {
     u32 idx;
     u32 type;
     u32 prev_idx;
     u32 size;
-} lbHeap_803BA380[5] = {
+};
+
+struct lbHeap_HeapOffsetView {
+    u8 pad[0x10];
+    struct Heap heap;
+};
+
+struct lbHeap_HeapDesc lbHeap_803BA380[5] = {
     { 2, 1, 6, 0x800 },    { 3, 1, 2, 0x4F8800 }, { 4, 2, 6, 0x64B400 },
     { 5, 4, 6, 0x96C800 }, { 6, 0, 0, 0 },
 };
+
+#define lbHeap_GetHeapOffsetView(offset)                                      \
+    ((struct lbHeap_HeapOffsetView*) ((u32) (&lbHeap_80431FA0) + (offset)))
+
+static inline void lbHeap_ResetHeap(struct Heap* heap)
+{
+    heap->id = -1;
+    heap->handle = (Handle*) -1;
+    heap->start = 0;
+    heap->size = 0;
+    heap->type = 1;
+    heap->transient = 1;
+    heap->status = 1;
+}
+
+static inline void
+lbHeap_DestroyOffsetViewIfCreated(struct lbHeap_HeapOffsetView* view)
+{
+    struct Heap* heap = &view->heap;
+
+    if (view->heap.status == 0) {
+        if (heap->type == 0) {
+            OSDestroyHeap(heap->id);
+            heap->id = -1;
+        } else {
+            lbMemory_80014EEC(heap->handle);
+            heap->handle = (Handle*) -1;
+        }
+        heap->status = 1;
+    }
+}
+
+static inline void
+lbHeap_CreateOffsetViewIfDestroyed(struct lbHeap_HeapOffsetView* view)
+{
+    struct Heap* heap = &view->heap;
+
+    if (view->heap.status == 1) {
+        if (heap->type == 0) {
+            heap->id = OSCreateHeap((void*) heap->start,
+                                    (void*) (heap->start + heap->size));
+        } else {
+            heap->handle = lbMemory_80014E24(
+                (void*) heap->start, (void*) (heap->start + heap->size));
+        }
+        heap->status = 0;
+    }
+}
 
 void lbHeap_800158D0(int arg0, int arg1)
 {
@@ -32,127 +87,109 @@ int lbHeap_800158E8(int arg0)
 void lbHeap_80015900(void)
 {
     s32 temp_r0;
-    s32 i;
-    u32* aram_hi;
-    u32* aram_lo;
-    u32* arena_hi;
-    u32* arena_lo;
+    struct lbHeap_HeapOffsetView* destroy_view;
+    struct Heap* bounds_heap;
+    struct lbHeap_HeapOffsetView* create_view;
+    s32 destroy_i;
+    s32 heap_offset;
+    s32 bounds_i;
+    s32 create_i;
+    u32 arena_lo;
+    u32 aram_lo;
+    u32 aram_hi;
+    u32 arena_hi;
+    struct Heap* main_heap;
+    struct Heap* aram_heap;
 
     /// @remarks 0 and 1 are reserved for HSD and ARAM
-    for (i = 2; i < 6; i++) {
-        if (lbHeap_80431FA0.heap_array[i].transient == 1) {
-            if (lbHeap_80431FA0.heap_array[i].status == 0) {
-                if (lbHeap_80431FA0.heap_array[i].type == 0) {
-                    OSDestroyHeap(lbHeap_80431FA0.heap_array[i].id);
-                    lbHeap_80431FA0.heap_array[i].id = -1;
-                } else {
-                    lbMemory_80014EEC(lbHeap_80431FA0.heap_array[i].handle);
-                    lbHeap_80431FA0.heap_array[i].handle = (Handle*) -1;
+    for (destroy_i = 2, heap_offset = 0x38; destroy_i < 6;
+         destroy_i++, heap_offset += sizeof(struct Heap))
+    {
+        if (lbHeap_80431FA0.heap_array[destroy_i].transient == 1) {
+            destroy_view = lbHeap_GetHeapOffsetView(heap_offset);
+            lbHeap_DestroyOffsetViewIfCreated(destroy_view);
+        }
+    }
+
+    arena_lo = (u32) lbHeap_80431FA0.arena_lo;
+    arena_hi = (u32) lbHeap_80431FA0.arena_hi;
+    aram_lo = lbHeap_80431FA0.aram_lo;
+    aram_hi = lbHeap_80431FA0.aram_hi;
+
+    for (bounds_i = 2; bounds_i < 4; bounds_i++) {
+        bounds_heap = &lbHeap_80431FA0.heap_array[bounds_i * 2 - 2];
+        if (bounds_heap->transient == 0) {
+            switch (bounds_heap->type) {
+            case 1:
+                temp_r0 = bounds_heap->start + bounds_heap->size;
+                if (arena_lo < temp_r0) {
+                    arena_lo = temp_r0;
                 }
+                break;
+
+            case 2:
+                if (arena_hi > bounds_heap->start) {
+                    arena_hi = bounds_heap->start;
+                }
+                break;
+
+            case 4:
+                temp_r0 = bounds_heap->start + bounds_heap->size;
+                if (aram_lo < temp_r0) {
+                    aram_lo = temp_r0;
+                }
+                break;
+            }
+        }
+
+        bounds_heap++;
+        if (bounds_heap->transient == 0) {
+            switch (bounds_heap->type) {
+            case 1:
+                temp_r0 = bounds_heap->start + bounds_heap->size;
+                if (arena_lo < temp_r0) {
+                    arena_lo = temp_r0;
+                }
+                break;
+
+            case 2:
+                if (arena_hi > bounds_heap->start) {
+                    arena_hi = bounds_heap->start;
+                }
+                break;
+
+            case 4:
+                temp_r0 = bounds_heap->start + bounds_heap->size;
+                if (aram_lo < temp_r0) {
+                    aram_lo = temp_r0;
+                }
+                break;
             }
         }
     }
 
-    arena_lo = lbHeap_80431FA0.arena_lo;
-    arena_hi = lbHeap_80431FA0.arena_hi;
-    aram_lo = (u32*) lbHeap_80431FA0.aram_lo;
-    aram_hi = (u32*) lbHeap_80431FA0.aram_hi;
-
-    /// @todo this loop isnt entirely right, its purpose is to calculate where
-    // the main heap can be allocated. This currently checks heaps 2 and 3,
-    // then 2 and 1... checking 2 twice.
-    for (i = 2; i > 0; i--) {
-        if (lbHeap_80431FA0.heap_array[i].transient == 0) {
-            if (lbHeap_80431FA0.heap_array[i].type != 3) {
-                switch (lbHeap_80431FA0.heap_array[i].type) {
-                case 1:
-                    temp_r0 = lbHeap_80431FA0.heap_array[i].start +
-                              lbHeap_80431FA0.heap_array[i].size;
-                    if (arena_lo < (u32*) temp_r0) {
-                        arena_lo = (u32*) temp_r0;
-                    }
-                    break;
-
-                case 2:
-                    if (arena_hi > (u32*) lbHeap_80431FA0.heap_array[i].start)
-                    {
-                        arena_hi = (u32*) lbHeap_80431FA0.heap_array[i].start;
-                    }
-                    break;
-
-                case 4:
-                    temp_r0 = lbHeap_80431FA0.heap_array[i].start +
-                              lbHeap_80431FA0.heap_array[i].size;
-                    if (aram_lo < (u32*) temp_r0) {
-                        aram_lo = (u32*) temp_r0;
-                    }
-                    break;
-                }
-            }
-        }
-
-        if (lbHeap_80431FA0.heap_array[i + 1].transient == 0) {
-            if (lbHeap_80431FA0.heap_array[i + 1].type != 3) {
-                switch (lbHeap_80431FA0.heap_array[i + 1].type) {
-                case 1:
-                    temp_r0 = lbHeap_80431FA0.heap_array[i + 1].start +
-                              lbHeap_80431FA0.heap_array[i + 1].size;
-                    if (arena_lo < (u32*) temp_r0) {
-                        arena_lo = (u32*) temp_r0;
-                    }
-                    break;
-
-                case 2:
-                    if (arena_hi >
-                        (u32*) lbHeap_80431FA0.heap_array[i + 1].start)
-                    {
-                        arena_hi =
-                            (u32*) lbHeap_80431FA0.heap_array[i + 1].start;
-                    }
-                    break;
-
-                case 4:
-                    temp_r0 = lbHeap_80431FA0.heap_array[i + 1].start +
-                              lbHeap_80431FA0.heap_array[i + 1].size;
-                    if (aram_lo < (u32*) temp_r0) {
-                        aram_lo = (u32*) temp_r0;
-                    }
-                    break;
-                }
-            }
-        }
-    }
-
-    lbHeap_80431FA0.heap_array[0].id = HSD_CreateMainHeap(arena_lo, arena_hi);
-    lbHeap_80431FA0.heap_array[0].start = *arena_lo;
-    lbHeap_80431FA0.heap_array[0].size = *arena_hi - *arena_lo;
-    lbHeap_80431FA0.heap_array[0].status = 0;
-    lbHeap_80431FA0.heap_array[0].type = 0;
+    main_heap = &lbHeap_80431FA0.heap_array[0];
+    main_heap->id = HSD_CreateMainHeap((void*) arena_lo, (void*) arena_hi);
+    main_heap->start = arena_lo;
+    aram_heap = &lbHeap_80431FA0.heap_array[1];
+    main_heap->size = arena_hi - arena_lo;
+    main_heap->status = 0;
+    main_heap->type = 0;
 
     lbMemory_800155A4();
 
-    lbHeap_80431FA0.heap_array[1].handle = lbMemory_800154D4(aram_lo, aram_hi);
-    lbHeap_80431FA0.heap_array[1].start = *aram_lo;
-    lbHeap_80431FA0.heap_array[1].size = *aram_hi - *aram_lo;
-    lbHeap_80431FA0.heap_array[1].status = 0;
-    lbHeap_80431FA0.heap_array[1].type = 3;
+    aram_heap->handle = lbMemory_800154D4((void*) aram_lo, (void*) aram_hi);
+    aram_heap->start = aram_lo;
+    aram_heap->size = aram_hi - aram_lo;
+    aram_heap->status = 0;
+    aram_heap->type = 3;
 
-    for (i = 2; i < 6; i++) {
-        if (lbHeap_80431FA0.heap_array[i].transient == 0) {
-            if (lbHeap_80431FA0.heap_array[i].status == 1) {
-                if (lbHeap_80431FA0.heap_array[i].type == 0) {
-                    lbHeap_80431FA0.heap_array[i].id = OSCreateHeap(
-                        (void*) lbHeap_80431FA0.heap_array[i].start,
-                        (void*) (lbHeap_80431FA0.heap_array[i].start +
-                                 lbHeap_80431FA0.heap_array[i].size));
-                } else {
-                    lbHeap_80431FA0.heap_array[i].handle = lbMemory_80014E24(
-                        (void*) lbHeap_80431FA0.heap_array[i].start,
-                        (void*) (lbHeap_80431FA0.heap_array[i].start +
-                                 lbHeap_80431FA0.heap_array[i].size));
-                }
-                lbHeap_80431FA0.heap_array[i].status = 0;
-            }
+    for (create_i = 2, heap_offset = 0x38; create_i < 6;
+         create_i++, heap_offset += sizeof(struct Heap))
+    {
+        if (lbHeap_80431FA0.heap_array[create_i].transient == 0) {
+            create_view = lbHeap_GetHeapOffsetView(heap_offset);
+            lbHeap_CreateOffsetViewIfDestroyed(create_view);
         }
     }
 }
@@ -263,28 +300,25 @@ void lbHeap_80015F3C(void)
     int prev_idx;
     struct Heap* curr_heap;
     struct Heap* prev_heap;
-    int i;
+    struct lbHeap_HeapDesc* desc;
 
     HSD_GetNextArena(&lbHeap_80431FA0.arena_lo, &lbHeap_80431FA0.arena_hi);
     lbMemory_800154BC(&lbHeap_80431FA0.aram_lo, &lbHeap_80431FA0.aram_hi);
 
-    for (i = 0; i < 6; i++) {
-        lbHeap_80431FA0.heap_array[i].id = -1;
-        lbHeap_80431FA0.heap_array[i].handle = (Handle*) -1;
-        lbHeap_80431FA0.heap_array[i].start = 0;
-        lbHeap_80431FA0.heap_array[i].size = 0;
-        lbHeap_80431FA0.heap_array[i].type = 1;
-        lbHeap_80431FA0.heap_array[i].transient = 1;
-        lbHeap_80431FA0.heap_array[i].status = 1;
-    }
+    lbHeap_ResetHeap(&lbHeap_80431FA0.heap_array[0]);
+    lbHeap_ResetHeap(&lbHeap_80431FA0.heap_array[1]);
+    lbHeap_ResetHeap(&lbHeap_80431FA0.heap_array[2]);
+    lbHeap_ResetHeap(&lbHeap_80431FA0.heap_array[3]);
+    lbHeap_ResetHeap(&lbHeap_80431FA0.heap_array[4]);
+    lbHeap_ResetHeap(&lbHeap_80431FA0.heap_array[5]);
 
-    i = 0;
-    while ((curr_idx = lbHeap_803BA380[i].idx) != 6) {
+    desc = lbHeap_803BA380;
+    while ((curr_idx = desc->idx) != 6) {
         curr_heap = &lbHeap_80431FA0.heap_array[curr_idx];
 
-        curr_heap->type = lbHeap_803BA380[i].type;
-        curr_heap->size = lbHeap_803BA380[i].size;
-        prev_idx = lbHeap_803BA380[i].prev_idx;
+        curr_heap->type = desc->type;
+        curr_heap->size = desc->size;
+        prev_idx = desc->prev_idx;
         if (prev_idx == 6) {
             switch (curr_heap->type) {
             case 3:
@@ -316,6 +350,6 @@ void lbHeap_80015F3C(void)
                 break;
             }
         }
-        i++;
+        desc++;
     }
 }


### PR DESCRIPTION
## Summary
- improves lbHeap_80015900 from 94.3% to 96.5%
- keeps the rest of lbheap matched, including lbHeap_80015F3C at 100%
- fixes the heap bounds scan to cover heaps 2-5 and factors repeated heap create/destroy setup through local helpers

## Verification
- ninja
- python tools/checkdiff.py lbHeap_80015900
- python tools/checkdiff.py lbHeap_80015F3C