### PR TITLE
lb: improve lbmthp matching

### DIFF
--- a/src/melee/lb/lb_01F8.c
+++ b/src/melee/lb/lb_01F8.c
@@ -109,7 +109,7 @@ void lbMthp8001FAA0(const char* filename, int width, int height)
     THPDec_8032F8D4(lbl_804335B8.unk94, context);
     decode_buf = HSD_MemAlloc(THPDec_8032FD40(context, header.h));
     decoded = THPVideoDecode(&header, &output, decode_buf,
-                             (s32) lbl_804335B8.unk94, context);
+                             (void*) lbl_804335B8.unk94, context);
     if ((u16) lbl_804335B8.x6C == 0x280) {
         THPDec_80331340(decoded, lbl_804335B8.x20, lbl_804335B8.x44,
                         lbl_804335B8.x68, lbl_804335B8.x6C);

--- a/src/melee/lb/lbmthp.c
+++ b/src/melee/lb/lbmthp.c
@@ -15,80 +15,87 @@
 #include <MSL/string.h>
 #include <Runtime/runtime.h>
 
-void fn_8001E910(int arg0, int arg1, void* arg2, bool cancelflag)
+#define LBMTHP_ASSERT(line, cond, msg)                                        \
+    ((cond) ? ((void) 0) : __assert(lbl_803BADB0, line, msg))
+#define LBMTHP_ASSERTREPORT(line, cond, msg, ...)                             \
+    ((cond) ? ((void) 0)                                                      \
+            : (OSReport(__VA_ARGS__), __assert(lbl_803BADB0, line, msg)))
+
+void fn_8001E910(int arg0, int arg1, void* arg2, int cancelflag)
 {
+    struct lbl_804333E0_t* streamPlayer = &Movieplayer;
     s32 tick_diff;
     s32 var_r0;
     s32 var_r4;
-    u32 tick;
+    unsigned int var_r3;
     BOOL intr;
 
-    HSD_ASSERT(0x148, !cancelflag);
+    LBMTHP_ASSERT(0x148, !cancelflag, lbl_803BADBC);
 
-    tick_diff = OSGetTick() - Movieplayer.unk_13C;
-    Movieplayer.unk_134 = tick_diff;
-    Movieplayer.unk_130 = tick_diff >> 0x1F;
-    Movieplayer.unk_108 += 1;
-    if ((u32) Movieplayer.unk_74 != 0U) {
-        Movieplayer.unk_120 += Movieplayer.currPackedSize;
+    tick_diff = OSGetTick() - streamPlayer->unk_13C;
+    streamPlayer->unk_134 = tick_diff;
+    streamPlayer->unk_130 = tick_diff >> 0x1F;
+    streamPlayer->unk_108 += 1;
+    if ((u32) streamPlayer->unk_74 != 0U) {
+        streamPlayer->curr_file_offset += streamPlayer->currPackedSize;
     } else {
-        Movieplayer.unk_120 = Movieplayer.unk_20;
+        streamPlayer->curr_file_offset = streamPlayer->unk_20;
     }
-    if ((u32) Movieplayer.unk_8C == 0) {
-        var_r0 = Movieplayer.unk_104 - 1;
+    if ((u32) streamPlayer->unk_8C == 0) {
+        var_r0 = streamPlayer->unk_104 - 1;
     } else {
-        var_r0 = Movieplayer.unk_8C - 1;
+        var_r0 = streamPlayer->unk_8C - 1;
     }
-    Movieplayer.currPackedSize = *(u32*) Movieplayer.unk_4C[var_r0];
-    if (((u32) Movieplayer.unk_90 != (u32) Movieplayer.unk_8C) &&
-        ((s32) Movieplayer.unk_70 != 0))
+    streamPlayer->currPackedSize = *(u32*) streamPlayer->frame_buffers[var_r0];
+    if (((u32) streamPlayer->unk_90 != (u32) streamPlayer->unk_8C) &&
+        ((s32) streamPlayer->unk_70 != 0))
     {
         intr = OSDisableInterrupts();
-        tick = OSGetTick();
-        Movieplayer.unk_13C = tick;
-        var_r4 = 0;
-        Movieplayer.unk_138 = 0;
-        if ((u32) Movieplayer.unk_74 != (u32) Movieplayer.unk_40) {
-            struct lbl_804333E0_t* streamPlayer = &Movieplayer;
-            HSD_ASSERTREPORT(0x121, (u32) streamPlayer->currPackedSize != 0,
-                             "filnum = %d, ofs = %d, by sugano.",
-                             Movieplayer.unk_128, Movieplayer.unk_120);
+        streamPlayer->unk_13C = OSGetTick();
+        streamPlayer->unk_138 = (var_r4 = 0);
+        if ((u32) streamPlayer->unk_74 != (u32) streamPlayer->unk_40) {
+            LBMTHP_ASSERTREPORT(0x121, (u32) streamPlayer->currPackedSize != 0,
+                                lbl_803BADEC, lbl_803BADC8,
+                                streamPlayer->file_entrynum,
+                                streamPlayer->curr_file_offset);
 
             HSD_DevComRequest(
-                Movieplayer.unk_128, Movieplayer.unk_120,
-                (uintptr_t) Movieplayer.unk_4C[Movieplayer.unk_8C],
-                (Movieplayer.currPackedSize + 0x1F) & 0xFFFFFFE0, 0x21, 1,
+                streamPlayer->file_entrynum, streamPlayer->curr_file_offset,
+                (uintptr_t) streamPlayer->frame_buffers[streamPlayer->unk_8C],
+                (streamPlayer->currPackedSize + 0x1F) & 0xFFFFFFE0, 0x21, 1,
                 fn_8001E910, NULL);
-            Movieplayer.unk_74 += 1;
-            if (((u32) Movieplayer.unk_74 == (u32) Movieplayer.unk_40) &&
-                ((s32) Movieplayer.unk_68 != 0))
+            streamPlayer->unk_74 += 1;
+            if (((u32) streamPlayer->unk_74 == (u32) streamPlayer->unk_40) &&
+                ((s32) streamPlayer->unk_68 != 0))
             {
-                Movieplayer.unk_74 = 0U;
+                streamPlayer->unk_74 = 0U;
             }
             {
-                u32 var_r3 = Movieplayer.unk_8C + 1;
-                if (var_r3 >= (u32) Movieplayer.unk_104) {
+                var_r3 = streamPlayer->unk_8C + 1;
+                if (var_r3 >= (u32) streamPlayer->unk_104) {
                     var_r3 = 0;
                 }
-                Movieplayer.unk_8C = var_r3;
+                streamPlayer->unk_8C = var_r3;
             }
-            var_r4 = 1;
-            Movieplayer.unk_110 = 1;
+            streamPlayer->unk_110 = (var_r4 = 1);
+        } else {
+            goto request_done;
         }
+    request_done:
         if (var_r4 == 0) {
-            Movieplayer.unk_110 = 0;
+            streamPlayer->unk_110 = 0;
         }
         OSRestoreInterrupts(intr);
         return;
     }
-    Movieplayer.unk_110 = 0;
+    streamPlayer->unk_110 = 0;
 }
 
 s32 fn_8001EB14(THPDecComp* data, const char* path)
 {
     THPInit();
-    data->unk_128 = DVDConvertPathToEntrynum(path);
-    lbFile_800161C4(data->unk_128, 0, (u32) data, 0x40, 0x21, 1);
+    data->file_entrynum = DVDConvertPathToEntrynum(path);
+    lbFile_800161C4(data->file_entrynum, 0, (u32) data, 0x40, 0x21, 1);
 
     data->unk_40 = data->unk_1C;
     data->width = data->unk_10;
@@ -96,11 +103,11 @@ s32 fn_8001EB14(THPDecComp* data, const char* path)
     data->unk_100 = data->unk_0C;
 
     if (data->unk_24 != 0) {
-        OSReport("Warning : frame offsets not supported\n");
+        OSReport(str_Warning_frame_offsets_not_supported);
     }
 
     if (data->unk_08 > 2) {
-        OSReport("Warning : file format is newer than player\n");
+        OSReport(lbl_803BAE3C);
     }
 
     data->unk_11C = 1;
@@ -128,49 +135,34 @@ s32 fn_8001EBF0(THPDecComp* data)
 
     data->unk_104 = 0x20;
 
-    /* Load width first */
     width = data->width;
-    /* Load unk_100 */
     aligned_100 = data->unk_100;
-    /* Load height */
     height = data->height;
-    /* Load unk_104 */
     unk_104_val = data->unk_104;
 
-    /* Align unk_100 */
     aligned_100 = ALIGN_32(aligned_100);
 
-    /* Store width */
-    data->unk_A0 = (u16) width;
+    data->unk_9C.val1 = (u16) width;
 
-    /* Multiply width * height */
     wh = width * height;
 
-    /* Reload and store height */
     height = data->height;
-    data->unk_A2 = (u16) height;
+    data->unk_9C._pad = (u16) height;
 
-    /* size = aligned * unk_104 */
     size = aligned_100 * unk_104_val;
 
-    /* Store 4 to unk_A4 */
-    data->unk_A4 = 4;
+    data->unk_9C.val2 = 4;
 
-    /* Zero unk_9C */
-    data->unk_9C = 0;
+    data->unk_9C.val0 = 0;
 
-    /* size += wh */
     size += wh;
 
-    /* size += wh/4 twice */
     wh_div4 = wh >> 2;
     size += wh_div4;
     size += wh_div4;
 
-    /* Call THPDec_8032FD40 with &unk_9C and height as u16 */
     size += THPDec_8032FD40(&data->unk_9C, (u16) data->height);
 
-    /* Zero various fields */
     data->unk_7C = 0;
     data->unk_78 = 0;
     data->unk_84 = 0;
@@ -180,12 +172,10 @@ s32 fn_8001EBF0(THPDecComp* data)
     data->unk_94 = -1;
     data->unk_68 = 0;
 
-    /* Copy width/height again */
     data->unk_A8 = (u16) data->width;
     data->unk_AA = (u16) data->height;
     data->unk_AC = 0;
 
-    /* Add aligned sizes */
     size += ALIGN_32(data->unk_104 * 4);
     size += ALIGN_32(data->unk_40 * 4);
 
@@ -194,48 +184,55 @@ s32 fn_8001EBF0(THPDecComp* data)
 
 void fn_8001ECF4(THPDecComp* data, void* buf)
 {
+    u32 width;
+    u32 height;
+    u32 count;
+    u8* var_r29;
     u32 y_size;
     u32 uv_size;
-    u32 var_r24;
     u32 var_r25;
+    u32 var_r24;
     u8* csizep;
-    u8* var_r29;
     PAD_STACK(8);
 
-    data->unk_4C = (u32*) buf;
-    y_size = data->width * data->height;
+    width = data->width;
+    height = data->height;
+    data->frame_buffers = (u32*) buf;
+    y_size = width * height;
+    count = data->unk_104;
     data->unk_64 = 0;
     uv_size = y_size >> 2U;
-    var_r29 = (u8*) buf + (((data->unk_104 * 4) + 0x1F) & 0xFFFFFFE0);
+    var_r29 = (u8*) buf + (((count * 4) + 0x1F) & 0xFFFFFFE0);
     if (((s32) data->unk_6C != 0) && ((s32) data->unk_11C != 0)) {
         var_r24 = data->unk_28;
         csizep = (u8*) &data->unk_28;
         var_r25 = 0;
-        data->unk_120 = data->unk_20;
+        data->curr_file_offset = data->unk_20;
         for (; var_r25 < (u32) data->unk_104; var_r25++) {
-            data->unk_4C[var_r25] = (u32) var_r29;
+            data->frame_buffers[var_r25] = (u32) var_r29;
             if (var_r24 == 0) {
-                OSReport("by sugano & yoshiki.\n");
-                OSReport("base %x\n", var_r29);
-                OSReport("size %d\n", var_r24);
-                OSReport("count %d\n", var_r25);
-                OSReport("csizep %x\n", csizep);
-                OSReport("[LbMthp] magic = %s\n", data);
-                OSReport("[LbMthp] version = %d\n", data->unk_08);
-                OSReport("[LbMthp] bufSize = %d\n", data->unk_0C);
-                OSReport("[LbMthp] xSize = %d\n", data->unk_10);
-                OSReport("[LbMthp] ySize = %d\n", data->unk_14);
-                OSReport("[LbMthp] framerate = %d\n", data->unk_18);
-                OSReport("[LbMthp] numFrames = %d\n", data->unk_1C);
-                OSReport("[LbMthp] firstFrame = %d\n", data->unk_20);
-                OSReport("[LbMthp] frameOffsets = %d\n", data->unk_24);
-                OSReport("[LbMthp] firstFrameSize = %d\n", data->unk_28);
-                HSD_ASSERT(0x10A, NULL);
+                OSReport(lbl_803BAE68);
+                OSReport(lbl_803BAE80, var_r29);
+                OSReport(lbl_803BAE8C, var_r24);
+                OSReport(lbl_803BAE98, var_r25);
+                OSReport(lbl_803BAEA4, csizep);
+                OSReport(lbl_803BAEB0, data);
+                OSReport(lbl_803BAEC8, data->unk_08);
+                OSReport(lbl_803BAEE0, data->unk_0C);
+                OSReport(lbl_803BAEF8, data->unk_10);
+                OSReport(lbl_803BAF10, data->unk_14);
+                OSReport(lbl_803BAF28, data->unk_18);
+                OSReport(lbl_803BAF44, data->unk_1C);
+                OSReport(lbl_803BAF60, data->unk_20);
+                OSReport(lbl_803BAF7C, data->unk_24);
+                OSReport(lbl_803BAF98, data->unk_28);
+                LBMTHP_ASSERT(0x10A, 0, str_0);
             }
-            lbFile_800161C4(data->unk_128, data->unk_120, (u32) var_r29,
-                            (var_r24 + 0x1F) & 0xFFFFFFE0, 0x21, 1);
+            lbFile_800161C4(data->file_entrynum, data->curr_file_offset,
+                            (u32) var_r29, (var_r24 + 0x1F) & 0xFFFFFFE0, 0x21,
+                            1);
             csizep = var_r29;
-            data->unk_120 += var_r24;
+            data->curr_file_offset += var_r24;
             var_r24 = *(u32*) var_r29;
             var_r29 = var_r29 + data->unk_100;
         }
@@ -259,7 +256,8 @@ void fn_8001ECF4(THPDecComp* data, void* buf)
     var_r29 = var_r29 + uv_size;
     data->unk_58 = var_r29;
     DCInvalidateRange(var_r29, uv_size);
-    data->unk_98 = (s32) (var_r29 + uv_size);
+    var_r29 = var_r29 + uv_size;
+    data->unk_98 = (s32) var_r29;
 }
 
 s32 fn_8001EF5C(THPDecComp* data)
@@ -269,9 +267,9 @@ s32 fn_8001EF5C(THPDecComp* data)
 
     if ((u32) data->unk_94 != data->unk_90) {
         intr = OSDisableInterrupts();
-        data->unk_98 =
-            THPVideoDecode(&data->unk_A8, &spC, (void*) data->unk_98,
-                           data->unk_4C[data->unk_90] + 4, &data->unk_9C);
+        data->unk_98 = THPVideoDecode(
+            &data->unk_A8, &spC, (void*) data->unk_98,
+            (void*) (data->frame_buffers[data->unk_90] + 4), &data->unk_9C);
         OSRestoreInterrupts(intr);
 
         if (data->width == 0x280) {
@@ -340,13 +338,15 @@ s32 fn_8001F13C(THPDecComp* streamPlayer)
         streamPlayer->unk_13C = OSGetTick();
         streamPlayer->unk_138 = 0;
         if (streamPlayer->unk_74 != streamPlayer->unk_40) {
-            HSD_ASSERTREPORT(0x121, (u32) streamPlayer->currPackedSize != 0,
-                             "filnum = %d, ofs = %d, by sugano.",
-                             streamPlayer->unk_128, streamPlayer->unk_120);
-            HSD_DevComRequest(streamPlayer->unk_128, streamPlayer->unk_120,
-                              streamPlayer->unk_4C[streamPlayer->unk_8C],
-                              ALIGN_32(streamPlayer->currPackedSize), 0x21, 1,
-                              fn_8001E910, NULL);
+            LBMTHP_ASSERTREPORT(0x121, (u32) streamPlayer->currPackedSize != 0,
+                                lbl_803BADEC, lbl_803BADC8,
+                                streamPlayer->file_entrynum,
+                                streamPlayer->curr_file_offset);
+            HSD_DevComRequest(
+                streamPlayer->file_entrynum, streamPlayer->curr_file_offset,
+                streamPlayer->frame_buffers[streamPlayer->unk_8C],
+                ALIGN_32(streamPlayer->currPackedSize), 0x21, 1, fn_8001E910,
+                NULL);
             streamPlayer->unk_74++;
             if ((streamPlayer->unk_74 == streamPlayer->unk_40) &&
                 (streamPlayer->unk_68 != 0))
@@ -368,121 +368,99 @@ s32 fn_8001F13C(THPDecComp* streamPlayer)
 
 s32 fn_8001F294(void);
 
-s32 fn_8001F2A4(void)
+static inline u32 lbMthp_GetFrame(u32** rate_table, u32 counter)
 {
-    s32 frame;
-    s32* rate_ptr;
-    s32 counter;
-    s32 count, ticks, total;
+    u32* rate_ptr = *rate_table;
+    u32 frame = 0;
+    u32 count;
+    u32 ticks;
+    u32 total;
 
-    /* Convert unk_80 ticks to frame number using rate table */
-    frame = 0;
-    rate_ptr = (s32*) Movieplayer.unk_12C;
-    counter = Movieplayer.unk_80;
-    if ((u32) rate_ptr != 0U) {
+    if (rate_ptr != NULL) {
         for (;; rate_ptr += 2) {
             count = rate_ptr[0];
             ticks = rate_ptr[1];
             total = count * ticks;
-            if ((u32) counter >= (u32) total) {
+            if (counter >= total) {
                 frame += count;
                 counter -= total;
                 continue;
-            }
-            frame += (u32) counter / (u32) ticks;
-            break;
-        }
-    } else {
-        frame = counter;
-    }
-
-    if ((u32) Movieplayer.unk_78 == (u32) frame) {
-        Movieplayer.unk_80 += 1;
-
-        /* Recompute frame after increment */
-        frame = 0;
-        rate_ptr = (s32*) Movieplayer.unk_12C;
-        counter = Movieplayer.unk_80;
-        if ((u32) rate_ptr != 0U) {
-            for (;; rate_ptr += 2) {
-                count = rate_ptr[0];
-                ticks = rate_ptr[1];
-                total = count * ticks;
-                if ((u32) counter >= (u32) total) {
-                    frame += count;
-                    counter -= total;
-                    continue;
-                }
-                frame += (u32) counter / (u32) ticks;
+            } else {
+                frame += counter / ticks;
                 break;
             }
-        } else {
-            frame = counter;
-        }
-
-        if ((u32) Movieplayer.unk_40 == (u32) frame) {
-            if (Movieplayer.unk_68 != 0) {
-                Movieplayer.unk_80 = 0;
-            } else {
-                Movieplayer.unk_80 -= 1;
-                Movieplayer.unk_144 = 1;
-            }
-        }
-    }
-
-    /* Final conversion for frame change check */
-    rate_ptr = (s32*) Movieplayer.unk_12C;
-    frame = 0;
-    counter = Movieplayer.unk_80;
-    if ((u32) rate_ptr != 0U) {
-        for (;; rate_ptr += 2) {
-            count = rate_ptr[0];
-            ticks = rate_ptr[1];
-            total = count * ticks;
-            if ((u32) counter >= (u32) total) {
-                frame += count;
-                counter -= total;
-                continue;
-            }
-            frame += (u32) counter / (u32) ticks;
-            break;
         }
     } else {
         frame = counter;
     }
 
-    if ((u32) Movieplayer.unk_78 != (u32) frame) {
-        return fn_8001F06C((THPDecComp*) &Movieplayer);
-    }
-    return (s32) &Movieplayer;
+    return frame;
 }
 
-void lbMthp_8001F410(const char* filename, void* rate_table, int buf_arg,
+s32 fn_8001F2A4(void)
+{
+    struct lbl_804333E0_t* streamPlayer;
+    u32** rate_table;
+    u32 frame;
+
+    streamPlayer = &Movieplayer;
+    rate_table = &streamPlayer->rate_table;
+
+    frame = lbMthp_GetFrame(rate_table, streamPlayer->unk_80);
+
+    if ((u32) streamPlayer->unk_78 == frame) {
+        streamPlayer->unk_80 += 1;
+
+        frame = lbMthp_GetFrame(rate_table, streamPlayer->unk_80);
+
+        if ((u32) streamPlayer->unk_40 == frame) {
+            if (streamPlayer->unk_68 != 0) {
+                streamPlayer->unk_80 = 0;
+            } else {
+                streamPlayer->unk_80 -= 1;
+                streamPlayer->unk_144 = 1;
+            }
+        }
+    }
+
+    frame = lbMthp_GetFrame(rate_table, streamPlayer->unk_80);
+
+    if ((u32) streamPlayer->unk_78 != frame) {
+        return fn_8001F06C((THPDecComp*) streamPlayer);
+    }
+    return (s32) streamPlayer;
+}
+
+void lbMthp_8001F410(const char* filename, void* rate_table, int buf,
                      int heap_size, int loop)
 {
     s32 memoryRequired;
-    void* buf = (void*) buf_arg;
+    struct lbl_804333E0_t* streamPlayer;
+    s32* power;
 
-    HSD_ASSERT(0x341, !Movieplayer.power);
+    streamPlayer = &Movieplayer;
+    power = &streamPlayer->power;
+    LBMTHP_ASSERT(0x341, !streamPlayer->power, lbl_803BAFB8);
 
-    Movieplayer.power = 1;
-    fn_8001EB14((THPDecComp*) &Movieplayer, filename);
-    Movieplayer.unk_12C = (s32) rate_table;
-    memoryRequired = fn_8001EBF0((THPDecComp*) &Movieplayer);
-    if (buf != NULL) {
-        HSD_ASSERT(0x350, heap_size >= memoryRequired);
-        Movieplayer.unk_140 = NULL;
+    *power = 1;
+    fn_8001EB14((THPDecComp*) streamPlayer, filename);
+    streamPlayer->rate_table = rate_table;
+    memoryRequired = fn_8001EBF0((THPDecComp*) streamPlayer);
+    if ((u32) buf != 0U) {
+        LBMTHP_ASSERT(0x350, (u32) heap_size >= (u32) memoryRequired,
+                      lbl_803BAFCC);
+        streamPlayer->unk_140 = NULL;
     } else {
-        buf = HSD_MemAlloc(memoryRequired);
-        Movieplayer.unk_140 = buf;
+        buf = (int) HSD_MemAlloc(memoryRequired);
+        streamPlayer->unk_140 = (void*) buf;
     }
-    Movieplayer.unk_68 = loop;
-    fn_8001ECF4((THPDecComp*) &Movieplayer, buf);
-    Movieplayer.unk_144 = 0;
-    Movieplayer.unk_148 = 1;
-    OSCreateAlarm(&Movieplayer.unk_150);
+    streamPlayer->unk_68 = loop;
+    fn_8001ECF4((THPDecComp*) streamPlayer, (void*) buf);
+    streamPlayer->unk_144 = 0;
+    streamPlayer->unk_148 = 1;
+    OSCreateAlarm(&streamPlayer->unk_150);
     OSSetPeriodicAlarm(
-        &Movieplayer.unk_150,
+        &streamPlayer->unk_150,
         __cvt_dbl_usll((f64) (0.016666668f * (f32) (*(u32*) 0x800000F8 >> 2))),
         __cvt_dbl_usll((f64) (0.016666668f * (f32) (*(u32*) 0x800000F8 >> 2))),
         (OSAlarmHandler) fn_8001F2A4);
@@ -542,30 +520,33 @@ HSD_SObj* lbMthp_8001F624(HSD_GObj* gobj, int width, int height)
 
 void lbMthp_8001F67C(HSD_GObj* gobj, int arg1)
 {
-    fn_8001EF5C((THPDecComp*) &Movieplayer);
-    if ((s32) Movieplayer.unk_148 != 0) {
-        GXInitTexObj(&Movieplayer.unk_178, Movieplayer.unk_50,
-                     (u16) Movieplayer.unk_44, (u16) Movieplayer.unk_48,
+    struct lbl_804333E0_t* streamPlayer = &Movieplayer;
+    PAD_STACK(8);
+
+    fn_8001EF5C((THPDecComp*) streamPlayer);
+    if ((s32) streamPlayer->unk_148 != 0) {
+        GXInitTexObj(&streamPlayer->unk_178, streamPlayer->unk_50,
+                     (u16) streamPlayer->unk_44, (u16) streamPlayer->unk_48,
                      GX_TF_I8, GX_CLAMP, GX_CLAMP, 0U);
-        GXInitTexObjLOD(&Movieplayer.unk_178, GX_NEAR, GX_NEAR, 0.0f, 0.0f,
+        GXInitTexObjLOD(&streamPlayer->unk_178, GX_NEAR, GX_NEAR, 0.0f, 0.0f,
                         0.0f, 0U, 0U, GX_ANISO_1);
-        GXLoadTexObj(&Movieplayer.unk_178, GX_TEXMAP0);
+        GXLoadTexObj(&streamPlayer->unk_178, GX_TEXMAP0);
 
-        GXInitTexObj(&Movieplayer.unk_198, Movieplayer.unk_54,
-                     (u16) ((u32) Movieplayer.unk_44 >> 1U),
-                     (u16) ((u32) Movieplayer.unk_48 >> 1U), GX_TF_I8,
+        GXInitTexObj(&streamPlayer->unk_198, streamPlayer->unk_54,
+                     (u16) ((u32) streamPlayer->unk_44 >> 1U),
+                     (u16) ((u32) streamPlayer->unk_48 >> 1U), GX_TF_I8,
                      GX_CLAMP, GX_CLAMP, 0U);
-        GXInitTexObjLOD(&Movieplayer.unk_198, GX_NEAR, GX_NEAR, 0.0f, 0.0f,
+        GXInitTexObjLOD(&streamPlayer->unk_198, GX_NEAR, GX_NEAR, 0.0f, 0.0f,
                         0.0f, 0U, 0U, GX_ANISO_1);
-        GXLoadTexObj(&Movieplayer.unk_198, GX_TEXMAP1);
+        GXLoadTexObj(&streamPlayer->unk_198, GX_TEXMAP1);
 
-        GXInitTexObj(&Movieplayer.unk_1B8, Movieplayer.unk_58,
-                     (u16) ((u32) Movieplayer.unk_44 >> 1U),
-                     (u16) ((u32) Movieplayer.unk_48 >> 1U), GX_TF_I8,
+        GXInitTexObj(&streamPlayer->unk_1B8, streamPlayer->unk_58,
+                     (u16) ((u32) streamPlayer->unk_44 >> 1U),
+                     (u16) ((u32) streamPlayer->unk_48 >> 1U), GX_TF_I8,
                      GX_CLAMP, GX_CLAMP, 0U);
-        GXInitTexObjLOD(&Movieplayer.unk_1B8, GX_NEAR, GX_NEAR, 0.0f, 0.0f,
+        GXInitTexObjLOD(&streamPlayer->unk_1B8, GX_NEAR, GX_NEAR, 0.0f, 0.0f,
                         0.0f, 0U, 0U, GX_ANISO_1);
-        GXLoadTexObj(&Movieplayer.unk_1B8, GX_TEXMAP2);
+        GXLoadTexObj(&streamPlayer->unk_1B8, GX_TEXMAP2);
 
         HSD_SObjLib_803A49E0(gobj, arg1);
     }

--- a/src/melee/lb/lbmthp.h
+++ b/src/melee/lb/lbmthp.h
@@ -8,14 +8,15 @@
 #include <baselib/forward.h>
 
 #include <dolphin/gx/GXStruct.h>
+#include <dolphin/thp/thp.h>
 
 /* THPDec function declarations */
 BOOL THPInit(void);
 void THPDec_8032F8D4(u32, void*);
-s32 THPDec_8032FD40(void* arg0, u16 height);
+s32 THPDec_8032FD40(THPDec_8032FD40_Data* arg0, u16 height);
 void THPDec_80331340(s32, void*, void*, void*, s32);
 void THPDec_803313D0(s32, void*, void*, void*);
-s32 THPVideoDecode(void*, void*, void*, s32, void*);
+s32 THPVideoDecode(void*, void*, void*, void*, void*);
 
 /* Struct used by fn_8001EBF0 for THP decode component init */
 typedef struct THPDecComp {
@@ -33,7 +34,7 @@ typedef struct THPDecComp {
     /* 0x40 */ u32 unk_40;
     /* 0x44 */ u32 width;
     /* 0x48 */ u32 height;
-    /* 0x4C */ u32* unk_4C;
+    /* 0x4C */ u32* frame_buffers;
     /* 0x50 */ void* unk_50;
     /* 0x54 */ void* unk_54;
     /* 0x58 */ void* unk_58;
@@ -52,11 +53,7 @@ typedef struct THPDecComp {
     /* 0x90 */ u32 unk_90;
     /* 0x94 */ s32 unk_94;
     /* 0x98 */ s32 unk_98;
-    /* 0x9C */ u32 unk_9C;
-    /* 0xA0 */ u16 unk_A0;
-    /* 0xA2 */ u16 unk_A2;
-    /* 0xA4 */ u8 unk_A4;
-    /* 0xA5 */ u8 padA5[0xA8 - 0xA5];
+    /* 0x9C */ THPDec_8032FD40_Data unk_9C;
     /* 0xA8 */ u16 unk_A8;
     /* 0xAA */ u16 unk_AA;
     /* 0xAC */ u8 unk_AC;
@@ -68,9 +65,9 @@ typedef struct THPDecComp {
     /* 0x110 */ s32 unk_110;
     /* 0x114 */ u8 pad114[0x11C - 0x114];
     /* 0x11C */ s32 unk_11C;
-    /* 0x120 */ u32 unk_120;
+    /* 0x120 */ u32 curr_file_offset;
     /* 0x124 */ u32 currPackedSize;
-    /* 0x128 */ s32 unk_128;
+    /* 0x128 */ s32 file_entrynum;
     /* 0x12C */ u8 pad12C[0x130 - 0x12C];
     /* 0x130 */ s32 unk_130;
     /* 0x134 */ s32 unk_134;
@@ -85,7 +82,7 @@ struct lbl_804333E0_t {
     /* 0x040 */ u32 unk_40;
     /* 0x044 */ u32 unk_44;
     /* 0x048 */ u32 unk_48;
-    /* 0x04C */ void** unk_4C;
+    /* 0x04C */ void** frame_buffers;
     /* 0x050 */ void* unk_50;
     /* 0x054 */ void* unk_54;
     /* 0x058 */ void* unk_58;
@@ -107,10 +104,10 @@ struct lbl_804333E0_t {
     /* 0x10C */ s32 unk_10C;
     /* 0x110 */ s32 unk_110;
     /* 0x114 */ char pad_114[0xC];
-    /* 0x120 */ u32 unk_120;
+    /* 0x120 */ u32 curr_file_offset;
     /* 0x124 */ u32 currPackedSize;
-    /* 0x128 */ s32 unk_128;
-    /* 0x12C */ s32 unk_12C;
+    /* 0x128 */ s32 file_entrynum;
+    /* 0x12C */ u32* rate_table;
     /* 0x130 */ s32 unk_130;
     /* 0x134 */ s32 unk_134;
     /* 0x138 */ s32 unk_138;
@@ -126,7 +123,7 @@ struct lbl_804333E0_t {
 }; /* size = 0x1D8 */
 STATIC_ASSERT(sizeof(struct lbl_804333E0_t) == 0x1D8);
 
-/* 01E910 */ void fn_8001E910(int, int, void*, bool);
+/* 01E910 */ void fn_8001E910(int, int, void*, int);
 /* 01EB14 */ s32 fn_8001EB14(THPDecComp* data, const char* path);
 /* 01EBF0 */ s32 fn_8001EBF0(THPDecComp* data);
 /* 01ECF4 */ void fn_8001ECF4(THPDecComp* data, void* buf);
@@ -135,7 +132,8 @@ STATIC_ASSERT(sizeof(struct lbl_804333E0_t) == 0x1D8);
 /* 01F13C */ s32 fn_8001F13C(THPDecComp* data);
 /* 01F294 */ s32 fn_8001F294(void);
 /* 01F2A4 */ s32 fn_8001F2A4(void);
-/* 01F410 */ void lbMthp_8001F410(const char* filename, UNK_T, int, int, int);
+/* 01F410 */ void lbMthp_8001F410(const char* filename, void* rate_table,
+                                  int buf, int heap_size, int loop);
 /* 01F578 */ void lbMthp_8001F578(void);
 /* 01F5C4 */ s32 lbMthp_8001F5C4(void);
 /* 01F5D4 */ s32 lbMthp_8001F5D4(void);

--- a/src/melee/lb/lbmthp.static.h
+++ b/src/melee/lb/lbmthp.static.h
@@ -5,7 +5,8 @@
 
 #include <dolphin/os/OSAlarm.h>
 
-/* 4333E0 */ static struct lbl_804333E0_t Movieplayer;
+/* 4333E0 */ static struct lbl_804333E0_t lbl_804333E0;
+#define Movieplayer lbl_804333E0
 /* 4D7CC0 */ static float lb_804D7CC0;
 
 /* 4D7CE0 */ static float lbl_804D7CE0;
@@ -20,7 +21,68 @@ struct lbl_803BAFE8_t {
     /* 0x14 */ s32 x14;
 }; /* size = 0x18 */
 
-/* 3BAFE8 */ extern struct lbl_803BAFE8_t lbl_803BAFE8;
+typedef struct lbMthp_DataBlock {
+    /* 0x000 */ char file[0xC];
+    /* 0x00C */ char assert_cancelflag[0xC];
+    /* 0x018 */ char report_filnum[0x24];
+    /* 0x03C */ char assert_curr_packed_size[0x28];
+    /* 0x064 */ char warning_frame_offsets[0x28];
+    /* 0x08C */ char warning_file_format[0x2C];
+    /* 0x0B8 */ char report_by_sugano[0x18];
+    /* 0x0D0 */ char report_base[0xC];
+    /* 0x0DC */ char report_size[0xC];
+    /* 0x0E8 */ char report_count[0xC];
+    /* 0x0F4 */ char report_csizep[0xC];
+    /* 0x100 */ char report_magic[0x18];
+    /* 0x118 */ char report_version[0x18];
+    /* 0x130 */ char report_buf_size[0x18];
+    /* 0x148 */ char report_x_size[0x18];
+    /* 0x160 */ char report_y_size[0x18];
+    /* 0x178 */ char report_framerate[0x1C];
+    /* 0x194 */ char report_num_frames[0x1C];
+    /* 0x1B0 */ char report_first_frame[0x1C];
+    /* 0x1CC */ char report_frame_offsets[0x1C];
+    /* 0x1E8 */ char report_first_frame_size[0x20];
+    /* 0x208 */ char assert_movieplayer_power[0x14];
+    /* 0x21C */ char assert_heap_size[0x1C];
+    /* 0x238 */ struct lbl_803BAFE8_t sobj_desc;
+} lbMthp_DataBlock;
+STATIC_ASSERT(sizeof(lbMthp_DataBlock) == 0x250);
+
+/* 3BADB0 */ static char lbl_803BADB0[9] = "lbmthp.c";
+/* 3BADBC */ static char lbl_803BADBC[0xC] = "!cancelflag";
+/* 3BADC8 */ static char lbl_803BADC8[0x22] =
+    "filnum = %d, ofs = %d, by sugano.";
+/* 3BADEC */ static char lbl_803BADEC[0x27] =
+    "(u32)streamPlayer->currPackedSize != 0";
+/* 3BAE14 */ static char str_Warning_frame_offsets_not_supported[0x27] =
+    "Warning : frame offsets not supported\n";
+/* 3BAE3C */ static char lbl_803BAE3C[0x2C] =
+    "Warning : file format is newer than player\n";
+/* 3BAE68 */ static char lbl_803BAE68[0x16] = "by sugano & yoshiki.\n";
+/* 3BAE80 */ static char lbl_803BAE80[0x9] = "base %x\n";
+/* 3BAE8C */ static char lbl_803BAE8C[0x9] = "size %d\n";
+/* 3BAE98 */ static char lbl_803BAE98[0xA] = "count %d\n";
+/* 3BAEA4 */ static char lbl_803BAEA4[0xB] = "csizep %x\n";
+/* 3BAEB0 */ static char lbl_803BAEB0[0x15] = "[LbMthp] magic = %s\n";
+/* 3BAEC8 */ static char lbl_803BAEC8[0x17] = "[LbMthp] version = %d\n";
+/* 3BAEE0 */ static char lbl_803BAEE0[0x17] = "[LbMthp] bufSize = %d\n";
+/* 3BAEF8 */ static char lbl_803BAEF8[0x15] = "[LbMthp] xSize = %d\n";
+/* 3BAF10 */ static char lbl_803BAF10[0x15] = "[LbMthp] ySize = %d\n";
+/* 3BAF28 */ static char lbl_803BAF28[0x19] = "[LbMthp] framerate = %d\n";
+/* 3BAF44 */ static char lbl_803BAF44[0x19] = "[LbMthp] numFrames = %d\n";
+/* 3BAF60 */ static char lbl_803BAF60[0x1A] = "[LbMthp] firstFrame = %d\n";
+/* 3BAF7C */ static char lbl_803BAF7C[0x1C] = "[LbMthp] frameOffsets = %d\n";
+/* 3BAF98 */ static char lbl_803BAF98[0x1E] = "[LbMthp] firstFrameSize = %d\n";
+/* 3BAFB8 */ static char lbl_803BAFB8[0x13] = "!MoviePlayer.power";
+/* 3BAFCC */ static char lbl_803BAFCC[0x1C] = "heap_size >= memoryRequired";
+/* 3BAFE8 */ static struct lbl_803BAFE8_t lbMthp_803BAFE8 = {
+    0, 0x280, 0x1E0, 6, 0, 0, 0,
+};
+
+#define lbl_803BAFE8 (((lbMthp_DataBlock*) lbl_803BADB0)->sobj_desc)
+
+/* 4D3830 */ static SDATA char str_0[] = "0";
 /* 4D3834 */ extern s32 lbl_804D3834;
 
 #endif


### PR DESCRIPTION
## Summary
- Type lbmthp static data, THP decode state, and movie-player file/buffer fields.
- Match several lbmthp helpers and replace literal/assert data references with named static data.
- Fix the THPVideoDecode pointer signature/call site used by lb.

## Test Plan
- python configure.py --wrapper wine && ninja