### PR TITLE
lb: improve lbarq matching

### DIFF
--- a/src/melee/lb/lbarq.c
+++ b/src/melee/lb/lbarq.c
@@ -3,10 +3,13 @@
 #include <dolphin/os.h>
 #include <baselib/debug.h>
 
-u32 lbArq_80014ABC(lbArqNode* arg0)
+#pragma push
+#pragma dont_inline on
+lbArqState lbArq_80014ABC(lbArqNode* arg0)
 {
     return arg0->state;
 }
+#pragma pop
 
 void lbArq_80014AC4(lbArqHandle* handle)
 {
@@ -25,14 +28,14 @@ void lbArq_80014AC4(lbArqHandle* handle)
     }
     *prev = node->next;
 
-    /* Add to done list (list[2]) */
-    tail = &global->list[2];
+    /* Add to done list */
+    tail = &global->list[LB_ARQ_STATE_DONE];
     while (*tail != NULL) {
         tail = &(*tail)->next;
     }
     *tail = node;
     node->next = NULL;
-    node->state = 2;
+    node->state = LB_ARQ_STATE_DONE;
 
     OSRestoreInterrupts(intr);
 
@@ -49,14 +52,14 @@ void lbArq_80014AC4(lbArqHandle* handle)
         }
         *prev = node->next;
 
-        /* Add to free list (list[0]) */
-        tail = &global->list[0];
+        /* Add to free list */
+        tail = &global->list[LB_ARQ_STATE_FREE];
         while (*tail != NULL) {
             tail = &(*tail)->next;
         }
         *tail = node;
         node->next = NULL;
-        node->state = 0;
+        node->state = LB_ARQ_STATE_FREE;
 
         OSRestoreInterrupts(intr);
     }
@@ -71,29 +74,30 @@ void lbArq_80014BD0(u32 source, void* dest, size_t length,
     lbArqNode** free_head;
     BOOL intr;
 
+    PAD_STACK(16);
     DCInvalidateRange(dest, length);
     intr = OSDisableInterrupts();
-    rp = global->list[0];
-    free_head = &global->list[0];
+    rp = global->list[LB_ARQ_STATE_FREE];
+    free_head = &global->list[LB_ARQ_STATE_FREE];
     HSD_ASSERT(0x67, rp);
     *free_head = rp->next;
     rp->callback = callback;
     rp->callback_arg = callback_arg;
 
-    tail = &global->list[1];
+    tail = &global->list[LB_ARQ_STATE_PENDING];
     while (*tail != NULL) {
         tail = &(*tail)->next;
     }
     *tail = rp;
     rp->next = NULL;
-    rp->state = 1;
+    rp->state = LB_ARQ_STATE_PENDING;
 
     ARQPostRequest(&rp->arq, (u32) rp, 1, 0, source, (u32) dest, length,
                    (ARQCallback) lbArq_80014AC4);
 
     if (rp->callback == NULL) {
         OSRestoreInterrupts(intr);
-        while (lbArq_80014ABC(rp) != 2) {
+        while (lbArq_80014ABC(rp) != LB_ARQ_STATE_DONE) {
         }
         intr = OSDisableInterrupts();
         tail = &global->list[rp->state];
@@ -106,7 +110,7 @@ void lbArq_80014BD0(u32 source, void* dest, size_t length,
         }
         *free_head = rp;
         rp->next = NULL;
-        rp->state = 0;
+        rp->state = LB_ARQ_STATE_FREE;
     }
     OSRestoreInterrupts(intr);
 }
@@ -114,22 +118,22 @@ void lbArq_80014BD0(u32 source, void* dest, size_t length,
 void lbArq_80014D2C(void)
 {
     lbArqGlobal* global = &lbArq_804316C0;
-    lbArqNode* nodes = (lbArqNode*) global;
+    lbArqNode* nodes = global->nodes;
     lbArqNode* node;
     int i;
 
-    global->list[0] = NULL;
-    global->list[1] = NULL;
-    global->list[2] = NULL;
-    global->list[0] = nodes;
+    global->list[LB_ARQ_STATE_FREE] = NULL;
+    global->list[LB_ARQ_STATE_PENDING] = NULL;
+    global->list[LB_ARQ_STATE_DONE] = NULL;
+    global->list[LB_ARQ_STATE_FREE] = nodes;
 
     for (i = 0; i < 9; i++) {
         node = &nodes[i];
         node->next = node + 1;
-        node->state = 0;
+        node->state = LB_ARQ_STATE_FREE;
     }
     node->next = NULL;
-    node->state = 0;
+    node->state = LB_ARQ_STATE_FREE;
 
     PAD_STACK(8);
 }

--- a/src/melee/lb/lbarq.h
+++ b/src/melee/lb/lbarq.h
@@ -8,16 +8,22 @@
 
 typedef void (*lbArqCallback)(void* arg);
 
+typedef enum lbArqState {
+    LB_ARQ_STATE_FREE = 0,
+    LB_ARQ_STATE_PENDING = 1,
+    LB_ARQ_STATE_DONE = 2,
+} lbArqState;
+
 typedef struct lbArqNode {
     /* 0x00 */ struct lbArqNode* next;
-    /* 0x04 */ u32 state;
+    /* 0x04 */ lbArqState state;
     /* 0x08 */ ARQRequest arq;
     /* 0x28 */ lbArqCallback callback;
     /* 0x2C */ void* callback_arg;
 } lbArqNode;
 
 typedef struct lbArqGlobal {
-    /* 0x000 */ u8 pad[0x1E0];
+    /* 0x000 */ lbArqNode nodes[10];
     /* 0x1E0 */ lbArqNode* list[3];
 } lbArqGlobal;
 
@@ -28,7 +34,7 @@ typedef struct lbArqHandle {
 
 extern lbArqGlobal lbArq_804316C0;
 
-/* 014ABC */ u32 lbArq_80014ABC(lbArqNode* arg0);
+/* 014ABC */ lbArqState lbArq_80014ABC(lbArqNode* arg0);
 /* 014AC4 */ void lbArq_80014AC4(lbArqHandle* handle);
 /* 014BD0 */ void lbArq_80014BD0(u32, void*, size_t, lbArqCallback, void*);
 /* 014D2C */ void lbArq_80014D2C(void);


### PR DESCRIPTION
## Summary
- add concrete lbArq state/list types and replace the opaque global padding with the 10-node pool
- keep lbArq_80014ABC out-of-line and improve lbArq_80014BD0 stack/codegen
- name the verified ARQ node states used by lbarq

## Matching
- lbArq_80014ABC: 100%
- lbArq_80014D2C: 100%
- lbArq_80014AC4: 96.9403% (remaining drift is one first-list address calculation order)
- lbArq_80014BD0: 96.55173% (remaining drift is saved-register allocation plus one extra move around the free-list head)

## Verification
- python tools/checkdiff.py lbArq_80014ABC --format json
- python tools/checkdiff.py lbArq_80014AC4 --format json
- python tools/checkdiff.py lbArq_80014BD0 --format json
- python tools/checkdiff.py lbArq_80014D2C --format json
- python configure.py && ninja