### PR TITLE
lb: match fn_80026650 (100%), improve fn_800268B4 and lb_8000FD48

### DIFF
--- a/src/melee/lb/lb_00F9.c
+++ b/src/melee/lb/lb_00F9.c
@@ -146,6 +146,17 @@ void lb_8000FD18(DynamicsDesc* desc)
     desc->data = NULL;
 }
 
+static inline struct DynamicsData* popDynamicsData(void)
+{
+    struct DynamicsData* entry = cur_data;
+    if (entry == NULL) {
+        return NULL;
+    }
+    cur_data = entry->next;
+    entry->next = NULL;
+    return entry;
+}
+
 void lb_8000FD48(HSD_JObj* jobj, DynamicsDesc* desc, size_t max_count)
 {
     struct DynamicsData* prev;
@@ -163,27 +174,11 @@ void lb_8000FD48(HSD_JObj* jobj, DynamicsDesc* desc, size_t max_count)
     desc->count = 0;
 
     while ((s32) desc->count < (s32) max_count) {
-        struct DynamicsData* entry;
-
         if ((s32) desc->count == 0) {
-            entry = cur_data;
-            if (entry == NULL) {
-                entry = NULL;
-            } else {
-                cur_data = entry->next;
-                entry->next = NULL;
-            }
-            prev = entry;
+            prev = popDynamicsData();
             desc->data = prev;
         } else {
-            entry = cur_data;
-            if (entry == NULL) {
-                entry = NULL;
-            } else {
-                cur_data = entry->next;
-                entry->next = NULL;
-            }
-            prev->next = entry;
+            prev->next = popDynamicsData();
             prev = prev->next;
         }
 

--- a/src/melee/lb/lbaudio_ax.c
+++ b/src/melee/lb/lbaudio_ax.c
@@ -2114,22 +2114,21 @@ void fn_800268B4(void)
     lbl_804D6450 = 0;
     lbl_804D644C = 0;
     lbl_804D6448 = 0;
-
-    arr_38a4 = lbl_80433710.x194;
-    arr_3984 = lbl_80433710.x274;
+    arr_38a4 = lbl_804338A4;
+    arr_3984 = lbl_80433984;
     arr_4e4 = offsets_arr_803BC4E4;
 
-    for (i = 0x37; i > 0; i--) {
+    for (i = 0x37; i != 0; i--) {
         int flag1, flag2;
         int flags;
 
-        if (arr_38a4[i] == -1) {
+        if (*arr_38a4 == -1) {
             flag1 = 0;
         } else {
             flag1 = 1;
         }
 
-        if (arr_3984[i] == -1) {
+        if (*arr_3984 == -1) {
             flag2 = 0;
         } else {
             flag2 = 2;
@@ -2141,17 +2140,20 @@ void fn_800268B4(void)
         case 0:
             break;
         case 1:
-            lbl_804D644C += arr_4e4[i][0];
-            lbl_804D6450 += arr_4e4[i][0];
+            lbl_804D644C += (*arr_4e4)[0];
+            lbl_804D6450 += (*arr_4e4)[0];
             break;
         case 2:
-            lbl_804D6448 += arr_4e4[i][0];
+            lbl_804D6448 += (*arr_4e4)[0];
             break;
         case 3:
-            lbl_804D644C += arr_4e4[i][0];
-            lbl_804D6448 += arr_4e4[i][0];
+            lbl_804D644C += (*arr_4e4)[0];
+            lbl_804D6448 += (*arr_4e4)[0];
             break;
         }
+        arr_38a4++;
+        arr_3984++;
+        arr_4e4++;
     }
 }
 

--- a/src/melee/lb/lbaudio_ax.c
+++ b/src/melee/lb/lbaudio_ax.c
@@ -2034,8 +2034,8 @@ s32 fn_80026650(void)
 
     for (priority = 4; priority >= 0; priority--) {
         s8(*arr_5d0)[4] = s32_arr_803BB5D0;
-        int* arr_38a4 = lbl_80433710.x194;
-        int* arr_3984 = lbl_80433710.x274;
+        int* arr_38a4 = lbl_804338A4;
+        int* arr_3984 = lbl_80433984;
 
         for (i = 0; i < 0x37; i++) {
             if (priority == arr_5d0[i][1] && arr_38a4[i] == 1 &&


### PR DESCRIPTION
## Summary

- Match `fn_80026650` to 100% (lbaudio_ax.c) by using named externs `lbl_804338A4` / `lbl_80433984` directly instead of the `lbl_80433710` struct anchor.
- Improve `fn_800268B4` (lbaudio_ax.c): same named-extern swap plus pointer-increment loop form — 88.5% → 88.7% with the prologue now using `bdnz`/`mtctr` CTR-loop matching the expected layout.
- Refactor `lb_8000FD48` (lb_00F9.c) free-list pop into a `popDynamicsData` static inline mirroring the existing `inlineA0` pattern — 93.7% → 94.2%.

## Functions matched

- `fn_80026650`: 100% (78.6% baseline → match)
- `fn_800268B4`: 88.7% (was 88.5%)
- `lb_8000FD48`: 94.2% (was 93.7%)

## Files

- `src/melee/lb/lbaudio_ax.c`
- `src/melee/lb/lb_00F9.c`

## Verification

- `python configure.py && ninja` → green
- Each touched function rechecked individually with `tools/checkdiff.py` to confirm the recorded match%