### PR TITLE
lb: implement lb_80019628; improve four lbbgflash functions

### DIFF
--- a/src/melee/lb/lb_0192.c
+++ b/src/melee/lb/lb_0192.c
@@ -232,6 +232,66 @@ void fn_800195FC(void)
     lbSnap_8001D2BC();
 }
 
+void lb_80019628(void)
+{
+    OSAlarm* alarm = &lb_804329F0.alarm;
+    OSTime period;
+    u64 new_val = lb_804329F0.x38;
+
+    if ((s64) new_val == lb_804329F0.x0[0].x0) {
+        return;
+    }
+
+    lb_804329F0.x0[0].x0 = (s64) new_val;
+
+    if (lb_804329F0.x0[0].x8 >= lb_804329F0.x0[0].x0) {
+        lb_804329F0.x0[0].x8 = 0;
+    }
+
+    period = (OSTime) (f64) (u32) OS_TIMER_CLOCK;
+
+    if (lb_804329F0.x0[0].x0 < period) {
+        period = lb_804329F0.x0[0].x0;
+    }
+
+    if (lb_804329F0.x0[1].x0 < period) {
+        period = lb_804329F0.x0[1].x0;
+    }
+
+    {
+        OSTime fps_period =
+            (OSTime) (f64) (0.016666668f * (f32) (u32) OS_TIMER_CLOCK);
+        if (period >= fps_period) {
+            period = fps_period;
+        }
+    }
+
+    if ((s64) lb_804329F0.x40 == period) {
+        return;
+    }
+
+    lb_804329F0.x40 = (u64) period;
+
+    {
+        u32 rate = (u32) ((u64) period / (OS_TIMER_CLOCK / 1000));
+        if (rate > 11) {
+            rate = 11;
+        }
+        if (lb_804329F0.x4 != rate) {
+            PADSetSamplingRate(rate);
+            lb_804329F0.x4 = rate;
+        }
+    }
+
+    if (lb_804329F0.x48 != 0) {
+        OSCancelAlarm(alarm);
+    }
+    OSCreateAlarm(alarm);
+    OSSetPeriodicAlarm(alarm, lb_804329F0.x40, lb_804329F0.x40,
+                       (OSAlarmHandler) fn_800195FC);
+    lb_804329F0.x48 = 1;
+}
+
 void lb_80019880(u64 arg0)
 {
     lb_804329F0.x38 = arg0;

--- a/src/melee/lb/lbbgflash.c
+++ b/src/melee/lb/lbbgflash.c
@@ -80,66 +80,82 @@ void fn_8001FC08(void)
     f32 val;
 
     if (data->x20[0] > 0.0f) {
-        val = data->x10[0] + data->x20[0];
-        if (val < (f32) data->x8.r) {
-            data->x10[0] = val;
+        u8 target = data->x8.r;
+        f32* cur = &data->x10[0];
+        val = *cur + data->x20[0];
+        if (val < (f32) target) {
+            *cur = val;
         } else {
-            data->x10[0] = (f32) data->x8.r;
+            *cur = (f32) target;
         }
     } else {
-        val = data->x10[0] + data->x20[0];
-        if (val > (f32) data->x8.r) {
-            data->x10[0] = val;
+        u8 target = data->x8.r;
+        f32* cur = &data->x10[0];
+        val = *cur + data->x20[0];
+        if (val > (f32) target) {
+            *cur = val;
         } else {
-            data->x10[0] = (f32) data->x8.r;
+            *cur = (f32) target;
         }
     }
 
     if (data->x20[1] > 0.0f) {
-        val = data->x10[1] + data->x20[1];
-        if (val < (f32) data->x8.g) {
-            data->x10[1] = val;
+        u8 target = data->x8.g;
+        f32* cur = &data->x10[1];
+        val = *cur + data->x20[1];
+        if (val < (f32) target) {
+            *cur = val;
         } else {
-            data->x10[1] = (f32) data->x8.g;
+            *cur = (f32) target;
         }
     } else {
-        val = data->x10[1] + data->x20[1];
-        if (val > (f32) data->x8.g) {
-            data->x10[1] = val;
+        u8 target = data->x8.g;
+        f32* cur = &data->x10[1];
+        val = *cur + data->x20[1];
+        if (val > (f32) target) {
+            *cur = val;
         } else {
-            data->x10[1] = (f32) data->x8.g;
+            *cur = (f32) target;
         }
     }
 
     if (data->x20[2] > 0.0f) {
-        val = data->x10[2] + data->x20[2];
-        if (val < (f32) data->x8.b) {
-            data->x10[2] = val;
+        u8 target = data->x8.b;
+        f32* cur = &data->x10[2];
+        val = *cur + data->x20[2];
+        if (val < (f32) target) {
+            *cur = val;
         } else {
-            data->x10[2] = (f32) data->x8.b;
+            *cur = (f32) target;
         }
     } else {
-        val = data->x10[2] + data->x20[2];
-        if (val > (f32) data->x8.b) {
-            data->x10[2] = val;
+        u8 target = data->x8.b;
+        f32* cur = &data->x10[2];
+        val = *cur + data->x20[2];
+        if (val > (f32) target) {
+            *cur = val;
         } else {
-            data->x10[2] = (f32) data->x8.b;
+            *cur = (f32) target;
         }
     }
 
     if (data->x20[3] > 0.0f) {
-        val = data->x10[3] + data->x20[3];
-        if (val < (f32) data->x8.a) {
-            data->x10[3] = val;
+        u8 target = data->x8.a;
+        f32* cur = &data->x10[3];
+        val = *cur + data->x20[3];
+        if (val < (f32) target) {
+            *cur = val;
         } else {
-            data->x10[3] = (f32) data->x8.a;
+            *cur = (f32) target;
         }
     } else {
-        val = data->x10[3] + data->x20[3];
-        if (val > (f32) data->x8.a) {
-            data->x10[3] = val;
+        u8 target = data->x8.a;
+        f32* cur = &data->x10[3];
+        val = *cur + data->x20[3];
+        if (val > (f32) target) {
+            *cur = val;
         } else {
-            data->x10[3] = (f32) data->x8.a;
+            *cur = (f32) target;
         }
     }
 }

--- a/src/melee/lb/lbbgflash.c
+++ b/src/melee/lb/lbbgflash.c
@@ -595,11 +595,11 @@ void lbBgFlash_80020E38(HSD_JObj* jobj, Vec3* dir, f32 max_angle,
     f32 z_col_z;
     f32 z_col_y;
     f32 z_col_x;
-    f32 dz2 = dz * dz;
     f32 dx2 = dx * dx;
     f32 dy2 = dy * dy;
+    f32 dz2 = dz * dz;
     volatile f32 tmp;
-    if (dz2 + dy2 + dx2 == 0.0f) {
+    if (dx2 + dy2 + dz2 == 0.0f) {
         return;
     }
 

--- a/src/melee/lb/lbbgflash.c
+++ b/src/melee/lb/lbbgflash.c
@@ -688,11 +688,12 @@ void fn_8002113C(HSD_JObj* jobj, Vec3* axis, f32 angle)
     PSMTXRotAxisRad(rotMtx, (Vec*) &localAxis, -angle);
 
     if (!(jobj->flags & JOBJ_USE_QUATERNION)) {
-        Fake_HSD_JObjGetRotation(jobj, &rot);
-        HSD_MkRotationMtx(tmpMtx, (Vec3*) &rot);
+        Quaternion* volatile rot_ptr = &rot;
+        Fake_HSD_JObjGetRotation(jobj, rot_ptr);
+        HSD_MkRotationMtx(tmpMtx, (Vec3*) rot_ptr);
         PSMTXConcat(tmpMtx, rotMtx, result);
-        HSD_QuatLib_8037EB28(result, (Vec3*) &rot);
-        FakeHSD_JObjSetRotation(jobj, &rot);
+        HSD_QuatLib_8037EB28(result, (Vec3*) rot_ptr);
+        FakeHSD_JObjSetRotation(jobj, rot_ptr);
     } else {
         HSD_JObjGetRotation(jobj, &rot2);
         HSD_MtxQuat(tmpMtx, &rot2);


### PR DESCRIPTION
## Summary

- **`lb_0192.c`** (`lb_80019628`): adds a C body for the pad-sampling-rate maintenance function called from `lb_80019894`. Snapshots `lb_804329F0.x38`, picks the minimum of `x0[0].x0` / `x0[1].x0` / `OS_TIMER_CLOCK` / `OS_TIMER_CLOCK * 1/60` as the new period, divides by `OS_TIMER_CLOCK/1000` for the ms cap (≤ 11), then updates `PADSetSamplingRate` and reschedules the periodic alarm with `fn_800195FC`.
- **`lbbgflash.c`** (`fn_8001FC08`): restructures each per-channel saturation block to use branch-local `u8 target` / `f32* cur` locals so MWCC keeps the byte target and the `x10[i]` pointer in r5/r4 across the rising/falling logic.
- **`lbbgflash.c`** (`lbBgFlash_80020E38`): reorders the squared-component locals (dx2/dy2/dz2 instead of dz2/dx2/dy2) and the sum to match how the original schedules the lfs/fmuls/fadds pipeline.
- **`lbbgflash.c`** (`fn_8002113C`): routes `&rot` through a `Quaternion* volatile` local so MWCC keeps the inline-substituted asserts at `jobj.h:699/700` in the `Fake_HSD_JObjGetRotation` expansion (previously the compiler proved `&rot` non-null and elided the assert call entirely).
- **`lbbgflash.c`** (`fn_80020AEC`): expands `parent = jobj ? jobj->parent : NULL;` to an explicit `if/else` so MWCC schedules the non-null case first, matching the bne / b / li sequence the original emits for `parent`.

## Functions matched

No 100% matches. Five improvements toward the original:

- `lb_80019628`: 0% (no source body — was relying on the asm-only fallback) → **82.58%** fuzzy
- `fn_8001FC08`: 89.55% → **91.77%** fuzzy
- `fn_8002113C`: 93.17% → **94.72%** fuzzy
- `fn_80020AEC`: 88.27% → **88.77%** fuzzy
- `lbBgFlash_80020E38`: 98.46% → **98.52%** fuzzy

## Files

- `src/melee/lb/lb_0192.c`
- `src/melee/lb/lbbgflash.c`

## Verification

- `python configure.py && ninja` → green (`build/GALE01/main.dol: OK`)
- All sibling functions in both TUs unchanged.