### PR TITLE
lb: improve fn_80027488 matching, tidy a few header signatures

### DIFF
--- a/src/melee/lb/lb_00F9.h
+++ b/src/melee/lb/lb_00F9.h
@@ -17,7 +17,7 @@
 #include <dolphin/mtx.h>
 
 /* 00F9F8 */ void lb_8000F9F8(HSD_JObj* jobj);
-/* 00FA94 */ UNK_RET lb_8000FA94(UNK_PARAMS);
+/* 00FA94 */ void lb_8000FA94(void);
 /* 00FCDC */ void lb_8000FCDC(void);
 /* 00FD18 */ void lb_8000FD18(DynamicsDesc*);
 /* 00FD48 */ void lb_8000FD48(HSD_JObj*, DynamicsDesc*, size_t);
@@ -67,7 +67,7 @@ lb_800122C8(HSD_ImageDesc* image_desc, u16 origx, u16 origy,
 /* 014498 */ void lb_80014498(ColorOverlay*);
 /* 0144C8 */ bool lb_800144C8(ColorOverlay*, struct Fighter_804D653C_t*, int,
                               int);
-/* 014534 */ UNK_RET lb_80014534(UNK_PARAMS);
+/* 014534 */ void lb_80014534(void);
 /* 014574 */ void lb_80014574(u8, int, int, int);
 /* 0145C0 */ void lb_800145C0(u8 slot); ///< Reset pad rumble
 /* 0145F4 */ void lb_800145F4(void);

--- a/src/melee/lb/lb_0192.h
+++ b/src/melee/lb/lb_0192.h
@@ -5,14 +5,14 @@
 #include <platform.h>
 
 /* 0192A8 */ void lb_800192A8(void (*cb)(void));
-/* 01955C */ UNK_RET lb_8001955C(UNK_PARAMS);
+/* 01955C */ void lb_8001955C(void);
 /* 0195D0 */ void lb_800195D0(void);
-/* 0195FC */ UNK_RET fn_800195FC(UNK_PARAMS);
+/* 0195FC */ void fn_800195FC(void);
 /* 019628 */ void lb_80019628(void);
 /* 019880 */ void lb_80019880(u64);
 /* 019894 */ u8 lb_80019894(void);
-/* 0198E0 */ UNK_RET lb_800198E0(UNK_PARAMS);
-/* 019900 */ UNK_RET lb_80019900(UNK_PARAMS);
+/* 0198E0 */ void lb_800198E0(void);
+/* 019900 */ void lb_80019900(void);
 /* 019A30 */ int lb_80019A30(int);
 /* 019A48 */ void lb_80019A48(void);
 /* 019AAC */ void lb_80019AAC(void (*)(void));

--- a/src/melee/lb/lbaudio_ax.c
+++ b/src/melee/lb/lbaudio_ax.c
@@ -2420,8 +2420,8 @@ void lbAudioAx_80027168(void)
 
 s32 fn_80027488(void)
 {
-    int* a = lbl_80433710.x194;
-    int* b = lbl_80433710.x274;
+    int* b = lbl_80433984;
+    int* a = lbl_804338A4;
     int i;
 
     for (i = 0; i < 55; i++) {

--- a/src/melee/lb/lbcardgame.h
+++ b/src/melee/lb/lbcardgame.h
@@ -6,8 +6,8 @@
 
 #include <sysdolphin/baselib/gobj.h>
 
-/* 01C600 */ UNK_RET lb_8001C600(UNK_PARAMS);
-/* 01C658 */ const char* lb_8001C658(UNK_PARAMS);
+/* 01C600 */ void lb_8001C600(void);
+/* 01C658 */ const char* lb_8001C658(void);
 /* 01C820 */ int lb_8001C820(void);
 /* 01C87C */ u32 lb_8001C87C(void);
 /* 01C8BC */ bool lb_8001C8BC(void);
@@ -22,9 +22,9 @@
 /* 01CE78 */ u8 lb_8001CE78(void);
 /* 01CEC0 */ void fn_8001CEC0(HSD_GObj*);
 /* 01CEE4 */ void fn_8001CEE4(HSD_GObj*, int);
-/* 01CF18 */ UNK_RET lb_8001CF18(UNK_PARAMS);
+/* 01CF18 */ void lb_8001CF18(void);
 /* 01D164 */ void lb_8001D164(int);
-/* 01D1F4 */ UNK_RET lb_8001D1F4(UNK_PARAMS);
+/* 01D1F4 */ void lb_8001D1F4(void);
 /* 01D21C */ void lb_8001D21C(void);
 
 #endif


### PR DESCRIPTION
## Summary

- `fn_80027488` in `lbaudio_ax.c`: replaces `lbl_80433710.x194` / `.x274` struct-field accesses with direct references to the standalone extern arrays `lbl_804338A4` and `lbl_80433984` (which live at exactly those addresses per `symbols.txt`), and declares `b` before `a` so MWCC materializes the addresses in the order the original expects.
- Also tidies a few unrelated lb headers, replacing `UNK_RET` / `UNK_PARAMS` placeholders with the actual `void` signatures the `.c` files already use. Compile-time no-op (those macros already expand to `void`), but makes the headers honest about the ABI.

## Functions matched

No 100% matches. `fn_80027488` improves **89.55% → 94.86%** fuzzy. The remaining mismatch is one extra prologue instruction from MWCC's register cascade choice — `lis r3/lis r3` for the two HA halves vs `lis r4/lis r3` in the original.

## Files

- `src/melee/lb/lbaudio_ax.c`
- `src/melee/lb/lb_00F9.h`
- `src/melee/lb/lb_0192.h`
- `src/melee/lb/lbcardgame.h`

## Verification

- `python configure.py && ninja` → green (`build/GALE01/main.dol: OK`)
- No other functions in `lbaudio_ax.c` regressed.