### PR TITLE
Match mn menu record functions

### DIFF
--- a/src/melee/mn/mncount.c
+++ b/src/melee/mn/mncount.c
@@ -377,22 +377,40 @@ s32 mnCount_8025092C(s32 rank, u32 (*getVal)(s32), bool mode)
     return NUM_CHARACTERS;
 }
 
+static inline int mnCount_CountUnlockedChars(void)
+{
+    int i;
+    int c = 0;
+    for (i = 0; i < NUM_CHARACTERS; i++) {
+        if (gm_80164840(gm_8016400C((u8) i))) {
+            c += 1;
+        }
+    }
+    return c;
+}
+
+static inline int mnCount_CountUnlockedMaps(void)
+{
+    int i;
+    int c = 0;
+    for (i = 0; i < NUM_STAGES; i++) {
+        if (gm_80164430(gm_801641CC((u8) i))) {
+            c += 1;
+        }
+    }
+    return c;
+}
+
 int mnCount_GetRowValue_Character(mnCount_row row)
 {
     int c;
-    int i;
     switch (row) {
     case LONGEST_TIME:
         return mnCount_8025035C(0, mnCount_GetMatchTime);
     case SECOND_LONGEST_TIME:
         return mnCount_8025035C(1, mnCount_GetMatchTime);
     case SHORTEST_TIME:
-        c = 0;
-        for (i = 0; i < NUM_CHARACTERS; i++) {
-            if (gm_80164840(gm_8016400C(i))) {
-                c += 1;
-            }
-        }
+        c = mnCount_CountUnlockedChars();
         if (c < 3) {
             return NUM_CHARACTERS;
         }
@@ -419,7 +437,6 @@ int mnCount_GetRowValue_Character(mnCount_row row)
 unsigned int mnCount_GetRowValue_Number(int row)
 {
     unsigned int ret;
-    PAD_STACK(8);
     switch (row) {
     case POWER_COUNT:
         ret = *(unsigned int*) gmMainLib_GetPowerCount();
@@ -469,26 +486,12 @@ unsigned int mnCount_GetRowValue_Number(int row)
     case SELFDESTRUCT_TOTAL:
         ret = *(unsigned int*) gmMainLib_GetSelfDestructTotal();
         break;
-    case AVAILABLE_CHARACTERS: {
-        int i, c;
-        c = 0;
-        for (i = 0; i < NUM_CHARACTERS; i++) {
-            if (gm_80164840(gm_8016400C(i))) {
-                c++;
-            }
-        }
-        ret = c;
-    } break;
-    case AVAILABLE_MAPS: {
-        int i, c;
-        c = 0;
-        for (i = 0; i < NUM_STAGES; i++) {
-            if (gm_80164430(gm_801641CC(i))) {
-                c++;
-            }
-        }
-        ret = c;
-    } break;
+    case AVAILABLE_CHARACTERS:
+        ret = mnCount_CountUnlockedChars();
+        break;
+    case AVAILABLE_MAPS:
+        ret = mnCount_CountUnlockedMaps();
+        break;
     case TROPHY_TOTAL:
         ret = un_GetTrophyTotal();
         break;

--- a/src/melee/mn/mndatadel.c
+++ b/src/melee/mn/mndatadel.c
@@ -740,26 +740,28 @@ void mnDataDel_8024FE4C(u8 arg0)
 void mnDataDel_80250170(void)
 {
     HSD_GObjProc* proc;
+    HSD_Archive* archive;
+    StaticModelDesc* assets;
 
+    assets = &mnDataDel_804A0918;
     mn_804D6BC8.cooldown = 5;
     mn_804A04F0.prev_menu = mn_804A04F0.cur_menu;
     mn_804A04F0.cur_menu = 0x18;
     mn_804A04F0.hovered_selection = 0;
     mnDataDel_804D6C6C = NULL;
+    archive = mn_804D6BB8;
     lbArchive_LoadSections(
-        mn_804D6BB8, (void**) &mnDataDel_804A0918.joint,
-        "MenMainConDl_Top_joint", &mnDataDel_804A0918.animjoint,
-        "MenMainConDl_Top_animjoint", &mnDataDel_804A0918.matanim_joint,
-        "MenMainConDl_Top_matanim_joint", &mnDataDel_804A0918.shapeanim_joint,
-        "MenMainConDl_Top_shapeanim_joint", &mnDataDel_804A0928.joint,
-        "MenMainCursorDl_Top_joint", &mnDataDel_804A0928.animjoint,
-        "MenMainCursorDl_Top_animjoint", &mnDataDel_804A0928.matanim_joint,
-        "MenMainCursorDl_Top_matanim_joint",
-        &mnDataDel_804A0928.shapeanim_joint,
-        "MenMainCursorDl_Top_shapeanim_joint", &mnDataDel_804A0938.joint,
-        "MenMainWarCmn_Top_joint", &mnDataDel_804A0938.animjoint,
-        "MenMainWarCmn_Top_animjoint", &mnDataDel_804A0938.matanim_joint,
-        "MenMainWarCmn_Top_matanim_joint", &mnDataDel_804A0938.shapeanim_joint,
+        archive, (void**) &assets[0].joint, "MenMainConDl_Top_joint",
+        &assets[0].animjoint, "MenMainConDl_Top_animjoint",
+        &assets[0].matanim_joint, "MenMainConDl_Top_matanim_joint",
+        &assets[0].shapeanim_joint, "MenMainConDl_Top_shapeanim_joint",
+        &assets[1].joint, "MenMainCursorDl_Top_joint", &assets[1].animjoint,
+        "MenMainCursorDl_Top_animjoint", &assets[1].matanim_joint,
+        "MenMainCursorDl_Top_matanim_joint", &assets[1].shapeanim_joint,
+        "MenMainCursorDl_Top_shapeanim_joint", &assets[2].joint,
+        "MenMainWarCmn_Top_joint", &assets[2].animjoint,
+        "MenMainWarCmn_Top_animjoint", &assets[2].matanim_joint,
+        "MenMainWarCmn_Top_matanim_joint", &assets[2].shapeanim_joint,
         "MenMainWarCmn_Top_shapeanim_joint", 0);
     mnDataDel_8024FE4C(0U);
     proc = HSD_GObj_SetupProc(GObj_Create(0U, 1U, 0x80U), fn_8024F840, 0U);

--- a/src/melee/mn/mndatadel.static.h
+++ b/src/melee/mn/mndatadel.static.h
@@ -77,8 +77,8 @@ static struct MnDataDelData mnDataDel_803EF870 = {
     { 0, 19, -0.1 },
     { 20, 29, -0.1 },
 };
-static AnimLoopSettings mnDataDel_803EF888 = { 0, 5, -0.1 };
-static AnimLoopSettings mnDataDel_803EF894 = { 0, 0, -0.1 };
+static AnimLoopSettings mnDataDel_803EF888 = { 0, 5, -0.1F };
+static AnimLoopSettings mnDataDel_803EF894 = { 0, 0, -0.1F };
 static AnimLoopSettings mnDataDel_803EF8A0 = {
     0.0f, 9.0f, -0.1f
 }; /// mnDataDel_803EF870[4]
@@ -86,7 +86,7 @@ static u32 mnDataDel_803EF8AC[] = { 1, 2, 3, 4, 5, 6, 7 };
 static u16 mnDataDel_803EF8C8[] = {
     0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC6,
 };
-static Vec3 lbl_803EF8D4 = { -5.5, -2.8, 23 };
+static Vec3 lbl_803EF8D4 = { -5.5F, -2.8F, 23 };
 static StaticModelDesc mnDataDel_804A0918;
 static StaticModelDesc mnDataDel_804A0928;
 static StaticModelDesc mnDataDel_804A0938;

--- a/src/melee/mn/mndiagram.c
+++ b/src/melee/mn/mndiagram.c
@@ -1,3 +1,4 @@
+#define MNDIAGRAM_SOURCE
 #include "mndiagram.static.h"
 #include "mndiagram2.static.h"
 
@@ -162,12 +163,12 @@ u32 mnDiagram_ConvertDistanceForDisplay(u32 distance)
     return distance / 100;
 }
 
-s32 mnDiagram_GetHitPercentage(u8 is_name_mode, u8 player_index)
+s32 mnDiagram_GetHitPercentage(int is_name_mode, u8 player_index)
 {
     f32 player_attacks;
     f32 tag_player_attacks;
 
-    if (is_name_mode != 0) {
+    if ((u8) is_name_mode != 0) {
         if (GetPersistentNameData(player_index)->attacks_total != 0) {
             tag_player_attacks =
                 GetPersistentNameData(player_index)->attacks_total;
@@ -194,7 +195,7 @@ s32 mnDiagram_GetPlayPercentage(u8 is_name_mode, u8 player_index)
     s32 i;
     f32 zero = 0.0f;
 
-    if (is_name_mode != 0) {
+    if ((u8) is_name_mode != 0) {
         total_play_time = 0.0f;
         i = 0;
         do {
@@ -224,12 +225,12 @@ s32 mnDiagram_GetPlayPercentage(u8 is_name_mode, u8 player_index)
     return 0;
 }
 
-s32 mnDiagram_GetAveragePlayerCount(u8 is_name_mode, u8 player_index)
+s32 mnDiagram_GetAveragePlayerCount(int is_name_mode, u8 player_index)
 {
     f32 temp_f31;
     f32 temp_f31_2;
 
-    if (is_name_mode != 0) {
+    if ((u8) is_name_mode != 0) {
         if ((u16) GetPersistentNameData((s32) player_index)->match_count != 0)
         {
             temp_f31_2 =

--- a/src/melee/mn/mndiagram.h
+++ b/src/melee/mn/mndiagram.h
@@ -9,9 +9,14 @@
 /* 23EA40 */ u8 mnDiagram_GetNameByIndex(int idx);
 /* 23EA54 */ bool mnDiagram_IsDistanceOverflow(u32 distance);
 /* 23EAC4 */ u32 mnDiagram_ConvertDistanceForDisplay(u32 distance);
-/* 23EB84 */ s32 mnDiagram_GetHitPercentage(u8 is_name_mode, u8 player_index);
+/* 23EB84 */ s32 mnDiagram_GetHitPercentage(int is_name_mode, u8 player_index);
+#ifdef MNDIAGRAM_SOURCE
 /* 23ECC4 */ s32 mnDiagram_GetPlayPercentage(u8 is_name_mode, u8 player_index);
-/* 23EE38 */ s32 mnDiagram_GetAveragePlayerCount(u8 is_name_mode,
+#else
+/* 23ECC4 */ s32 mnDiagram_GetPlayPercentage(int is_name_mode,
+                                             u8 player_index);
+#endif
+/* 23EE38 */ s32 mnDiagram_GetAveragePlayerCount(int is_name_mode,
                                                  u8 player_index);
 /* 23EF70 */ int mnDiagram_GetNameTotalKOs(u8 field_index);
 /* 23EFE4 */ int mnDiagram_GetNameTotalFalls(u8 field_index);

--- a/src/melee/mn/mndiagram2.c
+++ b/src/melee/mn/mndiagram2.c
@@ -452,6 +452,7 @@ int mnDiagram2_GetStatValue(int is_name_mode, u8 stat_type, u8 entity_idx)
 {
     u8 typeVal;
     u8 idxVal;
+    u16 val16;
 
     typeVal = stat_type;
     idxVal = entity_idx;
@@ -471,12 +472,14 @@ int mnDiagram2_GetStatValue(int is_name_mode, u8 stat_type, u8 entity_idx)
 
     case VSSTAT_SD_COUNT:
         if ((u8) is_name_mode) {
-            return GetPersistentNameData(idxVal)->sd_count;
+            val16 = GetPersistentNameData(idxVal)->sd_count;
+        } else {
+            val16 = GetPersistentFighterData(idxVal)->sd_count;
         }
-        return GetPersistentFighterData(idxVal)->sd_count;
+        return val16;
 
     case VSSTAT_HIT_PERCENTAGE:
-        return mnDiagram_GetHitPercentage((u8) is_name_mode, idxVal);
+        return mnDiagram_GetHitPercentage(is_name_mode, idxVal);
 
     case VSSTAT_DAMAGE_DEALT:
         if ((u8) is_name_mode) {
@@ -498,27 +501,35 @@ int mnDiagram2_GetStatValue(int is_name_mode, u8 stat_type, u8 entity_idx)
 
     case VSSTAT_PEAK_DAMAGE:
         if ((u8) is_name_mode) {
-            return GetPersistentNameData(idxVal)->peak_damage;
+            val16 = GetPersistentNameData(idxVal)->peak_damage;
+        } else {
+            val16 = GetPersistentFighterData(idxVal)->peak_damage;
         }
-        return GetPersistentFighterData(idxVal)->peak_damage;
+        return val16;
 
     case VSSTAT_MATCH_COUNT:
         if ((u8) is_name_mode) {
-            return GetPersistentNameData(idxVal)->match_count;
+            val16 = GetPersistentNameData(idxVal)->match_count;
+        } else {
+            val16 = GetPersistentFighterData(idxVal)->match_count;
         }
-        return GetPersistentFighterData(idxVal)->match_count;
+        return val16;
 
     case VSSTAT_VICTORIES:
         if ((u8) is_name_mode) {
-            return GetPersistentNameData(idxVal)->victories;
+            val16 = GetPersistentNameData(idxVal)->victories;
+        } else {
+            val16 = GetPersistentFighterData(idxVal)->victories;
         }
-        return GetPersistentFighterData(idxVal)->victories;
+        return val16;
 
     case VSSTAT_LOSSES:
         if ((u8) is_name_mode) {
-            return GetPersistentNameData(idxVal)->losses;
+            val16 = GetPersistentNameData(idxVal)->losses;
+        } else {
+            val16 = GetPersistentFighterData(idxVal)->losses;
         }
-        return GetPersistentFighterData(idxVal)->losses;
+        return val16;
 
     case VSSTAT_PLAY_TIME:
         if ((u8) is_name_mode) {
@@ -527,10 +538,10 @@ int mnDiagram2_GetStatValue(int is_name_mode, u8 stat_type, u8 entity_idx)
         return GetPersistentFighterData(idxVal)->play_time;
 
     case VSSTAT_PLAY_PERCENTAGE:
-        return mnDiagram_GetPlayPercentage((u8) is_name_mode, idxVal);
+        return mnDiagram_GetPlayPercentage(is_name_mode, idxVal);
 
     case VSSTAT_AVG_PLAYERS:
-        return mnDiagram_GetAveragePlayerCount((u8) is_name_mode, idxVal);
+        return mnDiagram_GetAveragePlayerCount(is_name_mode, idxVal);
 
     case VSSTAT_WALK_DISTANCE:
         if ((u8) is_name_mode) {
@@ -588,7 +599,7 @@ int mnDiagram2_GetStatValue(int is_name_mode, u8 stat_type, u8 entity_idx)
     default:
         break;
     }
-    return 0;
+    return is_name_mode;
 }
 
 /// @brief Creates a single stat row entry in the VS Records display.
@@ -848,6 +859,11 @@ typedef struct {
     /* 0x0C */ HSD_JObj* jobj;
 } mnDiagram2_AnimCompleteData;
 
+typedef struct MnDiagram2DataLayout {
+    u8 stat_name_ids[0x90];
+    AnimLoopSettings anim[2];
+} MnDiagram2DataLayout;
+
 /// @brief Animation completion callback - destroys GObj when animation ends.
 void mnDiagram2_OnAnimComplete(HSD_GObj* gobj)
 {
@@ -875,10 +891,13 @@ void mnDiagram2_UpdateScrollArrows(HSD_GObj* gobj)
 {
     Diagram2* data;
     HSD_JObj* jobj;
-    data = gobj->user_data;
+    MnDiagram2DataLayout* base;
+
+    base = (MnDiagram2DataLayout*) &mnDiagram2_803EEAD0;
+    data = HSD_GObjGetUserData(gobj);
 
     jobj = data->down_arrow;
-    mn_8022ED6C(jobj, &mnDiagram2_803EEB60[1]);
+    mn_8022ED6C(jobj, &base->anim[1]);
     if (data->is_name_mode) {
         if (data->scroll_offset + 10 < 0x18) {
             HSD_JObjClearFlagsAll(jobj, 0x10);
@@ -894,7 +913,7 @@ void mnDiagram2_UpdateScrollArrows(HSD_GObj* gobj)
     }
 
     jobj = data->up_arrow;
-    mn_8022ED6C(jobj, &mnDiagram2_803EEB60[1]);
+    mn_8022ED6C(jobj, &base->anim[1]);
     if (data->scroll_offset) {
         HSD_JObjClearFlagsAll(jobj, 0x10);
     } else {
@@ -902,7 +921,7 @@ void mnDiagram2_UpdateScrollArrows(HSD_GObj* gobj)
     }
 
     jobj = data->left_arrow;
-    mn_8022ED6C(jobj, &mnDiagram2_803EEB60[1]);
+    mn_8022ED6C(jobj, &base->anim[1]);
     if (data->is_name_mode) {
         if (data->selected_name_idx) {
             HSD_JObjClearFlagsAll(jobj, 0x10);
@@ -918,7 +937,7 @@ void mnDiagram2_UpdateScrollArrows(HSD_GObj* gobj)
     }
 
     jobj = data->right_arrow;
-    mn_8022ED6C(jobj, &mnDiagram2_803EEB60[1]);
+    mn_8022ED6C(jobj, &base->anim[1]);
     if (data->is_name_mode != 0) {
         if (data->selected_name_idx !=
             (u8) mnDiagram_GetNextNameIndex(data->selected_name_idx))

--- a/src/melee/mn/mninfo.c
+++ b/src/melee/mn/mninfo.c
@@ -31,6 +31,13 @@ typedef struct MnInfoTextCursor {
     /* +18 */ HSD_Text* right;
 } MnInfoTextCursor;
 
+typedef struct MnInfoDataLayout {
+    AnimLoopSettings anim;
+    u32 sis_ids[4];
+    char date_format[0xC];
+    char time_format[0xC];
+} MnInfoDataLayout;
+
 StaticModelDesc mnInfo_804A0958;
 u8 mnInfo_804A0968[0x48];
 HSD_GObj* mnInfo_804D6C78;
@@ -110,9 +117,30 @@ s32 mnInfo_80251AFC(void)
     return 0;
 }
 
+static AnimLoopSettings mnInfo_803EFC08[0x12] = {
+    { 0.0f, 199.0f, 0.0f },
+    { 1.8e-42f, 1.802e-42f, 1.803e-42f },
+    { 1.805e-42f, 2.1092525e-16f, 1.379729e31f },
+    { 0.0f, 2.109659e-16f, 1.4748028e31f },
+    { 0.0f, 225.43028f, 5.083402e31f },
+    { 5.085142e31f, 7.153577e22f, 2.817505e20f },
+    { 6.162976e-33f, 4.6115556e27f, 2.8237532e23f },
+    { 0.0f, 3.0854143e32f, 1.6456562e19f },
+    { 1.4757395e20f, 2.405757e8f, 2.6912729e20f },
+    { 7.3738955e28f, 1.5307577e19f, 1.6892836e19f },
+    { 1.8878586e28f, 2.405757e8f, 2.6912729e20f },
+    { 7.3738955e28f, 1.5307577e19f, 1.6244036e19f },
+    { 4.5346362e27f, 1.8878586e28f, 2.405757e8f },
+    { 2.6912729e20f, 7.3738955e28f, 1.5307577e19f },
+    { 1.710508e19f, 2.7487011e20f, 1.6892836e19f },
+    { 1.8878586e28f, 2.405757e8f, 2.6912729e20f },
+    { 7.3738955e28f, 1.5307577e19f, 1.7539375e19f },
+    { 2.8395941e29f, 1.7935375e25f, 7.2243537e28f },
+};
+
 #pragma push
 #pragma dont_inline on
-s32 mnInfo_80251D58(MenuInfo_GObj* arg0, s32 arg1, u32 arg3)
+s32 mnInfo_80251D58(MenuInfo_GObj* arg0, s32 arg1, u32 arg2, u32 arg3)
 {
     char sp34[5];
     char sp30[3];
@@ -121,14 +149,16 @@ s32 mnInfo_80251D58(MenuInfo_GObj* arg0, s32 arg1, u32 arg3)
     char sp24[3];
     char sp20[3];
     datetime sp18;
-    HSD_Text* text;
     HSD_Text** slot;
+    HSD_Text* text;
     MnInfoData* data;
+    MnInfoDataLayout* layout;
 
     data = arg0->user_data;
-    slot = &data->left_column[arg1];
-    if (*slot != NULL) {
-        HSD_SisLib_803A5CC4(*slot);
+    layout = (MnInfoDataLayout*) mnInfo_803EFC08;
+    slot = (HSD_Text**) ((u8*) data + (arg1 * 4));
+    if (*(slot += 2) != NULL) {
+        HSD_SisLib_803A5CC4(data->left_column[arg1]);
     }
     text = HSD_SisLib_803A6754(0, 1);
     *slot = text;
@@ -147,39 +177,55 @@ s32 mnInfo_80251D58(MenuInfo_GObj* arg0, s32 arg1, u32 arg3)
     mn_8022EA78(sp24, 2, sp18.month);
     mn_8022EA78(sp20, 2, sp18.day);
     if (lbLang_IsSavedLanguageUS() != 0) {
-        HSD_SisLib_803A6B98(text, 0.0f, 0.0f, "%s.%s.%s", sp24, sp20, sp34);
+        HSD_SisLib_803A6B98(text, 0.0f, 0.0f, layout->date_format, sp24, sp20,
+                            sp34);
     } else {
-        HSD_SisLib_803A6B98(text, 0.0f, 0.0f, "%s.%s.%s", sp34, sp24, sp20);
+        HSD_SisLib_803A6B98(text, 0.0f, 0.0f, layout->date_format, sp34, sp24,
+                            sp20);
     }
-    return HSD_SisLib_803A6B98(text, 0.0f, 40.0f, "%s:%s:%s", sp30, sp2C,
-                               sp28);
+    return HSD_SisLib_803A6B98(text, 0.0f, 40.0f, layout->time_format, sp30,
+                               sp2C, sp28);
 }
 #pragma pop
 
 #pragma push
 #pragma dont_inline on
-void mnInfo_80251F04(MenuInfo_GObj* arg0, u32 arg1, u32 arg2)
+void mnInfo_80251F04(MenuInfo_GObj* arg0, s32 arg1, u32 arg2)
 {
     s16 sp16;
-    HSD_Text* temp_r3_2;
-    HSD_Text** temp_r31;
-    MnInfoData* temp_r3;
+    s16 unused;
+    HSD_Text** slot;
+    HSD_Text* text;
+    MnInfoData* data;
 
-    temp_r3 = arg0->user_data;
-    temp_r31 = &temp_r3->right_column[arg1];
-    if (temp_r3->right_column[arg1] != NULL) {
-        HSD_SisLib_803A5CC4(temp_r3->right_column[arg1]);
+    data = arg0->user_data;
+    slot = (HSD_Text**) ((u8*) data + (arg1 * 4));
+    if (*(slot += 6) != NULL) {
+        HSD_SisLib_803A5CC4(data->right_column[arg1]);
     }
-    temp_r3_2 = HSD_SisLib_803A5ACC(0, 0, -5.0f, (3.45f * (f32) arg1) + -5.9f,
-                                    17.0f, 514.2857f, 142.85715f);
-    *temp_r31 = temp_r3_2;
-    temp_r3_2->font_size.x = 0.035f;
-    temp_r3_2->font_size.y = 0.035f;
-    temp_r3_2->default_fitting = 1;
+    text = HSD_SisLib_803A5ACC(0, 0, -5.0f, (3.45f * (f32) arg1) + -5.9f,
+                               17.0f, 514.2857f, 142.85715f);
+    *slot = text;
+    text->font_size.x = 0.035f;
+    text->font_size.y = 0.035f;
+    text->default_fitting = 1;
     un_802FE3F8((s32) arg2, 0x4BD, &sp16, NULL);
-    HSD_SisLib_803A6368(temp_r3_2, (s32) (u16) sp16);
+    HSD_SisLib_803A6368(text, (s32) (u16) sp16);
 }
 #pragma pop
+
+static inline s32 mnInfo_CountUnlocked(void)
+{
+    s32 i;
+    s32 count = 0;
+
+    for (i = 0; i < 0x42; i++) {
+        if (mnInfo_80251A08(i) != 0) {
+            count += 1;
+        }
+    }
+    return count;
+}
 
 void fn_80251FE4(void)
 {
@@ -233,8 +279,7 @@ void fn_80251FE4(void)
                 if (mnInfo_80251A08(*trophy) != 0) {
                     u8 id = *trophy;
 
-                    gmMainLib_8015D804(id);
-                    mnInfo_80251D58(gobj, i, id);
+                    mnInfo_80251D58(gobj, i, id, *gmMainLib_8015D804(id));
                     mnInfo_80251F04(gobj, i, id);
                 }
                 trophy++;
@@ -272,8 +317,7 @@ void fn_80251FE4(void)
                 if (mnInfo_80251A08(*trophy) != 0) {
                     u8 id = *trophy;
 
-                    gmMainLib_8015D804(id);
-                    mnInfo_80251D58(gobj, i, id);
+                    mnInfo_80251D58(gobj, i, id, *gmMainLib_8015D804(id));
                     mnInfo_80251F04(gobj, i, id);
                 }
                 trophy++;
@@ -282,37 +326,15 @@ void fn_80251FE4(void)
     }
 }
 
-static AnimLoopSettings mnInfo_803EFC08[0x12] = {
-    { 0.0f, 199.0f, 0.0f },
-    { 1.8e-42f, 1.802e-42f, 1.803e-42f },
-    { 1.805e-42f, 2.1092525e-16f, 1.379729e31f },
-    { 0.0f, 2.109659e-16f, 1.4748028e31f },
-    { 0.0f, 225.43028f, 5.083402e31f },
-    { 5.085142e31f, 7.153577e22f, 2.817505e20f },
-    { 6.162976e-33f, 4.6115556e27f, 2.8237532e23f },
-    { 0.0f, 3.0854143e32f, 1.6456562e19f },
-    { 1.4757395e20f, 2.405757e8f, 2.6912729e20f },
-    { 7.3738955e28f, 1.5307577e19f, 1.6892836e19f },
-    { 1.8878586e28f, 2.405757e8f, 2.6912729e20f },
-    { 7.3738955e28f, 1.5307577e19f, 1.6244036e19f },
-    { 4.5346362e27f, 1.8878586e28f, 2.405757e8f },
-    { 2.6912729e20f, 7.3738955e28f, 1.5307577e19f },
-    { 1.710508e19f, 2.7487011e20f, 1.6892836e19f },
-    { 1.8878586e28f, 2.405757e8f, 2.6912729e20f },
-    { 7.3738955e28f, 1.5307577e19f, 1.7539375e19f },
-    { 2.8395941e29f, 1.7935375e25f, 7.2243537e28f },
-};
-
 #pragma push
-#pragma dont_inline on
+#pragma auto_inline off
 void mnInfo_802522B8(HSD_GObj* gobj)
 {
     s32 count;
-    s32 i;
     MnInfoData* data;
     HSD_JObj* jobj;
     HSD_JObj* child;
-    PAD_STACK(12);
+    PAD_STACK(4);
 
     jobj = gobj->hsd_obj;
     data = gobj->user_data;
@@ -323,19 +345,14 @@ void mnInfo_802522B8(HSD_GObj* gobj)
         HSD_JObjSetFlagsAll(child, JOBJ_HIDDEN);
     }
     lb_80011E24(jobj, &child, 1, -1);
-    count = 0;
-    for (i = 0; i < 0x42; i++) {
-        if (mnInfo_80251A08(i) != 0) {
-            count++;
-        }
-    }
+    count = mnInfo_CountUnlocked();
 
     if ((data->scroll_idx + 4) < count) {
         HSD_JObjClearFlagsAll(child, JOBJ_HIDDEN);
     } else {
         HSD_JObjSetFlagsAll(child, JOBJ_HIDDEN);
     }
-    mn_8022ED6C(jobj, mnInfo_803EFC08);
+    mn_8022ED6C(jobj, (AnimLoopSettings*) mnInfo_803EFC08);
 }
 #pragma pop
 
@@ -394,7 +411,7 @@ void fn_802523D8(HSD_GObj* gobj)
     } else {
         HSD_JObjSetFlagsAll(sp1C, JOBJ_HIDDEN);
     }
-    mn_8022ED6C(temp_r28, mnInfo_803EFC08);
+    mn_8022ED6C(temp_r28, (AnimLoopSettings*) mnInfo_803EFC08);
 }
 
 void fn_80252548(HSD_GObj* gobj)
@@ -406,6 +423,8 @@ void fn_80252548(HSD_GObj* gobj)
     MnInfoData* data;
     MnInfoTextCursor* left;
     MnInfoTextCursor* right;
+    u32 date;
+    PAD_STACK(24);
 
     data = gobj->user_data;
     if (mn_804A04F0.cur_menu != MENU_KIND_DATA_SPECIAL) {
@@ -413,8 +432,8 @@ void fn_80252548(HSD_GObj* gobj)
         proc = HSD_GObj_SetupProc(gobj, fn_802523B8, 0);
         proc->flags_3 = HSD_GObj_804D783C;
         i = 0;
-        left = (MnInfoTextCursor*) data;
-        right = (MnInfoTextCursor*) data;
+        left = (MnInfoTextCursor*) gobj->user_data;
+        right = (MnInfoTextCursor*) gobj->user_data;
         do {
             if (left->left != NULL) {
                 HSD_SisLib_803A5CC4(right->left);
@@ -440,8 +459,8 @@ void fn_80252548(HSD_GObj* gobj)
         if (mnInfo_80251A08(*trophy) != 0) {
             u8 id = *trophy;
 
-            gmMainLib_8015D804(id);
-            mnInfo_80251D58((MenuInfo_GObj*) gobj, i, id);
+            date = *gmMainLib_8015D804(id);
+            mnInfo_80251D58((MenuInfo_GObj*) gobj, i, id, date);
             mnInfo_80251F04((MenuInfo_GObj*) gobj, i, id);
         }
         trophy++;

--- a/src/melee/mn/mninfo.h
+++ b/src/melee/mn/mninfo.h
@@ -4,6 +4,7 @@
 #include "placeholder.h"
 
 #include "baselib/forward.h"
+#include "sc/forward.h"
 
 /// seems like each menu probably has its own struct, and isnt just the 'Menu'
 /// in types.h
@@ -44,11 +45,14 @@ struct MenuInfo_GObj {
 typedef struct HSD_GObj MenuInfo_GObj;
 #endif
 
+extern StaticModelDesc mnInfo_804A0958;
+extern u8 mnInfo_804A0968[0x48];
+
 /* 251A08 */ s32 mnInfo_80251A08(s32);
 /* 251AA4 */ s32 mnInfo_80251AA4(void);
 /* 251AFC */ s32 mnInfo_80251AFC(void);
-/* 251D58 */ s32 mnInfo_80251D58(MenuInfo_GObj*, s32, u32);
-/* 251F04 */ void mnInfo_80251F04(MenuInfo_GObj*, u32, u32);
+/* 251D58 */ s32 mnInfo_80251D58(MenuInfo_GObj*, s32, u32, u32);
+/* 251F04 */ void mnInfo_80251F04(MenuInfo_GObj*, s32, u32);
 /* 251FE4 */ void fn_80251FE4(void);
 /* 2522B8 */ void mnInfo_802522B8(HSD_GObj*);
 /* 2523B8 */ void fn_802523B8(HSD_GObj*);

--- a/src/melee/mn/mnnamenew.c
+++ b/src/melee/mn/mnnamenew.c
@@ -30,6 +30,16 @@
 #include <dolphin/os.h>
 typedef char* GlyphRow[4];
 
+typedef struct MnNameNewDataLayout {
+    AnimLoopSettings anim[3];
+    u16 key_jobj_ids[8];
+    char* x34[50];
+    char* xFC[50];
+    char* character_bytes[50];
+    GlyphRow lower_glyphs[50];
+    GlyphRow upper_glyphs[50];
+} MnNameNewDataLayout;
+
 extern volatile char mnNameNew_NullCharacter;
 extern u8 mnNameNew_PortInUse;
 extern char mnNameNew_CurrentNameText[0x10];
@@ -456,12 +466,12 @@ bool NameContainsOnlySpaces(void)
     for (i = 0; i < 4; i++) {
         if (null_char != text[0]) {
             if (space0 != text[0] || sp[1] != text[1]) {
-                return FALSE;
+                return false;
             }
         }
         text += 3;
     }
-    return TRUE;
+    return true;
 }
 
 s32 WriteCharactersForNameAtIndex(u8 arg0, s32 arg1)
@@ -524,8 +534,10 @@ char* AddCharacterToName(char* arg0, u8 arg1, u8 arg2, u8 arg3)
     char ch;
     char* var_r4;
     char** table;
+    MnNameNewDataLayout* layout;
     u32 temp;
 
+    layout = (MnNameNewDataLayout*) mnNameNew_803EDA58;
     if ((s32) arg3 != 2) {
         if (((((s32) (temp = arg3)) < ((unsigned short) 2)) & 0xFFFFFFFF) &&
             (((s32) ((unsigned long) arg3)) >= 0))
@@ -535,22 +547,24 @@ char* AddCharacterToName(char* arg0, u8 arg1, u8 arg2, u8 arg3)
 
             if ((u8) (arg1 - 0x30) <= 1U) {
                 if ((arg2 % 2) != 0) {
-                    table =
-                        AddCharacterToName_getGlyphs(mnNameNew_803EE004, arg1);
+                    table = AddCharacterToName_getGlyphs(layout->upper_glyphs,
+                                                         arg1);
                 } else {
-                    table =
-                        AddCharacterToName_getGlyphs(mnNameNew_803EDCE4, arg1);
+                    table = AddCharacterToName_getGlyphs(layout->lower_glyphs,
+                                                         arg1);
                 }
             } else if ((arg3 == 0 && (arg2 % 2) == 0) ||
                        (arg3 == 1 && (arg2 % 2) != 0))
             {
-                table = AddCharacterToName_getGlyphs(mnNameNew_803EDCE4, arg1);
+                table =
+                    AddCharacterToName_getGlyphs(layout->lower_glyphs, arg1);
             } else {
-                table = AddCharacterToName_getGlyphs(mnNameNew_803EE004, arg1);
+                table =
+                    AddCharacterToName_getGlyphs(layout->upper_glyphs, arg1);
             }
             var_r4 = arg0;
 
-            for (idx = mnNameNew_803EDC1C[arg1][1] * 0;
+            for (idx = layout->character_bytes[arg1][1] * 0;
                  (null = (mnNameNew_NullCharacter & 0xFFFF) & 0xFFFF) !=
                  (ch = table[arg2 / 2][idx] & (0xFF & 0xFFu));
                  idx++)
@@ -561,9 +575,9 @@ char* AddCharacterToName(char* arg0, u8 arg1, u8 arg2, u8 arg3)
         }
         return arg0;
     }
-    arg0[0] = mnNameNew_803EDC1C[arg1][0];
-    arg0[1] = mnNameNew_803EDC1C[arg1][1];
-    arg0[2] = mnNameNew_803EDC1C[arg1][2];
+    arg0[0] = layout->character_bytes[arg1][0];
+    arg0[1] = layout->character_bytes[arg1][1];
+    arg0[2] = layout->character_bytes[arg1][2];
     return arg0;
 }
 
@@ -1528,19 +1542,24 @@ void fn_8023DBE8(HSD_GObj* arg0)
 
 void mnNameNew_8023E0D8(NameNewEntry* arg0)
 {
+    MnNameNewDataLayout* layout;
+    AnimLoopSettings* anim;
     HSD_JObj* jobj;
+    u16* jobj_ids;
     s32 i;
 
+    layout = (MnNameNewDataLayout*) mnNameNew_803EDA58;
+    anim = layout->anim;
     jobj = arg0->jobjs[12];
-    HSD_JObjReqAnim(jobj, mnNameNew_803EDA58[2].start_frame);
+    HSD_JObjReqAnim(jobj, anim[2].start_frame);
     HSD_JObjAnim(jobj);
 
     jobj = arg0->jobjs[13];
-    HSD_JObjReqAnim(jobj, mnNameNew_803EDA58[2].start_frame);
+    HSD_JObjReqAnim(jobj, anim[2].start_frame);
     HSD_JObjAnim(jobj);
 
     jobj = arg0->jobjs[4];
-    HSD_JObjReqAnim(jobj, mnNameNew_803EDA58[0].start_frame);
+    HSD_JObjReqAnim(jobj, anim[0].start_frame);
     HSD_JObjAnim(jobj);
 
     jobj = arg0->jobjs[5];
@@ -1548,7 +1567,7 @@ void mnNameNew_8023E0D8(NameNewEntry* arg0)
     HSD_JObjAnimAll(jobj);
 
     jobj = arg0->jobjs[2];
-    HSD_JObjReqAnim(jobj, mnNameNew_803EDA58[0].start_frame);
+    HSD_JObjReqAnim(jobj, anim[0].start_frame);
     HSD_JObjAnim(jobj);
 
     jobj = arg0->jobjs[5];
@@ -1556,12 +1575,13 @@ void mnNameNew_8023E0D8(NameNewEntry* arg0)
     HSD_JObjAnimAll(jobj);
 
     jobj = arg0->jobjs[6];
-    HSD_JObjReqAnim(jobj, mnNameNew_803EDA58[0].start_frame);
+    HSD_JObjReqAnim(jobj, anim[0].start_frame);
     HSD_JObjAnim(jobj);
 
+    jobj_ids = layout->key_jobj_ids;
     for (i = 0x32; i < 0x3A; i++) {
-        jobj = arg0->jobjs[mnNameNew_803EDA7C[i - 0x32]];
-        HSD_JObjReqAnimAll(jobj, (f32) (i == arg0->x1));
+        jobj = arg0->jobjs[jobj_ids[i - 0x32]];
+        HSD_JObjReqAnimAll(jobj, (f32) (arg0->x1 == i));
         HSD_JObjAnimAll(jobj);
     }
 }

--- a/src/melee/mn/mnnamenew.h
+++ b/src/melee/mn/mnnamenew.h
@@ -17,7 +17,7 @@
 /* 23BFE4 */ s32 WriteCharactersForNameAtIndex(u8 arg0, s32 arg1);
 /* 23C148 */ char* AddCharacterToName(char* arg0, u8 arg1, u8 arg2, u8 arg3);
 /* 23C290 */ void mnNameNew_GlyphVariantInput(void);
-/* 23C54C */ UNK_RET mnNameNew_MainInput(HSD_GObj*);
+/* 23C54C */ void mnNameNew_MainInput(HSD_GObj*);
 /* 23CE4C */ void mnNameNew_8023CE4C(void);
 /* 23CFC8 */ void fn_8023CFC8(HSD_GObj* arg0);
 /* 23D0F8 */ void fn_8023D0F8(void*);

--- a/src/melee/mn/mnruleplus.c
+++ b/src/melee/mn/mnruleplus.c
@@ -39,7 +39,7 @@ extern MenuKindData mn_803EB6B0[];
 extern HSD_GObj* mn_804D6BE0;
 extern f32 mn_804D6BE4;
 
-static mn_803ED1D0_t mn_803ED1D0 = {
+mn_803ED1D0_t mn_803ED1D0 = {
     { 3, 4, 5, 6, 7, 8, 9 },
     { 7, 2, 2, 2, 2, 0 },
     { 20.0f, 21.0f, 22.0f, 23.0f, 24.0f, 25.0f, 26.0f, 27.0f, 28.0f, 29.0f,
@@ -61,16 +61,58 @@ AnimLoopSettings mn_803ED294[7] = {
     { 50.0f, 69.0f, -0.1f },
 };
 
-u8 mn_803ED2E8[16][2] = { 0 };
+struct {
+    /* 0x00 */ u8 stat[6][2];
+    /* 0x0C */ u8 desc[6][3];
+    /* 0x1E */ u8 pad[2];
+} mn_803ED2E8 = {
+    { { 0, 99 }, { 0, 1 }, { 0, 1 }, { 0, 1 }, { 0, 2 }, { 0, 0 } },
+    { { 0x37, 0x00, 0x00 },
+      { 0x38, 0x39, 0x00 },
+      { 0x3A, 0x3B, 0x00 },
+      { 0x3D, 0x3C, 0x00 },
+      { 0x3F, 0x3E, 0x40 },
+      { 0x41, 0x00, 0x00 } },
+    { 0x00, 0x00 },
+};
+
+char mn_803ED308[0x18] = "Can't get user_data.\n";
+char mn_803ED320[0x10] = "mnruleplus.c";
+char mn_803ED330[0x10] = "user_data";
 
 typedef union {
     s32 packed;
     u8 idx[4];
 } JObjIndices;
 
-static JObjIndices mn_804DBE40 = { 0x02030506 };
-static f32 mn_804DBE44 = 0.0f;
-static JObjIndices mn_804DBE48 = { 0x02030506 };
+f32 mn_804D4B98 = 1.0f;
+volatile const f64 mn_804DBE38 = 4503599627370496.0;
+const JObjIndices mn_804DBE40 = { 0x02030506 };
+volatile f32 mn_804DBE44 = 0.0f;
+const JObjIndices mn_804DBE48 = { 0x02030506 };
+const f32 mn_804DBE4C = -9.5f;
+const f32 mn_804DBE50 = 8.0f;
+const f32 mn_804DBE54 = 17.0f;
+const f32 mn_804DBE58 = 364.68332f;
+const f32 mn_804DBE5C = 76.77544f;
+const f32 mn_804DBE60 = 0.0521f;
+volatile const f64 mn_804DBE68 = 4503599627370496.0;
+
+static inline void SisLib_ClearText(HSD_Text** text)
+{
+    if (*text != NULL) {
+        HSD_SisLib_803A5CC4(*text);
+        *text = NULL;
+    }
+}
+
+static inline u8 mnRulePlus_GetDescIdx(u8 sel, u8 confirmed)
+{
+    if ((s32) sel == 0 || (s32) sel == 5) {
+        return mn_803ED2E8.desc[sel][0];
+    }
+    return mn_803ED2E8.desc[sel][confirmed];
+}
 
 /// @brief Copy rule values from menu data to the global game rules.
 static inline void mnRulePlus_SaveRules(void)
@@ -175,7 +217,7 @@ void fn_8023201C(HSD_GObj* gobj)
         return;
     } else if ((u16) mn_804A04F0.hovered_selection != 5) {
         /// D-Pad Left/Right: adjust value for non-stage options
-        u8* bounds = mn_803ED2E8[mn_804A04F0.hovered_selection];
+        u8* bounds = mn_803ED2E8.stat[mn_804A04F0.hovered_selection];
         if (buttons & 4) {
             lbAudioAx_80024030(2);
             if ((u8) mn_804A04F0.confirmed_selection > (u8) bounds[0]) {
@@ -206,7 +248,7 @@ AnimLoopSettings* mn_80232458(u8 option, u8 value, u8 direction)
         return NULL;
     }
 
-    count = mn_803ED2E8[option][1];
+    count = mn_803ED2E8.stat[option][1];
 
     if (direction != 0) {
         if (value == 0) {
@@ -503,71 +545,55 @@ void mn_802327A4(HSD_GObj* gobj, u32 arg1, u32 arg2)
 void mn_80232D4C(HSD_GObj* gobj, u32 arg1, u32 arg2)
 {
     MenuRulesPlusData* data = gobj->user_data;
-    u16 selection;
+    u32 raw_selection;
+    u8 selection;
     u8 confirmed;
     u8 desc_idx;
     HSD_Text* text;
     PAD_STACK(8);
 
     if ((s32) arg1 != 0) {
-        selection = mn_804A04F0.hovered_selection;
+        raw_selection = mn_804A04F0.hovered_selection;
     } else {
-        selection = (u16) data->hovered_selection;
+        raw_selection = data->hovered_selection;
     }
+    selection = (u8) raw_selection;
 
     switch ((s32) data->state) {
+    case 2:
     case 4:
-        text = data->description;
-        if (text != NULL) {
-            HSD_SisLib_803A5CC4(text);
-            data->description = NULL;
-            return;
-        }
+        SisLib_ClearText(&data->description);
     case 5:
         return;
     case 3:
     case 1:
-        text = data->description;
-        if (text == NULL) {
+        if (data->description == NULL) {
             confirmed = mn_804A04F0.confirmed_selection;
-            if (text != NULL) {
-                HSD_SisLib_803A5CC4(text);
-                data->description = NULL;
-            }
-            if ((s32) (u8) selection == 0 || (s32) (u8) selection == 5) {
-                desc_idx = mn_803ED2E8[(u8) selection][0];
-            } else {
-                desc_idx = mn_803ED2E8[(u8) selection][confirmed];
-            }
-            text = HSD_SisLib_803A5ACC(0, 1, -9.5f, 8.0f, 17.0f, 364.68332f,
-                                       76.77544f);
+            SisLib_ClearText(&data->description);
+            desc_idx = mnRulePlus_GetDescIdx(selection, confirmed);
+            text = HSD_SisLib_803A5ACC(0, 1, mn_804DBE4C, mn_804DBE50,
+                                       mn_804DBE54, mn_804DBE58, mn_804DBE5C);
             data->description = text;
-            text->font_size.x = 0.0521f;
-            text->font_size.y = 0.0521f;
+            text->font_size.y = text->font_size.x = mn_804DBE60;
             HSD_SisLib_803A6368(text, (s32) desc_idx);
             return;
         }
         break;
     case 0:
         if ((s32) arg1 != 0 ||
-            ((s32) arg2 != 0 && (u8) selection != 0 && (u8) selection != 5))
+            ((s32) arg2 != 0 && selection != 0 && selection != 5))
         {
-            text = data->description;
             confirmed = mn_804A04F0.confirmed_selection;
-            if (text != NULL) {
-                HSD_SisLib_803A5CC4(text);
-                data->description = NULL;
-            }
-            if ((s32) (u8) selection == 0 || (s32) (u8) selection == 5) {
-                desc_idx = mn_803ED2E8[(u8) selection][0];
+            SisLib_ClearText(&data->description);
+            if ((s32) selection == 0 || (s32) selection == 5) {
+                desc_idx = mn_803ED2E8.desc[selection][0];
             } else {
-                desc_idx = mn_803ED2E8[(u8) selection][confirmed];
+                desc_idx = mn_803ED2E8.desc[selection][confirmed];
             }
-            text = HSD_SisLib_803A5ACC(0, 1, -9.5f, 8.0f, 17.0f, 364.68332f,
-                                       76.77544f);
+            text = HSD_SisLib_803A5ACC(0, 1, mn_804DBE4C, mn_804DBE50,
+                                       mn_804DBE54, mn_804DBE58, mn_804DBE5C);
             data->description = text;
-            text->font_size.x = 0.0521f;
-            text->font_size.y = 0.0521f;
+            text->font_size.y = text->font_size.x = mn_804DBE60;
             HSD_SisLib_803A6368(text, (s32) desc_idx);
         }
         break;
@@ -881,7 +907,7 @@ HSD_GObj* mn_80233218(MenuState state)
                         {
                             val_als = NULL;
                         } else if (val == 0) {
-                            val_als = &mn_803ED270[mn_803ED2E8[i][1]];
+                            val_als = &mn_803ED270[mn_803ED2E8.stat[i][1]];
                         } else {
                             val_als = &mn_803ED270[val - 1];
                         }
@@ -911,23 +937,15 @@ HSD_GObj* mn_80233218(MenuState state)
     }
 
     {
-        HSD_Text* text = user_data->description;
+        HSD_Text* text;
         u8 desc_idx;
         confirmed = mn_804A04F0.confirmed_selection;
-        if (text != NULL) {
-            HSD_SisLib_803A5CC4(text);
-            user_data->description = NULL;
-        }
-        if ((s32) selected == 0 || (s32) selected == 5) {
-            desc_idx = mn_803ED2E8[selected][0];
-        } else {
-            desc_idx = mn_803ED2E8[selected][confirmed];
-        }
-        text = HSD_SisLib_803A5ACC(0, 1, -9.5f, 8.0f, 17.0f, 364.68332f,
-                                   76.77544f);
+        SisLib_ClearText(&user_data->description);
+        desc_idx = mnRulePlus_GetDescIdx(selected, confirmed);
+        text = HSD_SisLib_803A5ACC(0, 1, mn_804DBE4C, mn_804DBE50, mn_804DBE54,
+                                   mn_804DBE58, mn_804DBE5C);
         user_data->description = text;
-        text->font_size.x = 0.0521f;
-        text->font_size.y = 0.0521f;
+        text->font_size.y = text->font_size.x = mn_804DBE60;
         HSD_SisLib_803A6368(text, (s32) desc_idx);
     }
 

--- a/src/melee/mn/mnruleplus.h
+++ b/src/melee/mn/mnruleplus.h
@@ -61,4 +61,12 @@ STATIC_ASSERT(sizeof(mn_803ED1D0_t) == 0xA0);
 /* 233218 */ HSD_GObj* mn_80233218(MenuState);
 /* 2339FC */ void mn_802339FC(void);
 
+extern volatile f32 mn_804DBE44;
+extern const f32 mn_804DBE4C;
+extern const f32 mn_804DBE50;
+extern const f32 mn_804DBE54;
+extern const f32 mn_804DBE58;
+extern const f32 mn_804DBE5C;
+extern const f32 mn_804DBE60;
+
 #endif

--- a/src/melee/mn/mnsnap.c
+++ b/src/melee/mn/mnsnap.c
@@ -409,9 +409,8 @@ void mnSnap_80253AE4(s32 mode)
 /// @returns 0 if no movement, 1 if moved within page, 2 if page changed.
 s32 mnSnap_80253BE0(u64 buttons, s32* cursor, s32 count)
 {
-    s32 cur = *cursor;
-    s32 next = cur;
-    PAD_STACK(8);
+    s32 next = *cursor;
+    s32 cur = next;
 
     if (buttons & 1) {
         if ((next & 1) == 1) {
@@ -436,7 +435,7 @@ s32 mnSnap_80253BE0(u64 buttons, s32* cursor, s32 count)
         if (next >= 4) {
             next -= 4;
         } else {
-            next = ((count - 1) & ~3) + (cur % 4);
+            next = ((count - 1) & ~3) + (next % 4);
             if (next >= count) {
                 next &= ~3;
             }
@@ -2322,21 +2321,27 @@ void fn_80257D7C(void)
                 HSD_GObjPLink_80390228(mnSnap_804A0A10.sub_gobj);
             }
             if (snap->cursor_gobj != NULL) {
-                HSD_GObjPLink_80390228(mnSnap_804A0A10.cursor_gobj);
+                HSD_GObjPLink_80390228(snap->cursor_gobj);
             }
             if (mnSnap_804A0A10.warn_gobj != NULL) {
                 HSD_GObjPLink_80390228(mnSnap_804A0A10.warn_gobj);
             }
 
-            for (i = 0; i < 4; i++) {
-                if (mnSnap_804A0A10.thumb_labels[i] != NULL) {
-                    HSD_SisLib_803A5CC4(mnSnap_804A0A10.thumb_labels[i]);
+            {
+                HSD_Text** text_p;
+                for (text_p = (HSD_Text**) snap, i = 0; i < 4; i++, text_p++) {
+                    if (text_p[0x3E] != NULL) {
+                        HSD_SisLib_803A5CC4(text_p[0x3E]);
+                    }
                 }
             }
 
-            for (i = 0; i < 2; i++) {
-                if (mnSnap_804A0A10.count_texts[i] != NULL) {
-                    HSD_SisLib_803A5CC4(mnSnap_804A0A10.count_texts[i]);
+            {
+                HSD_Text** text_p;
+                for (i = 0, text_p = (HSD_Text**) snap; i < 2; i++, text_p++) {
+                    if (text_p[0x42] != NULL) {
+                        HSD_SisLib_803A5CC4(text_p[0x42]);
+                    }
                 }
             }
 

--- a/src/melee/mn/mnsoundtest.c
+++ b/src/melee/mn/mnsoundtest.c
@@ -134,24 +134,26 @@ static char mnSoundTest_803EF57C[] = "MenMainConTs_Top_shapeanim_joint";
 
 void mnSoundTest_8024A790(HSD_GObj* arg0)
 {
-    f32 temp_f30;
     f32 temp_f31;
+    f32 temp_f30;
+    soundtest_user_data* temp_r31;
     s32 temp_r30;
     s32 temp_r30_2;
     s32 temp_r3;
     s32 temp_r3_2;
 
-    soundtest_user_data* temp_r31 = (soundtest_user_data*) arg0->user_data;
+    temp_r31 = (soundtest_user_data*) arg0->user_data;
     // control the volume by holding down L trigger
-    temp_f31 = 1.0f * (1.0f - HSD_PadCopyStatus->nml_analogL) *
-               (1.0f - HSD_PadCopyStatus[1].nml_analogL) *
-               (1.0f - HSD_PadCopyStatus[2].nml_analogL) *
-               (1.0f - HSD_PadCopyStatus[3].nml_analogL);
+    temp_f30 = 1.0f;
+    temp_f31 = temp_f30 * (1.0f - HSD_PadCopyStatus->nml_analogL);
+    temp_f30 *= 1.0f - HSD_PadCopyStatus->nml_analogR;
+    temp_f31 *= 1.0f - HSD_PadCopyStatus[1].nml_analogL;
+    temp_f30 *= 1.0f - HSD_PadCopyStatus[1].nml_analogR;
+    temp_f31 *= 1.0f - HSD_PadCopyStatus[2].nml_analogL;
+    temp_f30 *= 1.0f - HSD_PadCopyStatus[2].nml_analogR;
+    temp_f31 *= 1.0f - HSD_PadCopyStatus[3].nml_analogL;
     // R trigger doesn't seem to do anything
-    temp_f30 = 1.0f * (1.0f - HSD_PadCopyStatus->nml_analogR) *
-               (1.0f - HSD_PadCopyStatus[1].nml_analogR) *
-               (1.0f - HSD_PadCopyStatus[2].nml_analogR) *
-               (1.0f - HSD_PadCopyStatus[3].nml_analogR);
+    temp_f30 *= 1.0f - HSD_PadCopyStatus[3].nml_analogR;
     PAD_STACK(24);
     if ((temp_f31 < 0.9f) || (temp_r31->unk8 < 1.0f)) {
         temp_r30 =

--- a/src/melee/mn/mnvibration.c
+++ b/src/melee/mn/mnvibration.c
@@ -1,5 +1,15 @@
 #include "mnvibration.h"
 
+#include <baselib/debug.h>
+#undef HSD_ASSERT
+#define HSD_ASSERT(line, cond)                                                \
+    ((cond) ? ((void) 0)                                                      \
+            : __assert(mnVibration_804D4FF4, line, mnVibration_804D4FFC))
+#include <baselib/jobj.h>
+#undef HSD_ASSERT
+#define HSD_ASSERT(line, cond)                                                \
+    ((cond) ? ((void) 0) : __assert(__FILE__, line, #cond))
+
 #include "ft/ft_0C31.h"
 #include "gm/gm_1A36.h"
 #include "gm/gmmain_lib.h"
@@ -9,7 +19,6 @@
 #include "lb/lbaudio_ax.h"
 #include "mn/inlines.h"
 #include "mn/mnmain.h"
-#include "mn/mnname.h"
 #include "mn/types.h"
 
 #include <dolphin/os.h>
@@ -20,13 +29,37 @@
 #include <baselib/gobjplink.h>
 #include <baselib/gobjproc.h>
 #include <baselib/gobjuserdata.h>
-#include <baselib/jobj.h>
 #include <baselib/memory.h>
 #include <baselib/sislib.h>
 
 /// --- Externs ---
 extern long HSD_GObj_804D783C;
+char* GetNameText(u8 slot);
+int GetNameCount(void);
 void lb_8001CE00(void);
+
+typedef struct MnVibrationDataLayout {
+    AnimLoopSettings intro_anim;
+    AnimLoopSettings main_anim;
+    AnimLoopSettings cursor_anim;
+    Vec3 name_pos;
+    char user_data_error[0x18];
+    char file_name[0x10];
+    char user_data_name[0xC];
+    char title_top_joint[0x18];
+    char title_top_animjoint[0x1C];
+    char title_top_matanim_joint[0x20];
+    char title_top_shapeanim_joint[0x24];
+    char scl_top_joint[0x18];
+    char scl_top_animjoint[0x1C];
+    char scl_top_matanim_joint[0x20];
+    char scl_top_shapeanim_joint[0x24];
+    char option_top_joint[0x1C];
+    char option_top_animjoint[0x20];
+    char option_top_matanim_joint[0x24];
+    char option_top_shapeanim_joint[0x24];
+    char panel_top_joint[0x20];
+} MnVibrationDataLayout;
 
 // Local inline JObj functions using ftCo_800C6AFC pattern
 static inline f32 mnVibration_JObjGetTranslationX(HSD_JObj* jobj)
@@ -85,7 +118,29 @@ static inline void mnVibration_JObjSetTranslateZ(HSD_JObj* jobj, f32 z)
 
 // --- Static data ---
 static u16 mnVibration_804D4FE8[4] = { 0x16, 0x15, 0x14, 0x13 };
-static s32 mnVibration_804D4FF0;
+s32 mnVibration_804D4FF0 = 0x20010000;
+SDATA char mnVibration_804D4FF4[] = "jobj.h";
+SDATA char mnVibration_804D4FFC[] = "jobj";
+AnimLoopSettings mnVibration_803EECE0 = { 0.0f, 20.0f, -0.1f };
+AnimLoopSettings mnVibration_803EECEC = { 50.0f, 70.0f, -0.1f };
+AnimLoopSettings mnVibration_803EECF8 = { 0.0f, 14.0f, -0.1f };
+Vec3 mnVibration_803EED04 = { -0.4f, 0.5f, 0.0f };
+static char mnVibration_803EED10[0x18] = "Can't get user_data.\n";
+static char mnVibration_803EED28[0x10] = "mnvibration.c";
+static char mnVibration_803EED38[0xC] = "user_data";
+static char mnVibration_803EED44[0x18] = "MenMainConVi_Top_joint";
+static char mnVibration_803EED5C[0x1C] = "MenMainConVi_Top_animjoint";
+static char mnVibration_803EED78[0x20] = "MenMainConVi_Top_matanim_joint";
+static char mnVibration_803EED98[0x24] = "MenMainConVi_Top_shapeanim_joint";
+static char mnVibration_803EEDBC[0x18] = "MenMainCtlVi_Top_joint";
+static char mnVibration_803EEDD4[0x1C] = "MenMainCtlVi_Top_animjoint";
+static char mnVibration_803EEDF0[0x20] = "MenMainCtlVi_Top_matanim_joint";
+static char mnVibration_803EEE10[0x24] = "MenMainCtlVi_Top_shapeanim_joint";
+static char mnVibration_803EEE34[0x1C] = "MenMainOnoffVi_Top_joint";
+static char mnVibration_803EEE50[0x20] = "MenMainOnoffVi_Top_animjoint";
+static char mnVibration_803EEE70[0x24] = "MenMainOnoffVi_Top_matanim_joint";
+static char mnVibration_803EEE94[0x24] = "MenMainOnoffVi_Top_shapeanim_joint";
+static char mnVibration_803EEEB8[0x20] = "MenMainCursorVi_Top_joint";
 
 // --- Globals ---
 HSD_GObj* mnVibration_804D6C28;
@@ -132,6 +187,27 @@ MnVibrationJointAssets mnVibration_804A0888;
 MnVibrationJointAssets mnVibration_804A0898;
 
 /// --- Function Implementation ---
+
+static inline s32 mnVibration_GetNameSlot(MnVibrationData* data, s32 j)
+{
+    u8 scroll_offset = data->scroll_offset;
+    s32 count = GetNameCount();
+    s32 name_idx;
+
+    if ((count < 8) && (j >= count)) {
+        return 0xFF;
+    }
+    name_idx = scroll_offset + j;
+    if (count <= name_idx) {
+        return 0xFF;
+    }
+    return (u8) name_idx;
+}
+
+inline u8 mnVibration_GetNameRumble(s32 name_idx)
+{
+    return GetPersistentNameData(name_idx)->x1A1;
+}
 
 HSD_JObj* mnVibration_802474C4(s32 count)
 {
@@ -433,23 +509,24 @@ void mnVibration_802480B4(HSD_JObj* arg0, u8 arg1, u8 arg2)
     HSD_JObj* sp14;
     HSD_JObj* sp10;
     u8 temp_ret;
-    MnVibrationFloatData* floats = &mnVibration_803EECE0;
+    MnVibrationDataLayout* floats =
+        (MnVibrationDataLayout*) &mnVibration_803EECE0;
 
     lb_80011E24(arg0, &sp14, 1, -1);
     if (arg2 != 0) {
         HSD_JObjReqAnimAll(sp14, (f32) arg1);
         HSD_JObjAnimAll(sp14);
         if (GetRumbleSettingOfPort((s32) arg1) != 0) {
-            HSD_JObjReqAnimAll(sp14, floats->x1C);
+            HSD_JObjReqAnimAll(sp14, floats->cursor_anim.end_frame);
         } else {
-            HSD_JObjReqAnimAll(sp14, floats->x18);
+            HSD_JObjReqAnimAll(sp14, floats->cursor_anim.start_frame);
         }
         mn_8022F3D8(sp14, 0xFF, MOBJ_MASK);
         HSD_JObjAnimAll(sp14);
     } else {
         HSD_JObjReqAnimAll(sp14, mnVibration_804DC020);
         HSD_JObjAnimAll(sp14);
-        HSD_JObjReqAnimAll(sp14, floats->x1C);
+        HSD_JObjReqAnimAll(sp14, floats->cursor_anim.end_frame);
         mn_8022F3D8(sp14, 0xFF, MOBJ_MASK);
         HSD_JObjAnimAll(sp14);
     }
@@ -520,11 +597,13 @@ void mnVibration_80248444(HSD_GObj* arg0, u8 arg1, u8 arg2)
     u8 name_flag;
     HSD_JObj* new_jobj;
     f32 spacing;
-    PAD_STACK(8);
+    f32 pos_x;
+    f32 pos_y;
+    f32 pos_z;
 
     assets = &mnVibration_804A0888;
     data = arg0->user_data;
-    name_flag = GetPersistentNameData((s32) arg1)->x1A1;
+    name_flag = mnVibration_GetNameRumble((s32) arg1);
     jobj17 = data->jobjs[17];
     spacing = HSD_JObjGetTranslationY(jobj17);
     jobj18 = data->jobjs[18];
@@ -532,86 +611,53 @@ void mnVibration_80248444(HSD_GObj* arg0, u8 arg1, u8 arg2)
     lb_8000B1CC(data->jobjs[17], &mnVibration_803EED04, &sp20);
     text = HSD_SisLib_803A6754(0, 1);
     data->texts[arg2] = text;
-    text->pos_x = sp20.x;
-    text->pos_y = -(spacing * (f32) arg2 + sp20.y);
-    text->pos_z = sp20.z;
+    pos_y = -(spacing * (f32) arg2 + sp20.y);
+    pos_z = sp20.z;
+    pos_x = sp20.x;
+    text->pos_x = pos_x;
+    text->pos_y = pos_y;
+    text->pos_z = pos_z;
     text->font_size.x = 0.03f;
     text->font_size.y = 0.03f;
     HSD_SisLib_803A6B98(text, 0.0f, 0.0f, GetNameText(arg1));
-    new_jobj = HSD_JObjLoadJoint(assets->joint);
+    new_jobj = new_jobj = HSD_JObjLoadJoint(assets->joint);
     HSD_JObjAddAnimAll(new_jobj, assets->animjoint, assets->matanim,
                        assets->shapeanim);
-    HSD_JObjReqAnimAll(new_jobj, (f32) name_flag);
+    HSD_JObjReqAnimAll(new_jobj, name_flag);
     HSD_JObjAnimAll(new_jobj);
     HSD_JObjSetTranslateY(new_jobj, spacing * (f32) arg2);
     HSD_JObjAddChild(data->jobjs[17], new_jobj);
 }
 
-s32 mnVibration_80248644(HSD_GObj* arg0)
+void mnVibration_80248644(HSD_GObj* arg0)
 {
-    s32 i;
+    s32 j;
+    MnVibrationData* ptr2;
     MnVibrationData* data;
-    HSD_Text** ptr1;
-    HSD_Text** ptr2;
-    s32 zero;
+    s32 i;
     HSD_JObj* jobj17;
     HSD_JObj* child;
-    s32 j;
-    u8 scroll_offset;
     s32 name_idx;
-    s32 count;
 
-    i = 0;
-    zero = 0;
-    data = arg0->user_data;
-    ptr2 = data->texts;
-    ptr1 = data->texts + i;
-    do {
-        if (*ptr2 != NULL) {
-            HSD_SisLib_803A5CC4(*ptr1);
-            *ptr2 = NULL;
+    ptr2 = data = arg0->user_data;
+    for (i = 0; i < 8; i++) {
+        if (data->texts[i] != NULL) {
+            HSD_SisLib_803A5CC4(ptr2->texts[i]);
+            data->texts[i] = NULL;
         }
-        i += 1;
-        ptr2++;
-        ptr1++;
-    } while (i < 8);
+    }
     jobj17 = data->jobjs[17];
-    if (jobj17 == NULL) {
-        child = NULL;
-    } else {
-        child = jobj17->child;
-    }
+    child = HSD_JObjGetChild(jobj17);
     if (child != NULL) {
-        if (jobj17 == NULL) {
-            jobj17 = NULL;
-        } else {
-            jobj17 = jobj17->child;
-        }
-        HSD_JObjRemoveAll(jobj17);
+        HSD_JObjRemoveAll(HSD_JObjGetChild(jobj17));
     }
-    j = 0;
-    do {
-        scroll_offset = data->scroll_offset;
-        count = GetNameCount();
-        if ((count < 8) && (j >= count)) {
-            name_idx = 0xFF;
-        } else {
-            name_idx = scroll_offset + j;
-            if (count <= name_idx) {
-                name_idx = 0xFF;
-            } else {
-                name_idx = (u8) name_idx;
-            }
-        }
-        if ((u8) name_idx != 0xFF) {
+    for (j = 0; j < 8; j++) {
+        name_idx = mnVibration_GetNameSlot(data, j);
+        if ((s32) (u8) name_idx != 0xFF) {
             mnVibration_80248444(arg0, (u8) name_idx, (u8) j);
         }
-        j += 1;
-    } while (j < 8);
-    return count;
+    }
 }
-
-static AnimLoopSettings mnVibration_803EECEC = { 50.0f, 70.0f, -0.1f };
 
 void fn_80248748(HSD_GObj* gobj)
 {
@@ -624,8 +670,6 @@ void fn_80248748(HSD_GObj* gobj)
         HSD_GObjPLink_80390228(gobj);
     }
 }
-
-static AnimLoopSettings mnVibration_803EECF8 = { 0.0f, 14.0f, -0.1f };
 
 void fn_802487A8(HSD_GObj* gobj)
 {
@@ -909,6 +953,8 @@ void mnVibration_80248ED4(s32 arg0)
     HSD_Text* text;
     s32 i;
     MnVibrationData* data;
+    MnVibrationDataLayout* layout =
+        (MnVibrationDataLayout*) &mnVibration_803EECE0;
 
     (void) arg0;
     PAD_STACK(24);
@@ -920,22 +966,18 @@ void mnVibration_80248ED4(s32 arg0)
     GObj_SetupGXLink(gobj, HSD_GObj_JObjCallback, 4, 0x80);
     HSD_JObjAddAnimAll(jobj, assets->animjoint, assets->matanim,
                        assets->shapeanim);
-    HSD_JObjReqAnimAll(jobj, 0.0f);
+    HSD_JObjReqAnimAll(jobj, mnVibration_804DC030);
     data = HSD_MemAlloc(sizeof(MnVibrationData));
     if (data == NULL) {
-        OSReport("couldn't allocate\n");
-        __assert("mnvibration.c", 0x3A7, "data");
+        OSReport(layout->user_data_error);
+        __assert(layout->file_name, 0x3A7, layout->user_data_name);
     }
     data->x0[0] = 0;
     data->x0[1] = 0;
-    data->x0[2] = 0;
-    data->x6[0] = (HSD_PadCopyStatus[0].err != 0) ? 0 : 1;
-    data->x0[3] = 0;
-    data->x6[1] = (HSD_PadCopyStatus[1].err != 0) ? 0 : 1;
-    data->x0[4] = 0;
-    data->x6[2] = (HSD_PadCopyStatus[2].err != 0) ? 0 : 1;
-    data->x0[5] = 0;
-    data->x6[3] = (HSD_PadCopyStatus[3].err != 0) ? 0 : 1;
+    for (i = 0; i < 4; i++) {
+        data->x0[i + 2] = 0;
+        data->x6[i] = HSD_PadCopyStatus[(u8) i].err != 0 ? 0 : 1;
+    }
     data->scroll_offset = 0;
     data->texts[0] = NULL;
     data->texts[1] = NULL;
@@ -946,20 +988,21 @@ void mnVibration_80248ED4(s32 arg0)
     data->texts[6] = NULL;
     data->texts[7] = NULL;
     GObj_InitUserData(gobj, 0, HSD_Free, data);
-    i = 0;
-    do {
-        lb_80011E24(jobj, &data->jobjs[i], i, -1);
-        i += 1;
-    } while (i < 0x19);
+    {
+        s32 k = 0;
+        do {
+            lb_80011E24(jobj, &data->jobjs[k], k, -1);
+            k += 1;
+        } while (k < 0x19);
+    }
     HSD_JObjSetFlagsAll(data->jobjs[22], 0x10);
     HSD_JObjSetFlagsAll(data->jobjs[21], 0x10);
     HSD_JObjSetFlagsAll(data->jobjs[20], 0x10);
     HSD_JObjSetFlagsAll(data->jobjs[19], 0x10);
     HSD_GObj_SetupProc(gobj, (void (*)(HSD_GObj*)) fn_80248A78, 0);
     mnVibration_8024829C(gobj);
-    text = data->title_text;
-    if (text != NULL) {
-        HSD_SisLib_803A5CC4(text);
+    if (data->title_text != NULL) {
+        HSD_SisLib_803A5CC4(data->title_text);
     }
     text =
         HSD_SisLib_803A5ACC(0, 1, -9.5f, 9.1f, 17.0f, 364.68332f, 38.38772f);
@@ -971,51 +1014,43 @@ void mnVibration_80248ED4(s32 arg0)
 
 void mnVibration_80249174(int arg0)
 {
-    int saved_arg = arg0;
+    HSD_Archive* archive;
     HSD_GObj* gobj;
-    u8* gobj_flags_ptr;
-    PAD_STACK(8);
+    HSD_GObjProc* proc;
+    MnVibrationJointAssets* assets;
+    MnVibrationDataLayout* strings;
 
+    strings = (MnVibrationDataLayout*) &mnVibration_803EECE0;
+    assets = (MnVibrationJointAssets*) &mnVibration_804A0868;
     mn_804D6BC8.cooldown = 5;
     mn_804A04F0.prev_menu = mn_804A04F0.cur_menu;
     mn_804A04F0.cur_menu = 19;
     mn_804A04F0.hovered_selection = 0;
+    archive = mn_804D6BB8;
 
-    // Correct Order: Title -> SCl -> Option -> Panel
     lbArchive_LoadSections(
-        mn_804D6BB8, &mnVibration_804A0868.Title_Top_joint,
-        "MnVibTitle_Top_joint", &mnVibration_804A0868.Title_Top_animjoint,
-        "MnVibTitle_Top_animjoint",
-        &mnVibration_804A0868.Title_Top_matanim_joint,
-        "MnVibTitle_Top_matanim_joint",
-        &mnVibration_804A0868.Title_Top_shapeanim_joint,
-        "MnVibTitle_Top_shapeanim_joint",
+        archive, &assets[3].joint, strings->title_top_joint,
+        &assets[3].animjoint, strings->title_top_animjoint, &assets[3].matanim,
+        strings->title_top_matanim_joint, &assets[3].shapeanim,
+        strings->title_top_shapeanim_joint,
 
-        &mnVibration_804A0868.SCl_Top_joint, "MnVibSCl_Top_joint",
+        &assets[1].joint, strings->scl_top_joint, &assets[1].animjoint,
+        strings->scl_top_animjoint, &assets[1].matanim,
+        strings->scl_top_matanim_joint, &assets[1].shapeanim,
+        strings->scl_top_shapeanim_joint,
 
-        &mnVibration_804A0868.Option_Top_joint, "MnVibOption_Top_joint",
-        &mnVibration_804A0868.Option_Top_animjoint,
-        "MnVibOption_Top_animjoint",
-        &mnVibration_804A0868.Option_Top_matanim_joint,
-        "MnVibOption_Top_matanim_joint",
-        &mnVibration_804A0868.Option_Top_shapeanim_joint,
-        "MnVibOption_Top_shapeanim_joint",
+        &assets[2].joint, strings->option_top_joint, &assets[2].animjoint,
+        strings->option_top_animjoint, &assets[2].matanim,
+        strings->option_top_matanim_joint, &assets[2].shapeanim,
+        strings->option_top_shapeanim_joint,
 
-        &mnVibration_804A0868.Panel_Top_joint, "MnVibPanel_Top_joint",
-        &mnVibration_804A0868.Panel_Top_animjoint, "MnVibPanel_Top_animjoint",
-        &mnVibration_804A0868.Panel_Top_matanim_joint,
-        "MnVibPanel_Top_matanim_joint",
-        &mnVibration_804A0868.Panel_Top_shapeanim_joint,
-        "MnVibPanel_Top_shapeanim_joint",
+        &assets[0].joint, strings->panel_top_joint,
 
         NULL);
 
-    mnVibration_80248ED4(saved_arg);
+    mnVibration_80248ED4(arg0);
 
     gobj = GObj_Create(0, 1, 0x80);
-    HSD_GObj_SetupProc(gobj, (void (*)(HSD_GObj*)) fn_80247510, 0);
-
-    gobj_flags_ptr = (u8*) gobj + 0xD;
-    *gobj_flags_ptr =
-        (*gobj_flags_ptr & 0xCF) | ((HSD_GObj_804D783C << 4) & 0x30);
+    proc = HSD_GObj_SetupProc(gobj, (void (*)(HSD_GObj*)) fn_80247510, 0);
+    proc->flags_3 = HSD_GObj_804D783C;
 }

--- a/src/melee/mn/mnvibration.h
+++ b/src/melee/mn/mnvibration.h
@@ -8,15 +8,8 @@
 
 #include <dolphin/mtx.h>
 
-typedef struct MnVibrationFloatData {
-    u8 pad0[0x18];
-    f32 x18;
-    f32 x1C;
-} MnVibrationFloatData;
-
-extern MnVibrationFloatData mnVibration_803EECE0;
 extern f32 mnVibration_804DC020;
-extern Vec3 mnVibration_803EED04;
+extern f32 mnVibration_804DC030;
 extern SDATA char mnVibration_804D4FF4[];
 extern SDATA char mnVibration_804D4FFC[];
 
@@ -26,7 +19,7 @@ extern SDATA char mnVibration_804D4FFC[];
 /* 2480B4 */ void mnVibration_802480B4(HSD_JObj* arg0, u8 arg1, u8 arg2);
 /* 24829C */ void mnVibration_8024829C(HSD_GObj* arg0);
 /* 248444 */ void mnVibration_80248444(HSD_GObj* arg0, u8 arg1, u8 arg2);
-/* 248644 */ s32 mnVibration_80248644(HSD_GObj* arg0);
+/* 248644 */ void mnVibration_80248644(HSD_GObj* arg0);
 /* 248748 */ void fn_80248748(HSD_GObj* gobj);
 /* 2487A8 */ void fn_802487A8(HSD_GObj* gobj);
 /* 248A78 */ void fn_80248A78(HSD_GObj*);


### PR DESCRIPTION
## Summary
- Match `mn_80232D4C`
- Match `AddCharacterToName` and `mnNameNew_8023E0D8`
- Match `mnDiagram2_GetStatValue` and `mnDiagram2_UpdateScrollArrows`
- Match `mnVibration_80248444`, `mnVibration_80248644`, `mnVibration_80248ED4`, and `mnVibration_80249174`
- Match `mnSoundTest_8024A790`, `mnDataDel_80250170`, `mnInfo_80251D58`, `mnInfo_80251F04`, `mnInfo_802522B8`, `mnSnap_80253BE0`, and `fn_80257D7C`
- Match `mnCount_GetRowValue_Character` and improve adjacent count-row value logic

## Verification
- `python configure.py --require-protos && ninja`