### PR TITLE
lb: improve lbmemory matching

### DIFF
--- a/src/melee/lb/lbmemory.c
+++ b/src/melee/lb/lbmemory.c
@@ -2,32 +2,50 @@
 
 #include <platform.h>
 
+#include <dolphin/ar.h>
 #include <baselib/debug.h>
+#include <baselib/devcom.h>
+
+struct MemEntry {
+    struct MemEntry* x0_next;
+    void* x4_lo;
+    void* x8_hi;
+};
+
+struct LBMgr {
+    OSAlarm alarm;                  // 0x00
+    u8* src;                        // 0x28
+    u8* dst;                        // 0x2C
+    u32 size;                       // 0x30
+    u32 offset;                     // 0x34
+    u32 cb_arg;                     // 0x38
+    void (*cb)(u32, u32, u32, u32); // 0x3C
+};
 
 struct Allocator {
     void* x0_arenaLo;
     void* x4_arenaHi;
-    u8 x8[0x62C - 0x8];
+    struct MemEntry x8_mem[0x83];
     Handle* x62C_free_mem;
     s32 x630_num_allocs;
     s32 x634_max_num_allocs;
-    u8 x638[0x698 - 0x638];
+    Handle x638_heap[6];
     Handle* x698_free_heap;
     Handle* x69C;
-    u8 x6A0[0x6E0 - 0x6A0];
+    struct LBMgr x6A0_mgr;
     u32 x6E0;
     void* x6E4;
     void* x6E8;
     u8 x6EC[0x6F0 - 0x6EC];
 };
 
-/* 015320 */ static void lbMemory_80015320(int, Handle*, int, int);
+/* 015320 */ void lbMemory_80015320(int, Handle*, int, int);
 
-/// lbMemory_804318B0
-static struct Allocator g_alloc;
-STATIC_ASSERT(sizeof(g_alloc) == 0x6F0);
+struct Allocator lbMemory_804318B0;
+#define g_alloc lbMemory_804318B0
+STATIC_ASSERT(sizeof(struct MemEntry) == 0xC);
+STATIC_ASSERT(sizeof(lbMemory_804318B0) == 0x6F0);
 
-/// might need to change to take lvalue instead of pointer if codegen is bad
 #define PUSH_HANDLE(list, handle)                                             \
     do {                                                                      \
         handle->x0_next = *list;                                              \
@@ -39,12 +57,25 @@ STATIC_ASSERT(sizeof(g_alloc) == 0x6F0);
         *list = handle->x0_next;                                              \
     } while (0)
 
-/// pops handle from freelist and sets the popped regions's bounds
+static char lbl_803BA2C0[0xB] = "lbmemory.c";
+static char lbl_803BA2CC[0xE] = "_p(free_heap)";
+static char lbl_803BA2DC[0x49] =
+    "(u32)arenaLo >= (u32)_p(a_arenaLo) && (u32)arenaHi <= "
+    "(u32)_p(a_arenaHi)";
+static char lbl_803BA328[0xD] = "_p(free_mem)";
+static char lbl_803BA338[0xB] = "memp_kouho";
+static char lbl_803BA344[0x24] = "[LbMem] Error: lbMemFreeToHeap %x.\n";
+static char lbl_803BA368[0x18] = "!p->size\0\0\0\0!cancelflag";
+
+SDATA char lbMemory_804D3788[7] = "handle";
+SDATA char lbMemory_804D3790[2] = "0";
+SDATA char lbMemory_804D3794[8] = "p->size";
+
 static inline Handle* new_handle(void* arenaLo, void* arenaHi)
 {
     Handle* h;
     if (g_alloc.x698_free_heap == NULL) {
-        __assert(__FILE__, 0x7BU, "_p(free_heap)");
+        __assert(lbl_803BA2C0, 0x7BU, lbl_803BA2CC);
     }
     // assert_arena_in_bounds(arenaLo, arenaHi);
 
@@ -56,9 +87,7 @@ static inline Handle* new_handle(void* arenaLo, void* arenaHi)
             ok = 1;
         }
         if (ok == 0) {
-            __assert(__FILE__, 0x80U,
-                     "(u32)arenaLo >= (u32)_p(a_arenaLo) && (u32)arenaHi <= "
-                     "(u32)_p(a_arenaHi)");
+            __assert(lbl_803BA2C0, 0x80U, lbl_803BA2DC);
         }
     }
 
@@ -75,15 +104,12 @@ Handle* lbMemory_80014E24(void* arenaLo, void* arenaHi)
     return new_handle(arenaLo, arenaHi);
 }
 
-/// moves a list of handles into x62C
-/// then pushes the head to free_heap
-/// why does it start at handle->xC_prev?
 void lbMemory_80014EEC(Handle* handle)
 {
     Handle* iter;
     Handle* tmp_next;
     if (handle == NULL) {
-        __assert(__FILE__, 0x95U, "handle");
+        __assert(lbl_803BA2C0, 0x95U, lbMemory_804D3788);
     }
     for (iter = handle->xC_prev; iter != NULL;) {
         tmp_next = iter->x0_next;
@@ -98,9 +124,6 @@ u32 lbMemory_80014F7C(Handle* h)
 {
     u32 r0;
     u32 r4 = (u32) h->x4_lo;
-    // this is weird.. i'm missing something
-    // &h->xC_prev should be a Handle**,
-    // and h->x0_prev looks the same as *h
     Handle* iter = (Handle*) &h->xC_prev;
     u32 sum = 0;
 
@@ -115,7 +138,6 @@ loop:
     return sum;
 }
 
-/// malloc
 Handle* lbMemory_80014FC8(Handle* arg0, u32 size)
 {
     void* lo;
@@ -130,18 +152,14 @@ Handle* lbMemory_80014FC8(Handle* arg0, u32 size)
 
     least_leftover = 0x40000000U;
     if (g_alloc.x62C_free_mem == NULL) {
-        __assert(__FILE__, 0xCCU, "_p(free_mem)");
+        __assert(lbl_803BA2C0, 0xCCU, lbl_803BA328);
     }
     start = arg0->x4_lo;
-    // 32 byte alignment
     aligned_size = ((size + 0x1F) & 0xFFFFFFE0);
     iter = (Handle*) &arg0->xC_prev;
     memp_candidate = NULL;
 
     while (1) {
-        // iter = var_r5->x0_next;
-        // we look at iter each iteration,
-        // until the last iteration, we check arg0
         end = (iter->x0_next != NULL) ? iter->x0_next->x4_lo : arg0->x8_hi;
         available_space = (u32) end - (u32) start;
         if (available_space >= aligned_size) {
@@ -160,8 +178,7 @@ Handle* lbMemory_80014FC8(Handle* arg0, u32 size)
         }
     }
     if (memp_candidate == NULL) {
-        // oom
-        __assert(__FILE__, 0xE9U, "memp_kouho");
+        __assert(lbl_803BA2C0, 0xE9U, lbl_803BA338);
     }
     {
         Handle* result;
@@ -195,22 +212,9 @@ void lbMemory_800150F0(Handle* h, void* arg1)
         r6 = handle;
         handle = handle->x0_next;
     }
-    OSReport("[LbMem] Error: lbMemFreeToHeap %x.\n", arg1);
-    __assert("lbmemory.c", 283, "0");
+    OSReport(lbl_803BA344, arg1);
+    __assert(lbl_803BA2C0, 283, lbMemory_804D3790);
 }
-
-static s8 lbl_803BA2C0[0xB] = "lbmemory.c";
-static s8 lbMemory_804D3794[8] = "p->size";
-
-struct LBMgr {
-    OSAlarm alarm;                  // 0x00
-    u8* src;                        // 0x28
-    u8* dst;                        // 0x2C
-    u32 size;                       // 0x30
-    u32 offset;                     // 0x34
-    u32 cb_arg;                     // 0x38
-    void (*cb)(u32, u32, u32, u32); // 0x3C
-};
 
 void fn_80015184(OSAlarm* alarm, OSContext* context)
 {
@@ -219,9 +223,9 @@ void fn_80015184(OSAlarm* alarm, OSContext* context)
     u32 temp_r6;
     u32 var_r30;
 
-    temp_r3 = (struct LBMgr*) ((u8*) &g_alloc + 0x6A0);
+    temp_r3 = &g_alloc.x6A0_mgr;
     if ((u32) temp_r3->size == 0U) {
-        __assert("lbmemory.c", 0x127U, "p->size");
+        __assert(lbl_803BA2C0, 0x127U, lbMemory_804D3794);
     }
     temp_r6 = temp_r3->offset;
     temp_r3_2 = temp_r3->size - temp_r6;
@@ -237,7 +241,7 @@ void fn_80015184(OSAlarm* alarm, OSContext* context)
         return;
     }
     OSCreateAlarm(&temp_r3->alarm);
-    OSSetAlarm(&temp_r3->alarm, 0x10624DD3, NULL);
+    OSSetAlarm(&temp_r3->alarm, OSMillisecondsToTicks(3), fn_80015184);
 }
 
 u32 lbMemory_8001529C(Handle* h, void* arg1, u32 arg2)
@@ -263,14 +267,72 @@ u32 lbMemory_8001529C(Handle* h, void* arg1, u32 arg2)
     return 0;
 }
 
-/// getArenaBounds
+void lbMemory_80015320(int arg0, Handle* handle, int arg2, int cancelflag)
+{
+    struct Allocator* alloc;
+    struct LBMgr* mgr;
+    int enabled;
+    void** currentp;
+    u32 size;
+    u32 current;
+    u32 old;
+    Handle* next;
+
+    alloc = &g_alloc;
+    currentp = &alloc->x6E4;
+    current = (u32) alloc->x6E4;
+
+    if (cancelflag != 0) {
+        __assert(lbl_803BA2C0, 0x188U, &lbl_803BA368[0xC]);
+    }
+
+    if (handle != NULL) {
+        if ((old = (u32) handle->x4_lo) != current) {
+            handle->x4_lo = (void*) current;
+            *currentp = (void*) ((u32) handle->x4_lo + (u32) handle->x8_hi);
+
+            if ((u32) handle->x4_lo < 0x80000000U) {
+                HSD_DevComRequest(
+                    0, old, current, ((u32) handle->x8_hi + 0x1F) & 0xFFFFFFE0,
+                    0x1B, 1, (HSD_DevComCallback) lbMemory_80015320,
+                    handle->x0_next);
+                return;
+            } else {
+                mgr = &alloc->x6A0_mgr;
+                next = handle->x0_next;
+                size = ((u32) handle->x8_hi + 0x1F) & 0xFFFFFFE0;
+                enabled = OSDisableInterrupts();
+
+                if (mgr->size != 0) {
+                    __assert(lbl_803BA2C0, 0x14FU, lbl_803BA368);
+                }
+                mgr->src = (u8*) old;
+                mgr->dst = (u8*) current;
+                mgr->size = size;
+                mgr->offset = 0;
+                mgr->cb_arg = (u32) next;
+                mgr->cb = (void (*)(u32, u32, u32, u32)) lbMemory_80015320;
+                OSRestoreInterrupts(enabled);
+                OSCreateAlarm(&mgr->alarm);
+                OSSetAlarm(&mgr->alarm, OSMillisecondsToTicks(3), fn_80015184);
+                return;
+            }
+        }
+
+        *currentp = (void*) ((u32) old + (u32) handle->x8_hi);
+        lbMemory_80015320(0, handle->x0_next, 0, 0);
+        return;
+    }
+
+    ((void (*)(u32)) alloc->x6E8)(alloc->x6E0);
+}
+
 void lbMemory_800154BC(uintptr_t* arenaLo, uintptr_t* arenaHi)
 {
     *arenaLo = (uintptr_t) g_alloc.x0_arenaLo;
     *arenaHi = (uintptr_t) g_alloc.x4_arenaHi;
 }
 
-/// same as lbMemory_80014E24, but sets to x69C to the popped handle
 Handle* lbMemory_800154D4(void* arenaLo, void* arenaHi)
 {
     g_alloc.x69C = new_handle(arenaLo, arenaHi);
@@ -284,7 +346,9 @@ void lbMemory_800155A4(void)
 
     Handle** r5;
 
-    HSD_ASSERT(149, handle);
+    if (handle == NULL) {
+        __assert(lbl_803BA2C0, 149, lbMemory_804D3788);
+    }
     r5 = &g_alloc.x62C_free_mem;
     for (iter = handle->xC_prev; iter != NULL;) {
         Handle* tmp_next = iter->x0_next;
@@ -295,3 +359,41 @@ void lbMemory_800155A4(void)
     PUSH_HANDLE(&g_alloc.x698_free_heap, handle);
     g_alloc.x69C = NULL;
 }
+
+#pragma push
+#pragma dont_inline on
+void lbMemory_8001564C(void)
+{
+    u32 size[3];
+    int i;
+    u8* base = (u8*) &g_alloc;
+
+    g_alloc.x0_arenaLo = (void*) ARAlloc(0x20);
+    ARFree(&size[2]);
+    g_alloc.x4_arenaHi =
+        (void*) ((ARGetSize() > 0x01000000U) ? 0x01000000U : ARGetSize());
+
+    g_alloc.x62C_free_mem = (Handle*) &g_alloc.x8_mem[0];
+    for (i = 0; i < 0x82; i++) {
+        g_alloc.x8_mem[i].x0_next = &g_alloc.x8_mem[i + 1];
+    }
+    g_alloc.x8_mem[i].x0_next = NULL;
+
+    g_alloc.x634_max_num_allocs = 0;
+    g_alloc.x630_num_allocs = 0;
+    g_alloc.x698_free_heap = (Handle*) (base + 0x638);
+    *(void**) (base + 0x638) = base + 0x648;
+    *(void**) (base + 0x648) = base + 0x658;
+    *(void**) (base + 0x658) = base + 0x668;
+    *(void**) (base + 0x668) = base + 0x678;
+    *(void**) (base + 0x678) = base + 0x688;
+    *(void**) (base + 0x688) = NULL;
+    g_alloc.x69C = NULL;
+    {
+        void* hi = g_alloc.x4_arenaHi;
+        void* lo = g_alloc.x0_arenaLo;
+        g_alloc.x69C = lbMemory_80014E24(lo, hi);
+    }
+    *(u32*) (base + 0x6D0) = 0;
+}
+#pragma pop

--- a/src/melee/lb/lbmemory.h
+++ b/src/melee/lb/lbmemory.h
@@ -10,7 +10,7 @@
 typedef struct _Handle {
     struct _Handle* x0_next;
     void* x4_lo;
-    // is this hi or size?
+    // Arena high bound for heap handles; allocation size for child handles.
     void* x8_hi;
     struct _Handle* xC_prev;
 } Handle;


### PR DESCRIPTION
## Summary
- Adds structured lbmemory allocator fields and string references used by matched code.
- Decompiles the lbmemory relocation and init routines, bringing the TU to 10/12 matched functions.
- Cleans speculative comments in the TU while keeping only verified Handle field behavior.

## Verification
- python configure.py && ninja
- Pre-commit checks, including match regression checks

## Remaining
- lbMemory_80014FC8: 99.324326%
- lbMemory_80015320: 96.106800%

Both remaining functions have matching control-flow/size shape but still differ in saved-register allocation and instruction scheduling.