### PR TITLE
Match several particle functions

### DIFF
--- a/src/melee/ef/eflib.c
+++ b/src/melee/ef/eflib.c
@@ -682,7 +682,7 @@ void efLib_particles_proc_aux(HSD_GObj* gobj)
 HSD_Generator* efLib_CreateGenerator(s32 gfx_id, Vec3* pos)
 {
     HSD_Generator* generator;
-    u8 linkNo;
+    int linkNo;
 
     linkNo = 0;
     switch (gfx_id) {

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1674,19 +1674,23 @@ void fn_80393C14(const u8* buf, size_t size)
     hsd_804CF7E8.x11 = line_len;
 }
 
+#pragma push
+#pragma dont_inline on
 s32 hsd_80393D2C(s32 enable)
 {
-    s32 old = hsd_804CF7E8.x0_b1;
+    struct ParticleConsoleState* sp = &hsd_804CF7E8;
+    s32 old = sp->x0_b1;
 
     if (enable != 0) {
-        hsd_804CF7E8.x0_b1 = 1;
+        sp->x0_b1 = 1;
         HSD_SetReportCallback(fn_80393C14);
     } else {
-        hsd_804CF7E8.x0_b1 = 0;
+        sp->x0_b1 = 0;
         HSD_SetReportCallback(NULL);
     }
     return old;
 }
+#pragma pop
 
 void hsd_80393DA0(u8* buf, size_t size)
 {

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -8565,7 +8565,6 @@ void hsd_8039EE24(u32 mask)
     }
 }
 
-// @TODO: Currently 91.82% match - 2 dead beq instructions in target
 HSD_Generator* hsd_8039EFAC(s32 linkNo, s32 bank, s32 gfx_id, HSD_JObj* jobj)
 {
     HSD_Generator* gen;
@@ -8574,14 +8573,19 @@ HSD_Generator* hsd_8039EFAC(s32 linkNo, s32 bank, s32 gfx_id, HSD_JObj* jobj)
     if (gen == NULL) {
         return NULL;
     }
-    gen->jobj = jobj;
-    ref_INC(jobj);
+    if (gen != NULL) {
+        gen->jobj = jobj;
+        if (jobj != NULL) {
+            ref_INC(jobj);
+        }
+    }
     gen->type |= (gen->kind & 0x20000) ? 0x500 : 0x700;
     return gen;
 }
 
-// @TODO: Currently 80.55% match - ASM bytes identical, relocation differences
-HSD_Generator* hsd_8039F05C(s8 linkNo, s32 bank, s32 idx)
+// @TODO: Currently 80.79% match - .bss.0 section anchor hoist causes
+// register-allocation cascade (extra saved reg + frame shift)
+HSD_Generator* hsd_8039F05C(s32 linkNo, s32 bank, s32 idx)
 {
     HSD_PSCmdList** cmdListArr;
     HSD_PSCmdList* cl;
@@ -8809,7 +8813,6 @@ HSD_Generator* hsd_8039F05C(s8 linkNo, s32 bank, s32 idx)
     return gen;
 }
 
-// @TODO: Currently 92.50% match - dead beq instructions in target
 HSD_Generator* hsd_8039F6CC(s32 linkNo, s32 bank, s32 gfx_id, HSD_JObj* jobj)
 {
     HSD_Generator* gen;
@@ -8818,8 +8821,12 @@ HSD_Generator* hsd_8039F6CC(s32 linkNo, s32 bank, s32 gfx_id, HSD_JObj* jobj)
     if (gen == NULL) {
         return NULL;
     }
-    gen->jobj = jobj;
-    ref_INC(jobj);
+    if (gen != NULL) {
+        gen->jobj = jobj;
+        if (jobj != NULL) {
+            ref_INC(jobj);
+        }
+    }
     gen->type |= (gen->kind & 0x20000) ? 0x500 : 0x700;
     hsd_804D78F4 =
         (u32) HSD_SListAllocAndAppend((HSD_SList*) hsd_804D78F4, gen);

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -2949,8 +2949,7 @@ static inline void ps_remove_node(struct ParticleScreenState* sp, void* node)
     if (node == NULL) {
         return;
     }
-    head_ptr = &sp->xD0;
-    if (*head_ptr == NULL) {
+    if (*(head_ptr = &sp->xD0) == NULL) {
         return;
     }
     while ((cur = *head_ptr) != NULL && cur != node) {
@@ -3248,9 +3247,9 @@ s32 hsd_803962A8(void* data)
     return 0;
 }
 
-// @TODO: Currently 96.49% match - needs minor register allocation fix
 s32 hsd_803966A0(void* data)
 {
+    struct ParticleScreenState* sp = &hsd_804CF810;
     s32 result;
 
     result = hsd_80395550(data);
@@ -3261,32 +3260,32 @@ s32 hsd_803966A0(void* data)
         u32 cmd = *(u32*) ((u8*) data + 0x14);
         switch (cmd) {
         case 0:
-            (&hsd_804CF810)->xBC = 8;
+            sp->xBC = 8;
             break;
         case 1:
-            (&hsd_804CF810)->xBC = 4;
+            sp->xBC = 4;
             break;
         case 2:
-            (&hsd_804CF810)->xBC = 1;
+            sp->xBC = 1;
             break;
         case 3:
-            (&hsd_804CF810)->xBC = 2;
+            sp->xBC = 2;
             break;
         case 4:
-            (&hsd_804CF810)->xBC = 0x100;
+            sp->xBC = 0x100;
             break;
         case 5:
-            (&hsd_804CF810)->xBC = 0x400;
+            sp->xBC = 0x400;
             break;
         case 6:
-            (&hsd_804CF810)->xBC = 0x200;
+            sp->xBC = 0x200;
             break;
         }
-        ps_remove_node(&hsd_804CF810, data);
+        ps_remove_node(sp, data);
         return 0;
     }
     case -1:
-        ps_remove_node(&hsd_804CF810, data);
+        ps_remove_node(sp, data);
         return 1;
     default:
         return 0;
@@ -3403,8 +3402,6 @@ s32 hsd_80396A20(void* data)
     return 0;
 }
 
-// @TODO: Currently 96.49% match - ps_remove_node inline scheduling (addi/lwz
-// order)
 s32 hsd_80396C78(void* data)
 {
     struct ParticleScreenState* sp = &hsd_804CF810;
@@ -3697,36 +3694,34 @@ void hsd_80397110(void)
     *px50 = saved;
 }
 
-// @TODO: Currently 98.13% match - ps_remove_node inline scheduling (addi/lwz
-// order)
 s32 fn_80397374(void* data)
 {
-    struct ParticleScreenState* sp;
+    struct ParticleScreenState* sp = &hsd_804CF810;
     extern u8 lbl_8040BEC4[];
     u32 bit = 1;
     u32 spr_off = *(u32*) (lbl_8040BEC4 + 0x10);
     u32 sel = *(u32*) (lbl_8040BEC4 + 0x14);
 
-    while (bit <= (&hsd_804CF810)->xBC) {
-        switch ((&hsd_804CF810)->xBC & bit) {
+    while (bit <= sp->xBC) {
+        switch (sp->xBC & bit) {
         case 0x8:
             if (sel != 0) {
                 sel--;
             } else if (spr_off != 0) {
                 spr_off--;
             } else {
-                u32 max = (&hsd_804CF810)->x1C - 4;
+                u32 max = sp->x1C - 4;
                 sel = max;
                 spr_off = 0x44;
                 spr_off = spr_off - max;
             }
             *(u32*) (lbl_8040BEC4 + 0x10) = spr_off;
             *(u32*) (lbl_8040BEC4 + 0x14) = sel;
-            if ((&hsd_804CF810)->x1C) {
+            if (sp->x1C) {
             }
             return 1;
         case 0x4:
-            if (sel < (u32) ((&hsd_804CF810)->x1C - 4)) {
+            if (sel < (u32) (sp->x1C - 4)) {
                 sel++;
             } else if (spr_off + sel < 0x43) {
                 spr_off++;
@@ -3745,7 +3740,7 @@ s32 fn_80397374(void* data)
         case 0x1000:
             return 1;
         case 0x200:
-            ps_remove_node(&hsd_804CF810, data);
+            ps_remove_node(sp, data);
             return 1;
         default:
             bit <<= 1;

--- a/src/sysdolphin/baselib/particle.h
+++ b/src/sysdolphin/baselib/particle.h
@@ -143,7 +143,7 @@ struct hsd_804D0F60_t {
 /* 39EE24 */ void hsd_8039EE24(u32);
 /* 39EFAC */ HSD_Generator* hsd_8039EFAC(s32 linkNo, s32 bank, s32 gfx_id,
                                          HSD_JObj*);
-/* 39F05C */ HSD_Generator* hsd_8039F05C(s8 linkNo, s32 bank, s32 idx);
+/* 39F05C */ HSD_Generator* hsd_8039F05C(s32 linkNo, s32 bank, s32 idx);
 /* 39F6CC */ HSD_Generator* hsd_8039F6CC(s32 linkNo, s32 bank, s32 gfx_id,
                                          HSD_JObj*);
 


### PR DESCRIPTION
Matches six functions in `src/sysdolphin/baselib/particle.c`:

- `hsd_80393D2C`
- `hsd_803966A0`
- `hsd_80396C78`
- `fn_80397374`
- `hsd_8039EFAC`
- `hsd_8039F6CC`

This also corrects the first parameter of `hsd_8039F05C` from `s8` to `s32`, matching the `int linkNo` convention used by the surrounding particle APIs. The widened prototype removes spurious caller-side narrowing; `efLib_CreateGenerator`'s local `linkNo` is widened from `u8` to `int` so that caller remains matched.

Additional report improvements:

- `hsd_80395D88`
- `hsd_803962A8`
- `hsd_80396A20`
- `fn_80397814`
- `hsd_8039F05C`

Verification:

- `python configure.py --require-protos`
- `ninja`
- GALE01 report shows the six listed functions at 100.0%.