### PR TITLE
Match and improve several source functions

### DIFF
--- a/extern/dolphin/src/dolphin/thp/THPDec.c
+++ b/extern/dolphin/src/dolphin/thp/THPDec.c
@@ -36,6 +36,13 @@ static THPCoeff* __THPMCUBuffer[6];
 static THPFileInfo* __THPInfo;
 static BOOL __THPInitFlag = FALSE;
 
+typedef struct THPRestartFields {
+    u8 pad[0x8FC];
+    u16 nMCU;
+    u16 currMCU;
+    u8 RST;
+} THPRestartFields;
+
 #define THPROUNDUP(a, b) ((((s32) (a)) + ((s32) (b) - 1L)) / ((s32) (b)))
 
 void __THPPrepBitStream(THPFileInfo* info)
@@ -886,11 +893,12 @@ static int __THPHuffGenerateDecoderTables(THPFileInfo* info, u8 tabIndex)
 
 static u8 __THPRestartDefinition(THPFileInfo* info)
 {
-    info->RST = TRUE;
+    THPRestartFields* restart = (THPRestartFields*) info;
+    restart->RST = TRUE;
     info->file += 2;
-    info->nMCU = (u16) ((info->file)[0] << 8 | (info->file)[1]);
+    restart->nMCU = (u16) ((info->file)[0] << 8 | (info->file)[1]);
     info->file += 2;
-    info->currMCU = info->nMCU;
+    restart->currMCU = restart->nMCU;
     return 0;
 }
 

--- a/src/melee/ft/ft_0892.c
+++ b/src/melee/ft/ft_0892.c
@@ -168,7 +168,6 @@ void ft_800895E0(Fighter* fp, int arg1)
     union Struct2070 val;
     union Struct2070 sp18;
     union Struct2070 sp14;
-    Item_GObj* temp;
     union Struct2070 spC;
 
     spC.x2070_int = arg1;
@@ -181,8 +180,7 @@ void ft_800895E0(Fighter* fp, int arg1)
         val = sp18;
     }
     if (val.x2073 == 0x62) {
-        temp = fp->item_gobj;
-        if (temp != NULL && it_8026B6C8(temp) != 0) {
+        if (fp->item_gobj != NULL && it_8026B6C8(fp->item_gobj) != 0) {
             sp14.x2070_int = 0x44003D;
             val = sp14;
         }

--- a/src/melee/gr/gricemt.c
+++ b/src/melee/gr/gricemt.c
@@ -1474,7 +1474,7 @@ int grIceMt_801F9ACC(Ground_GObj* gobj, float y, GrIceMtSegmentLookup ev,
     f32 f;
     f32 f2;
     HSD_JObj** new_var;
-    s16 id;
+    s32 id;
     PAD_STACK(16);
 
     if (seg[0] == -1 || seg[1] == -1) {

--- a/src/melee/gr/gricemt.c
+++ b/src/melee/gr/gricemt.c
@@ -1456,11 +1456,6 @@ static inline HSD_GObj* grIceMt_801F71E8_noinline2(int id)
     return grIceMt_801F71E8_inner2(id);
 }
 
-static inline void* grIceMt_GetUserData(HSD_GObj* gobj)
-{
-    return gobj->user_data;
-}
-
 int grIceMt_801F9ACC(Ground_GObj* gobj, float y, GrIceMtSegmentLookup ev,
                      Ground_GObj* arg3)
 {
@@ -1487,16 +1482,16 @@ int grIceMt_801F9ACC(Ground_GObj* gobj, float y, GrIceMtSegmentLookup ev,
     HSD_ASSERT(0xABA, jobj);
     cur = HSD_JObjGetTranslationY(jobj);
     if (ABS(cur) < 10.0f) {
-        gp = grIceMt_GetUserData(Ground_801C2BA4(seg[1]));
+        gp = GET_GROUND(Ground_801C2BA4(seg[1]));
         ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1 = 1;
     } else if (ABS(cur + f) < 10.0f) {
-        gp = grIceMt_GetUserData(Ground_801C2BA4(seg[0]));
+        gp = GET_GROUND(Ground_801C2BA4(seg[0]));
         ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1 = 1;
     }
     if (cur < 0.5f * -f) {
         id = seg[0];
         if (id != -1) {
-            gp = grIceMt_GetUserData(Ground_801C2BA4(id));
+            gp = GET_GROUND(Ground_801C2BA4(id));
             if (!((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b0) {
                 ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b0 = 1;
                 ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1 = 1;
@@ -1504,13 +1499,13 @@ int grIceMt_801F9ACC(Ground_GObj* gobj, float y, GrIceMtSegmentLookup ev,
         }
         id = seg[1];
         if (id != -1) {
-            gp = grIceMt_GetUserData(Ground_801C2BA4(id));
+            gp = GET_GROUND(Ground_801C2BA4(id));
             ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b0 = 0;
         }
     } else {
         id = seg[1];
         if (id != -1) {
-            gp = grIceMt_GetUserData(Ground_801C2BA4(id));
+            gp = GET_GROUND(Ground_801C2BA4(id));
             if (!((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b0) {
                 ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b0 = 1;
                 ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1 = 1;
@@ -1518,7 +1513,7 @@ int grIceMt_801F9ACC(Ground_GObj* gobj, float y, GrIceMtSegmentLookup ev,
         }
         id = seg[0];
         if (id != -1) {
-            gp = grIceMt_GetUserData(Ground_801C2BA4(id));
+            gp = GET_GROUND(Ground_801C2BA4(id));
             ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b0 = 0;
         }
     }
@@ -1544,10 +1539,10 @@ int grIceMt_801F9ACC(Ground_GObj* gobj, float y, GrIceMtSegmentLookup ev,
         }
         mgobj = Ground_801C2BA4(seg[0]);
         if (mgobj != NULL) {
-            gp = grIceMt_GetUserData(mgobj);
+            gp = GET_GROUND(mgobj);
             if (gp != NULL) {
                 ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1 = 1;
-                gp = grIceMt_GetUserData(mgobj);
+                gp = GET_GROUND(mgobj);
                 new_var = &gp->gv.icemt2.xC8;
                 if (((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1) {
                     ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1 = 0;
@@ -1590,10 +1585,10 @@ int grIceMt_801F9ACC(Ground_GObj* gobj, float y, GrIceMtSegmentLookup ev,
         }
         mgobj = Ground_801C2BA4(seg[1]);
         if (mgobj != NULL) {
-            gp = grIceMt_GetUserData(mgobj);
+            gp = GET_GROUND(mgobj);
             if (gp != NULL) {
                 ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1 = 1;
-                gp = grIceMt_GetUserData(mgobj);
+                gp = GET_GROUND(mgobj);
                 new_var = &gp->gv.icemt2.xC8;
                 if (((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1) {
                     ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1 = 0;

--- a/src/melee/gr/gricemt.c
+++ b/src/melee/gr/gricemt.c
@@ -1456,8 +1456,13 @@ static inline HSD_GObj* grIceMt_801F71E8_noinline2(int id)
     return grIceMt_801F71E8_inner2(id);
 }
 
-void grIceMt_801F9ACC(Ground_GObj* gobj, float y, GrIceMtSegmentLookup ev,
-                      Ground_GObj* arg3)
+static inline void* grIceMt_GetUserData(HSD_GObj* gobj)
+{
+    return gobj->user_data;
+}
+
+int grIceMt_801F9ACC(Ground_GObj* gobj, float y, GrIceMtSegmentLookup ev,
+                     Ground_GObj* arg3)
 {
     s16* seg = (s16*) gobj;
     s32 did = 0;
@@ -1468,10 +1473,12 @@ void grIceMt_801F9ACC(Ground_GObj* gobj, float y, GrIceMtSegmentLookup ev,
     f32 cur;
     f32 f;
     f32 f2;
+    HSD_JObj** new_var;
     s16 id;
+    PAD_STACK(16);
 
     if (seg[0] == -1 || seg[1] == -1) {
-        return;
+        return 0;
     }
     f = grIceMt_801F993C(seg[0], seg[1]);
     mgobj = Ground_801C2BA4(seg[1]);
@@ -1480,16 +1487,16 @@ void grIceMt_801F9ACC(Ground_GObj* gobj, float y, GrIceMtSegmentLookup ev,
     HSD_ASSERT(0xABA, jobj);
     cur = HSD_JObjGetTranslationY(jobj);
     if (ABS(cur) < 10.0f) {
-        gp = Ground_801C2BA4(seg[1])->user_data;
+        gp = grIceMt_GetUserData(Ground_801C2BA4(seg[1]));
         ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1 = 1;
     } else if (ABS(cur + f) < 10.0f) {
-        gp = Ground_801C2BA4(seg[0])->user_data;
+        gp = grIceMt_GetUserData(Ground_801C2BA4(seg[0]));
         ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1 = 1;
     }
     if (cur < 0.5f * -f) {
         id = seg[0];
         if (id != -1) {
-            gp = Ground_801C2BA4(id)->user_data;
+            gp = grIceMt_GetUserData(Ground_801C2BA4(id));
             if (!((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b0) {
                 ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b0 = 1;
                 ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1 = 1;
@@ -1497,13 +1504,13 @@ void grIceMt_801F9ACC(Ground_GObj* gobj, float y, GrIceMtSegmentLookup ev,
         }
         id = seg[1];
         if (id != -1) {
-            gp = Ground_801C2BA4(id)->user_data;
+            gp = grIceMt_GetUserData(Ground_801C2BA4(id));
             ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b0 = 0;
         }
     } else {
         id = seg[1];
         if (id != -1) {
-            gp = Ground_801C2BA4(id)->user_data;
+            gp = grIceMt_GetUserData(Ground_801C2BA4(id));
             if (!((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b0) {
                 ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b0 = 1;
                 ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1 = 1;
@@ -1511,7 +1518,7 @@ void grIceMt_801F9ACC(Ground_GObj* gobj, float y, GrIceMtSegmentLookup ev,
         }
         id = seg[0];
         if (id != -1) {
-            gp = Ground_801C2BA4(id)->user_data;
+            gp = grIceMt_GetUserData(Ground_801C2BA4(id));
             ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b0 = 0;
         }
     }
@@ -1537,13 +1544,14 @@ void grIceMt_801F9ACC(Ground_GObj* gobj, float y, GrIceMtSegmentLookup ev,
         }
         mgobj = Ground_801C2BA4(seg[0]);
         if (mgobj != NULL) {
-            gp = mgobj->user_data;
+            gp = grIceMt_GetUserData(mgobj);
             if (gp != NULL) {
                 ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1 = 1;
-                gp = mgobj->user_data;
+                gp = grIceMt_GetUserData(mgobj);
+                new_var = &gp->gv.icemt2.xC8;
                 if (((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1) {
                     ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1 = 0;
-                    ptrs = &gp->gv.icemt2.xC8;
+                    ptrs = new_var;
                     if (ptrs[0]) {
                         Ground_801C2D0C(0, ptrs[0]);
                     }
@@ -1582,13 +1590,14 @@ void grIceMt_801F9ACC(Ground_GObj* gobj, float y, GrIceMtSegmentLookup ev,
         }
         mgobj = Ground_801C2BA4(seg[1]);
         if (mgobj != NULL) {
-            gp = mgobj->user_data;
+            gp = grIceMt_GetUserData(mgobj);
             if (gp != NULL) {
                 ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1 = 1;
-                gp = mgobj->user_data;
+                gp = grIceMt_GetUserData(mgobj);
+                new_var = &gp->gv.icemt2.xC8;
                 if (((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1) {
                     ((UnkFlagStruct*) &gp->gv.icemt2.xC4)->b1 = 0;
-                    ptrs = &gp->gv.icemt2.xC8;
+                    ptrs = new_var;
                     if (ptrs[0]) {
                         Ground_801C2D0C(0, ptrs[0]);
                     }
@@ -1609,6 +1618,7 @@ void grIceMt_801F9ACC(Ground_GObj* gobj, float y, GrIceMtSegmentLookup ev,
     if (did != 0) {
         grIceMt_801FA854();
     }
+    return did;
 }
 
 static inline HSD_JObj** grIceMt_FA0BC_jobjs(Ground* g)

--- a/src/melee/gr/gricemt.h
+++ b/src/melee/gr/gricemt.h
@@ -142,8 +142,8 @@ extern f32 grIm_804DB570;
 /* 1F96E0 */ float grIceMt_801F96E0(struct grIceMt_GroundVars*, float);
 /* 1F98A8 */ void grIceMt_801F98A8(HSD_GObj* param1);
 /* 1F993C */ f32 grIceMt_801F993C(s32, s32);
-/* 1F9ACC */ void grIceMt_801F9ACC(Ground_GObj*, float, GrIceMtSegmentLookup,
-                                   Ground_GObj*);
+/* 1F9ACC */ int grIceMt_801F9ACC(Ground_GObj*, float, GrIceMtSegmentLookup,
+                                  Ground_GObj*);
 /* 1FA0BC */ void grIceMt_801FA0BC(s16*);
 /* 1FA364 */ bool grIceMt_801FA364(void* state, float* out, HSD_GObjEvent cb,
                                    Ground_GObj* gobj);

--- a/src/melee/mn/mncount.c
+++ b/src/melee/mn/mncount.c
@@ -319,8 +319,8 @@ static inline bool mnCount_8025092C_inline(void)
 s32 mnCount_8025092C(s32 rank, u32 (*getVal)(s32), bool mode)
 {
     CountEntry entries[NUM_CHARACTERS];
+    CountEntry tmp;
     int i, j, min;
-    PAD_STACK(8);
     if (mnCount_8025092C_inline()) {
         return NUM_CHARACTERS;
     }
@@ -331,12 +331,12 @@ s32 mnCount_8025092C(s32 rank, u32 (*getVal)(s32), bool mode)
     for (i = 0; i < NUM_CHARACTERS; i++) {
         min = i;
         for (j = i + 1; j < NUM_CHARACTERS; j++) {
-            if (entries[j].val < entries[min].val) {
+            if (entries[min].val < entries[j].val) {
                 min = j;
             }
         }
         if (min != i) {
-            CountEntry tmp = entries[min];
+            tmp = entries[min];
             for (j = min; j > i; j--) {
                 entries[j] = entries[j - 1];
             }

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -4834,7 +4834,6 @@ void hsd_80398A08(u32 unused)
     base[7] = 0;
 }
 
-// @TODO: Currently 99.63% match - asm bytes identical, relocation differences
 HSD_Particle* hsd_80398C04(HSD_Particle** head, int linkNo, int bank, u32 kind,
                            u16 texGroup, u8* list, int life, int palflag,
                            f32 x, f32 y, f32 z, f32 vx, f32 vy, f32 vz,
@@ -4870,7 +4869,7 @@ HSD_Particle* hsd_80398C04(HSD_Particle** head, int linkNo, int bank, u32 kind,
     }
 
     if (head == NULL) {
-        slot = (HSD_Particle**) ((s32*) hsd_804D08E8 + 0x20 / 4 + linkNo);
+        slot = (HSD_Particle**) &hsd_804D0908[linkNo];
         pp->next = *slot;
         *slot = pp;
     } else {
@@ -4908,14 +4907,14 @@ HSD_Particle* hsd_80398C04(HSD_Particle** head, int linkNo, int bank, u32 kind,
     pp->cmdWait = cmd_wait;
     pp->poseNum = 0;
     pp->palNum = 0xFF;
-    pp->envCol.a = 0xFF;
-    pp->envCol.b = 0xFF;
-    pp->envCol.g = 0xFF;
-    pp->envCol.r = 0xFF;
-    pp->envColTarget.a = 0;
-    pp->envColTarget.b = 0;
-    pp->envColTarget.g = 0;
-    pp->envColTarget.r = 0;
+    pp->primCol.a = 0xFF;
+    pp->primCol.b = 0xFF;
+    pp->primCol.g = 0xFF;
+    pp->primCol.r = 0xFF;
+    pp->envCol.a = 0;
+    pp->envCol.b = 0;
+    pp->envCol.g = 0;
+    pp->envCol.r = 0;
     pp->envColCount = 0;
     pp->primColCount = 0;
     pp->sizeCount = 0;
@@ -4927,7 +4926,7 @@ HSD_Particle* hsd_80398C04(HSD_Particle** head, int linkNo, int bank, u32 kind,
     pp->aCmpRemain = 0;
     pp->aCmpCount = 0;
     pp->rotateCount = 0;
-    pp->sizeTarget = 0.0F;
+    pp->rotateTarget = 0.0F;
     pp->rotate = 0.0F;
     pp->gen = gp;
     if (gp != NULL) {


### PR DESCRIPTION
## Summary

This batches a few independent source matching improvements:

- improve `grIceMt_801F9ACC` by tightening the Ice Mountain data/ID handling
- match `hsd_80398C04` in `particle.c`
- match `__THPRestartDefinition` in `THPDec.c`
- improve `ft_800895E0` by reusing the item GObj load shape
- improve `mnCount_8025092C` by reshaping the row comparison

## Verification

- `python configure.py --require-protos`
- `ninja build/GALE01/report.json`
- `ninja`
