### PR TITLE
Match several ft, pl, and if functions

### DIFF
--- a/src/melee/ft/chara/ftCommon/ftCo_Guard.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Guard.c
@@ -245,14 +245,10 @@ void ftCo_80091E78(HSD_GObj* gobj, float arg1)
 
 void ftCo_80092158(Fighter_GObj* gobj, int arg1, HSD_JObj* arg2)
 {
-    u8 temp_ret = Player_GetUnk45(GET_FIGHTER(gobj)->player_id);
-    u8* temp_r7 = &Fighter_804D650C[temp_ret];
-    u8 temp_r7_2 = M2C_FIELD(temp_r7, u8*, 2);
+    int offset = Player_GetUnk45(GET_FIGHTER(gobj)->player_id) << 2;
+    u8* color = Fighter_804D650C + offset;
     efSync_Spawn(arg1, gobj, arg2,
-                 temp_r7_2 |
-                     (((M2C_FIELD(temp_r7, u8*, 1) << 8) & ~0xFF0000) |
-                      ((M2C_FIELD(temp_r7, u8*, 0) << 0x10) & 0xFF0000)),
-                 temp_r7_2, M2C_BITWISE(float, temp_ret));
+                 (color[0] << 16) | (color[1] << 8) | color[2]);
 }
 void ftCo_800921DC(HSD_GObj* gobj)
 {
@@ -721,14 +717,12 @@ void ftCo_8009370C(Fighter_GObj* gobj, HSD_GObjEvent on_reflect)
 
 void ftCo_80093790(Fighter_GObj* gobj)
 {
+    u8 _[8] = { 0 };
     Fighter* fp = gobj->user_data;
     ftCommon_8007DB24(gobj);
-    {
-        HSD_JObj* jobj = fp->parts[fp->ft_data->x8->x11].joint;
-        ftCo_80092158(gobj, 1050, jobj);
-        fp->x2219_b0 = true;
-        ft_PlaySFX(fp, 128, 127, 64);
-    }
+    ftCo_80092158(gobj, 1050, fp->parts[fp->ft_data->x8->x11].joint);
+    fp->x2219_b0 = true;
+    ft_PlaySFX(fp, 128, 127, 64);
 }
 
 void ftCo_80093850(Fighter_GObj* gobj)

--- a/src/melee/ft/chara/ftCommon/ftCo_Guard.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Guard.c
@@ -115,60 +115,51 @@ void ftCo_80091B9C(Fighter_GObj* gobj)
     fp->mv.co.guard.x24 = p_ftCommonData->x68;
 }
 
-static inline float normalizeAngle180(float deg)
-{
-    if (deg > 180) {
-        deg -= 360;
-    } else if (deg < -180) {
-        deg += 360;
-    }
-    return deg;
-}
-
-static inline float normalizeAngle0(float deg)
-{
-    if (deg > 360) {
-        deg -= 360;
-    } else if (deg < 0) {
-        deg += 360;
-    }
-    return deg;
-}
-
 void ftCo_80091BC4(Fighter* fp)
 {
-    float lstick_x = fp->input.lstick.x * fp->facing_dir;
-    float lstick_rad = lb_8000D008(fp->input.lstick.y, lstick_x);
-    if (lstick_rad < 0) {
-        lstick_rad += 2 * (float) M_PI;
+    float stick_rad, stick_deg, deg_delta, guard_deg, smoothed_deg, stick_mag;
+
+    stick_rad =
+        lb_8000D008(fp->input.lstick.y, fp->input.lstick.x * fp->facing_dir);
+    if (stick_rad < 0) {
+        stick_rad += 2 * (float) M_PI;
     }
-    {
-        float lstick_deg = rad_to_deg * lstick_rad;
-        if (lstick_deg < 0) {
-            lstick_deg = 0;
-        }
-        if (lstick_deg > 359) {
-            lstick_deg = 359;
-        }
-        {
-            Fighter* fp0;
-            float offset = (fp0 = fp)->mv.co.guard.x8 - 10;
-            float deg = lstick_deg - offset;
-            lstick_x = normalizeAngle180(deg);
-            fp->mv.co.guard.x8 =
-                10 + normalizeAngle0(lstick_x * p_ftCommonData->x44C + offset);
-            {
-                float lstick_mag =
-                    sqrtf(SQ(fp0->input.lstick.x) + SQ(fp0->input.lstick.y));
-                if (lstick_mag > 1) {
-                    lstick_mag = 1;
-                }
-                fp->mv.co.guard.x4 = (lstick_rad = p_ftCommonData->x44C) *
-                                         (lstick_mag - fp->mv.co.guard.x4) +
-                                     fp->mv.co.guard.x4;
-            }
+
+    stick_deg = rad_to_deg * stick_rad;
+    if (stick_deg < 0) {
+        stick_deg = 0;
+    }
+    if (stick_deg > 359) {
+        stick_deg = 359;
+    }
+
+    guard_deg = fp->mv.co.guard.x8 - 10;
+    deg_delta = stick_deg - guard_deg;
+    if (deg_delta > 180) {
+        deg_delta -= 360;
+    } else if (deg_delta < -180) {
+        deg_delta += 360;
+    }
+
+    smoothed_deg = deg_delta * p_ftCommonData->x44C + guard_deg;
+    if (smoothed_deg > 360) {
+        guard_deg = smoothed_deg;
+        guard_deg -= 360;
+    } else {
+        guard_deg = smoothed_deg;
+        if (guard_deg < 0) {
+            guard_deg += 360;
         }
     }
+    fp->mv.co.guard.x8 = 10 + guard_deg;
+
+    stick_mag = sqrtf(fp->input.lstick.x * fp->input.lstick.x +
+                      fp->input.lstick.y * fp->input.lstick.y);
+    if (stick_mag > 1) {
+        stick_mag = 1;
+    }
+    fp->mv.co.guard.x4 +=
+        p_ftCommonData->x44C * (stick_mag - fp->mv.co.guard.x4);
 }
 
 static inline float inlineB0(Fighter* fp)

--- a/src/melee/if/if_2FC93.c
+++ b/src/melee/if/if_2FC93.c
@@ -35,12 +35,12 @@
     unsigned char x28[4];
     unsigned char x2C[4];
     unsigned char x30;
-    unsigned char x31;
+    signed char x31;
     unsigned char x32;
 } un_804A1F10;
 
 /// .sdata2
-/* 4DDBA8 */ static char un_804DDBA8[4] = { 0, 1, 2, 3 };
+/* 4DDBA8 */ static char const un_804DDBA8[4] = { 0, 1, 2, 3 };
 
 /// .sbss
 /* 4D6D90 */ static int un_804D6D90;
@@ -107,75 +107,88 @@ void fn_802FDA4C(HSD_GObj* gobj, int pass)
 
 void fn_802FDA78(HSD_GObj* gobj)
 {
-    int i, j, k;
+    struct un_804A1F10_t* p = &un_804A1F10;
+    int i;
     float v[] = { 0.0, -1.3, -2.6, -3.9 };
     HSD_JObj* jobj = gobj->hsd_obj;
     unsigned char* pslot = gobj->user_data;
     unsigned char slot = *pslot;
+    u8 j = 0;
+    u8 k = 0;
     HSD_JObjSetTranslateZ(jobj, 0.0);
-    PAD_STACK(24);
-    jobj->child->u.dobj->mobj->mat->diffuse = un_804A1F10.x14[slot];
-    jobj->child->u.dobj->next->mobj->mat->diffuse = un_804A1F10.x14[slot];
-    jobj->child->u.dobj->next->next->mobj->mat->diffuse =
-        un_804A1F10.x14[slot];
-    if (!un_804A1F10.x28[0] && !un_804A1F10.x28[1] && !un_804A1F10.x28[2] &&
-        !un_804A1F10.x28[3])
     {
-        un_804A1F10.x31 = 0xFF;
-        un_804A1F10.x32 = 0;
+        HSD_MObj* m = jobj->child->u.dobj->mobj;
+        m->mat->diffuse.r = p->x14[slot].r;
+        m->mat->diffuse.g = p->x14[slot].g;
+        m->mat->diffuse.b = p->x14[slot].b;
+        m->mat->diffuse.a = p->x14[slot].a;
     }
-    switch (un_804A1F10.x28[slot]) {
+    {
+        HSD_MObj* m = jobj->child->u.dobj->next->mobj;
+        m->mat->diffuse.r = p->x14[slot].r;
+        m->mat->diffuse.g = p->x14[slot].g;
+        m->mat->diffuse.b = p->x14[slot].b;
+        m->mat->diffuse.a = p->x14[slot].a;
+    }
+    {
+        HSD_MObj* m = jobj->child->u.dobj->next->next->mobj;
+        m->mat->diffuse.r = p->x14[slot].r;
+        m->mat->diffuse.g = p->x14[slot].g;
+        m->mat->diffuse.b = p->x14[slot].b;
+        m->mat->diffuse.a = p->x14[slot].a;
+    }
+    if (!p->x28[0] && !p->x28[1] && !p->x28[2] && !p->x28[3]) {
+        p->x31 = -1;
+        p->x32 = 0;
+    }
+    switch (p->x28[slot]) {
     case 0:
         HSD_JObjSetTranslateZ(jobj, 10000.0);
         break;
     case 1:
-        if (un_804A1F10.x31 == 0xFF) {
-            un_804A1F10.x31 = slot;
-        } else if (un_804A1F10.x28[un_804A1F10.x31] == 1) {
-            if (un_804A1F10.x32 == 0 && un_804A1F10.x30 == 0) {
+        if (p->x31 == -1) {
+            p->x31 = slot;
+        } else if (p->x28[p->x31] == 1) {
+            if (p->x32 == 0 && p->x30 == 0) {
                 lbAudioAx_80024030(4);
             }
-            un_804A1F10.x32 = (un_804A1F10.x32 + 1) % 51;
+            p->x32 = (p->x32 + 1) % 51;
         }
-        j = 0;
         for (i = 0; i < slot; i++) {
-            if (un_804A1F10.x28[i] == 1) {
+            if (p->x28[i] == 1) {
                 j++;
             }
         }
-        k = 0;
         for (i = 0; i < 4; i++) {
-            if (un_804A1F10.x28[i] == 1) {
+            if (p->x28[i] == 1) {
                 k++;
             }
         }
         HSD_JObjSetRotationZ(jobj, 0.0);
-        HSD_JObjSetTranslateY(jobj, 2.6 * j + v[k == 0 ? 0 : k - 1]);
+        HSD_JObjSetTranslateY(jobj, 2.6f * j + v[k == 0 ? 0 : k - 1]);
         HSD_JObjSetTranslateX(jobj, -25.0);
         break;
     case 2:
-        if (un_804A1F10.x31 == 0xFF) {
-            un_804A1F10.x31 = slot;
-        } else if (un_804A1F10.x28[un_804A1F10.x31] == 2) {
-            if (un_804A1F10.x32 == 0 && un_804A1F10.x30 == 0) {
+        if (p->x31 == -1) {
+            p->x31 = slot;
+        } else if (p->x28[p->x31] == 2) {
+            if (p->x32 == 0 && p->x30 == 0) {
                 lbAudioAx_80024030(4);
             }
-            un_804A1F10.x32 = (un_804A1F10.x32 + 1) % 51;
+            p->x32 = (p->x32 + 1) % 51;
         }
-        j = 0;
         for (i = 0; i < slot; i++) {
-            if (un_804A1F10.x28[i] == 2) {
+            if (p->x28[i] == 2) {
                 j++;
             }
         }
-        k = 0;
         for (i = 0; i < 4; i++) {
-            if (un_804A1F10.x28[i] == 2) {
+            if (p->x28[i] == 2) {
                 k++;
             }
         }
         HSD_JObjSetRotationZ(jobj, 3.1415927);
-        HSD_JObjSetTranslateY(jobj, 2.6 * j + v[k == 0 ? 0 : k - 1]);
+        HSD_JObjSetTranslateY(jobj, 2.6f * j + v[k == 0 ? 0 : k - 1]);
         HSD_JObjSetTranslateX(jobj, 25.0);
         break;
     }
@@ -184,9 +197,10 @@ void fn_802FDA78(HSD_GObj* gobj)
 
 void un_802FE260(void)
 {
+    struct un_804A1F10_t* p = &un_804A1F10;
+    int i;
     HSD_GObj* gobj;
     HSD_JObj* jobj;
-    int i;
 
     un_804D6D90 = 0;
     lbArchive_LoadSections(*ifAll_802F3690(), (void*) &un_804A1F10.x0,
@@ -194,16 +208,16 @@ void un_802FE260(void)
     for (i = 0; i < 4; i++) {
         gobj = GObj_Create(HSD_GOBJ_CLASS_UI, 15, 0);
         jobj = HSD_JObjLoadJoint(un_804A1F10.x0[0]->joint);
-        gobj->user_data = &un_804DDBA8[i];
+        gobj->user_data = (void*) &un_804DDBA8[i];
         HSD_GObjObject_80390A70(gobj, HSD_GObj_804D7849, jobj);
         GObj_SetupGXLink(gobj, fn_802FDA4C, 11, 0);
         gm_8016895C(jobj, un_804A1F10.x0[0], 0);
         HSD_GObj_SetupProc(gobj, fn_802FDA78, 17);
         HSD_JObjReqAnimAll(jobj, 0.0);
         HSD_JObjAnimAll(jobj);
-        un_804A1F10.x24[i] = 0;
-        un_804A1F10.x28[i] = 0;
-        un_804A1F10.x4[i] = gobj;
+        p->x24[i] = 0;
+        p->x28[i] = 0;
+        p->x4[i] = gobj;
     }
     un_804A1F10.x31 = -1;
     un_804A1F10.x32 = 0;

--- a/src/melee/pl/plattack.c
+++ b/src/melee/pl/plattack.c
@@ -10,48 +10,34 @@ void plAttack_80037590(void)
     unk_804D6480 = 1;
 }
 
+static inline void clearAttackStats(struct plAttackStats* s)
+{
+    int i;
+    for (i = 0; i < StatsAttack_Count; i++) {
+        s->by_attack_counts[i] = 0;
+    }
+    s->total = 0;
+    s->thrown_item_count = 0;
+    s->aerials_count = 0;
+    s->specials_count = 0;
+    s->x1A0_count = 0;
+    s->x1A4_count = 0;
+    s->x1A8 = 0;
+}
+
 ///< brief resets the players stats
 void plAttack_8003759C(u32 slot)
 {
     plActionStats* stats;
-    s32 i;
+    int i;
 
     stats = Player_GetActionStats((s32) slot);
 
-    for (i = 2; i < StatsAttack_Count; i++) {
-        stats->attacks.by_attack_counts[i] = 0;
-    }
-    stats->attacks.total = 0;
-    stats->attacks.thrown_item_count = 0;
-    stats->attacks.aerials_count = 0;
-    stats->attacks.specials_count = 0;
-    stats->attacks.x1A0_count = 0;
-    stats->attacks.x1A4_count = 0;
-    stats->attacks.x1A8 = 0;
+    clearAttackStats(&stats->attacks);
+    clearAttackStats(&stats->hits);
+    clearAttackStats(&stats->x358_hits);
 
-    for (i = 2; i < StatsAttack_Count; i++) {
-        stats->hits.by_attack_counts[i] = 0;
-    }
-    stats->hits.total = 0;
-    stats->hits.thrown_item_count = 0;
-    stats->hits.aerials_count = 0;
-    stats->hits.specials_count = 0;
-    stats->hits.x1A0_count = 0;
-    stats->hits.x1A4_count = 0;
-    stats->hits.x1A8 = 0;
-
-    for (i = 2; i < StatsAttack_Count; i++) {
-        stats->x358_hits.by_attack_counts[i] = 0;
-    }
-    stats->x358_hits.total = 0;
-    stats->x358_hits.thrown_item_count = 0;
-    stats->x358_hits.aerials_count = 0;
-    stats->x358_hits.specials_count = 0;
-    stats->x358_hits.x1A0_count = 0;
-    stats->x358_hits.x1A4_count = 0;
-    stats->x358_hits.x1A8 = 0;
-
-    for (i = 2; i < StatsAttack_Count; i++) {
+    for (i = 0; i < StatsAttack_Count; i++) {
         stats->x504[i] = 0;
     }
     stats->x568 = 0;


### PR DESCRIPTION
Matches five functions across ftCo guard, plattack, and if_2FC93:

- `ftCo_80091BC4`
- `ftCo_80092158`
- `ftCo_80093790`
- `plAttack_8003759C`
- `un_802FE260`

Also improves `fn_802FDA78` in `if_2FC93` through the same file-local struct typing used for `un_802FE260`.

Verification:

- `python configure.py --require-protos`
- `ninja build/GALE01/report.json`
- `ninja`
