### PR TITLE
Improve matching across multiple source files

### DIFF
--- a/extern/dolphin/src/dolphin/thp/THPDec.c
+++ b/extern/dolphin/src/dolphin/thp/THPDec.c
@@ -43,6 +43,16 @@ typedef struct THPRestartFields {
     u8 RST;
 } THPRestartFields;
 
+typedef struct THPMCURowFields {
+    u8 pad[0x8CC];
+    u16 MCUsPerRow;
+} THPMCURowFields;
+
+typedef struct THPFileInfoMCUBufferView {
+    u8 pad[0x10];
+    THPCoeff* mcuBuffer[6];
+} THPFileInfoMCUBufferView;
+
 #define THPROUNDUP(a, b) ((((s32) (a)) + ((s32) (b) - 1L)) / ((s32) (b)))
 
 void __THPPrepBitStream(THPFileInfo* info)
@@ -752,7 +762,7 @@ static u8 __THPReadHuffmanTableSpecification(THPFileInfo* info)
     u8 tab_index;
     u16 length, num_Vij;
     u8* huffmanBits;
-    int result;
+    u8 result;
 
     //__THPHuffmanSizeTab = __THPWorkArea;
     //__THPHuffmanCodeTab = (u16*)((u32)__THPWorkArea + 256 + 1);
@@ -774,7 +784,7 @@ static u8 __THPReadHuffmanTableSpecification(THPFileInfo* info)
 
         info->huffmanTabs[tab_index].bits = huffmanBits;
         info->huffmanTabs[tab_index].Vij = info->file;
-        info->huffmanTabs[tab_index].pad2[1] = num_Vij;
+        *(u16*) &info->huffmanTabs[tab_index].pad2[1] = num_Vij;
         info->file += num_Vij;
         result =
             __THPHuffGenerateSizeTable(info, tab_index, (int) huffmanBits);
@@ -1813,6 +1823,21 @@ _FailedCheckNoBits1:
     return (h->Vij[(s32) (code + h->valPtr[cnt])]);
 }
 
+typedef struct THPFileInfoDCTCompYView {
+    u8 pad[0x83E];
+    THPCoeff predDC;
+} THPFileInfoDCTCompYView;
+
+typedef struct THPFileInfoDCTCompUView {
+    u8 pad[0x86A];
+    THPCoeff predDC;
+} THPFileInfoDCTCompUView;
+
+typedef struct THPFileInfoDCTCompVView {
+    u8 pad[0x896];
+    THPCoeff predDC;
+} THPFileInfoDCTCompVView;
+
 static void __THPDecompressiMCURow640x480(void)
 {
     u8 cl_num;
@@ -1820,57 +1845,67 @@ static void __THPDecompressiMCURow640x480(void)
     THPComponent* comp;
 
     THPFileInfo* info = __THPInfo;
-    THPCoeff** r28 = __THPMCUBuffer;
 
     LCQueueWait(3);
 
-    {
-        for (cl_num = 0; cl_num < __THPInfo->MCUsPerRow; cl_num++) {
-            THPFileInfo* um = __THPInfo;
-            __THPHuffDecodeDCTCompY(um, r28[10]);
-            __THPHuffDecodeDCTCompY(info, r28[5]);
-            __THPHuffDecodeDCTCompY(info, r28[6]);
-            __THPHuffDecodeDCTCompY(info, r28[7]);
-            __THPHuffDecodeDCTCompU(info, r28[8]);
-            __THPHuffDecodeDCTCompV(info, r28[9]);
+    for (cl_num = 0; cl_num < ((THPMCURowFields*) info)->MCUsPerRow;
+         cl_num++) {
+        __THPHuffDecodeDCTCompY(
+            info, ((THPFileInfoMCUBufferView*) info)->mcuBuffer[0]);
+        __THPHuffDecodeDCTCompY(
+            info, ((THPFileInfoMCUBufferView*) info)->mcuBuffer[1]);
+        __THPHuffDecodeDCTCompY(
+            info, ((THPFileInfoMCUBufferView*) info)->mcuBuffer[2]);
+        __THPHuffDecodeDCTCompY(
+            info, ((THPFileInfoMCUBufferView*) info)->mcuBuffer[3]);
+        __THPHuffDecodeDCTCompU(
+            info, ((THPFileInfoMCUBufferView*) info)->mcuBuffer[4]);
+        __THPHuffDecodeDCTCompV(
+            info, ((THPFileInfoMCUBufferView*) info)->mcuBuffer[5]);
 
-            comp = &__THPInfo->components[0];
-            Gbase = __THPLCWork672[0];
-            Gwid = 640;
-            Gq = __THPInfo->quantTabs[comp->quantizationTableSelector];
-            x_pos = (u32) (cl_num * 16);
-            __THPInverseDCTNoYPos(__THPMCUBuffer[0], x_pos);
-            __THPInverseDCTNoYPos(r28[5], x_pos + 8);
-            __THPInverseDCTY8(r28[6], x_pos);
-            __THPInverseDCTY8(r28[3], x_pos + 8);
+        comp = &info->components[0];
+        Gbase = __THPLCWork672[0];
+        Gwid = 640;
+        Gq = info->quantTabs[comp->quantizationTableSelector];
+        x_pos = (u32) (cl_num * 16);
+        __THPInverseDCTNoYPos(
+            ((THPFileInfoMCUBufferView*) info)->mcuBuffer[0], x_pos);
+        __THPInverseDCTNoYPos(
+            ((THPFileInfoMCUBufferView*) info)->mcuBuffer[1], x_pos + 8);
+        __THPInverseDCTY8(
+            ((THPFileInfoMCUBufferView*) info)->mcuBuffer[2], x_pos);
+        __THPInverseDCTY8(
+            ((THPFileInfoMCUBufferView*) info)->mcuBuffer[3], x_pos + 8);
 
-            comp = &__THPInfo->components[1];
-            Gbase = __THPLCWork672[1];
-            Gwid = 320;
-            Gq = __THPInfo->quantTabs[comp->quantizationTableSelector];
-            x_pos /= 2;
-            __THPInverseDCTNoYPos(__THPMCUBuffer[4], x_pos);
+        comp = &info->components[1];
+        Gbase = __THPLCWork672[1];
+        Gwid = 320;
+        Gq = info->quantTabs[comp->quantizationTableSelector];
+        x_pos /= 2;
+        __THPInverseDCTNoYPos(
+            ((THPFileInfoMCUBufferView*) info)->mcuBuffer[4], x_pos);
 
-            comp = &__THPInfo->components[2];
-            Gbase = __THPLCWork672[2];
-            Gq = __THPInfo->quantTabs[comp->quantizationTableSelector];
-            __THPInverseDCTNoYPos(__THPMCUBuffer[5], x_pos);
+        comp = &info->components[2];
+        Gbase = __THPLCWork672[2];
+        Gq = info->quantTabs[comp->quantizationTableSelector];
+        __THPInverseDCTNoYPos(
+            ((THPFileInfoMCUBufferView*) info)->mcuBuffer[5], x_pos);
 
-            if (__THPInfo->RST != 0) {
-                __THPInfo->currMCU--;
-                if (__THPInfo->currMCU == 0) {
-                    __THPInfo->currMCU = __THPInfo->nMCU;
+        if (((THPRestartFields*) info)->RST != 0) {
+            ((THPRestartFields*) info)->currMCU--;
+            if (((THPRestartFields*) info)->currMCU == 0) {
+                ((THPRestartFields*) info)->currMCU =
+                    ((THPRestartFields*) info)->nMCU;
 
-                    __THPInfo->cnt = 1 + ((__THPInfo->cnt + 6) & 0xFFFFFFF8);
+                info->cnt = 1 + ((info->cnt + 6) & 0xFFFFFFF8);
 
-                    if (__THPInfo->cnt > 32) {
-                        __THPInfo->cnt = 33;
-                    }
-
-                    __THPInfo->components[0].predDC = 0;
-                    __THPInfo->components[1].predDC = 0;
-                    __THPInfo->components[2].predDC = 0;
+                if (info->cnt > 32) {
+                    info->cnt = 33;
                 }
+
+                ((THPFileInfoDCTCompYView*) info)->predDC = 0;
+                ((THPFileInfoDCTCompUView*) info)->predDC = 0;
+                ((THPFileInfoDCTCompVView*) info)->predDC = 0;
             }
         }
     }
@@ -1890,67 +1925,71 @@ static void __THPDecompressiMCURowNxN(void)
     u32 x_pos, x;
     THPComponent* comp;
     THPFileInfo* info = __THPInfo;
+    THPCoeff** mcuBuffer = (THPCoeff**) ((u8*) info + 0x10);
 
     x = __THPInfo->xPixelSize;
 
     LCQueueWait(3);
 
-    for (cl_num = 0; cl_num < __THPInfo->MCUsPerRow; cl_num++) {
-        __THPHuffDecodeDCTCompY(info, __THPMCUBuffer[0]);
-        __THPHuffDecodeDCTCompY(info, __THPMCUBuffer[1]);
-        __THPHuffDecodeDCTCompY(info, __THPMCUBuffer[2]);
-        __THPHuffDecodeDCTCompY(info, __THPMCUBuffer[3]);
-        __THPHuffDecodeDCTCompU(info, __THPMCUBuffer[4]);
-        __THPHuffDecodeDCTCompV(info, __THPMCUBuffer[5]);
+    for (cl_num = 0; cl_num < ((THPMCURowFields*) info)->MCUsPerRow;
+         cl_num++) {
+        __THPHuffDecodeDCTCompY(info, mcuBuffer[0]);
+        __THPHuffDecodeDCTCompY(info, mcuBuffer[1]);
+        __THPHuffDecodeDCTCompY(info, mcuBuffer[2]);
+        __THPHuffDecodeDCTCompY(info, mcuBuffer[3]);
+        __THPHuffDecodeDCTCompU(info, mcuBuffer[4]);
+        __THPHuffDecodeDCTCompV(info, mcuBuffer[5]);
 
         comp = &__THPInfo->components[0];
         Gbase = __THPLCWork672[0];
         Gwid = x;
         Gq = __THPInfo->quantTabs[comp->quantizationTableSelector];
         x_pos = (u32) (cl_num * 16);
-        __THPInverseDCTNoYPos(__THPMCUBuffer[0], x_pos);
-        __THPInverseDCTNoYPos(__THPMCUBuffer[1], x_pos + 8);
-        __THPInverseDCTY8(__THPMCUBuffer[2], x_pos);
-        __THPInverseDCTY8(__THPMCUBuffer[3], x_pos + 8);
+        __THPInverseDCTNoYPos(mcuBuffer[0], x_pos);
+        __THPInverseDCTNoYPos(mcuBuffer[1], x_pos + 8);
+        __THPInverseDCTY8(mcuBuffer[2], x_pos);
+        __THPInverseDCTY8(mcuBuffer[3], x_pos + 8);
 
         comp = &__THPInfo->components[1];
         Gbase = __THPLCWork672[1];
         Gwid = x / 2;
         Gq = __THPInfo->quantTabs[comp->quantizationTableSelector];
         x_pos /= 2;
-        __THPInverseDCTNoYPos(__THPMCUBuffer[4], x_pos);
+        __THPInverseDCTNoYPos(mcuBuffer[4], x_pos);
 
         comp = &__THPInfo->components[2];
         Gbase = __THPLCWork672[2];
         Gq = __THPInfo->quantTabs[comp->quantizationTableSelector];
-        __THPInverseDCTNoYPos(__THPMCUBuffer[5], x_pos);
+        __THPInverseDCTNoYPos(mcuBuffer[5], x_pos);
 
-        if (__THPInfo->RST != 0) {
-            __THPInfo->currMCU--;
-            if (__THPInfo->currMCU == 0) {
-                __THPInfo->currMCU = __THPInfo->nMCU;
-                __THPInfo->cnt = 1 + ((__THPInfo->cnt + 6) & 0xFFFFFFF8);
+        if (((THPRestartFields*) info)->RST != 0) {
+            ((THPRestartFields*) info)->currMCU--;
+            if (((THPRestartFields*) info)->currMCU == 0) {
+                ((THPRestartFields*) info)->currMCU =
+                    ((THPRestartFields*) info)->nMCU;
+                info->cnt = 1 + ((info->cnt + 6) & 0xFFFFFFF8);
 
-                if (__THPInfo->cnt > 32) {
-                    __THPInfo->cnt = 33;
+                if (info->cnt > 32) {
+                    info->cnt = 33;
                 }
 
-                __THPInfo->components[0].predDC = 0;
-                __THPInfo->components[1].predDC = 0;
-                __THPInfo->components[2].predDC = 0;
+                ((THPFileInfoDCTCompYView*) info)->predDC = 0;
+                ((THPFileInfoDCTCompUView*) info)->predDC = 0;
+                ((THPFileInfoDCTCompVView*) info)->predDC = 0;
             }
         }
     }
 
     {
+        THPDecodeInfo* decode = (THPDecodeInfo*) info;
         u8** work = __THPLCWork672;
-        LCStoreData(info->dLC[0], work[0], ((4 * sizeof(u8) * 64) * (x / 16)));
-        LCStoreData(info->dLC[1], work[1], ((sizeof(u8) * 64) * (x / 16)));
-        LCStoreData(info->dLC[2], work[2], ((sizeof(u8) * 64) * (x / 16)));
+        LCStoreData(decode->x8F0, work[0], ((4 * sizeof(u8) * 64) * (x / 16)));
+        LCStoreData(decode->x8F4, work[1], ((sizeof(u8) * 64) * (x / 16)));
+        LCStoreData(decode->x8F8, work[2], ((sizeof(u8) * 64) * (x / 16)));
+        decode->x8F0 = (u8*) decode->x8F0 + ((4 * sizeof(u8) * 64) * (x / 16));
+        decode->x8F4 = (u8*) decode->x8F4 + ((sizeof(u8) * 64) * (x / 16));
+        decode->x8F8 = (u8*) decode->x8F8 + ((sizeof(u8) * 64) * (x / 16));
     }
-    info->dLC[0] += ((4 * sizeof(u8) * 64) * (x / 16));
-    info->dLC[1] += ((sizeof(u8) * 64) * (x / 16));
-    info->dLC[2] += ((sizeof(u8) * 64) * (x / 16));
 }
 
 static void __THPHuffDecodeDCTCompY(register THPFileInfo* info,
@@ -2021,8 +2060,8 @@ static void __THPHuffDecodeDCTCompY(register THPFileInfo* info,
         };
 
         __dcbz((void*) block, 96);
-        dc = (s16) (info->components[0].predDC + diff);
-        block[0] = info->components[0].predDC = dc;
+        dc = (s16) (((THPFileInfoDCTCompYView*) info)->predDC + diff);
+        block[0] = ((THPFileInfoDCTCompYView*) info)->predDC = dc;
     }
 
     {
@@ -2404,8 +2443,8 @@ static void __THPHuffDecodeDCTCompU(register THPFileInfo* info,
     }
 
     __dcbz((void*) block, 96);
-    dc = (s16) (info->components[1].predDC + cnt);
-    block[0] = info->components[1].predDC = dc;
+    dc = (s16) (((THPFileInfoDCTCompUView*) info)->predDC + cnt);
+    block[0] = ((THPFileInfoDCTCompUView*) info)->predDC = dc;
 
     for (k = 1; k < 64; k++) {
         ssss = __THPHuffDecodeTab(info, Uachuff);
@@ -2531,8 +2570,8 @@ static void __THPHuffDecodeDCTCompV(register THPFileInfo* info,
 
     __dcbz((void*) block, 96);
 
-    dc = (s16) (info->components[2].predDC + diff);
-    block[0] = info->components[2].predDC = dc;
+    dc = (s16) (((THPFileInfoDCTCompVView*) info)->predDC + diff);
+    block[0] = ((THPFileInfoDCTCompVView*) info)->predDC = dc;
 
     for (k = 1; k < 64; k++) {
         ssss = __THPHuffDecodeTab(info, Vachuff);

--- a/src/melee/cm/camera.c
+++ b/src/melee/cm/camera.c
@@ -708,7 +708,7 @@ inline float get_max_bounds_length(CameraBounds* bounds)
 
 void Camera_80029CF8(CameraBounds* bounds, CameraTransformState* transform)
 {
-    u8 _padA[16];
+    u8 _padA[8];
     f32 len;
     Vec3 scroll_offset;
     Vec3 scroll_offset2;
@@ -719,12 +719,12 @@ void Camera_80029CF8(CameraBounds* bounds, CameraTransformState* transform)
     f32 fov_r;
     f32 fov_l;
     f32 tan_fov_u;
-    f32 temp_f26;
     f32 temp_f28;
     f32 temp_f29;
     f32 temp_f31;
     f32 mid_x;
     f32 temp_f31_3;
+    f32 temp_f26;
     f32 var_f28;
     f32 vert_frustum_dist;
     f32 pitch_angle;
@@ -1385,7 +1385,6 @@ void Camera_8002B3D4(void* arg0)
     f32 temp_f31;
     f32 var_f1;
     f32 var_f1_2;
-    BOOL var_r0;
 
     Camera_80030DF8();
     Camera_800293E0();
@@ -1395,23 +1394,11 @@ void Camera_8002B3D4(void* arg0)
     total_dist = cm_80452C68.transform.target_fov - cm_80452C68.transform.fov;
     cm_80452C68.transform.fov += total_dist * cm_803BCCA0.x44;
     Camera_80029BC4(&bounds, &cm_80452C68.transform);
-    if ((Camera_80030AF8() != 0) &&
-        ((p1_fgp = Ground_801C57A4(), p1_fgp != NULL)))
+    if (!((Camera_80030AF8() != 0) &&
+          ((p1_fgp = Ground_801C57A4(), p1_fgp != NULL)) &&
+          (ftLib_80086644(p1_fgp, &fighter_pos),
+           abs_threshold_inline(fighter_pos.z, 30.0f))))
     {
-        ftLib_80086644(p1_fgp, &fighter_pos);
-        /// @todo inline?
-        var_f1 = fighter_pos.z;
-        var_r0 = abs_threshold_inline(var_f1, 30.0f);
-        // if (var_f1 < 0.0f) {
-        //     var_f1 = -var_f1;
-        // }
-        // if (var_f1 > 30.0f) {
-        //     var_r0 = 1;
-        // } else {
-        //     var_r0 = 0;
-        // }
-    }
-    if (var_r0 == 0) {
         Camera_80029CF8(&bounds, &cm_80452C68.transform);
         Camera_8002A768(&cm_80452C68.transform, 0);
     }
@@ -1421,21 +1408,11 @@ void Camera_8002B3D4(void* arg0)
         cm_80452C68.transform_copy.target_fov - cm_80452C68.transform_copy.fov;
     cm_80452C68.transform_copy.fov += temp_f31 * cm_803BCCA0.x44;
     Camera_80029BC4(&sp2C, &cm_80452C68.transform_copy);
-    if ((Camera_80030AF8() != 0) &&
-        ((p1_fgp = Ground_801C57A4(), p1_fgp != NULL)))
+    if (!((Camera_80030AF8() != 0) &&
+          ((p1_fgp = Ground_801C57A4(), p1_fgp != NULL)) &&
+          (ftLib_80086644(p1_fgp, &fighter_pos),
+           abs_threshold_inline(fighter_pos.z, 30.0f))))
     {
-        ftLib_80086644(p1_fgp, &fighter_pos);
-        var_f1_2 = fighter_pos.z;
-        if (var_f1_2 < 0.0f) {
-            var_f1_2 = -var_f1_2;
-        }
-        if (var_f1_2 > 30.0f) {
-            var_r0 = 1;
-        } else {
-            var_r0 = 0;
-        }
-    }
-    if (var_r0 == 0) {
         Camera_80029CF8(&sp2C, &cm_80452C68.transform_copy);
         Camera_8002A768(&cm_80452C68.transform_copy, 0);
     }
@@ -2405,11 +2382,11 @@ after_loop:
             f32 coeff;
 
             tgt_interest = &transform->target_interest;
-            transform->target_interest = cam->x308;
+            cam->transform.target_interest = cam->x308;
             lbVector_Add(tgt_interest, &cam->x314);
 
             tgt_position = &transform->target_position;
-            transform->target_position = *tgt_interest;
+            cam->transform.target_position = *tgt_interest;
             lbVector_Add(tgt_position, &cam->pause_eye_offset);
 
             position = &transform->position;
@@ -2429,9 +2406,9 @@ after_loop:
             sp60.z *= coeff;
             lbVector_Add(&transform->interest, &sp60);
 
-            transform->target_fov = globals->x6C;
-            transform->fov +=
-                (transform->target_fov - transform->fov) * globals->x70;
+            cam->transform.target_fov = globals->x6C;
+            cam->transform.fov +=
+                (cam->transform.target_fov - cam->transform.fov) * globals->x70;
         }
     }
     return;
@@ -2449,8 +2426,9 @@ fallback_path: {
     Camera_8002958C(&bounds3, transform);
 
     globals = &cm_803BCCA0;
-    transform->target_fov = globals->x40;
-    transform->fov += (transform->target_fov - transform->fov) * globals->x44;
+    cam->transform.target_fov = globals->x40;
+    cam->transform.fov +=
+        (cam->transform.target_fov - cam->transform.fov) * globals->x44;
     Camera_80029BC4(&bounds3, transform);
 
     if (Camera_80030AF8()) {
@@ -2476,9 +2454,9 @@ check_done:
 
     transform_copy = &cam->transform_copy;
     Camera_8002958C(&bounds2, transform_copy);
-    transform_copy->target_fov = globals->x40;
-    transform_copy->fov +=
-        (transform_copy->target_fov - transform_copy->fov) * globals->x44;
+    cam->transform_copy.target_fov = globals->x40;
+    cam->transform_copy.fov +=
+        (cam->transform_copy.target_fov - cam->transform_copy.fov) * globals->x44;
     Camera_80029BC4(&bounds2, transform_copy);
 
     if (Camera_80030AF8()) {
@@ -4271,6 +4249,10 @@ Vec3* Camera_8003019C(void)
 
 static void fn_800301D0(HSD_GObj* gobj, int arg1)
 {
+    s64 var_r4;
+    s64 var_r0;
+    s64 var_r3;
+    s64 var_r5;
     HSD_CObj* cobj;
     PAD_STACK(56);
 
@@ -4291,117 +4273,83 @@ static void fn_800301D0(HSD_GObj* gobj, int arg1)
         HSD_LObjDeleteCurrentAll(NULL);
 
         Camera_800310A0(2);
-        {
-            s64 var_r4;
-            s64 var_r0;
-
-            if (cm_80452C68.x398_b2) {
-                var_r4 = 0;
-            } else {
-                var_r4 = 8;
-            }
-            if (cm_80452C68.x398_b4) {
-                var_r0 = 0;
-            } else {
-                var_r0 = 1;
-            }
-            gobj->gxlink_prios = var_r0 | var_r4;
-            HSD_GObj_80390ED0(gobj, 7);
+        if (cm_80452C68.x398_b2) {
+            var_r4 = 0;
+        } else {
+            var_r4 = 8;
         }
+        if (cm_80452C68.x398_b4) {
+            var_r0 = 0;
+        } else {
+            var_r0 = 1;
+        }
+        gobj->gxlink_prios = var_r0 | var_r4;
+        HSD_GObj_80390ED0(gobj, 7);
 
         Camera_800310A0(1);
-        {
-            s64 var_r3;
-
-            if (cm_80452C68.x398_b2) {
-                var_r3 = 0;
-            } else {
-                var_r3 = 8;
-            }
-            gobj->gxlink_prios = var_r3;
-            HSD_GObj_80390ED0(gobj, 7);
+        if (cm_80452C68.x398_b2) {
+            var_r3 = 0;
+        } else {
+            var_r3 = 8;
         }
+        gobj->gxlink_prios = var_r3;
+        HSD_GObj_80390ED0(gobj, 7);
 
         Camera_800310A0(0);
-        {
-            s64 var_r3;
-
-            if (cm_80452C68.x398_b2) {
-                var_r3 = 0;
-            } else {
-                var_r3 = 8;
-            }
-            gobj->gxlink_prios = var_r3;
-            HSD_GObj_80390ED0(gobj, 3);
+        if (cm_80452C68.x398_b2) {
+            var_r3 = 0;
+        } else {
+            var_r3 = 8;
         }
+        gobj->gxlink_prios = var_r3;
+        HSD_GObj_80390ED0(gobj, 3);
 
         lbRefract_80022560();
-        {
-            s64 prios;
-
-            if (cm_80452C68.x398_b4) {
-                prios = 0;
-            } else {
-                prios = 1;
-            }
-            Camera_800311EC(gobj, prios);
+        if (cm_80452C68.x398_b4) {
+            var_r5 = 0;
+        } else {
+            var_r5 = 1;
         }
+        Camera_800311EC(gobj, var_r5);
 
         Camera_80031074(0);
-        {
-            s64 var_r4;
-            s64 var_r0;
-
-            if (cm_80452C68.x398_b2) {
-                var_r4 = 0;
-            } else {
-                var_r4 = 8;
-            }
-            if (cm_80452C68.x398_b4) {
-                var_r0 = 0;
-            } else {
-                var_r0 = 1;
-            }
-            gobj->gxlink_prios = var_r0 | var_r4;
-            HSD_GObj_80390ED0(gobj, 4);
+        if (cm_80452C68.x398_b2) {
+            var_r4 = 0;
+        } else {
+            var_r4 = 8;
         }
-
-        {
-            s64 arg2;
-
-            if (cm_80452C68.x398_b4) {
-                arg2 = 0;
-            } else {
-                arg2 = 1;
-            }
-            Camera_80031328(gobj, arg2);
+        if (cm_80452C68.x398_b4) {
+            var_r0 = 0;
+        } else {
+            var_r0 = 1;
         }
+        gobj->gxlink_prios = var_r0 | var_r4;
+        HSD_GObj_80390ED0(gobj, 4);
+
+        if (cm_80452C68.x398_b4) {
+            var_r5 = 0;
+        } else {
+            var_r5 = 1;
+        }
+        Camera_80031328(gobj, var_r5);
 
         HSD_FogSet(NULL);
-        {
-            s64 var_r3;
-
-            if (cm_80452C68.x398_b3) {
-                var_r3 = 0;
-            } else {
-                var_r3 = 0x80;
-            }
-            gobj->gxlink_prios = var_r3;
-            HSD_GObj_80390ED0(gobj, 7);
+        if (cm_80452C68.x398_b3) {
+            var_r3 = 0;
+        } else {
+            var_r3 = 0x80;
         }
+        gobj->gxlink_prios = var_r3;
+        HSD_GObj_80390ED0(gobj, 7);
 
         Camera_800310A0(3);
-        {
-            s64 var_r3;
-
-            if (cm_80452C68.x398_b2) {
-                var_r3 = 0;
-            } else {
-                var_r3 = 8;
-            }
-            gobj->gxlink_prios = var_r3;
-            HSD_GObj_80390ED0(gobj, 7);
+        if (cm_80452C68.x398_b2) {
+            var_r3 = 0;
+        } else {
+            var_r3 = 8;
         }
+        gobj->gxlink_prios = var_r3;
+        HSD_GObj_80390ED0(gobj, 7);
 
         if (Camera_80030AC4() != 0) {
             if (Camera_80030A78() != 0) {

--- a/src/melee/ft/chara/ftCommon/ftCo_09F7.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_09F7.c
@@ -127,141 +127,50 @@ block_11:
                   temp_r30->parts[var_r27].joint, &spA8);
     return;
 block_12:
-    if (gfx_id == 0x487) {
+    switch (gfx_id) {
+    case 0x402:
+    case 0x403:
+    case 0x409:
+    case 0x412:
+    case 0x413:
+    case 0x414:
+    case 0x422:
+    case 0x487:
+    case 0x4D1:
+    case 0x4E5:
+    case 0x4E6:
+    case 0x4FE:
+    case 0x500:
+    case 0x501:
+    case 0x502:
         goto block_61;
-    }
-    if (gfx_id >= 0x487) {
-        goto block_40;
-    }
-    if (gfx_id == 0x422) {
-        goto block_61;
-    }
-    if (gfx_id >= 0x422) {
-        goto block_27;
-    }
-    if (gfx_id >= 0x412) {
-        goto block_22;
-    }
-    if (gfx_id == 0x409) {
-        goto block_61;
-    }
-    if (gfx_id >= 0x409) {
-        goto block_70;
-    }
-    if (gfx_id >= 0x404) {
-        goto block_70;
-    }
-    if (gfx_id >= 0x402) {
-        goto block_61;
-    }
-    goto block_70;
-block_22:
-    if (gfx_id == 0x41E) {
-        goto block_63;
-    }
-    if (gfx_id >= 0x41E) {
-        goto block_70;
-    }
-    if (gfx_id == 0x415) {
-        goto block_63;
-    }
-    if (gfx_id >= 0x415) {
-        goto block_70;
-    }
-    goto block_61;
-block_27:
-    if (gfx_id >= 0x43A) {
-        goto block_34;
-    }
-    if (gfx_id >= 0x42B) {
-        goto block_32;
-    }
-    if (gfx_id >= 0x428) {
-        goto block_63;
-    }
-    if (gfx_id >= 0x425) {
-        goto block_70;
-    }
-    goto block_67;
-block_32:
-    if (gfx_id >= 0x438) {
-        goto block_66;
-    }
-    goto block_70;
-block_34:
-    if (gfx_id == 0x447) {
-        goto block_70;
-    }
-    if (gfx_id >= 0x447) {
-        goto block_38;
-    }
-    if (gfx_id >= 0x446) {
+    case 0x446:
+    case 0x448:
+    case 0x4E1:
         goto block_62;
-    }
-    goto block_70;
-block_38:
-    if (gfx_id >= 0x449) {
-        goto block_70;
-    }
-    goto block_62;
-block_40:
-    if (gfx_id == 0x4D1) {
-        goto block_61;
-    }
-    if (gfx_id >= 0x4D1) {
-        goto block_51;
-    }
-    if (gfx_id >= 0x4C1) {
-        goto block_47;
-    }
-    if (gfx_id == 0x49D) {
-        goto block_65;
-    }
-    if (gfx_id >= 0x49D) {
-        goto block_70;
-    }
-    if (gfx_id == 0x495) {
+    case 0x415:
+    case 0x41E:
+    case 0x428:
+    case 0x429:
+    case 0x42A:
+        goto block_63;
+    case 0x495:
         goto block_64;
-    }
-    goto block_70;
-block_47:
-    if (gfx_id == 0x4C3) {
-        goto block_70;
-    }
-    if (gfx_id < 0x4C3) {
+    case 0x49D:
+        goto block_65;
+    case 0x438:
+    case 0x439:
+        goto block_66;
+    case 0x423:
+    case 0x424:
+    case 0x4C1:
+    case 0x4C2:
+    case 0x4C4:
+    case 0x4C5:
         goto block_67;
-    }
-    if (gfx_id >= 0x4C6) {
+    default:
         goto block_70;
     }
-    goto block_67;
-block_51:
-    if (gfx_id == 0x4FE) {
-        goto block_61;
-    }
-    if (gfx_id >= 0x4FE) {
-        goto block_58;
-    }
-    if (gfx_id >= 0x4E5) {
-        goto block_56;
-    }
-    if (gfx_id == 0x4E1) {
-        goto block_62;
-    }
-    goto block_70;
-block_56:
-    if (gfx_id >= 0x4E7) {
-        goto block_70;
-    }
-    goto block_61;
-block_58:
-    if (gfx_id >= 0x503) {
-        goto block_70;
-    }
-    if (gfx_id >= 0x500) {
-        goto block_61;
-    }
-    goto block_70;
 block_61:
     efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 0, gfx_id,
                   temp_r30->parts[var_r27].joint);

--- a/src/melee/ft/chara/ftCommon/ftCo_09F7.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_09F7.c
@@ -63,6 +63,7 @@ void ftCo_8009F834(Fighter_GObj* gobj, int arg1, enum Fighter_Part arg2,
     Vec3 sp84;
     f32 sp80;
     f32 sp7C;
+    int gfx_id;
     Fighter* temp_r30;
     Fighter* temp_r9;
     Fighter* temp_r9_2;
@@ -74,8 +75,9 @@ void ftCo_8009F834(Fighter_GObj* gobj, int arg1, enum Fighter_Part arg2,
     f32 var_f1;
     f32 var_f1_2;
     u8 temp_r3;
-    PAD_STACK(72);
+    PAD_STACK(68);
 
+    gfx_id = arg1;
     var_r27 = arg2;
     temp_r30 = gobj->user_data;
     if (arg4 == 0) {
@@ -107,10 +109,10 @@ block_7:
     }
     var_r27 = ftParts_GetBoneIndex(temp_r30, var_r27);
 block_9:
-    if (arg1 < 0x250) {
+    if (gfx_id < 0x250) {
         goto block_11;
     }
-    if ((arg1 / 1000) != 0x1E) {
+    if ((gfx_id / 1000) != 0x1E) {
         goto block_12;
     }
 block_11:
@@ -121,166 +123,166 @@ block_11:
     temp_f2 = 2.0f * arg6->z;
     spA8.z += temp_f2 * temp_f1;
     temp_r9 = gobj->user_data;
-    efAsync_Spawn(gobj, &temp_r9->x60C, 2, arg1,
+    efAsync_Spawn(gobj, &temp_r9->x60C, 2, gfx_id,
                   temp_r30->parts[var_r27].joint, &spA8);
     return;
 block_12:
-    if (arg1 == 0x487) {
+    if (gfx_id == 0x487) {
         goto block_61;
     }
-    if (arg1 >= 0x487) {
+    if (gfx_id >= 0x487) {
         goto block_40;
     }
-    if (arg1 == 0x422) {
+    if (gfx_id == 0x422) {
         goto block_61;
     }
-    if (arg1 >= 0x422) {
+    if (gfx_id >= 0x422) {
         goto block_27;
     }
-    if (arg1 >= 0x412) {
+    if (gfx_id >= 0x412) {
         goto block_22;
     }
-    if (arg1 == 0x409) {
+    if (gfx_id == 0x409) {
         goto block_61;
     }
-    if (arg1 >= 0x409) {
+    if (gfx_id >= 0x409) {
         goto block_70;
     }
-    if (arg1 >= 0x404) {
+    if (gfx_id >= 0x404) {
         goto block_70;
     }
-    if (arg1 >= 0x402) {
+    if (gfx_id >= 0x402) {
         goto block_61;
     }
     goto block_70;
 block_22:
-    if (arg1 == 0x41E) {
+    if (gfx_id == 0x41E) {
         goto block_63;
     }
-    if (arg1 >= 0x41E) {
+    if (gfx_id >= 0x41E) {
         goto block_70;
     }
-    if (arg1 == 0x415) {
+    if (gfx_id == 0x415) {
         goto block_63;
     }
-    if (arg1 >= 0x415) {
+    if (gfx_id >= 0x415) {
         goto block_70;
     }
     goto block_61;
 block_27:
-    if (arg1 >= 0x43A) {
+    if (gfx_id >= 0x43A) {
         goto block_34;
     }
-    if (arg1 >= 0x42B) {
+    if (gfx_id >= 0x42B) {
         goto block_32;
     }
-    if (arg1 >= 0x428) {
+    if (gfx_id >= 0x428) {
         goto block_63;
     }
-    if (arg1 >= 0x425) {
+    if (gfx_id >= 0x425) {
         goto block_70;
     }
     goto block_67;
 block_32:
-    if (arg1 >= 0x438) {
+    if (gfx_id >= 0x438) {
         goto block_66;
     }
     goto block_70;
 block_34:
-    if (arg1 == 0x447) {
+    if (gfx_id == 0x447) {
         goto block_70;
     }
-    if (arg1 >= 0x447) {
+    if (gfx_id >= 0x447) {
         goto block_38;
     }
-    if (arg1 >= 0x446) {
+    if (gfx_id >= 0x446) {
         goto block_62;
     }
     goto block_70;
 block_38:
-    if (arg1 >= 0x449) {
+    if (gfx_id >= 0x449) {
         goto block_70;
     }
     goto block_62;
 block_40:
-    if (arg1 == 0x4D1) {
+    if (gfx_id == 0x4D1) {
         goto block_61;
     }
-    if (arg1 >= 0x4D1) {
+    if (gfx_id >= 0x4D1) {
         goto block_51;
     }
-    if (arg1 >= 0x4C1) {
+    if (gfx_id >= 0x4C1) {
         goto block_47;
     }
-    if (arg1 == 0x49D) {
+    if (gfx_id == 0x49D) {
         goto block_65;
     }
-    if (arg1 >= 0x49D) {
+    if (gfx_id >= 0x49D) {
         goto block_70;
     }
-    if (arg1 == 0x495) {
+    if (gfx_id == 0x495) {
         goto block_64;
     }
     goto block_70;
 block_47:
-    if (arg1 == 0x4C3) {
+    if (gfx_id == 0x4C3) {
         goto block_70;
     }
-    if (arg1 < 0x4C3) {
+    if (gfx_id < 0x4C3) {
         goto block_67;
     }
-    if (arg1 >= 0x4C6) {
+    if (gfx_id >= 0x4C6) {
         goto block_70;
     }
     goto block_67;
 block_51:
-    if (arg1 == 0x4FE) {
+    if (gfx_id == 0x4FE) {
         goto block_61;
     }
-    if (arg1 >= 0x4FE) {
+    if (gfx_id >= 0x4FE) {
         goto block_58;
     }
-    if (arg1 >= 0x4E5) {
+    if (gfx_id >= 0x4E5) {
         goto block_56;
     }
-    if (arg1 == 0x4E1) {
+    if (gfx_id == 0x4E1) {
         goto block_62;
     }
     goto block_70;
 block_56:
-    if (arg1 >= 0x4E7) {
+    if (gfx_id >= 0x4E7) {
         goto block_70;
     }
     goto block_61;
 block_58:
-    if (arg1 >= 0x503) {
+    if (gfx_id >= 0x503) {
         goto block_70;
     }
-    if (arg1 >= 0x500) {
+    if (gfx_id >= 0x500) {
         goto block_61;
     }
     goto block_70;
 block_61:
-    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 0, arg1,
+    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 0, gfx_id,
                   temp_r30->parts[var_r27].joint);
     return;
 block_62:
-    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 7, arg1,
+    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 7, gfx_id,
                   temp_r30->parts[var_r27].joint, arg5);
     return;
 block_63:
-    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 3, arg1,
+    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 3, gfx_id,
                   temp_r30->parts[var_r27].joint,
                   &temp_r30->ft_data->x0->x168);
     return;
 block_64:
-    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 3, arg1,
+    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 3, gfx_id,
                   temp_r30->parts[var_r27].joint, &temp_r30->facing_dir);
     return;
 block_65:
     sp9C = *arg5;
     sp98 = 0.017453292f * (256.0f * arg6->x);
-    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 6, arg1,
+    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 6, gfx_id,
                   temp_r30->parts[var_r27].joint, &sp9C,
                   &temp_r30->facing_dir, &sp98);
     return;
@@ -300,7 +302,7 @@ block_67:
                     temp_r30->coll_data.floor.normal.y);
     sp90 = var_f1;
 block_69:
-    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 3, arg1,
+    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 3, gfx_id,
                   temp_r30->parts[var_r27].joint, &sp90);
     return;
 block_70:
@@ -310,154 +312,154 @@ block_70:
     var_f1_2 = HSD_Randf() - 0.5f;
     temp_f2_2 = 2.0f * arg6->z;
     sp84.z += temp_f2_2 * var_f1_2;
-    if (arg1 >= 0x412) {
+    if (gfx_id >= 0x412) {
         goto block_98;
     }
-    if (arg1 == 0x3FD) {
+    if (gfx_id == 0x3FD) {
         goto block_131;
     }
-    if (arg1 >= 0x3FD) {
+    if (gfx_id >= 0x3FD) {
         goto block_87;
     }
-    if (arg1 >= 0x3F3) {
+    if (gfx_id >= 0x3F3) {
         goto block_81;
     }
-    if (arg1 == 0x3ED) {
+    if (gfx_id == 0x3ED) {
         goto block_130;
     }
-    if (arg1 >= 0x3ED) {
+    if (gfx_id >= 0x3ED) {
         goto block_79;
     }
-    if (arg1 == 0x3E8) {
+    if (gfx_id == 0x3E8) {
         goto block_122;
     }
-    if (arg1 >= 0x3E8) {
+    if (gfx_id >= 0x3E8) {
         goto block_123;
     }
     goto block_134;
 block_79:
-    if (arg1 >= 0x3EF) {
+    if (gfx_id >= 0x3EF) {
         goto block_130;
     }
     goto block_134;
 block_81:
-    if (arg1 == 0x3F6) {
+    if (gfx_id == 0x3F6) {
         goto block_123;
     }
-    if (arg1 >= 0x3F6) {
+    if (gfx_id >= 0x3F6) {
         goto block_85;
     }
-    if (arg1 >= 0x3F5) {
+    if (gfx_id >= 0x3F5) {
         goto block_130;
     }
     goto block_123;
 block_85:
-    if (arg1 >= 0x3FA) {
+    if (gfx_id >= 0x3FA) {
         goto block_123;
     }
     goto block_131;
 block_87:
-    if (arg1 == 0x405) {
+    if (gfx_id == 0x405) {
         goto block_123;
     }
-    if (arg1 >= 0x405) {
+    if (gfx_id >= 0x405) {
         goto block_94;
     }
-    if (arg1 >= 0x402) {
+    if (gfx_id >= 0x402) {
         goto block_92;
     }
-    if (arg1 == 0x3FF) {
+    if (gfx_id == 0x3FF) {
         goto block_131;
     }
     goto block_130;
 block_92:
-    if (arg1 >= 0x404) {
+    if (gfx_id >= 0x404) {
         goto block_124;
     }
     goto block_134;
 block_94:
-    if (arg1 == 0x407) {
+    if (gfx_id == 0x407) {
         goto block_123;
     }
-    if (arg1 < 0x407) {
+    if (gfx_id < 0x407) {
         goto block_124;
     }
-    if (arg1 >= 0x40C) {
+    if (gfx_id >= 0x40C) {
         goto block_123;
     }
     goto block_134;
 block_98:
-    if (arg1 == 0x44B) {
+    if (gfx_id == 0x44B) {
         goto block_123;
     }
-    if (arg1 >= 0x44B) {
+    if (gfx_id >= 0x44B) {
         goto block_112;
     }
-    if (arg1 == 0x41F) {
+    if (gfx_id == 0x41F) {
         goto block_123;
     }
-    if (arg1 >= 0x41F) {
+    if (gfx_id >= 0x41F) {
         goto block_107;
     }
-    if (arg1 >= 0x41C) {
+    if (gfx_id >= 0x41C) {
         goto block_105;
     }
-    if (arg1 == 0x416) {
+    if (gfx_id == 0x416) {
         goto block_123;
     }
     goto block_134;
 block_105:
-    if (arg1 >= 0x41E) {
+    if (gfx_id >= 0x41E) {
         goto block_134;
     }
     goto block_123;
 block_107:
-    if (arg1 >= 0x425) {
+    if (gfx_id >= 0x425) {
         goto block_110;
     }
-    if (arg1 == 0x421) {
+    if (gfx_id == 0x421) {
         goto block_123;
     }
     goto block_134;
 block_110:
-    if (arg1 >= 0x427) {
+    if (gfx_id >= 0x427) {
         goto block_134;
     }
     goto block_123;
 block_112:
-    if (arg1 == 0x513) {
+    if (gfx_id == 0x513) {
         goto block_127;
     }
-    if (arg1 >= 0x513) {
+    if (gfx_id >= 0x513) {
         goto block_119;
     }
-    if (arg1 >= 0x4E2) {
+    if (gfx_id >= 0x4E2) {
         goto block_117;
     }
-    if (arg1 == 0x4D9) {
+    if (gfx_id == 0x4D9) {
         goto block_130;
     }
     goto block_134;
 block_117:
-    if (arg1 >= 0x4E5) {
+    if (gfx_id >= 0x4E5) {
         goto block_134;
     }
     goto block_123;
 block_119:
-    if (arg1 == 0x515) {
+    if (gfx_id == 0x515) {
         goto block_129;
     }
-    if (arg1 >= 0x515) {
+    if (gfx_id >= 0x515) {
         goto block_134;
     }
     goto block_128;
 block_122:
-    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 5, arg1,
+    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 5, gfx_id,
                   temp_r30->parts[var_r27].joint, &sp84,
                   &p_ftCommonData->x564);
     return;
 block_123:
-    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 2, arg1,
+    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 2, gfx_id,
                   temp_r30->parts[var_r27].joint, &sp84);
     return;
 block_124:
@@ -469,7 +471,7 @@ block_124:
                       temp_r30->coll_data.floor.normal.y);
     sp80 = var_f1_2;
 block_126:
-    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 5, arg1,
+    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 5, gfx_id,
                   temp_r30->parts[var_r27].joint, &sp84, &sp80);
     return;
 block_127:
@@ -485,7 +487,7 @@ block_129:
                   temp_r30->parts[var_r27].joint, &sp84);
     return;
 block_130:
-    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 5, arg1,
+    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 5, gfx_id,
                   temp_r30->parts[var_r27].joint, &sp84,
                   &temp_r30->facing_dir);
     return;
@@ -498,12 +500,12 @@ block_131:
                       temp_r30->coll_data.floor.normal.y);
     sp7C = var_f1_2;
 block_133:
-    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 6, arg1,
+    efAsync_Spawn(gobj, &GET_FIGHTER(gobj)->x60C, 6, gfx_id,
                   temp_r30->parts[var_r27].joint, &sp84,
                   &temp_r30->facing_dir, &sp7C);
     return;
 block_134:
-    OSReport("no effect from animlist %d\n", arg1);
+    OSReport("no effect from animlist %d\n", gfx_id);
     return;
 }
 

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -2880,14 +2880,18 @@ static inline f32 ftCo_800A648C_inline0(Fighter* fp, Item* ip)
 
 Item* ftCo_800A61D8(Fighter* fp)
 {
+    struct Fighter_x1A88_t* data;
     HSD_GObj* cur;
-    Item* ip;
     Item* closest;
+    Item* ip;
     f32 best;
     f32 dist;
     s32 relevant;
     s32 prio;
 
+    PAD_STACK(8);
+
+    data = &fp->x1A88;
     if (fp == NULL) {
         return NULL;
     }
@@ -2908,7 +2912,7 @@ Item* ftCo_800A61D8(Fighter* fp)
                 if (!inlineD0_it(fp, ip)) {
                     if (ip->kind < 0x23) {
                         prio = ftCo_803C5A68[ip->kind];
-                        if (prio >= fp->x1A88.x2C) {
+                        if (prio >= data->x2C) {
                             if (closest == NULL) {
                                 closest = ip;
                                 best = ftCo_800A648C_inline0(fp, ip);
@@ -4325,8 +4329,6 @@ void ftCo_800A9904(Fighter* fp)
     f32 var_f4;
     f32 var_f5;
 
-    f32* temp_r3;
-
     Vec3 sp4C;
     Vec3 sp40;
     int sp3C;
@@ -4351,7 +4353,6 @@ void ftCo_800A9904(Fighter* fp)
         } else {
             var_f0 = dx / fp->pos_delta.x;
         }
-        temp_r3 = &fp->co_attrs.grav;
         if (is_small(fp->co_attrs.grav)) {
             var_f5 = 1000.0F;
         } else {
@@ -4362,11 +4363,11 @@ void ftCo_800A9904(Fighter* fp)
             var_f4 = (fp->pos_delta.y * var_f0) + fp->cur_pos.y;
         } else if (var_f0 < var_f5) {
             var_f4 = fp->cur_pos.y + (fp->pos_delta.y * var_f0 -
-                                      0.5 * (*temp_r3 * sqrtf(var_f0)));
+                                      0.5 * (fp->co_attrs.grav * sqrtf(var_f0)));
         } else {
             var_f4 =
                 fp->cur_pos.y +
-                (fp->pos_delta.y * var_f5 - 0.5 * (*temp_r3 * sqrtf(var_f5)) -
+                (fp->pos_delta.y * var_f5 - 0.5 * (fp->co_attrs.grav * sqrtf(var_f5)) -
                  ((var_f0 - var_f5) * fp->co_attrs.terminal_vel));
         }
         {
@@ -6674,6 +6675,7 @@ void ftCo_800AEFB8(Fighter* fp)
 
 void ftCo_800AF290(Fighter* fp)
 {
+    struct Fighter_x1A88_t* temp_r27;
     struct Fighter_x1A88_t* data2;
     Vec3 sp54;
     Vec3 sp30;
@@ -6743,7 +6745,8 @@ void ftCo_800AF290(Fighter* fp)
     data->xF9_b6 = true;
     data->xF9_b7 = true;
     data->xF9_b1 = false;
-    data->x44 = ftCo_800A4BEC(fp);
+    fp->x1A88.x44 = ftCo_800A4BEC(fp);
+    temp_r27 = &fp->x1A88;
     item_gobj = fp->item_gobj;
     if (item_gobj != NULL) {
         kind = GET_ITEM(item_gobj)->kind;
@@ -6757,7 +6760,7 @@ void ftCo_800AF290(Fighter* fp)
             is_food = 0;
         }
         if (is_food == 0) {
-            data->x4C = NULL;
+            temp_r27->x4C = NULL;
         } else {
             goto block_30;
         }
@@ -6765,9 +6768,9 @@ void ftCo_800AF290(Fighter* fp)
         tmp = fp->x2168;
     block_30:
         if (tmp != 0) {
-            data->x4C = NULL;
+            temp_r27->x4C = NULL;
         } else {
-            data->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
+            temp_r27->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
         }
     }
     fp->x1A88.x50 = ftCo_800A648C(fp);

--- a/src/melee/ft/chara/ftCommon/ftCo_Bury.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Bury.c
@@ -256,7 +256,7 @@ void ftCo_800C0D0C(Fighter_GObj* gobj)
         float y = hip_pos.y - joint_pos.y;
         fp->mv.co.bury.x1C = y / p_ftCommonData->x5F4;
         fp->mv.co.bury.translate = fp->cur_pos;
-        efSync_Spawn(1095, gobj, &fp->cur_pos, &fp->x34_scale.y, y);
+        efSync_Spawn(1095, gobj, &fp->cur_pos, &fp->x34_scale.y);
     }
     fp->x2219_b0 = true;
 }
@@ -289,7 +289,7 @@ void ftCo_800C0FCC(HSD_GObj* arg0, Fighter_GObj* arg1)
     if (mpLib_80054ED8(fp->mv.co.bury.x20)) {
         Vec3 normal;
         Vec3 offset;
-        HSD_JObj* jobj = GET_JOBJ(arg0);
+        register HSD_JObj* jobj = GET_JOBJ(arg0);
         mpLineGetNormal(fp->mv.co.bury.x20, &normal);
         HSD_JObjSetRotationZ(jobj, atan2f(-normal.x, normal.y));
         if (mpGetSpeed(fp->coll_data.floor.index, &fp->mv.co.bury.translate,

--- a/src/melee/ft/chara/ftCommon/ftCo_Bury.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Bury.c
@@ -289,7 +289,7 @@ void ftCo_800C0FCC(HSD_GObj* arg0, Fighter_GObj* arg1)
     if (mpLib_80054ED8(fp->mv.co.bury.x20)) {
         Vec3 normal;
         Vec3 offset;
-        register HSD_JObj* jobj = GET_JOBJ(arg0);
+        HSD_JObj* jobj = GET_JOBJ(arg0);
         mpLineGetNormal(fp->mv.co.bury.x20, &normal);
         HSD_JObjSetRotationZ(jobj, atan2f(-normal.x, normal.y));
         if (mpGetSpeed(fp->coll_data.floor.index, &fp->mv.co.bury.translate,

--- a/src/melee/ft/chara/ftCommon/ftCo_DownBound.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_DownBound.c
@@ -105,12 +105,12 @@ static inline void inlineA0(Fighter_GObj* gobj, enum_t arg1, enum_t arg2,
 
 void ftCo_800978D4(Fighter_GObj* gobj)
 {
-    u8 pad[16];
     Fighter* fp = gobj->user_data;
-    float param =
-        atan2f(-*(f32*) ((u8*) fp + 0x844), *(f32*) ((u8*) fp + 0x848));
-    HSD_JObj** jobj_ptr = *(HSD_JObj***) ((u8*) fp + 0x5e8);
-    efAsync_Spawn(gobj, (u8*) gobj->user_data + 0x60c, 4, 0x406, *jobj_ptr,
+    float param = atan2f(-fp->coll_data.floor.normal.x,
+                         fp->coll_data.floor.normal.y);
+    HSD_JObj* jobj = fp->parts[FtPart_TopN].joint;
+    PAD_STACK(12);
+    efAsync_Spawn(gobj, (u8*) gobj->user_data + 0x60c, 4, 0x406, jobj,
                   &param);
     ftCo_800976A4(gobj);
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_Guard.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Guard.c
@@ -244,7 +244,8 @@ void ftCo_80092158(Fighter_GObj* gobj, int arg1, HSD_JObj* arg2)
 void ftCo_800921DC(HSD_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
-    PAD_STACK(8);
+    Vec3 trans;
+    PAD_STACK(12);
     ftCo_80092158(gobj, 1047, fp->parts[fp->ft_data->x8->x11].joint);
     fp->x2219_b0 = true;
     fp->mv.co.guard.xC = false;
@@ -254,18 +255,16 @@ void ftCo_800921DC(HSD_GObj* gobj)
     fp->mv.co.guard.x4 = 0;
     fp->mv.co.guard.x2C = 0;
     {
-        float lightshield_amount = fp->input.x650 / (1 - p_ftCommonData->x10);
+        float lightshield_amount = (fp->input.x650 - p_ftCommonData->x10) /
+                                   (1 - p_ftCommonData->x10);
         if (lightshield_amount < 0) {
             lightshield_amount = fp->mv.co.guard.x2C;
         }
         fp->lightshield_amount = lightshield_amount;
     }
     fp->mv.co.guard.x20 = fp->mv.co.guard.x24 = 0;
-    {
-        Vec3 trans;
-        trans.x = trans.y = trans.z = 0;
-        HSD_JObjSetTranslate(fp->parts[fp->ft_data->x8->x11].joint, &trans);
-    }
+    trans.x = trans.y = trans.z = 0;
+    HSD_JObjSetTranslate(fp->parts[fp->ft_data->x8->x11].joint, &trans);
     ftCo_80091E78(gobj, 0);
     ft_PlaySFX(fp, 110, 127, 64);
 }
@@ -648,7 +647,7 @@ void ftCo_800932DC(Fighter_GObj* gobj)
 void ftCo_GuardSetOff_Anim(HSD_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
-    PAD_STACK(8);
+    PAD_STACK(16);
     ftCo_80093BC0(gobj);
     if (!ftAnim_IsFramesRemaining(gobj)) {
         if (fp->mv.co.guard.xC) {

--- a/src/melee/ft/chara/ftKirby/ftKb_SpecialN.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_SpecialN.c
@@ -849,26 +849,33 @@ void ftKb_SpecialHi_800F3570(Fighter_GObj* gobj)
     }
 }
 
+struct ftKb_Init_803CB490_layout {
+    char pad[0x74];
+    Vec3 vec;
+};
+
 void ftKb_SpecialHi_800F36DC(Fighter_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    fp->mv.kb.speciallw.x24 = ftKb_Init_803CB4EC.vec;
+    struct ftKb_Init_803CB490_layout* p =
+        (struct ftKb_Init_803CB490_layout*) ftKb_Init_803CB490;
+    fp->mv.kb.speciallw.x24 = p->vec;
     fp->mv.kb.speciallw.x54 = fp->mv.kb.speciallw.x24;
     fp->mv.kb.speciallw.x88[0] = 0.0f;
     fp->mv.kb.speciallw.x88[4] = 0.0f;
-    fp->mv.kb.speciallw.x30 = ftKb_Init_803CB4EC.vec;
+    fp->mv.kb.speciallw.x30 = p->vec;
     fp->mv.kb.speciallw.x60 = fp->mv.kb.speciallw.x30;
     fp->mv.kb.speciallw.x88[1] = 0.0f;
     fp->mv.kb.speciallw.x88[5] = 0.0f;
-    fp->mv.kb.speciallw.x3C = ftKb_Init_803CB4EC.vec;
+    fp->mv.kb.speciallw.x3C = p->vec;
     fp->mv.kb.speciallw.x6C = fp->mv.kb.speciallw.x3C;
     fp->mv.kb.speciallw.x88[2] = 0.0f;
     fp->mv.kb.speciallw.x88[6] = 0.0f;
-    fp->mv.kb.speciallw.x48 = ftKb_Init_803CB4EC.vec;
+    fp->mv.kb.speciallw.x48 = p->vec;
     fp->mv.kb.speciallw.x78 = fp->mv.kb.speciallw.x48;
     fp->mv.kb.speciallw.x88[3] = 0.0f;
     fp->mv.kb.speciallw.x88[7] = 0.0f;
-    fp->mv.kb.speciallw.x18 = ftKb_Init_803CB4EC.vec;
+    fp->mv.kb.speciallw.x18 = p->vec;
     fp->mv.kb.speciallw.x84 = 0.0f;
 }
 
@@ -1225,11 +1232,6 @@ void ftKb_SpecialAirLwEnd_Phys(Fighter_GObj* gobj)
 {
     ft_80085134(gobj);
 }
-
-struct ftKb_Init_803CB490_layout {
-    char pad[0x74];
-    Vec3 vec;
-};
 
 void ftKb_SpecialLw1_Coll(Fighter_GObj* gobj)
 {

--- a/src/melee/ft/chara/ftKirby/ftKb_SpecialNNs.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_SpecialNNs.c
@@ -44,6 +44,18 @@
 
 #define SIGNF(x) ((x) > 0.0f ? 1.0f : -1.0f)
 
+static inline void ftKb_JObjSetRotationY(HSD_JObj* jobj, f32 y, f32* base)
+{
+    ((jobj) ? ((void) 0) : __assert("jobj.h", 660, "jobj"));
+    ((!(jobj->flags & JOBJ_USE_QUATERNION))
+         ? ((void) 0)
+         : __assert("jobj.h", 661, (char*) &base[8]));
+    jobj->rotate.y = y;
+    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
+        HSD_JObjSetMtxDirty(jobj);
+    }
+}
+
 extern float ftKb_Init_803CB710[4];
 extern float ftKb_Init_803CB720[4];
 
@@ -1572,8 +1584,8 @@ void ftKb_PrSpecialAirN_Anim(Fighter_GObj* gobj)
                         ftKb_SpecialNPr_801010D4(gobj, true, 0x40012, 0);
                         return;
                     }
-                    HSD_JObjSetRotationY(fp->parts[FtPart_TopN].joint,
-                                         M_PI_2);
+                    ftKb_JObjSetRotationY(fp->parts[FtPart_TopN].joint,
+                                          M_PI_2, scale_base);
                     return;
                 }
                 if (fp->mv.pr.specialn.x14 < M_PI && old_angle > M_PI) {
@@ -1581,10 +1593,12 @@ void ftKb_PrSpecialAirN_Anim(Fighter_GObj* gobj)
                     ftKb_SpecialNPr_801010D4(gobj, true, 0x40012, 0);
                     return;
                 }
-                HSD_JObjSetRotationY(fp->parts[FtPart_TopN].joint, M_PI_2);
+                ftKb_JObjSetRotationY(fp->parts[FtPart_TopN].joint, M_PI_2,
+                                      scale_base);
                 return;
             }
-            HSD_JObjSetRotationY(fp->parts[FtPart_TopN].joint, M_PI_2);
+            ftKb_JObjSetRotationY(fp->parts[FtPart_TopN].joint, M_PI_2,
+                                  scale_base);
             return;
         }
         ftPartSetRotY(fp, FtPart_TopN, M_PI_2);

--- a/src/melee/ft/chara/ftKirby/ftKb_SpecialNYs.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_SpecialNYs.c
@@ -1102,7 +1102,6 @@ void ftKb_SpecialNMs_8010B2FC(HSD_GObj* gobj)
 
 void ftKb_SpecialNMs_8010B4A0(HSD_GObj* gobj)
 {
-    Vec3 scale;
     PAD_STACK(4 * 6);
     {
         ftKb_DatAttrs* da;
@@ -1143,8 +1142,9 @@ void ftKb_SpecialNMs_8010B4A0(HSD_GObj* gobj)
 
     {
         Fighter* fp = GET_FIGHTER(gobj);
-        KirbyHatStruct* mars_hat = ft_80459B88.hats[FTKIND_MARS];
-        KirbyHatStruct* fe_hat = ft_80459B88.hats[FTKIND_EMBLEM];
+        Vec3 scale;
+        KirbyHatStruct* mars_hat = ft_80459B88.hats[FTKIND_MARS - 1];
+        KirbyHatStruct* fe_hat = ft_80459B88.hats[FTKIND_EMBLEM - 1];
 
         if (fp->fv.kb.hat.kind == FTKIND_MARS) {
             ftCommon_SetAccessory(fp, (HSD_Joint*) mars_hat->hat_dynamics[0]);

--- a/src/melee/ft/ft_0852.c
+++ b/src/melee/ft/ft_0852.c
@@ -13,6 +13,7 @@ ftData* gFtDataList[FTKIND_MAX];
 ft_8045993C_t ft_8045993C[6];
 
 int ft_8045996C[FTKIND_MAX];
+UnkCostumeStruct lbl_804599F0[5];
 
 void ft_8008521C(HSD_GObj* gobj)
 {

--- a/src/melee/ft/ft_0892.c
+++ b/src/melee/ft/ft_0892.c
@@ -170,8 +170,7 @@ void ft_800895E0(Fighter* fp, int arg1)
     union Struct2070 sp14;
     union Struct2070 spC;
 
-    spC.x2070_int = arg1;
-    val = spC;
+    val = *(union Struct2070*) &arg1;
     if (val.x2073 == 0 || val.x2073 != fp->x2070.x2073) {
         fp->x2074.x2088 = plAttack_80037B08();
     }

--- a/src/melee/ft/ftaction.c
+++ b/src/melee/ft/ftaction.c
@@ -303,9 +303,9 @@ void ftAction_8007121C(Fighter_GObj* gobj, CommandInfo* cmd)
     if ((skip->xF_b4) && (fp->x1064_thrownHitbox.owner == NULL)) {
         ftAction_800715EC(gobj, cmd);
     } else {
-        hitbox = &fp->x914[cmd->u->create_hitbox_0.id];
         hit_group = cmd->u->create_hitbox_0.hit_group;
-        if ((hitbox->state == HitCapsule_Disabled) ||
+        if (((hitbox = &fp->x914[cmd->u->create_hitbox_0.id])->state ==
+             HitCapsule_Disabled) ||
             (hitbox->x4 != hit_group))
         {
             hitbox->x4 = hit_group;
@@ -832,8 +832,8 @@ void ftAction_80072320(Fighter_GObj* gobj, CommandInfo* cmd)
     s32 sp8;
     enum FighterKind ft_kind;
     s32 sfx;
+    u32 behavior;
     u32 sfx_base;
-    u8 behavior;
     f32 direction;
     s32 temp_r8;
     s32 temp_r9;
@@ -841,8 +841,8 @@ void ftAction_80072320(Fighter_GObj* gobj, CommandInfo* cmd)
 
     fp = GET_FIGHTER(gobj);
     pitch_select = cmd->u->stage_sfx_0.pitch_select;
-    sfx_base = cmd->u->stage_sfx_0.sfx_base;
-    behavior = cmd->u->stage_sfx_0.x2_b0_7;
+    behavior = cmd->u->stage_sfx_0.sfx_base;
+    sfx_base = cmd->u->stage_sfx_0.x2_b0_7;
 
     switch (pitch_select) {
     case 0:
@@ -886,7 +886,7 @@ void ftAction_80072320(Fighter_GObj* gobj, CommandInfo* cmd)
         break;
 
     case 2:
-        if (!fp->x2225_b0) {
+        if (!fp->x2225_b6) {
             sp8 = fp->player_id + 0x1E + fp->x221F_b4;
             spC = -1;
             fp->x2144 = lbAudioAx_800264E4(
@@ -894,17 +894,20 @@ void ftAction_80072320(Fighter_GObj* gobj, CommandInfo* cmd)
                                    temp_r8, temp_r9, temp_r10, sp8, spC));
             break;
         }
-        /// @todo cant get the b instruction to generate here and in case 6
         ft_kind = fp->kind;
-        if (ft_kind == FTKIND_GAMEWATCH ||
-            (ft_kind < FTKIND_GAMEWATCH && (ft_kind != FTKIND_SAMUS)))
-        {
-            sp8 = fp->player_id + 0x1E + fp->x221F_b4;
-            spC = -1;
-            fp->x2144 = lbAudioAx_800264E4(
-                lbAudioAx_800263E8(direction, gobj, behavior, sfx, 127, 127,
-                                   temp_r8, temp_r9, temp_r10, sp8, spC));
+        if (ft_kind != FTKIND_GAMEWATCH) {
+            if (ft_kind >= FTKIND_GAMEWATCH) {
+                break;
+            }
+            if (ft_kind == FTKIND_SAMUS) {
+                break;
+            }
         }
+        sp8 = fp->player_id + 0x1E + fp->x221F_b4;
+        spC = -1;
+        fp->x2144 = lbAudioAx_800264E4(
+            lbAudioAx_800263E8(direction, gobj, behavior, sfx, 127, 127,
+                               temp_r8, temp_r9, temp_r10, sp8, spC));
         break;
 
     case 3:
@@ -932,7 +935,7 @@ void ftAction_80072320(Fighter_GObj* gobj, CommandInfo* cmd)
         break;
 
     case 6:
-        if (!fp->x2225_b0) {
+        if (!fp->x2225_b6) {
             sp8 = fp->player_id + 0x2A + fp->x221F_b4;
             spC = -1;
             fp->x2148 = lbAudioAx_800264E4(
@@ -942,15 +945,19 @@ void ftAction_80072320(Fighter_GObj* gobj, CommandInfo* cmd)
         }
 
         ft_kind = fp->kind;
-        if (ft_kind == FTKIND_GAMEWATCH ||
-            (ft_kind < FTKIND_GAMEWATCH && (ft_kind != FTKIND_SAMUS)))
-        {
-            sp8 = fp->player_id + 0x2A + fp->x221F_b4;
-            spC = -1;
-            fp->x2148 = lbAudioAx_800264E4(
-                lbAudioAx_800263E8(direction, gobj, behavior, sfx, 127, 127,
-                                   temp_r8, temp_r9, temp_r10, sp8, spC));
+        if (ft_kind != FTKIND_GAMEWATCH) {
+            if (ft_kind >= FTKIND_GAMEWATCH) {
+                break;
+            }
+            if (ft_kind == FTKIND_SAMUS) {
+                break;
+            }
         }
+        sp8 = fp->player_id + 0x2A + fp->x221F_b4;
+        spC = -1;
+        fp->x2148 = lbAudioAx_800264E4(
+            lbAudioAx_800263E8(direction, gobj, behavior, sfx, 127, 127,
+                               temp_r8, temp_r9, temp_r10, sp8, spC));
         break;
     }
 }

--- a/src/melee/ft/ftchangeparam.c
+++ b/src/melee/ft/ftchangeparam.c
@@ -117,11 +117,11 @@ void ftCo_800D0CBC(Fighter_GObj* fgp)
     PAD_STACK(8);
 
     fp = fgp->user_data;
-    orig_scale = fp->x34_scale.y;
     count = (temp_r30 = fp->x2D0)->x28;
     scale = 1.0f;
 
-    if (scale != orig_scale) {
+    if (scale != fp->x34_scale.y) {
+        orig_scale = fp->x34_scale.y;
         scale *= ftCo_CalcYScaledKnockback(1.0f, orig_scale,
                                            Fighter_804D6524->x28);
     }

--- a/src/melee/ft/ftcoll.c
+++ b/src/melee/ft/ftcoll.c
@@ -955,8 +955,8 @@ void ftColl_80077970(Item* item, HitCapsule* hit1, Fighter* fp,
 {
     Vec3 midpoint;
     int dmg1_int, dmg2_int;
+    u32 i;
     int dmg_count;
-    int i;
     PAD_STACK(16);
 
     midpoint.x =
@@ -1043,7 +1043,8 @@ void ftColl_80077970(Item* item, HitCapsule* hit1, Fighter* fp,
             item->xCF4_fighterGObjUnk = fp->gobj;
             item->xC48 = dmg_count;
 
-            vel_x = item->x40_vel.x;
+            vel_x_mag = item->x40_vel.x;
+            vel_x = vel_x_mag;
             if (vel_x < 0.0f) {
                 vel_x_mag = -vel_x;
             } else {
@@ -1577,7 +1578,6 @@ void ftColl_80078A2C(Fighter_GObj* this_gobj)
 
 void ftColl_80078C70(Fighter_GObj* this_gobj)
 { // clang-format off
-    const static u32 hit_sfx[20];
     Fighter* this_fp;
     HSD_GObj* victim_gobj;
     bool is_same_gobj;
@@ -1658,7 +1658,7 @@ void ftColl_80078C70(Fighter_GObj* this_gobj)
                                     if (this_fp->x221B_b0) {
                                         var_r3 = true;
                                         if (this_fp->x221B_b3) {
-                                            if (-1.0f == this_fp->facing_dir) {
+                                            if (ftColl_804D82F0 == this_fp->facing_dir) {
                                                 if (this_fp->cur_pos .x < victim_fp->cur_pos .x) {
                                                     var_r3 = false;
                                                 }
@@ -1688,7 +1688,7 @@ void ftColl_80078C70(Fighter_GObj* this_gobj)
                                                     if ((u32) temp_r23->element != (u32) HitElement_Inert) {
                                       if (ftColl_80076ED8((Fighter*) victim_fp, temp_r23, this_fp, (HitCapsule*)&this_fp ->hurt_capsules [n]) != false) {
                                                             if (((int) this_fp ->x1988 != 0) || ((int) this_fp ->x198C != 0) || this_fp ->x221D_b6 || ((&this_fp->hurt_capsules[n].capsule)->state != 0)) {
-                                                                ft_PlaySFX(this_fp, hit_sfx [temp_r23 ->sfx_severity], 0x7FU, 0x40U);
+                                                                ft_PlaySFX(this_fp, ftColl_803C0C40[temp_r23 ->sfx_severity], 0x7FU, 0x40U);
                                                                 var_r0_2 = true;
                                                             } else {
                                                                 var_r0_2 = false;

--- a/src/melee/ft/ftcoll.c
+++ b/src/melee/ft/ftcoll.c
@@ -1658,7 +1658,7 @@ void ftColl_80078C70(Fighter_GObj* this_gobj)
                                     if (this_fp->x221B_b0) {
                                         var_r3 = true;
                                         if (this_fp->x221B_b3) {
-                                            if (ftColl_804D82F0 == this_fp->facing_dir) {
+                                            if (-1.0f == this_fp->facing_dir) {
                                                 if (this_fp->cur_pos .x < victim_fp->cur_pos .x) {
                                                     var_r3 = false;
                                                 }

--- a/src/melee/ft/ftdynamics.c
+++ b/src/melee/ft/ftdynamics.c
@@ -788,11 +788,6 @@ bool ftCo_8009E714(Fighter_GObj* gobj, Fighter_Part bone_id, int arg2, float x,
 
 void ftCo_8009E7B4(Fighter* fp, u8 (*arg1)[2])
 {
-    s32 i;
-    s32 var_r3;
-    FigaTree*** dyn;
-    FigaTree** tree;
-
     if (fp->anim_id != -1) {
         if (fp->x2227_b6) {
             if (fp->kind != FTKIND_KIRBY) {
@@ -800,11 +795,15 @@ void ftCo_8009E7B4(Fighter* fp, u8 (*arg1)[2])
                     ftCo_8009CB40(fp, 0, 0, NULL);
                     return;
                 }
-                for (i = 0; i < fp->dynamics_num; i++) {
-                    ftCo_8009CB40(fp, i, 0, NULL);
+                {
+                    s32 i;
+                    for (i = 0; i < fp->dynamics_num; i++) {
+                        ftCo_8009CB40(fp, i, 0, NULL);
+                    }
                 }
             }
         } else {
+            s32 var_r3;
             if (fp->kind != FTKIND_MARS && fp->kind != FTKIND_EMBLEM) {
                 var_r3 = 0;
             } else if (fp->x2227_b6 || lb_80011ABC() > 0) {
@@ -818,14 +817,20 @@ void ftCo_8009E7B4(Fighter* fp, u8 (*arg1)[2])
                         ftCo_8009CB40(fp, 0, 1, NULL);
                         return;
                     }
-                    for (i = 0; i < fp->dynamics_num; i++) {
-                        ftCo_8009CB40(fp, i, 1, NULL);
+                    {
+                        s32 i;
+                        for (i = 0; i < fp->dynamics_num; i++) {
+                            ftCo_8009CB40(fp, i, 1, NULL);
+                        }
                     }
                 }
             } else if (fp->x594_b4) {
+                FigaTree*** dyn;
+                FigaTree** tree;
                 u8 blend_slot = arg1[0][1];
                 dyn = fp->ft_data->x2C->x10;
                 if (dyn == NULL) {
+                    s32 i;
                     for (i = 0; i < fp->dynamics_num; i++) {
                         ftCo_8009CB40(fp, i, 0, NULL);
                     }
@@ -833,13 +838,17 @@ void ftCo_8009E7B4(Fighter* fp, u8 (*arg1)[2])
                 }
                 tree = dyn[blend_slot];
                 if (tree == NULL) {
+                    s32 i;
                     for (i = 0; i < fp->dynamics_num; i++) {
                         ftCo_8009CB40(fp, i, 0, NULL);
                     }
                     return;
                 }
-                for (i = 0; i < fp->dynamics_num; i++) {
-                    ftCo_8009CB40(fp, i, 1, tree[i]);
+                {
+                    s32 i;
+                    for (i = 0; i < fp->dynamics_num; i++) {
+                        ftCo_8009CB40(fp, i, 1, tree[i]);
+                    }
                 }
                 return;
             } else if (fp->x594_b3) {
@@ -848,8 +857,11 @@ void ftCo_8009E7B4(Fighter* fp, u8 (*arg1)[2])
                         ftCo_8009CB40(fp, 0, 0, NULL);
                         return;
                     }
-                    for (i = 0; i < fp->dynamics_num; i++) {
-                        ftCo_8009CB40(fp, i, 0, NULL);
+                    {
+                        s32 i;
+                        for (i = 0; i < fp->dynamics_num; i++) {
+                            ftCo_8009CB40(fp, i, 0, NULL);
+                        }
                     }
                 }
             } else {
@@ -858,8 +870,11 @@ void ftCo_8009E7B4(Fighter* fp, u8 (*arg1)[2])
                         ftCo_8009CB40(fp, 0, 1, NULL);
                         return;
                     }
-                    for (i = 0; i < fp->dynamics_num; i++) {
-                        ftCo_8009CB40(fp, i, 1, NULL);
+                    {
+                        s32 i;
+                        for (i = 0; i < fp->dynamics_num; i++) {
+                            ftCo_8009CB40(fp, i, 1, NULL);
+                        }
                     }
                 }
             }
@@ -869,8 +884,11 @@ void ftCo_8009E7B4(Fighter* fp, u8 (*arg1)[2])
             ftCo_8009CB40(fp, 0, 0, NULL);
             return;
         }
-        for (i = 0; i < fp->dynamics_num; i++) {
-            ftCo_8009CB40(fp, i, 0, NULL);
+        {
+            s32 i;
+            for (i = 0; i < fp->dynamics_num; i++) {
+                ftCo_8009CB40(fp, i, 0, NULL);
+            }
         }
     }
 }

--- a/src/melee/ft/ftmaterial.c
+++ b/src/melee/ft/ftmaterial.c
@@ -46,9 +46,9 @@ void ftMaterial_800BF2B8(HSD_MObj* mobj, u32 rendermode)
     HSD_TObj* tobj;
     HSD_TExp texp;
     HSD_PEDesc pe;
-    u32 mobj_rendermode;
     HSD_TObj** cur_tobj;
     HSD_TExp* texp1;
+    u32 mobj_rendermode;
     HSD_PEDesc* pe_p;
     u32 unused;
 
@@ -219,10 +219,9 @@ void ftMaterial_800BF6BC(Fighter* fp, HSD_MObj* mobj, HSD_TExp* texp)
             if (overlay->x7C_color_enable) {
                 u32 temp_alpha;
                 s32 inv_alpha;
-                GXColor* color_hex = &overlay->x2C_hex;
                 GXColor* fp_color = &fp->x610_color_rgba[0];
-                u8 temp_r8;
-                s32 temp_r8_2;
+                GXColor* color_hex = &overlay->x2C_hex;
+                s32 temp_r8;
                 s32 temp_r7;
                 s32 temp_r4;
 
@@ -233,16 +232,15 @@ void ftMaterial_800BF6BC(Fighter* fp, HSD_MObj* mobj, HSD_TExp* texp)
                 } else {
                     inv_alpha = 0xFF - temp_alpha;
                     temp_r8 = fp_color->r;
-                    temp_r8_2 =
-                        temp_r8 +
-                        ((color_hex->a * (color_hex->r - temp_r8)) / 255);
-                    temp_r7 = temp_r8_2 * 0xFF;
+                    temp_r8 +=
+                        (color_hex->a * (color_hex->r - temp_r8)) / 255;
+                    temp_r7 = temp_r8 * 0xFF;
                     temp_r4 = temp_r7 / inv_alpha;
                     sp168.r = (u8) temp_r4;
                     if (sp168.r != 0) {
                         sp168.a = temp_r7 / sp168.r;
                     } else {
-                        sp168.a = ((inv_alpha - temp_r8_2) * 0xFF) / 255;
+                        sp168.a = ((inv_alpha - temp_r8) * 0xFF) / 255;
                     }
                     {
                         u8 temp_r8_3 = fp_color->g;

--- a/src/melee/gm/gm_1601.c
+++ b/src/melee/gm/gm_1601.c
@@ -1271,8 +1271,6 @@ s32 gm_8016247C(s32 arg0)
     u32* temp_r5;
     u32* temp_r30_2;
     u32* temp_r3;
-    u32 temp_r0;
-    u32 temp_r0_2;
     s32 temp_r29 = *gmMainLib_8015CCF0();
     u32* temp_r30 = gmMainLib_8015CCFC();
     s32 ret;
@@ -1285,7 +1283,11 @@ s32 gm_8016247C(s32 arg0)
     var_r3 = MAX(-1U, *temp_r5 + arg0);
     *temp_r5 = var_r3;
 
-    var_r28 = MIN(0x270FU, temp_r29 + arg0);
+    var_r28 = temp_r29;
+    var_r28 += arg0;
+    if (var_r28 > 0x270FU) {
+        var_r28 = 0x270FU;
+    }
     ret = (s32) var_r28;
     var_r29 = var_r28;
 
@@ -2343,8 +2345,8 @@ static inline bool gm_80164840_noinline(u8 ckind)
 void gm_80164910(int arg0)
 {
     u16* char_unlock_mask;
-    u8 internal_id;
-    s32 i;
+    s32 internal_id;
+    int i;
     u8 unlock_idx;
     u8 notify_val;
 
@@ -2869,30 +2871,34 @@ s32 fn_8016588C(lbl_8046B6A0_24C_t* arg0, s32 arg1)
     return v;
 }
 
+struct fn_80165AC0_loser_bits {
+    u8 hi : 4;
+    u8 lo : 4;
+};
+
 s32 fn_80165AC0(MatchEnd* arg0)
 {
-    s32 max_loser;
-    s32 count;
     s32 i;
     s32 j;
-    MatchPlayerData* p;
+    s32 max_loser;
+    s32 count;
 
     max_loser = 0;
     for (i = 0; i < 6; i++) {
-        p = &arg0->player_standings[i];
-        if (p->slot_type != 3) {
+        if (arg0->player_standings[i].slot_type != 3) {
             for (j = 0; j < 6; j++) {
-                if (arg0->player_standings[j].slot_type != 3 && j != i &&
-                    (s32) p->score < (s32) arg0->player_standings[j].score) {
-                    p->is_big_loser += 1;
+                if (arg0->player_standings[j].slot_type != 3 && i != j &&
+                    arg0->player_standings[i].score <
+                        arg0->player_standings[j].score) {
+                    arg0->player_standings[i].is_big_loser += 1;
                 }
             }
-            if (max_loser < (s32) p->is_big_loser) {
-                max_loser = p->is_big_loser;
+            if (max_loser < arg0->player_standings[i].is_big_loser) {
+                max_loser = arg0->player_standings[i].is_big_loser;
             }
         }
     }
-    arg0->loser = (arg0->loser & ~0xF0) | ((max_loser << 4) & 0xF0);
+    ((struct fn_80165AC0_loser_bits*) &arg0->loser)->hi = max_loser;
     count = 0;
     for (j = 0; j < 6; j++) {
         if (arg0->player_standings[j].slot_type != 3 &&

--- a/src/melee/gm/gm_16AE.c
+++ b/src/melee/gm/gm_16AE.c
@@ -1810,7 +1810,6 @@ void fn_8016E124(void)
 void fn_8016E2BC(void)
 {
     lbl_8046B6A0_t* tmp = &lbl_8046B6A0;
-    u8 _[4];
     Vec3 sp24;
     Vec3 sp18;
     float var_f1_2;

--- a/src/melee/gm/gm_16F1.c
+++ b/src/melee/gm/gm_16F1.c
@@ -2031,12 +2031,29 @@ bool fn_80172FAC(void)
     return var_r31;
 }
 
+static inline s32 fn_80173098_CountUnlocked(void)
+{
+    s32 i;
+    s32 count;
+
+    count = 0;
+    for (i = 0; i < 0x19; i++) {
+        if (gmMainLib_8015D0F4(i) != 0) {
+            count++;
+        } else if (gmMainLib_8015D21C(i) != 0) {
+            count++;
+        } else if (gmMainLib_8015D344(i) != 0) {
+            count++;
+        }
+    }
+    return count;
+}
+
 u8 fn_80173098(int arg0)
 {
     Unk1PData* temp_r3;
     UnkAdventureData* temp_r31;
     int var_r31;
-    int i;
 
     temp_r3 = fn_8017DEC8(arg0);
     if (temp_r3->xC.xD == 0) {
@@ -2047,16 +2064,7 @@ u8 fn_80173098(int arg0)
             return CKIND_DRMARIO;
         }
     }
-    var_r31 = 0;
-    for (i = 0; i < 0x19; i++) {
-        if (gmMainLib_8015D0F4(i) != 0) {
-            var_r31++;
-        } else if (gmMainLib_8015D21C(i) != 0) {
-            var_r31++;
-        } else if (gmMainLib_8015D344(i) != 0) {
-            var_r31++;
-        }
-    }
+    var_r31 = fn_80173098_CountUnlocked();
     if (var_r31 >= 10 && !gm_80164840(CKIND_CLINK)) {
         return CKIND_CLINK;
     }

--- a/src/melee/gm/gm_1832.c
+++ b/src/melee/gm/gm_1832.c
@@ -382,8 +382,6 @@ static char lbl_804D40A0[] = { 0x8C, 0x52, 0x92, 0x63, 0x00 };
 static const char* const lbl_803B7C58[] = { "IrAls", "IrEzTarg", "IrEzTuki",
                                             "IrEzFigG" };
 
-static char lbl_803D9438[] = "ScItrAllstar_scene_data";
-
 void fn_80184AB8(HSD_GObj* arg0)
 {
     HSD_JObj* sp110;
@@ -1088,9 +1086,9 @@ void fn_80186634(void* arg0)
     names[2] = lbl_803B7C58[2];
     names[3] = lbl_803B7C58[3];
     lbl_804D65F4 = lbArchive_80016DBC(names[lbl_804735E8.xE8], &lbl_804D65FC,
-                                      lbl_803D9438, 0);
+                                      "ScItrAllstar_scene_data", 0);
     lbl_804D65F8 = lbArchive_80016DBC(lbl_804D40B0, &lbl_804D6600,
-                                      lbl_803D9438, 0);
+                                      "ScItrAllstar_scene_data", 0);
 
     gobj = GObj_Create(0xB, 3, 0);
     HSD_GObjObject_80390A70(gobj, HSD_GObj_804D784A,
@@ -1608,8 +1606,6 @@ void fn_80187C9C(HSD_GObj* gobj, int arg1)
     HSD_StateInvalidate(0x40);
 }
 
-#pragma push
-#pragma global_optimizer off
 void fn_80187CF4(HSD_GObj* gobj)
 {
     HSD_JObj* jobj = GET_JOBJ(gobj);
@@ -1673,7 +1669,6 @@ void fn_80187CF4(HSD_GObj* gobj)
     HSD_JObjAnimAll(GET_JOBJ(gobj));
 }
 
-#pragma pop
 static char lbl_804D4138[] = "IrNml";
 
 static char* lbl_803D9750[] = {

--- a/src/melee/gm/gm_1832.c
+++ b/src/melee/gm/gm_1832.c
@@ -184,7 +184,6 @@ void fn_8018325C(HSD_GObj* arg0, int arg1)
     HSD_JObj* jobj = arg0->hsd_obj;
     HSD_JObj* src = lbl_804735A8.x4[0];
     int i;
-    HSD_JObj* arrow;
 
     HSD_JObjGetTranslation(src, &pos);
     HSD_JObjSetTranslate(jobj, &pos);
@@ -193,23 +192,21 @@ void fn_8018325C(HSD_GObj* arg0, int arg1)
     case 1:
         HSD_JObjAddTranslationZ(jobj, -10.0f);
         if (lbl_804735A8.x38 > 0x50U) {
-            arrow = lbl_804735A8.x4[2];
-            HSD_JObjSetTranslateX(arrow, -1.0f);
-            HSD_JObjSetTranslateY(arrow, 0.0f);
-            HSD_JObjSetTranslateZ(arrow, 5.0f);
-            HSD_JObjSetScaleX(arrow, 2.8f);
-            HSD_JObjSetScaleY(arrow, 2.8f);
+            HSD_JObjSetTranslateX(lbl_804735A8.x4[2], -1.0f);
+            HSD_JObjSetTranslateY(lbl_804735A8.x4[2], 0.0f);
+            HSD_JObjSetTranslateZ(lbl_804735A8.x4[2], 5.0f);
+            HSD_JObjSetScaleX(lbl_804735A8.x4[2], 2.8f);
+            HSD_JObjSetScaleY(lbl_804735A8.x4[2], 2.8f);
         }
         break;
     case 2:
         HSD_JObjAddTranslationZ(jobj, -30.0f);
         if (lbl_804735A8.x38 > 0x5AU) {
-            arrow = lbl_804735A8.x4[3];
-            HSD_JObjSetTranslateX(arrow, -0.5f);
-            HSD_JObjSetTranslateY(arrow, 3.0f);
-            HSD_JObjSetTranslateZ(arrow, 5.0f);
-            HSD_JObjSetScaleX(arrow, 2.2f);
-            HSD_JObjSetScaleY(arrow, 2.2f);
+            HSD_JObjSetTranslateX(lbl_804735A8.x4[3], -0.5f);
+            HSD_JObjSetTranslateY(lbl_804735A8.x4[3], 3.0f);
+            HSD_JObjSetTranslateZ(lbl_804735A8.x4[3], 5.0f);
+            HSD_JObjSetScaleX(lbl_804735A8.x4[3], 2.2f);
+            HSD_JObjSetScaleY(lbl_804735A8.x4[3], 2.2f);
         }
         break;
     }
@@ -240,18 +237,15 @@ void fn_8018325C(HSD_GObj* arg0, int arg1)
             jobj, lbl_804D6604->x6C[lbl_804735E8.xF1[arg1]].x04 +
                       lbl_804D6604->x18[lbl_804735E8.xEF].vals[arg1]);
 
-        {
-            f32 scale_factor = lbl_804D6604->x3C[lbl_804735E8.xEF].vals[arg1];
-            HSD_JObjSetScaleX(jobj,
-                              lbl_804D6604->x6C[lbl_804735E8.xF1[arg1]].x08.x *
-                                  scale_factor);
-            HSD_JObjSetScaleY(jobj,
-                              lbl_804D6604->x6C[lbl_804735E8.xF1[arg1]].x08.y *
-                                  scale_factor);
-            HSD_JObjSetScaleZ(jobj,
-                              lbl_804D6604->x6C[lbl_804735E8.xF1[arg1]].x08.z *
-                                  scale_factor);
-        }
+        HSD_JObjSetScaleX(jobj,
+                          lbl_804D6604->x6C[lbl_804735E8.xF1[arg1]].x08.x *
+                              lbl_804D6604->x3C[lbl_804735E8.xEF].vals[arg1]);
+        HSD_JObjSetScaleY(jobj,
+                          lbl_804D6604->x6C[lbl_804735E8.xF1[arg1]].x08.y *
+                              lbl_804D6604->x3C[lbl_804735E8.xEF].vals[arg1]);
+        HSD_JObjSetScaleZ(jobj,
+                          lbl_804D6604->x6C[lbl_804735E8.xF1[arg1]].x08.z *
+                              lbl_804D6604->x3C[lbl_804735E8.xEF].vals[arg1]);
     }
 
     for (i = 0; i < 6; i++) {
@@ -384,6 +378,11 @@ static char lbl_803D9414[] = { 0x82, 0x73, 0x82, 0x85, 0x82, 0x81,
                                0x82, 0x8D, 0,    0,    0,    0 };
 
 static char lbl_804D40A0[] = { 0x8C, 0x52, 0x92, 0x63, 0x00 };
+
+static const char* const lbl_803B7C58[] = { "IrAls", "IrEzTarg", "IrEzTuki",
+                                            "IrEzFigG" };
+
+static char lbl_803D9438[] = "ScItrAllstar_scene_data";
 
 void fn_80184AB8(HSD_GObj* arg0)
 {
@@ -747,27 +746,28 @@ void fn_8018575C(HSD_GObj* gobj)
 /// images. Distributes 10 image tiles across a grid with random offsets.
 void fn_801857C4(HSD_GObj* arg0)
 {
-    Vec3 pos;
-    Vec3 pos_copy;
     HSD_ImageDesc* descs[3];
+    Vec3 pos_copy;
+    Vec3 pos;
     HSD_SObj* sobj;
     u64 num_cols;
     s32 row;
     u32 total_tiles;
+    u8* img_idx;
     u32 delay;
     s32 i;
-    u8* img_idx;
 
     PAD_STACK(0x10);
 
     if (lbl_804735E8.xE1 != 0) {
         HSD_GObjPLink_80390228(lbl_804D65F0);
-        img_idx = lbl_804735E8.xD0;
+        img_idx = (u8*) lbl_804735E8.x40;
+        i = 0;
         delay = 1;
-        for (i = 0; i < 10; i++, img_idx++) {
-            descs[0] = &lbl_804735E8.x40[*img_idx];
+        for (; i < 10; i++, img_idx++) {
+            descs[0] = &lbl_804735E8.x40[img_idx[0x90]];
             descs[1] = 0;
-            descs[2] = &lbl_804735E8.x88[*img_idx];
+            descs[2] = &lbl_804735E8.x88[img_idx[0x90]];
             sobj = HSD_SObjLib_803A477C(lbl_804735E8.xDC, (s32) &descs[0], 0,
                                         0, 0x80, 1);
             total_tiles = 10;
@@ -1057,9 +1057,6 @@ void fn_80186400(void)
     }
 }
 
-static const char* const lbl_803B7C58[] = { "IrAls", "IrEzTarg", "IrEzTuki",
-                                            "IrEzFigG" };
-
 static char lbl_804D40B0[] = "IrRdMap";
 
 void fn_80186634(void* arg0)
@@ -1091,9 +1088,9 @@ void fn_80186634(void* arg0)
     names[2] = lbl_803B7C58[2];
     names[3] = lbl_803B7C58[3];
     lbl_804D65F4 = lbArchive_80016DBC(names[lbl_804735E8.xE8], &lbl_804D65FC,
-                                      "ScItrAllstar_scene_data", 0);
+                                      lbl_803D9438, 0);
     lbl_804D65F8 = lbArchive_80016DBC(lbl_804D40B0, &lbl_804D6600,
-                                      "ScItrAllstar_scene_data", 0);
+                                      lbl_803D9438, 0);
 
     gobj = GObj_Create(0xB, 3, 0);
     HSD_GObjObject_80390A70(gobj, HSD_GObj_804D784A,
@@ -1611,6 +1608,8 @@ void fn_80187C9C(HSD_GObj* gobj, int arg1)
     HSD_StateInvalidate(0x40);
 }
 
+#pragma push
+#pragma global_optimizer off
 void fn_80187CF4(HSD_GObj* gobj)
 {
     HSD_JObj* jobj = GET_JOBJ(gobj);
@@ -1674,6 +1673,7 @@ void fn_80187CF4(HSD_GObj* gobj)
     HSD_JObjAnimAll(GET_JOBJ(gobj));
 }
 
+#pragma pop
 static char lbl_804D4138[] = "IrNml";
 
 static char* lbl_803D9750[] = {

--- a/src/melee/gm/gm_18A5.c
+++ b/src/melee/gm/gm_18A5.c
@@ -1476,7 +1476,6 @@ void fn_8018E85C(DynamicModelDesc* model, s32 flag)
     u8* ptr;
     HSD_JObj* jobj;
     HSD_GObj* gobj;
-    DynamicModelDesc* mdl = model;
     s32 anim_frame;
     f32 pos_multiplier;
     f32 pos;
@@ -1517,10 +1516,10 @@ void fn_8018E85C(DynamicModelDesc* model, s32 flag)
             gobj = GObj_Create(0xE, 0x1B, 0);
             *(HSD_GObj**) (sub + 0x2C) = gobj;
             gobj = *(HSD_GObj**) (sub + 0x2C);
-            jobj = HSD_JObjLoadJoint(mdl->joint);
+            jobj = HSD_JObjLoadJoint(model->joint);
             HSD_GObjObject_80390A70(gobj, HSD_GObj_804D7849, jobj);
             GObj_SetupGXLink(gobj, HSD_GObj_JObjCallback, 4, 2);
-            gm_8016895C(jobj, mdl, 0);
+            gm_8016895C(jobj, model, 0);
 
             anim_frame = sub[0x4D] + sub[0x4F] * 0x1E;
             HSD_JObjReqAnimAll(jobj, (f32) anim_frame);
@@ -2281,13 +2280,15 @@ void gm_801905F0(StartMeleeData* arg0)
 {
     u8 _padA[8];
     GameRules* temp_r31 = gmMainLib_8015CC34();
+    TmData* tm;
     int i;
     TmVsData sp18;
 
+    tm = &gm_804771C4;
     gm_80168FC4();
     gm_80167A64(&arg0->rules);
     arg0->rules.is_teams = false;
-    arg0->rules.xE = gm_804771C4.x28;
+    arg0->rules.xE = tm->x28;
     fn_801640B0(&arg0->rules.x20);
     arg0->rules.x0_0 = temp_r31->mode;
     if (temp_r31->mode != 1) {
@@ -2343,7 +2344,7 @@ void gm_801905F0(StartMeleeData* arg0)
     } else {
         arg0->rules.x2_4 = true;
     }
-    if (temp_r31->score_display != 0 && !arg0->rules.x0_3) {
+    if (temp_r31->score_display != 0 && !arg0->rules.x0_0) {
         arg0->rules.x3_0 = true;
     } else {
         arg0->rules.x3_0 = false;
@@ -2351,32 +2352,31 @@ void gm_801905F0(StartMeleeData* arg0)
     gm_80167A14(arg0->players);
 
     for (i = 0; i < 4; i++) {
-        if (i < gm_804771C4.x30) {
+        if (i < tm->x30) {
             arg0->players[i].x20 = 1.0f;
-            arg0->players[i].xA = (u8) MIN(gm_804771C4.x4B8[i].x6, 0x78);
-            if (gm_804771C4.x4B8[i].x2 != 0) {
+            arg0->players[i].xA = (u8) MIN(tm->x4B8[i].x6, 0x78);
+            if (tm->x4B8[i].x2 != 0) {
                 arg0->players[i].c_kind = gm_801905F0_inline0(fn_8018F410());
                 arg0->players[i].color =
                     HSD_Randi(gm_80169238(arg0->players[i].c_kind));
             } else {
-                arg0->players[i].c_kind =
-                    gm_801905F0_inline0(gm_804771C4.x4B8[i].x1);
-                arg0->players[i].color = gm_804771C4.x4B8[i].x3;
+                arg0->players[i].c_kind = gm_801905F0_inline0(tm->x4B8[i].x1);
+                arg0->players[i].color = tm->x4B8[i].x3;
             }
-            arg0->players[i].slot_type = gm_804771C4.x4B8[i].x0;
+            arg0->players[i].slot_type = tm->x4B8[i].x0;
             arg0->players[i].stocks = temp_r31->stock_count;
             arg0->players[i].sub_color = 0;
             arg0->players[i].team = 0xFF;
             arg0->players[i].xC_b0 = gm_801677F8(i, arg0->players[i].xA);
-            if (gm_804771C4.x4B8[i].x0 == 1) {
+            if (tm->x4B8[i].x0 == 1) {
                 arg0->players[i].xC_b0 = false;
             }
             arg0->players[i].xE = 4;
-            arg0->players[i].cpu_level = gm_804771C4.x4B8[i].x4;
+            arg0->players[i].cpu_level = tm->x4B8[i].x4;
             arg0->players[i].x12 = 0;
             if (gmMainLib_8015CC34()->handicap != 0) {
-                arg0->players[i].x18 = fn_8016419C(gm_804771C4.x4B8[i].x5);
-                arg0->players[i].x1C = fn_801641B4(gm_804771C4.x4B8[i].x5);
+                arg0->players[i].x18 = fn_8016419C(tm->x4B8[i].x5);
+                arg0->players[i].x1C = fn_801641B4(tm->x4B8[i].x5);
             } else {
                 arg0->players[i].x18 = arg0->players[i].x1C = 1.0F;
             }
@@ -4602,10 +4602,36 @@ void fn_80194D84(s32* state, u32 buttons, u32 trigger)
 
 s32 lbl_804D6654;
 
+#pragma pack(push, 1)
+typedef struct TmData_80194F30 {
+    u8 pad_x0[0x2E];
+    u8 x2E;
+    u8 pad_x2F[0x37 - 0x2F];
+    struct {
+        u8 x0;
+        u8 x1;
+        u8 x2;
+        u8 x3;
+        u8 x4;
+        u8 x5;
+        u8 x6;
+        u8 x7;
+        u8 x8;
+        u16 x9;
+        u16 xB;
+        u8 xD;
+        u8 xE;
+        u8 xF;
+        u8 pad_X10[0x12 - 0x10];
+    } x37[64];
+} TmData_80194F30;
+#pragma pack(pop)
+
 /// Handles tournament settings menu input (entrant configuration).
 void fn_80194F30(s32* state_ptr, u32 buttons, u32 trigger)
 {
     TmData* tm = (TmData*) state_ptr;
+    TmData_80194F30* tm_alt = (TmData_80194F30*) state_ptr;
     s32 idx;
 
     if (trigger & 0x1000) {
@@ -4698,7 +4724,7 @@ void fn_80194F30(s32* state_ptr, u32 buttons, u32 trigger)
             idx = lbl_804799B8.x2 + lbl_804799B8.x3;
             tm->x37[idx].x8 = tm->x37[idx].x7;
             idx = lbl_804799B8.x2 + lbl_804799B8.x3;
-            tm->x37[idx].xB = tm->x37[idx].x9;
+            tm_alt->x37[idx].xB = tm->x37[idx].x9;
             idx = lbl_804799B8.x2 + lbl_804799B8.x3;
             tm->x37[idx].x6 = tm->x37[idx].x5;
             tm->cur_option += 1;
@@ -6389,7 +6415,8 @@ void fn_80198824(HSD_GObj* gobj)
     s32 in_range;
 
     gm_8018F634();
-    jobj = gobj->hsd_obj;
+    gobj = gobj->hsd_obj;
+    jobj = (HSD_JObj*) gobj;
 
     if ((s32) gm_8018F634()->cur_option >= 0x1F &&
         (s32) gm_8018F634()->cur_option <= 0x27)
@@ -6579,7 +6606,7 @@ void fn_80198EBC(void)
     HSD_JObj* jobj;
     HSD_JObj* jobj2;
     HSD_JObj* c;
-    struct lbl_803DA0D0_t* da0d0;
+    struct lbl_803DA0D0_t* da0d0 = &lbl_803DA0D0;
     s32 i, j;
     f32 anim_rate;
     f32 pos;
@@ -6588,8 +6615,8 @@ void fn_80198EBC(void)
     f32 f_858, f_834, f_85C;
     f32 f_7E4, f_7E0, f_7E8, f_7EC;
     f32 f_864;
+    PAD_STACK(8);
 
-    da0d0 = &lbl_803DA0D0;
     td = gm_8018F634();
     gm_8018F634();
 
@@ -7206,14 +7233,14 @@ void fn_8019A158(void)
 
 /// #fn_8019A158_end
 
-/// @todo Currently 98.36% match - needs branch pattern fix (beq+b vs bne)
-#pragma dont_inline on
 void fn_8019A71C(s32* state, u32 unused1, u32 unused2)
 {
     u32* counter = &lbl_804799D8.x0;
 
-    if (*state == 0x13) {
+    switch (*state) {
+    case 0x13:
         fn_8019B458(state);
+        break;
     }
 
     if (*state > 0x14) {
@@ -7251,8 +7278,6 @@ void fn_8019A71C(s32* state, u32 unused1, u32 unused2)
         *state = 0x1B;
     }
 }
-#pragma dont_inline reset
-
 extern s32 lbl_804D6678;
 
 void gm_8019A828(void)

--- a/src/melee/gm/gm_19EF.c
+++ b/src/melee/gm/gm_19EF.c
@@ -96,7 +96,7 @@ static void fn_8019F2D4(u32 arg0);
 
 static void fn_8019EFC4(HSD_PadStatus* pad)
 {
-    HSD_JObj* child_next;
+    register HSD_JObj* child_next;
 
     child_next = lbl_80479A98.x28->hsd_obj;
     if ((u8) lbl_80479A98.x60 != 0) {
@@ -414,8 +414,7 @@ void fn_8019F9C4(u32 arg0)
     cam_gobj = GObj_Create(0x13, 0x14, 0);
     HSD_GObjObject_80390A70(cam_gobj, HSD_GObj_804D784B, cobj);
     GObj_SetupGXLinkMax(cam_gobj, HSD_GObj_803910D8, 0);
-    cam_gobj->gx_link = (u8) 0x801; // TODO fix this, 0x801 doesnt fit in an u8
-    cam_gobj->p_link = 0;
+    cam_gobj->gxlink_prios = 0x801;
 
     gobj = GObj_Create(0xB, 0xF, 0);
     HSD_GObjObject_80390A70(gobj, HSD_GObj_804D784A,

--- a/src/melee/gm/gm_19EF.c
+++ b/src/melee/gm/gm_19EF.c
@@ -96,7 +96,7 @@ static void fn_8019F2D4(u32 arg0);
 
 static void fn_8019EFC4(HSD_PadStatus* pad)
 {
-    register HSD_JObj* child_next;
+    HSD_JObj* child_next;
 
     child_next = lbl_80479A98.x28->hsd_obj;
     if ((u8) lbl_80479A98.x60 != 0) {

--- a/src/melee/gm/gm_1A4C.c
+++ b/src/melee/gm/gm_1A4C.c
@@ -127,7 +127,8 @@ void gm_801A7B00(void)
     HSD_JObjSetRotationYWithMtxDirty(child, val);
 
     scale = 1.0f / un_803060BC(char_idx, 3);
-    scale = un_803060BC(char_idx, 4) * scale;
+    val = un_803060BC(char_idx, 4);
+    scale = val * scale;
     HSD_JObjSetScaleXWithMtxDirty(child, scale);
     HSD_JObjSetScaleYWithMtxDirty(child, scale);
     HSD_JObjSetScaleZWithMtxDirty(child, scale);
@@ -140,7 +141,11 @@ void gm_801A7B00(void)
     target = HSD_JObjGetChild(target);
     target = HSD_JObjGetChild(target);
     target = HSD_JObjGetChild(target);
-    target = HSD_JObjGetNext(target);
+    if (target == NULL) {
+        target = NULL;
+    } else {
+        target = target->next;
+    }
 
     lb_8000C1C0((HSD_JObj*) gobj->hsd_obj, target);
     lb_8000C290((HSD_JObj*) gobj->hsd_obj, target);
@@ -250,15 +255,16 @@ void fn_801A851C(HSD_GObj* gobj)
 void gm_801A85E4(HSD_JObj* jobj, s32 arg1, s32 arg2)
 {
     s32 idx;
+    s32 temp_idx;
     f32 angle;
     f32 x;
-    f32 z;
     PAD_STACK(0x20);
 
     if (arg1 <= 4) {
         arg2 = 4 - arg1;
-        idx = arg2 + 2;
-        if (idx > 4) {
+        temp_idx = arg2 + 2;
+        idx = temp_idx;
+        if (temp_idx > 4) {
             arg2 = 4 - idx;
             idx = arg2 + 2;
         }
@@ -266,12 +272,13 @@ void gm_801A85E4(HSD_JObj* jobj, s32 arg1, s32 arg2)
             0.017453292f * ((45.0f * (f32) idx) + (2.0f * HSD_Randf()) - 1.0f);
         x = 25.0f * cosf(angle);
         HSD_JObjSetTranslateX(jobj, x);
-        z = 0.9f * ((25.0f * -sinf(angle)) + -18.0f);
-        HSD_JObjSetTranslateZ(jobj, z);
+        x = 0.9f * ((25.0f * -sinf(angle)) + -18.0f);
+        HSD_JObjSetTranslateZ(jobj, x);
     } else if (arg1 <= 0xC) {
         arg2 = 0xC - arg1;
-        idx = arg2 + 8;
-        if (idx > 0xC) {
+        temp_idx = arg2 + 8;
+        idx = temp_idx;
+        if (temp_idx > 0xC) {
             arg2 = 0xC - idx;
             idx = arg2 + 8;
         }
@@ -279,12 +286,13 @@ void gm_801A85E4(HSD_JObj* jobj, s32 arg1, s32 arg2)
                 ((25.714285f * (f32) (idx - 5)) + (4.0f * HSD_Randf()) - 2.0f);
         x = 50.0f * cosf(angle);
         HSD_JObjSetTranslateX(jobj, x);
-        z = 0.9f * ((50.0f * -sinf(angle)) + -18.0f);
-        HSD_JObjSetTranslateZ(jobj, z);
+        x = 0.9f * ((50.0f * -sinf(angle)) + -18.0f);
+        HSD_JObjSetTranslateZ(jobj, x);
     } else if (arg1 <= 0x15) {
         arg2 = 0x15 - arg1;
-        idx = arg2 + 0x11;
-        if (idx > 0x15) {
+        temp_idx = arg2 + 0x11;
+        idx = temp_idx;
+        if (temp_idx > 0x15) {
             arg2 = 0x15 - idx;
             idx = arg2 + 0x11;
         }
@@ -292,8 +300,8 @@ void gm_801A85E4(HSD_JObj* jobj, s32 arg1, s32 arg2)
             0.017453292f * ((22.5f * (f32) (idx - 0xD)) + HSD_Randf() - 0.5f);
         x = 75.0f * cosf(angle);
         HSD_JObjSetTranslateX(jobj, x);
-        z = 0.8f * ((75.0f * -sinf(angle)) + -18.0f);
-        HSD_JObjSetTranslateZ(jobj, z);
+        x = 0.8f * ((75.0f * -sinf(angle)) + -18.0f);
+        HSD_JObjSetTranslateZ(jobj, x);
     } else if (arg1 == 0x16) {
         HSD_JObjSetTranslateX(jobj, -80.0f);
         HSD_JObjSetTranslateZ(jobj, -70.0f);
@@ -372,8 +380,8 @@ void gm_801A9094(void)
     s32 i;
     TyDspEntry* dsp;
     HSD_Joint* joint;
-    HSD_MatAnimJoint* matanim;
     HSD_Joint* bg_joint;
+    HSD_MatAnimJoint* matanim;
     HSD_GObj* gobj;
     HSD_JObj* root;
     HSD_JObj* child;
@@ -490,6 +498,7 @@ void gm_801A9630(void)
     HSD_LObj* lobj;
     HSD_JObj* jobj;
     HSD_JObj* child;
+    HSD_JObj* target;
     s32 i;
     PAD_STACK(8);
 
@@ -577,104 +586,183 @@ void gm_801A9630(void)
 
     // Walk JObj tree to find constraint target (3 levels deep)
     child = HSD_JObjGetChild(GET_JOBJ(gm_804D67BC));
-    child = HSD_JObjGetChild(child);
-    child = HSD_JObjGetChild(child);
+    target = HSD_JObjGetChild(child);
+    target = HSD_JObjGetChild(target);
 
-    lb_8000C1C0(jobj, child);
-    lb_8000C290(jobj, child);
+    lb_8000C1C0(jobj, target);
+    lb_8000C290(jobj, target);
     HSD_GObj_SetupProc(gobj, fn_801A80F0, 0x17);
 }
 
 static u8 gm_804D67C8;
 static u8 gm_804D67C9;
 
+char gm_803DB640[] = "GmRegendSimpleCaptain.thp";
+char gm_803DB65C[] = "GmRegendSimpleDonkey.thp";
+char gm_803DB678[] = "GmRegendSimpleFox.thp";
+char gm_803DB690[] = "GmRegendSimpleGamewatch.thp";
+char gm_803DB6AC[] = "GmRegendSimpleKirby.thp";
+char gm_803DB6C4[] = "GmRegendSimpleKoopa.thp";
+char gm_803DB6DC[] = "GmRegendSimpleLink.thp";
+char gm_803DB6F4[] = "GmRegendSimpleLuigi.thp";
+char gm_803DB70C[] = "GmRegendSimpleMario.thp";
+char gm_803DB724[] = "GmRegendSimpleMarth.thp";
+char gm_803DB73C[] = "GmRegendSimpleMewtwo.thp";
+char gm_803DB758[] = "GmRegendSimpleNess.thp";
+char gm_803DB770[] = "GmRegendSimplePeach.thp";
+char gm_803DB788[] = "GmRegendSimplePikachu.thp";
+char gm_803DB7A4[] = "GmRegendSimplePoponana.thp";
+char gm_803DB7C0[] = "GmRegendSimplePurin.thp";
+char gm_803DB7D8[] = "GmRegendSimpleSamus.thp";
+char gm_803DB7F0[] = "GmRegendSimpleYoshi.thp";
+char gm_803DB808[] = "GmRegendSimpleZeldaseak.thp";
+char gm_803DB824[] = "GmRegendSimpleFalco.thp";
+char gm_803DB83C[] = "GmRegendSimpleClink.thp";
+char gm_803DB854[] = "GmRegendSimpleDrmario.thp";
+char gm_803DB870[] = "GmRegendSimpleRoy.thp";
+char gm_803DB888[] = "GmRegendSimplePichu.thp";
+char gm_803DB8A0[] = "GmRegendSimpleGanon.thp";
+char gm_803DB920[] = "GmRegendAdventureCaptain.thp";
+char gm_803DB940[] = "GmRegendAdventureDonkey.thp";
+char gm_803DB95C[] = "GmRegendAdventureFox.thp";
+char gm_803DB978[] = "GmRegendAdventureGamewatch.thp";
+char gm_803DB998[] = "GmRegendAdventureKirby.thp";
+char gm_803DB9B4[] = "GmRegendAdventureKoopa.thp";
+char gm_803DB9D0[] = "GmRegendAdventureLink.thp";
+char gm_803DB9EC[] = "GmRegendAdventureLuigi.thp";
+char gm_803DBA08[] = "GmRegendAdventureMario.thp";
+char gm_803DBA24[] = "GmRegendAdventureMarth.thp";
+char gm_803DBA40[] = "GmRegendAdventureMewtwo.thp";
+char gm_803DBA5C[] = "GmRegendAdventureNess.thp";
+char gm_803DBA78[] = "GmRegendAdventurePeach.thp";
+char gm_803DBA94[] = "GmRegendAdventurePikachu.thp";
+char gm_803DBAB4[] = "GmRegendAdventurePoponana.thp";
+char gm_803DBAD4[] = "GmRegendAdventurePurin.thp";
+char gm_803DBAF0[] = "GmRegendAdventureSamus.thp";
+char gm_803DBB0C[] = "GmRegendAdventureYoshi.thp";
+char gm_803DBB28[] = "GmRegendAdventureZeldaseak.thp";
+char gm_803DBB48[] = "GmRegendAdventureFalco.thp";
+char gm_803DBB64[] = "GmRegendAdventureClink.thp";
+char gm_803DBB80[] = "GmRegendAdventureDrmario.thp";
+char gm_803DBBA0[] = "GmRegendAdventureRoy.thp";
+char gm_803DBBBC[] = "GmRegendAdventurePichu.thp";
+char gm_803DBBD8[] = "GmRegendAdventureGanon.thp";
+char gm_803DBC5C[] = "GmRegendAllstarCaptain.thp";
+char gm_803DBC78[] = "GmRegendAllstarDonkey.thp";
+char gm_803DBC94[] = "GmRegendAllstarFox.thp";
+char gm_803DBCAC[] = "GmRegendAllstarGamewatch.thp";
+char gm_803DBCCC[] = "GmRegendAllstarKirby.thp";
+char gm_803DBCE8[] = "GmRegendAllstarKoopa.thp";
+char gm_803DBD04[] = "GmRegendAllstarLink.thp";
+char gm_803DBD1C[] = "GmRegendAllstarLuigi.thp";
+char gm_803DBD38[] = "GmRegendAllstarMario.thp";
+char gm_803DBD54[] = "GmRegendAllstarMarth.thp";
+char gm_803DBD70[] = "GmRegendAllstarMewtwo.thp";
+char gm_803DBD8C[] = "GmRegendAllstarNess.thp";
+char gm_803DBDA4[] = "GmRegendAllstarPeach.thp";
+char gm_803DBDC0[] = "GmRegendAllstarPikachu.thp";
+char gm_803DBDDC[] = "GmRegendAllstarPoponana.thp";
+char gm_803DBDF8[] = "GmRegendAllstarPurin.thp";
+char gm_803DBE14[] = "GmRegendAllstarSamus.thp";
+char gm_803DBE30[] = "GmRegendAllstarYoshi.thp";
+char gm_803DBE4C[] = "GmRegendAllstarZeldaseak.thp";
+char gm_803DBE6C[] = "GmRegendAllstarFalco.thp";
+char gm_803DBE88[] = "GmRegendAllstarClink.thp";
+char gm_803DBEA4[] = "GmRegendAllstarDrmario.thp";
+char gm_803DBEC0[] = "GmRegendAllstarRoy.thp";
+char gm_803DBED8[] = "GmRegendAllstarPichu.thp";
+char gm_803DBEF4[] = "GmRegendAllstarGanon.thp";
+
 char* gm_803DB8B8[] = {
     // clang-format off
-    "GmRegendSimpleCaptain.thp",
-    "GmRegendSimpleDonkey.thp",
-    "GmRegendSimpleFox.thp",
-    "GmRegendSimpleGamewatch.thp",
-    "GmRegendSimpleKirby.thp",
-    "GmRegendSimpleKoopa.thp",
-    "GmRegendSimpleLink.thp",
-    "GmRegendSimpleLuigi.thp",
-    "GmRegendSimpleMario.thp",
-    "GmRegendSimpleMarth.thp",
-    "GmRegendSimpleMewtwo.thp",
-    "GmRegendSimpleNess.thp",
-    "GmRegendSimplePeach.thp",
-    "GmRegendSimplePikachu.thp",
-    "GmRegendSimplePoponana.thp",
-    "GmRegendSimplePurin.thp",
-    "GmRegendSimpleSamus.thp",
-    "GmRegendSimpleYoshi.thp",
-    "GmRegendSimpleZeldaseak.thp",
-    "GmRegendSimpleFalco.thp",
-    "GmRegendSimpleClink.thp",
-    "GmRegendSimpleDrmario.thp",
-    "GmRegendSimpleRoy.thp",
-    "GmRegendSimplePichu.thp",
-    "GmRegendSimpleGanon.thp",
+    gm_803DB640,
+    gm_803DB65C,
+    gm_803DB678,
+    gm_803DB690,
+    gm_803DB6AC,
+    gm_803DB6C4,
+    gm_803DB6DC,
+    gm_803DB6F4,
+    gm_803DB70C,
+    gm_803DB724,
+    gm_803DB73C,
+    gm_803DB758,
+    gm_803DB770,
+    gm_803DB788,
+    gm_803DB7A4,
+    gm_803DB7C0,
+    gm_803DB7D8,
+    gm_803DB7F0,
+    gm_803DB808,
+    gm_803DB808,
+    gm_803DB824,
+    gm_803DB83C,
+    gm_803DB854,
+    gm_803DB870,
+    gm_803DB888,
+    gm_803DB8A0,
     // clang-format on
 };
 
 char* gm_803DBBF4[] = {
     // clang-format off
-    "GmRegendAdventureCaptain.thp",
-    "GmRegendAdventureDonkey.thp",
-    "GmRegendAdventureFox.thp",
-    "GmRegendAdventureGamewatch.thp",
-    "GmRegendAdventureKirby.thp",
-    "GmRegendAdventureKoopa.thp",
-    "GmRegendAdventureLink.thp",
-    "GmRegendAdventureLuigi.thp",
-    "GmRegendAdventureMario.thp",
-    "GmRegendAdventureMarth.thp",
-    "GmRegendAdventureMewtwo.thp",
-    "GmRegendAdventureNess.thp",
-    "GmRegendAdventurePeach.thp",
-    "GmRegendAdventurePikachu.thp",
-    "GmRegendAdventurePoponana.thp",
-    "GmRegendAdventurePurin.thp",
-    "GmRegendAdventureSamus.thp",
-    "GmRegendAdventureYoshi.thp",
-    "GmRegendAdventureZeldaseak.thp",
-    "GmRegendAdventureFalco.thp",
-    "GmRegendAdventureClink.thp",
-    "GmRegendAdventureDrmario.thp",
-    "GmRegendAdventureRoy.thp",
-    "GmRegendAdventurePichu.thp",
-    "GmRegendAdventureGanon.thp",
+    gm_803DB920,
+    gm_803DB940,
+    gm_803DB95C,
+    gm_803DB978,
+    gm_803DB998,
+    gm_803DB9B4,
+    gm_803DB9D0,
+    gm_803DB9EC,
+    gm_803DBA08,
+    gm_803DBA24,
+    gm_803DBA40,
+    gm_803DBA5C,
+    gm_803DBA78,
+    gm_803DBA94,
+    gm_803DBAB4,
+    gm_803DBAD4,
+    gm_803DBAF0,
+    gm_803DBB0C,
+    gm_803DBB28,
+    gm_803DBB28,
+    gm_803DBB48,
+    gm_803DBB64,
+    gm_803DBB80,
+    gm_803DBBA0,
+    gm_803DBBBC,
+    gm_803DBBD8,
     // clang-format on
 };
 
 char* gm_803DBF10[] = {
     // clang-format off
-    "GmRegendAllstarCaptain.thp",
-    "GmRegendAllstarDonkey.thp",
-    "GmRegendAllstarFox.thp",
-    "GmRegendAllstarGamewatch.thp",
-    "GmRegendAllstarKirby.thp",
-    "GmRegendAllstarKoopa.thp",
-    "GmRegendAllstarLink.thp",
-    "GmRegendAllstarLuigi.thp",
-    "GmRegendAllstarMario.thp",
-    "GmRegendAllstarMarth.thp",
-    "GmRegendAllstarMewtwo.thp",
-    "GmRegendAllstarNess.thp",
-    "GmRegendAllstarPeach.thp",
-    "GmRegendAllstarPikachu.thp",
-    "GmRegendAllstarPoponana.thp",
-    "GmRegendAllstarPurin.thp",
-    "GmRegendAllstarSamus.thp",
-    "GmRegendAllstarYoshi.thp",
-    "GmRegendAllstarZeldaseak.thp",
-    "GmRegendAllstarFalco.thp",
-    "GmRegendAllstarClink.thp",
-    "GmRegendAllstarDrmario.thp",
-    "GmRegendAllstarRoy.thp",
-    "GmRegendAllstarPichu.thp",
-    "GmRegendAllstarGanon.thp",
+    gm_803DBC5C,
+    gm_803DBC78,
+    gm_803DBC94,
+    gm_803DBCAC,
+    gm_803DBCCC,
+    gm_803DBCE8,
+    gm_803DBD04,
+    gm_803DBD1C,
+    gm_803DBD38,
+    gm_803DBD54,
+    gm_803DBD70,
+    gm_803DBD8C,
+    gm_803DBDA4,
+    gm_803DBDC0,
+    gm_803DBDDC,
+    gm_803DBDF8,
+    gm_803DBE14,
+    gm_803DBE30,
+    gm_803DBE4C,
+    gm_803DBE4C,
+    gm_803DBE6C,
+    gm_803DBE88,
+    gm_803DBEA4,
+    gm_803DBEC0,
+    gm_803DBED8,
+    gm_803DBEF4,
     // clang-format on
 };
 

--- a/src/melee/gm/gm_1A4C.c
+++ b/src/melee/gm/gm_1A4C.c
@@ -597,172 +597,93 @@ void gm_801A9630(void)
 static u8 gm_804D67C8;
 static u8 gm_804D67C9;
 
-char gm_803DB640[] = "GmRegendSimpleCaptain.thp";
-char gm_803DB65C[] = "GmRegendSimpleDonkey.thp";
-char gm_803DB678[] = "GmRegendSimpleFox.thp";
-char gm_803DB690[] = "GmRegendSimpleGamewatch.thp";
-char gm_803DB6AC[] = "GmRegendSimpleKirby.thp";
-char gm_803DB6C4[] = "GmRegendSimpleKoopa.thp";
-char gm_803DB6DC[] = "GmRegendSimpleLink.thp";
-char gm_803DB6F4[] = "GmRegendSimpleLuigi.thp";
-char gm_803DB70C[] = "GmRegendSimpleMario.thp";
-char gm_803DB724[] = "GmRegendSimpleMarth.thp";
-char gm_803DB73C[] = "GmRegendSimpleMewtwo.thp";
-char gm_803DB758[] = "GmRegendSimpleNess.thp";
-char gm_803DB770[] = "GmRegendSimplePeach.thp";
-char gm_803DB788[] = "GmRegendSimplePikachu.thp";
-char gm_803DB7A4[] = "GmRegendSimplePoponana.thp";
-char gm_803DB7C0[] = "GmRegendSimplePurin.thp";
-char gm_803DB7D8[] = "GmRegendSimpleSamus.thp";
-char gm_803DB7F0[] = "GmRegendSimpleYoshi.thp";
-char gm_803DB808[] = "GmRegendSimpleZeldaseak.thp";
-char gm_803DB824[] = "GmRegendSimpleFalco.thp";
-char gm_803DB83C[] = "GmRegendSimpleClink.thp";
-char gm_803DB854[] = "GmRegendSimpleDrmario.thp";
-char gm_803DB870[] = "GmRegendSimpleRoy.thp";
-char gm_803DB888[] = "GmRegendSimplePichu.thp";
-char gm_803DB8A0[] = "GmRegendSimpleGanon.thp";
-char gm_803DB920[] = "GmRegendAdventureCaptain.thp";
-char gm_803DB940[] = "GmRegendAdventureDonkey.thp";
-char gm_803DB95C[] = "GmRegendAdventureFox.thp";
-char gm_803DB978[] = "GmRegendAdventureGamewatch.thp";
-char gm_803DB998[] = "GmRegendAdventureKirby.thp";
-char gm_803DB9B4[] = "GmRegendAdventureKoopa.thp";
-char gm_803DB9D0[] = "GmRegendAdventureLink.thp";
-char gm_803DB9EC[] = "GmRegendAdventureLuigi.thp";
-char gm_803DBA08[] = "GmRegendAdventureMario.thp";
-char gm_803DBA24[] = "GmRegendAdventureMarth.thp";
-char gm_803DBA40[] = "GmRegendAdventureMewtwo.thp";
-char gm_803DBA5C[] = "GmRegendAdventureNess.thp";
-char gm_803DBA78[] = "GmRegendAdventurePeach.thp";
-char gm_803DBA94[] = "GmRegendAdventurePikachu.thp";
-char gm_803DBAB4[] = "GmRegendAdventurePoponana.thp";
-char gm_803DBAD4[] = "GmRegendAdventurePurin.thp";
-char gm_803DBAF0[] = "GmRegendAdventureSamus.thp";
-char gm_803DBB0C[] = "GmRegendAdventureYoshi.thp";
-char gm_803DBB28[] = "GmRegendAdventureZeldaseak.thp";
-char gm_803DBB48[] = "GmRegendAdventureFalco.thp";
-char gm_803DBB64[] = "GmRegendAdventureClink.thp";
-char gm_803DBB80[] = "GmRegendAdventureDrmario.thp";
-char gm_803DBBA0[] = "GmRegendAdventureRoy.thp";
-char gm_803DBBBC[] = "GmRegendAdventurePichu.thp";
-char gm_803DBBD8[] = "GmRegendAdventureGanon.thp";
-char gm_803DBC5C[] = "GmRegendAllstarCaptain.thp";
-char gm_803DBC78[] = "GmRegendAllstarDonkey.thp";
-char gm_803DBC94[] = "GmRegendAllstarFox.thp";
-char gm_803DBCAC[] = "GmRegendAllstarGamewatch.thp";
-char gm_803DBCCC[] = "GmRegendAllstarKirby.thp";
-char gm_803DBCE8[] = "GmRegendAllstarKoopa.thp";
-char gm_803DBD04[] = "GmRegendAllstarLink.thp";
-char gm_803DBD1C[] = "GmRegendAllstarLuigi.thp";
-char gm_803DBD38[] = "GmRegendAllstarMario.thp";
-char gm_803DBD54[] = "GmRegendAllstarMarth.thp";
-char gm_803DBD70[] = "GmRegendAllstarMewtwo.thp";
-char gm_803DBD8C[] = "GmRegendAllstarNess.thp";
-char gm_803DBDA4[] = "GmRegendAllstarPeach.thp";
-char gm_803DBDC0[] = "GmRegendAllstarPikachu.thp";
-char gm_803DBDDC[] = "GmRegendAllstarPoponana.thp";
-char gm_803DBDF8[] = "GmRegendAllstarPurin.thp";
-char gm_803DBE14[] = "GmRegendAllstarSamus.thp";
-char gm_803DBE30[] = "GmRegendAllstarYoshi.thp";
-char gm_803DBE4C[] = "GmRegendAllstarZeldaseak.thp";
-char gm_803DBE6C[] = "GmRegendAllstarFalco.thp";
-char gm_803DBE88[] = "GmRegendAllstarClink.thp";
-char gm_803DBEA4[] = "GmRegendAllstarDrmario.thp";
-char gm_803DBEC0[] = "GmRegendAllstarRoy.thp";
-char gm_803DBED8[] = "GmRegendAllstarPichu.thp";
-char gm_803DBEF4[] = "GmRegendAllstarGanon.thp";
-
 char* gm_803DB8B8[] = {
     // clang-format off
-    gm_803DB640,
-    gm_803DB65C,
-    gm_803DB678,
-    gm_803DB690,
-    gm_803DB6AC,
-    gm_803DB6C4,
-    gm_803DB6DC,
-    gm_803DB6F4,
-    gm_803DB70C,
-    gm_803DB724,
-    gm_803DB73C,
-    gm_803DB758,
-    gm_803DB770,
-    gm_803DB788,
-    gm_803DB7A4,
-    gm_803DB7C0,
-    gm_803DB7D8,
-    gm_803DB7F0,
-    gm_803DB808,
-    gm_803DB808,
-    gm_803DB824,
-    gm_803DB83C,
-    gm_803DB854,
-    gm_803DB870,
-    gm_803DB888,
-    gm_803DB8A0,
+    "GmRegendSimpleCaptain.thp",
+    "GmRegendSimpleDonkey.thp",
+    "GmRegendSimpleFox.thp",
+    "GmRegendSimpleGamewatch.thp",
+    "GmRegendSimpleKirby.thp",
+    "GmRegendSimpleKoopa.thp",
+    "GmRegendSimpleLink.thp",
+    "GmRegendSimpleLuigi.thp",
+    "GmRegendSimpleMario.thp",
+    "GmRegendSimpleMarth.thp",
+    "GmRegendSimpleMewtwo.thp",
+    "GmRegendSimpleNess.thp",
+    "GmRegendSimplePeach.thp",
+    "GmRegendSimplePikachu.thp",
+    "GmRegendSimplePoponana.thp",
+    "GmRegendSimplePurin.thp",
+    "GmRegendSimpleSamus.thp",
+    "GmRegendSimpleYoshi.thp",
+    "GmRegendSimpleZeldaseak.thp",
+    "GmRegendSimpleFalco.thp",
+    "GmRegendSimpleClink.thp",
+    "GmRegendSimpleDrmario.thp",
+    "GmRegendSimpleRoy.thp",
+    "GmRegendSimplePichu.thp",
+    "GmRegendSimpleGanon.thp",
     // clang-format on
 };
 
 char* gm_803DBBF4[] = {
     // clang-format off
-    gm_803DB920,
-    gm_803DB940,
-    gm_803DB95C,
-    gm_803DB978,
-    gm_803DB998,
-    gm_803DB9B4,
-    gm_803DB9D0,
-    gm_803DB9EC,
-    gm_803DBA08,
-    gm_803DBA24,
-    gm_803DBA40,
-    gm_803DBA5C,
-    gm_803DBA78,
-    gm_803DBA94,
-    gm_803DBAB4,
-    gm_803DBAD4,
-    gm_803DBAF0,
-    gm_803DBB0C,
-    gm_803DBB28,
-    gm_803DBB28,
-    gm_803DBB48,
-    gm_803DBB64,
-    gm_803DBB80,
-    gm_803DBBA0,
-    gm_803DBBBC,
-    gm_803DBBD8,
+    "GmRegendAdventureCaptain.thp",
+    "GmRegendAdventureDonkey.thp",
+    "GmRegendAdventureFox.thp",
+    "GmRegendAdventureGamewatch.thp",
+    "GmRegendAdventureKirby.thp",
+    "GmRegendAdventureKoopa.thp",
+    "GmRegendAdventureLink.thp",
+    "GmRegendAdventureLuigi.thp",
+    "GmRegendAdventureMario.thp",
+    "GmRegendAdventureMarth.thp",
+    "GmRegendAdventureMewtwo.thp",
+    "GmRegendAdventureNess.thp",
+    "GmRegendAdventurePeach.thp",
+    "GmRegendAdventurePikachu.thp",
+    "GmRegendAdventurePoponana.thp",
+    "GmRegendAdventurePurin.thp",
+    "GmRegendAdventureSamus.thp",
+    "GmRegendAdventureYoshi.thp",
+    "GmRegendAdventureZeldaseak.thp",
+    "GmRegendAdventureFalco.thp",
+    "GmRegendAdventureClink.thp",
+    "GmRegendAdventureDrmario.thp",
+    "GmRegendAdventureRoy.thp",
+    "GmRegendAdventurePichu.thp",
+    "GmRegendAdventureGanon.thp",
     // clang-format on
 };
 
 char* gm_803DBF10[] = {
     // clang-format off
-    gm_803DBC5C,
-    gm_803DBC78,
-    gm_803DBC94,
-    gm_803DBCAC,
-    gm_803DBCCC,
-    gm_803DBCE8,
-    gm_803DBD04,
-    gm_803DBD1C,
-    gm_803DBD38,
-    gm_803DBD54,
-    gm_803DBD70,
-    gm_803DBD8C,
-    gm_803DBDA4,
-    gm_803DBDC0,
-    gm_803DBDDC,
-    gm_803DBDF8,
-    gm_803DBE14,
-    gm_803DBE30,
-    gm_803DBE4C,
-    gm_803DBE4C,
-    gm_803DBE6C,
-    gm_803DBE88,
-    gm_803DBEA4,
-    gm_803DBEC0,
-    gm_803DBED8,
-    gm_803DBEF4,
+    "GmRegendAllstarCaptain.thp",
+    "GmRegendAllstarDonkey.thp",
+    "GmRegendAllstarFox.thp",
+    "GmRegendAllstarGamewatch.thp",
+    "GmRegendAllstarKirby.thp",
+    "GmRegendAllstarKoopa.thp",
+    "GmRegendAllstarLink.thp",
+    "GmRegendAllstarLuigi.thp",
+    "GmRegendAllstarMario.thp",
+    "GmRegendAllstarMarth.thp",
+    "GmRegendAllstarMewtwo.thp",
+    "GmRegendAllstarNess.thp",
+    "GmRegendAllstarPeach.thp",
+    "GmRegendAllstarPikachu.thp",
+    "GmRegendAllstarPoponana.thp",
+    "GmRegendAllstarPurin.thp",
+    "GmRegendAllstarSamus.thp",
+    "GmRegendAllstarYoshi.thp",
+    "GmRegendAllstarZeldaseak.thp",
+    "GmRegendAllstarFalco.thp",
+    "GmRegendAllstarClink.thp",
+    "GmRegendAllstarDrmario.thp",
+    "GmRegendAllstarRoy.thp",
+    "GmRegendAllstarPichu.thp",
+    "GmRegendAllstarGanon.thp",
     // clang-format on
 };
 

--- a/src/melee/gm/gm_1BA8.c
+++ b/src/melee/gm/gm_1BA8.c
@@ -2349,6 +2349,8 @@ void gm_801BE638(HSD_GObj* gobj)
             temp_r30->x10 = 0;
         }
         break;
+    case 2:
+        break;
     }
     if (Player_GetRemainingHP(1) <= 0 && Player_GetRemainingHP(2) <= 0) {
         temp_r28_2 = temp_r31 + temp_r29;

--- a/src/melee/gm/gmcamera.c
+++ b/src/melee/gm/gmcamera.c
@@ -447,10 +447,11 @@ void gmCamera_801A2BF0(void)
 
 void gmCamera_801A2D44(void)
 {
+    gmCameraUnkStruct* gcus = &gmCamera_80479BC8.gcus;
     HSD_JObj* jobj;
     HSD_JObj* jobj_b;
+    u32* px18;
     f32 var_f31;
-    gmCameraUnkStruct* gcus = &gmCamera_80479BC8.gcus;
     PAD_STACK(24);
 
     if ((lbSnap_8001D338(0) != 0) || (lbSnap_8001D338(1) != 0)) {
@@ -472,23 +473,22 @@ void gmCamera_801A2D44(void)
         gmCamera_801A3048(0);
         return;
     }
-    if ((HSD_PadCopyStatus[3].trigger & 0x40001) && (s32) gcus->x18 != 0) {
+    px18 = &gcus->x18;
+    if ((HSD_PadCopyStatus[3].trigger & 0x40001) && (s32) *px18 != 0) {
         lbAudioAx_80024030(2);
-        gcus->x18 = 0;
+        *px18 = 0;
         lb_80011E24(gcus->x8, &jobj, 0xC, -1);
-        if ((s32) gcus->x18 != 0) {
+        if ((s32) *px18 != 0) {
             var_f31 = 5.0f;
         } else {
             var_f31 = -5.0f;
         }
         HSD_JObjSetTranslateX(jobj, var_f31);
-    } else if ((HSD_PadCopyStatus[3].trigger & 0x80002) &&
-               (s32) gcus->x18 != 1)
-    {
+    } else if ((HSD_PadCopyStatus[3].trigger & 0x80002) && (s32) *px18 != 1) {
         lbAudioAx_80024030(2);
-        gcus->x18 = 1;
+        *px18 = 1;
         lb_80011E24(gcus->x8, &jobj_b, 0xC, -1);
-        if ((s32) gcus->x18 != 0) {
+        if ((s32) *px18 != 0) {
             var_f31 = 5.0f;
         } else {
             var_f31 = -5.0f;

--- a/src/melee/gm/gmclassic.c
+++ b/src/melee/gm/gmclassic.c
@@ -71,6 +71,12 @@ typedef struct gmClassic_803DDEC8Data {
 } gmClassic_803DDEC8Data;
 STATIC_ASSERT(sizeof(gmClassic_803DDEC8Data) == 0x2F0);
 
+typedef struct gmClassicSceneData {
+    /* 0x000 */ GameScene scenes[26];
+    /* 0x270 */ gmClassic_803DDEC8Data matchups;
+} gmClassicSceneData;
+STATIC_ASSERT(sizeof(gmClassicSceneData) == 0x560);
+
 extern gmClassic_80490880Data gmClassic_80490880;
 extern gmClassic_803DDEC8Data gmClassic_803DDEC8;
 
@@ -481,12 +487,12 @@ static gm_803DDEC8Struct* gmClassic_801B2D54(gm_803DDEC8Struct* arg0)
 {
     gmClassic_80490880Data* o = &gmClassic_80490880;
     gm_803DDEC8Struct* ptr;
-    gmClassic_803DDEC8Data* d = &gmClassic_803DDEC8;
+    gmClassicSceneData* scene_data = (gmClassicSceneData*) gm_803DDC58_Scenes;
 
     for (ptr = arg0; (u8) ptr->x0 != 0xD; ptr++) {
         if (ptr->x1 & 8) {
             gmClassicMatchup* result =
-                gmClassic_801B2BA4(d->x2B0, o->x80, arg0);
+                gmClassic_801B2BA4(scene_data->matchups.x2B0, o->x80, arg0);
             if (result != NULL) {
                 ptr->xC = result;
             } else {
@@ -500,7 +506,7 @@ static gm_803DDEC8Struct* gmClassic_801B2D54(gm_803DDEC8Struct* arg0)
         u8 flags = ptr->x1;
         if ((flags & 2) && !(flags & 0x20)) {
             gmClassicMatchup* result =
-                gmClassic_801B2BA4(d->x26C, o->x74, arg0);
+                gmClassic_801B2BA4(scene_data->matchups.x26C, o->x74, arg0);
             if (result != NULL) {
                 ptr->xC = result;
             } else {
@@ -514,7 +520,7 @@ static gm_803DDEC8Struct* gmClassic_801B2D54(gm_803DDEC8Struct* arg0)
         u8 flags = ptr->x1;
         if ((flags & 0x10) && !(flags & 0x20)) {
             gmClassicMatchup* result =
-                gmClassic_801B2BA4(d->x1B8, o->x54, arg0);
+                gmClassic_801B2BA4(scene_data->matchups.x1B8, o->x54, arg0);
             if (result != NULL) {
                 ptr->xC = result;
             } else {
@@ -528,7 +534,7 @@ static gm_803DDEC8Struct* gmClassic_801B2D54(gm_803DDEC8Struct* arg0)
         u8 flags = ptr->x1;
         if (flags == 0 || flags == 4) {
             gmClassicMatchup* result =
-                gmClassic_801B2BA4(d->x0CC, o->x2C, arg0);
+                gmClassic_801B2BA4(scene_data->matchups.x0CC, o->x2C, arg0);
             if (result != NULL) {
                 ptr->xC = result;
             } else {
@@ -557,7 +563,7 @@ static gm_803DDEC8Struct* gmClassic_801B2D54(gm_803DDEC8Struct* arg0)
 
     for (ptr = arg0; (u8) ptr->x0 != 0xD; ptr++) {
         if (ptr->x1 & 0x20) {
-            ptr->xC = d->x0C0;
+            ptr->xC = scene_data->matchups.x0C0;
             return ptr;
         }
     }

--- a/src/melee/gm/gmregclear.c
+++ b/src/melee/gm/gmregclear.c
@@ -2952,9 +2952,6 @@ void fn_80181598(void)
 static DynamicModelDesc** lbl_804D65CC;
 static DynamicModelDesc** lbl_804D65D0;
 extern HSD_Archive* lbl_804D65C8;
-char lbl_803D8CD8[] = "IfHrNoCn";
-char lbl_803D8CE4[] = "ScInfCnt_scene_models";
-char lbl_803D8CFC[] = "IfHrReco";
 
 void fn_80181708(void)
 {
@@ -3012,10 +3009,10 @@ void fn_80181708(void)
 
 void gm_80181998(void)
 {
-    lbl_804D65C8 = lbArchive_80016DBC(lbl_803D8CD8, &lbl_804D65CC,
-                                      lbl_803D8CE4, 0);
-    lbl_804D65C8 = lbArchive_80016DBC(lbl_803D8CFC, &lbl_804D65D0,
-                                      lbl_803D8CE4, 0);
+    lbl_804D65C8 = lbArchive_80016DBC("IfHrNoCn", &lbl_804D65CC,
+                                      "ScInfCnt_scene_models", 0);
+    lbl_804D65C8 = lbArchive_80016DBC("IfHrReco", &lbl_804D65D0,
+                                      "ScInfCnt_scene_models", 0);
     fn_80181708();
 }
 

--- a/src/melee/gm/gmregclear.c
+++ b/src/melee/gm/gmregclear.c
@@ -126,12 +126,8 @@ struct lbl_80472E48_t {
     /* 0x10 */ u8 x10;
     /* 0x11 */ char pad_11[3];
     /* 0x14 */ s32 x14[0x1B];
-    /* 0x80 */ s32 x80;
-    /* 0x84 */ s32 x84;
-    /* 0x88 */ s32 x88;
-    /* 0x8C */ s32 x8C;
-}; /* size = 0x90 */
-STATIC_ASSERT(sizeof(struct lbl_80472E48_t) == 0x90);
+}; /* size = 0x80 */
+STATIC_ASSERT(sizeof(struct lbl_80472E48_t) == 0x80);
 
 /// Adventure mode stage data table entry (size 0x1A)
 /// Table has 110 entries: 22 stages × 5 difficulty levels
@@ -1904,8 +1900,8 @@ s32 fn_8017F2A4(HSD_Text** arg0, f32 farg0, f32 farg1)
     HSD_Text* text;
     HSD_Text** ptr;
     u8* data;
-    f32 x_end;
     f32 y;
+    f32 x_end;
     s32 temp;
     s32 i;
 
@@ -2319,11 +2315,12 @@ void fn_8017FBA4(void* arg0)
 void fn_8017FE54(HSD_GObj* gobj)
 {
     RegClearEv* ev = gobj->user_data;
+    struct lbl_80472D28_t* state = &lbl_80472D28;
 
     lb_800122C8(ev->x1C, 0, 0, 1);
-    lb_800138D8(lbl_80472D28.x2C, (int) (120.0F * lbl_80472D28.x10C) + 1);
+    lb_800138D8(state->x2C, (int) (120.0F * state->x10C) + 1);
 
-    ev->x20 = 0.0225F * (f32) lbl_80472D28.x110 - 0.175F;
+    ev->x20 = 0.0225F * (f32) state->x110 - 0.175F;
 
     if (ev->x20 < 0.05F) {
         ev->x20 = 0.0F;
@@ -2764,17 +2761,17 @@ void fn_80180C60(HSD_GObj* gobj)
         dist = 0;
     }
 
-    lbl_80472E48.x80 = dist;
+    lbl_80472EC8[0] = dist;
     b76 = ((u8) lbl_80472E48.x0 >> 6) & 3;
 
     if (b76 != 0 && (((u8) lbl_80472E48.x0 >> 4) & 3)) {
         ifTime_HideTimers();
-        if (lbl_80472E48.x80 == lbl_80472E48.x84) {
-            lbl_80472E48.x8C = lbl_80472E48.x8C + 1;
+        if (lbl_80472EC8[0] == lbl_80472EC8[1]) {
+            lbl_80472EC8[3] = lbl_80472EC8[3] + 1;
         } else {
-            lbl_80472E48.x8C = 0;
+            lbl_80472EC8[3] = 0;
         }
-        if (lbl_80472E48.x8C > 0x3C) {
+        if (lbl_80472EC8[3] > 0x3C) {
             ((x0_2bits*) &lbl_80472E48.x0)->b32 = 1;
             if (dist == 0 && !(lbl_80472E48.x0 & 3)) {
                 ((x0_2bits*) &lbl_80472E48.x0)->b10 = 1;
@@ -2783,12 +2780,12 @@ void fn_80180C60(HSD_GObj* gobj)
     } else {
         if (b76 != 0) {
             ifTime_HideTimers();
-            if (lbl_80472E48.x80 == lbl_80472E48.x84) {
-                lbl_80472E48.x8C = lbl_80472E48.x8C + 1;
+            if (lbl_80472EC8[0] == lbl_80472EC8[1]) {
+                lbl_80472EC8[3] = lbl_80472EC8[3] + 1;
             } else {
-                lbl_80472E48.x8C = 0;
+                lbl_80472EC8[3] = 0;
             }
-            if (lbl_80472E48.x8C > 0x78) {
+            if (lbl_80472EC8[3] > 0x78) {
                 ((x0_2bits*) &lbl_80472E48.x0)->b32 = 1;
                 if (!(lbl_80472E48.x0 & 3)) {
                     ((x0_2bits*) &lbl_80472E48.x0)->b10 = 1;
@@ -2809,7 +2806,7 @@ void fn_80180C60(HSD_GObj* gobj)
                 ((x0_2bits*) &lbl_80472E48.x0)->b54 = 1;
                 Player_80031790(0);
             }
-            lbl_80472E48.x8C = 0;
+            lbl_80472EC8[3] = 0;
         }
     }
 
@@ -2893,9 +2890,9 @@ void fn_80180C60(HSD_GObj* gobj)
     }
 
     HSD_JObjAnimAll(jobj);
-    lbl_80472E48.x84 = lbl_80472E48.x80;
-    if (lbl_80472E48.x80 > lbl_80472E48.x88 + 0xA) {
-        lbl_80472E48.x88 = lbl_80472E48.x80;
+    lbl_80472EC8[1] = lbl_80472EC8[0];
+    if (lbl_80472EC8[0] > lbl_80472EC8[2] + 0xA) {
+        lbl_80472EC8[2] = lbl_80472EC8[0];
         lbAudioAx_80023870(0xBB, 0x7F, 0x40, 0x8A);
     }
 }
@@ -2904,6 +2901,9 @@ extern s32 lbl_804D65D8;
 
 void fn_80181598(void)
 {
+    typedef struct {
+        u8 b76 : 2, b54 : 2, b32 : 2, b10 : 2;
+    } x0_2bits;
     u32 mode;
 
     PAD_STACK(0x20);
@@ -2918,8 +2918,7 @@ void fn_80181598(void)
         if (mode == 1) {
             lbAudioAx_800237A8(0xC0, 0x7F, 0x40);
             lbAudioAx_800237A8(0x148, 0x7F, 0x40);
-            mode = 2;
-            lbl_80472E48.x0 = (lbl_80472E48.x0 & ~3) | mode;
+            ((x0_2bits*) &lbl_80472E48.x0)->b10 = 2;
         }
         lbl_804D65D8 += 1;
         if (lbl_804D65D8 >= 0xF0 ||
@@ -2939,11 +2938,11 @@ void fn_80181598(void)
             (lbl_80472E48.xC >= 0xF0 ||
              (HSD_PadCopyStatus[lbl_80472E48.x10].trigger & 0x100)))
         {
-            if (lbl_80472E48.x80 >
+            if (lbl_80472EC8[0] >
                 lbl_80472E48.x14[gm_80164024((u8) lbl_80472E48.unk_4)])
             {
                 lbl_80472E48.x14[gm_80164024((u8) lbl_80472E48.unk_4)] =
-                    lbl_80472E48.x80;
+                    lbl_80472EC8[0];
             }
             gm_8016B328();
         }
@@ -2953,6 +2952,9 @@ void fn_80181598(void)
 static DynamicModelDesc** lbl_804D65CC;
 static DynamicModelDesc** lbl_804D65D0;
 extern HSD_Archive* lbl_804D65C8;
+char lbl_803D8CD8[] = "IfHrNoCn";
+char lbl_803D8CE4[] = "ScInfCnt_scene_models";
+char lbl_803D8CFC[] = "IfHrReco";
 
 void fn_80181708(void)
 {
@@ -2963,10 +2965,10 @@ void fn_80181708(void)
     HSD_JObj* jobj;
     HSD_GObj* gobj;
 
-    lbl_80472E48.x80 = 0;
-    lbl_80472E48.x84 = 0;
-    lbl_80472E48.x88 = 0;
-    lbl_80472E48.x8C = 0;
+    lbl_80472EC8[0] = 0;
+    lbl_80472EC8[1] = 0;
+    lbl_80472EC8[2] = 0;
+    lbl_80472EC8[3] = 0;
     ((x0_2bits*) &lbl_80472E48.x0)->b76 = 0;
     ((x0_2bits*) &lbl_80472E48.x0)->b54 = 0;
     ((x0_2bits*) &lbl_80472E48.x0)->b32 = 0;
@@ -3010,10 +3012,10 @@ void fn_80181708(void)
 
 void gm_80181998(void)
 {
-    lbl_804D65C8 = lbArchive_80016DBC("IfHrNoCn", &lbl_804D65CC,
-                                      "ScInfCnt_scene_models", 0);
-    lbl_804D65C8 = lbArchive_80016DBC("IfHrReco", &lbl_804D65D0,
-                                      "ScInfCnt_scene_models", 0);
+    lbl_804D65C8 = lbArchive_80016DBC(lbl_803D8CD8, &lbl_804D65CC,
+                                      lbl_803D8CE4, 0);
+    lbl_804D65C8 = lbArchive_80016DBC(lbl_803D8CFC, &lbl_804D65D0,
+                                      lbl_803D8CE4, 0);
     fn_80181708();
 }
 
@@ -3154,26 +3156,26 @@ int fn_80181BFC(int* arg0)
 
 s32 fn_80181C80(s32 arg0)
 {
-    s32 var_r29;
     s32 var_r30;
+    s32 var_r29;
     volatile s32 sp38;
     PlayerInitData sp10;
 
     gm_801A4310();
-    var_r30 = 0;
+    var_r29 = 0;
     sp10 = lbl_80472ED8.xC;
 
-    for (var_r29 = 1; var_r29 < 6; var_r29++) {
-        if (Player_GetFalls(var_r29) == 0 &&
-            Player_GetPlayerSlotType(var_r29) != Gm_PKind_NA)
+    for (var_r30 = 1; var_r30 < 6; var_r30++) {
+        if (Player_GetFalls(var_r30) == 0 &&
+            Player_GetPlayerSlotType(var_r30) != Gm_PKind_NA)
         {
-            var_r30++;
+            var_r29++;
         } else {
-            sp38 = var_r29;
+            sp38 = var_r30;
         }
     }
 
-    if ((s32) lbl_80472ED8.x54[arg0].x4 > var_r30 && lbl_80472ED8.x8 > 0x5A) {
+    if ((s32) lbl_80472ED8.x54[arg0].x4 > var_r29 && lbl_80472ED8.x8 > 0x5A) {
         if (Player_GetPlayerSlotType(sp38) != Gm_PKind_NA) {
             Player_SetFalls(sp38, 0);
             Player_SetSuicideCount(sp38, 0);
@@ -3191,7 +3193,6 @@ s32 fn_80181C80(s32 arg0)
         un_802FD28C(sp38);
         lbl_80472ED8.x0 += 1;
     }
-    return lbl_80472ED8.x0;
     PAD_STACK(8);
 }
 

--- a/src/melee/gm/gmresult.c
+++ b/src/melee/gm/gmresult.c
@@ -44,12 +44,14 @@ s32 fn_80174284(u8 slot)
     s32 i;
     u8* buf;
     struct UnkResultPlayerData* tmp = lbl_8046DBE8.x94->x44C;
+    PAD_STACK(8);
 
     count = 0;
-    do_call =
-        (lbl_8046DBE8.x94->player_standings[slot].slot_type == Gm_PKind_Human)
-            ? true
-            : false;
+    if (lbl_8046DBE8.x94->player_standings[slot].slot_type == Gm_PKind_Human) {
+        do_call = true;
+    } else {
+        do_call = false;
+    }
 
     for (i = 0; i < 0x100; i++) {
         if (tmp[slot].x0[i] != 0) {
@@ -1767,9 +1769,9 @@ extern HSD_Archive* lbl_804D65B8;
 void gm_80177368_OnEnter(void* arg0_)
 {
     ResultsMatchInfo* arg0 = arg0_;
+    HSD_LObj* temp_r3_3;
     HSD_GObj* temp_r3_2;
     HSD_GObj* temp_r3_4;
-    HSD_LObj* temp_r3_3;
     MatchEnd* temp_r29;
     ResultsData* data = &lbl_8046DBE8;
     int i;
@@ -1829,12 +1831,12 @@ void gm_80177368_OnEnter(void* arg0_)
     temp_r3_2 = GObj_Create(0xB, 3, 0);
     if (temp_r3_2 == NULL) {
         OSReport("Error : gobj dont't get (gmResultAddLight)\n");
-        __assert("gmresult.c", 0x68C, "0");
+        HSD_ASSERT(0x68C, 0);
     }
     temp_r3_3 = lb_80011AC4(data->pnlsce->lights);
     if (temp_r3_3 == NULL) {
         OSReport("Error : lobj dont't get (gmResultAddLight)\n");
-        __assert("gmresult.c", 0x68F, "0");
+        HSD_ASSERT(0x68F, 0);
     }
     HSD_GObjObject_80390A70(temp_r3_2, (u8) HSD_GObj_804D784A, temp_r3_3);
     GObj_SetupGXLink(temp_r3_2, HSD_GObj_LObjCallback, 0xA, 0);
@@ -1842,7 +1844,7 @@ void gm_80177368_OnEnter(void* arg0_)
     data->x18 = temp_r3_4;
     if (temp_r3_4 == NULL) {
         OSReport("Error : gobj dont't get (gmResultAddModel)\n");
-        __assert("gmresult.c", 0x6A2, "0");
+        HSD_ASSERT(0x6A2, 0);
     }
     HSD_GObj_SetupProc(temp_r3_4, fn_80179350, 0);
     fn_80176F60();

--- a/src/melee/gm/gmresultplayer.c
+++ b/src/melee/gm/gmresultplayer.c
@@ -94,8 +94,6 @@ typedef struct {
 
 extern CameraKindData lbl_803D6A08;
 
-extern f32 lbl_804DA378;
-extern f32 lbl_804DA37C;
 extern s32 lbl_804DA3F0;
 extern s32 lbl_804DA3F4;
 
@@ -961,11 +959,11 @@ static inline void fn_80179350_update(ResultsData* data, MatchEnd* match_end,
             ResultsData* d = &lbl_8046DBE8;
             HSD_JObj* jobj = (HSD_JObj*) arg0->hsd_obj;
             float frame = lbGetJObjCurrFrame(jobj);
-            if (frame >= lbl_804DA378 && !d->x0_1) {
+            if (frame >= 10.0f && !d->x0_1) {
                 fn_80177748();
                 d->x0_1 = 1;
             }
-            if (frame >= lbl_804DA37C) {
+            if (frame >= 40.0f) {
                 lb_8000BA0C(jobj, 0.0f);
                 d->x1 = 2;
             }

--- a/src/melee/gm/gmresultplayer.c
+++ b/src/melee/gm/gmresultplayer.c
@@ -94,6 +94,8 @@ typedef struct {
 
 extern CameraKindData lbl_803D6A08;
 
+extern f32 lbl_804DA378;
+extern f32 lbl_804DA37C;
 extern s32 lbl_804DA3F0;
 extern s32 lbl_804DA3F4;
 
@@ -959,11 +961,11 @@ static inline void fn_80179350_update(ResultsData* data, MatchEnd* match_end,
             ResultsData* d = &lbl_8046DBE8;
             HSD_JObj* jobj = (HSD_JObj*) arg0->hsd_obj;
             float frame = lbGetJObjCurrFrame(jobj);
-            if (frame >= 10.0f && !d->x0_1) {
+            if (frame >= lbl_804DA378 && !d->x0_1) {
                 fn_80177748();
                 d->x0_1 = 1;
             }
-            if (frame >= 40.0f) {
+            if (frame >= lbl_804DA37C) {
                 lb_8000BA0C(jobj, 0.0f);
                 d->x1 = 2;
             }

--- a/src/melee/gm/gmstaffroll.c
+++ b/src/melee/gm/gmstaffroll.c
@@ -831,7 +831,6 @@ void fn_801AB200(HSD_GObj* gobj)
 
         if (gm_804D6814 >= 0x1285 && gm_804D680C == NULL) {
             tally_count = 0;
-            tally_color = gm_804DAAEC;
             for (j = 0; j < 6; j++) {
                 HSD_SisLib_803A5CC4(gm_80480D58[j]);
                 gm_80480D58[j] = NULL;
@@ -854,7 +853,7 @@ void fn_801AB200(HSD_GObj* gobj)
             line_num = HSD_SisLib_803A6B98(
                 gm_804D680C, 0.0f, 0.0f, (char*) ((u8*) gm_803DBFD8 + 0x1264),
                 tally_count);
-            tally_color2 = tally_color;
+            tally_color2 = gm_804DAAEC;
             HSD_SisLib_803A74F0(gm_804D680C, line_num,
                                 (GXColor*) &tally_color2);
 

--- a/src/melee/gr/granime.c
+++ b/src/melee/gr/granime.c
@@ -826,15 +826,18 @@ void grAnime_801C7BA0(HSD_GObj* gobj, int arg1, u32 arg2, f32 arg8)
 void grAnime_801C7C1C(HSD_JObj* jobj, s32 map_id, s32 arg2, s32 arg3, s32 arg4,
                       int arg5, f32 farg0, f32 farg1)
 {
+    HSD_JObj* j = jobj;
+    s32 map = map_id;
+    s32 anim_idx = arg2;
+    s32 flags = arg3;
+    s32 file_idx = arg4;
+    int recurse = arg5;
     u32 var_r30 = 0;
     s32 var_r29 = 0;
     UnkArchiveStruct* archive;
     HSD_AnimJoint** ajp;
     HSD_MatAnimJoint** mjp;
     HSD_ShapeAnimJoint** sjp;
-    HSD_AnimJoint* aj_t;
-    HSD_MatAnimJoint* mj_t;
-    HSD_ShapeAnimJoint* sj_t;
     HSD_AnimJoint* aj;
     HSD_MatAnimJoint* mj;
     HSD_ShapeAnimJoint* sj;
@@ -845,46 +848,46 @@ void grAnime_801C7C1C(HSD_JObj* jobj, s32 map_id, s32 arg2, s32 arg3, s32 arg4,
     u8* eflags;
     s32 flag;
 
-    if (jobj == NULL) {
+    if (j == NULL) {
         return;
     }
-    archive = grDatFiles_801C6330(map_id);
+    archive = grDatFiles_801C6330(map);
     HSD_ASSERT(0x4DE, archive);
-    if ((arg3 & 1) &&
-        (ajp = archive->unk4->unk8[map_id].unk4, ajp != NULL) &&
-        (aj_t = ajp[arg4], aj_t != NULL))
+    if ((flags & 1) &&
+        (ajp = archive->unk4->unk8[map].unk4, ajp != NULL) &&
+        (aj = ajp[file_idx], aj != NULL))
     {
-        aj = &aj_t[arg2];
+        aj = &aj[anim_idx];
         var_r30 |= 0x81;
         var_r29 |= 0x220;
     } else {
         aj = NULL;
     }
-    if ((arg3 & 2) &&
-        (mjp = archive->unk4->unk8[map_id].unk8, mjp != NULL) &&
-        (mj_t = mjp[arg4], mj_t != NULL))
+    if ((flags & 2) &&
+        (mjp = archive->unk4->unk8[map].unk8, mjp != NULL) &&
+        (mj = mjp[file_idx], mj != NULL))
     {
-        mj = &mj_t[arg2];
+        mj = &mj[anim_idx];
         var_r30 |= 0x416;
         var_r29 |= 0x7484;
     } else {
         mj = NULL;
     }
-    if ((arg3 & 4) &&
-        (sjp = archive->unk4->unk8[map_id].unkC, sjp != NULL) &&
-        (sj_t = sjp[arg4], sj_t != NULL))
+    if ((flags & 4) &&
+        (sjp = archive->unk4->unk8[map].unkC, sjp != NULL) &&
+        (sj = sjp[file_idx], sj != NULL))
     {
-        sj = &sj_t[arg2];
+        sj = &sj[anim_idx];
         var_r30 |= 8;
         var_r29 |= 0x100;
     } else {
         sj = NULL;
     }
-    if (arg5 != 0) {
-        if (jobj != NULL) {
-            grAnime_801C6A54_noinline(jobj, aj, mj, sj);
-            if (!(jobj->flags & 0x1000)) {
-                child = jobj->child;
+    if (recurse != 0) {
+        if (j != NULL) {
+            grAnime_801C6A54_noinline(j, aj, mj, sj);
+            if (!(j->flags & 0x1000)) {
+                child = j->child;
                 if (aj != NULL) {
                     if (aj != NULL) {
                         caj = aj->child;
@@ -945,38 +948,38 @@ void grAnime_801C7C1C(HSD_JObj* jobj, s32 map_id, s32 arg2, s32 arg3, s32 arg4,
                 }
             }
         }
-        HSD_JObjReqAnimAllByFlags(jobj, var_r30, farg0);
+        HSD_JObjReqAnimAllByFlags(j, var_r30, farg0);
     } else {
-        if (jobj != NULL) {
+        if (j != NULL) {
             if (aj != NULL) {
                 if (aj->aobjdesc != NULL) {
-                    if (jobj->aobj != NULL) {
-                        HSD_AObjRemove(jobj->aobj);
+                    if (j->aobj != NULL) {
+                        HSD_AObjRemove(j->aobj);
                     }
-                    jobj->aobj = HSD_AObjLoadDesc(aj->aobjdesc);
-                    grAnime_801C69FC_noinline(jobj->aobj);
+                    j->aobj = HSD_AObjLoadDesc(aj->aobjdesc);
+                    grAnime_801C69FC_noinline(j->aobj);
                 }
-                grAnime_801C6960_noinline(jobj->robj, aj->robj_anim);
+                grAnime_801C6960_noinline(j->robj, aj->robj_anim);
             }
-            if ((jobj->flags & 0x4020) ? false : true) {
+            if ((j->flags & 0x4020) ? false : true) {
                 HSD_ShapeAnimDObj* sdobj = sj != NULL ? sj->shapeanimdobj : NULL;
                 HSD_MatAnim* manim = mj != NULL ? mj->matanim : NULL;
-                grAnime_801C683C_noinline(jobj->u.dobj, manim, sdobj);
+                grAnime_801C683C_noinline(j->u.dobj, manim, sdobj);
             }
         }
-        HSD_JObjReqAnimByFlags(jobj, var_r30, farg0);
+        HSD_JObjReqAnimByFlags(j, var_r30, farg0);
     }
-    grAnime_801C752C(jobj, arg5, var_r29, HSD_AObjSetRate, 1, farg1);
-    archive = grDatFiles_801C6330(map_id);
+    grAnime_801C752C(j, recurse, var_r29, HSD_AObjSetRate, 1, farg1);
+    archive = grDatFiles_801C6330(map);
     HSD_ASSERT(0x148, archive);
-    eflags = (u8*) archive->unk4->unk8[map_id].x28;
+    eflags = (u8*) archive->unk4->unk8[map].x28;
     if (eflags != NULL) {
-        flag = eflags[arg4];
+        flag = eflags[file_idx];
     } else {
         flag = 0;
     }
     if (flag != 0) {
-        grAnime_801C752C(jobj, arg5, var_r29, HSD_AObjSetFlags, 3,
+        grAnime_801C752C(j, recurse, var_r29, HSD_AObjSetFlags, 3,
                          0x20000000);
     }
 }

--- a/src/melee/gr/granime.c
+++ b/src/melee/gr/granime.c
@@ -826,18 +826,15 @@ void grAnime_801C7BA0(HSD_GObj* gobj, int arg1, u32 arg2, f32 arg8)
 void grAnime_801C7C1C(HSD_JObj* jobj, s32 map_id, s32 arg2, s32 arg3, s32 arg4,
                       int arg5, f32 farg0, f32 farg1)
 {
-    HSD_JObj* j = jobj;
-    s32 map = map_id;
-    s32 anim_idx = arg2;
-    s32 flags = arg3;
-    s32 file_idx = arg4;
-    int recurse = arg5;
     u32 var_r30 = 0;
     s32 var_r29 = 0;
     UnkArchiveStruct* archive;
     HSD_AnimJoint** ajp;
     HSD_MatAnimJoint** mjp;
     HSD_ShapeAnimJoint** sjp;
+    HSD_AnimJoint* aj_t;
+    HSD_MatAnimJoint* mj_t;
+    HSD_ShapeAnimJoint* sj_t;
     HSD_AnimJoint* aj;
     HSD_MatAnimJoint* mj;
     HSD_ShapeAnimJoint* sj;
@@ -848,46 +845,46 @@ void grAnime_801C7C1C(HSD_JObj* jobj, s32 map_id, s32 arg2, s32 arg3, s32 arg4,
     u8* eflags;
     s32 flag;
 
-    if (j == NULL) {
+    if (jobj == NULL) {
         return;
     }
-    archive = grDatFiles_801C6330(map);
+    archive = grDatFiles_801C6330(map_id);
     HSD_ASSERT(0x4DE, archive);
-    if ((flags & 1) &&
-        (ajp = archive->unk4->unk8[map].unk4, ajp != NULL) &&
-        (aj = ajp[file_idx], aj != NULL))
+    if ((arg3 & 1) &&
+        (ajp = archive->unk4->unk8[map_id].unk4, ajp != NULL) &&
+        (aj_t = ajp[arg4], aj_t != NULL))
     {
-        aj = &aj[anim_idx];
+        aj = &aj_t[arg2];
         var_r30 |= 0x81;
         var_r29 |= 0x220;
     } else {
         aj = NULL;
     }
-    if ((flags & 2) &&
-        (mjp = archive->unk4->unk8[map].unk8, mjp != NULL) &&
-        (mj = mjp[file_idx], mj != NULL))
+    if ((arg3 & 2) &&
+        (mjp = archive->unk4->unk8[map_id].unk8, mjp != NULL) &&
+        (mj_t = mjp[arg4], mj_t != NULL))
     {
-        mj = &mj[anim_idx];
+        mj = &mj_t[arg2];
         var_r30 |= 0x416;
         var_r29 |= 0x7484;
     } else {
         mj = NULL;
     }
-    if ((flags & 4) &&
-        (sjp = archive->unk4->unk8[map].unkC, sjp != NULL) &&
-        (sj = sjp[file_idx], sj != NULL))
+    if ((arg3 & 4) &&
+        (sjp = archive->unk4->unk8[map_id].unkC, sjp != NULL) &&
+        (sj_t = sjp[arg4], sj_t != NULL))
     {
-        sj = &sj[anim_idx];
+        sj = &sj_t[arg2];
         var_r30 |= 8;
         var_r29 |= 0x100;
     } else {
         sj = NULL;
     }
-    if (recurse != 0) {
-        if (j != NULL) {
-            grAnime_801C6A54_noinline(j, aj, mj, sj);
-            if (!(j->flags & 0x1000)) {
-                child = j->child;
+    if (arg5 != 0) {
+        if (jobj != NULL) {
+            grAnime_801C6A54_noinline(jobj, aj, mj, sj);
+            if (!(jobj->flags & 0x1000)) {
+                child = jobj->child;
                 if (aj != NULL) {
                     if (aj != NULL) {
                         caj = aj->child;
@@ -948,38 +945,38 @@ void grAnime_801C7C1C(HSD_JObj* jobj, s32 map_id, s32 arg2, s32 arg3, s32 arg4,
                 }
             }
         }
-        HSD_JObjReqAnimAllByFlags(j, var_r30, farg0);
+        HSD_JObjReqAnimAllByFlags(jobj, var_r30, farg0);
     } else {
-        if (j != NULL) {
+        if (jobj != NULL) {
             if (aj != NULL) {
                 if (aj->aobjdesc != NULL) {
-                    if (j->aobj != NULL) {
-                        HSD_AObjRemove(j->aobj);
+                    if (jobj->aobj != NULL) {
+                        HSD_AObjRemove(jobj->aobj);
                     }
-                    j->aobj = HSD_AObjLoadDesc(aj->aobjdesc);
-                    grAnime_801C69FC_noinline(j->aobj);
+                    jobj->aobj = HSD_AObjLoadDesc(aj->aobjdesc);
+                    grAnime_801C69FC_noinline(jobj->aobj);
                 }
-                grAnime_801C6960_noinline(j->robj, aj->robj_anim);
+                grAnime_801C6960_noinline(jobj->robj, aj->robj_anim);
             }
-            if ((j->flags & 0x4020) ? false : true) {
+            if ((jobj->flags & 0x4020) ? false : true) {
                 HSD_ShapeAnimDObj* sdobj = sj != NULL ? sj->shapeanimdobj : NULL;
                 HSD_MatAnim* manim = mj != NULL ? mj->matanim : NULL;
-                grAnime_801C683C_noinline(j->u.dobj, manim, sdobj);
+                grAnime_801C683C_noinline(jobj->u.dobj, manim, sdobj);
             }
         }
-        HSD_JObjReqAnimByFlags(j, var_r30, farg0);
+        HSD_JObjReqAnimByFlags(jobj, var_r30, farg0);
     }
-    grAnime_801C752C(j, recurse, var_r29, HSD_AObjSetRate, 1, farg1);
-    archive = grDatFiles_801C6330(map);
+    grAnime_801C752C(jobj, arg5, var_r29, HSD_AObjSetRate, 1, farg1);
+    archive = grDatFiles_801C6330(map_id);
     HSD_ASSERT(0x148, archive);
-    eflags = (u8*) archive->unk4->unk8[map].x28;
+    eflags = (u8*) archive->unk4->unk8[map_id].x28;
     if (eflags != NULL) {
-        flag = eflags[file_idx];
+        flag = eflags[arg4];
     } else {
         flag = 0;
     }
     if (flag != 0) {
-        grAnime_801C752C(j, recurse, var_r29, HSD_AObjSetFlags, 3,
+        grAnime_801C752C(jobj, arg5, var_r29, HSD_AObjSetFlags, 3,
                          0x20000000);
     }
 }

--- a/src/melee/gr/grbigblue.c
+++ b/src/melee/gr/grbigblue.c
@@ -619,7 +619,7 @@ void grBigBlue_801E6C60(Ground_GObj* gobj)
                     right_y = grBigBlue_801EC58C(&pos, NULL, 500.0f);
                     left_y = grBigBlue_801EC58C(&neg_pos, NULL, 500.0f);
 
-                    if (right_y != -3.4028235e38f || left_y != -3.4028235e38f)
+                    if (right_y != -F32_MAX || left_y != -F32_MAX)
                     {
                         f32 height_range;
                         s32 height_rand;
@@ -711,7 +711,7 @@ void grBigBlue_801E6C60(Ground_GObj* gobj)
                         if (found != 0) {
                             pos.y = 10.0f + Stage_GetCamBoundsTopOffset();
                         }
-                        if (pos.y == -3.4028235e38f) {
+                        if (pos.y == -F32_MAX) {
                             pos.y = 10.0f + Stage_GetCamBoundsTopOffset();
                         }
 
@@ -815,7 +815,7 @@ void grBigBlue_801E6C60(Ground_GObj* gobj)
 
             HSD_JObjGetTranslation(jobj, &cur_pos);
             surface_y = grBigBlue_801EC58C(&cur_pos, &normal, 500.0f);
-            if (surface_y == -3.4028235e38f) {
+            if (surface_y == -F32_MAX) {
                 normal.z = 0.0f;
                 *(f32*) &normal = 0.0f;
                 normal.y = 1.0f;
@@ -1050,7 +1050,7 @@ void grBigBlue_801E6C60(Ground_GObj* gobj)
                     (coll_result == 1 && cur_pos.y < coll_y))
                 {
                     if (target_y <= probe_y) {
-                        if (probe_y == -3.4028235e38f) {
+                        if (probe_y == -F32_MAX) {
                             gp->gv.bigblue.data[i].xC.z = fwd.y;
                         } else {
                             gp->gv.bigblue.data[i].xC.z =

--- a/src/melee/gr/grcastle.c
+++ b/src/melee/gr/grcastle.c
@@ -818,10 +818,9 @@ void grCastle_801CE3AC_dontinline(Ground_GObj* gobj)
 void grCastle_801CE3AC(Ground_GObj* gobj)
 {
     Ground* gp = GET_GROUND(gobj);
-    HSD_GObj* entity_gobj = gp->gv.castle5.xCC;
 
-    if (entity_gobj != NULL) {
-        HSD_JObj* jobj = GET_JOBJ(entity_gobj);
+    if (gp->gv.castle5.xCC != NULL) {
+        HSD_JObj* jobj = GET_JOBJ(gp->gv.castle5.xCC);
         Quaternion rot;
         Vec3 pos;
         Vec3 offset;

--- a/src/melee/gr/grcorneria.c
+++ b/src/melee/gr/grcorneria.c
@@ -628,12 +628,13 @@ void grCorneria_801DDAC0(Ground_GObj* arg) {}
 
 void grCorneria_801DDAC4(Ground_GObj* gobj)
 {
+    u32 slot = grCn_804D69A4;
     Ground* gp = GET_GROUND(gobj);
     HSD_JObj* jobj = GET_JOBJ(gobj);
     f32 scale;
 
-    gp->gv.arwing.xC8 = grCn_804D69A4;
-    grCn_803E1D38.arwing_gobj[grCn_804D69A4] = gobj;
+    gp->gv.arwing.xC8 = slot;
+    grCn_803E1D38.arwing_gobj[slot] = gobj;
     {
         s32 idx = grCn_803E1D38.arwing_group[gp->gv.arwing.xC8];
         HSD_GObj* arwing = grCorneria_801DD534(grCn_803E1D38.x3D8[idx]);
@@ -2053,8 +2054,9 @@ void grCorneria_801E1348(Ground_GObj* gobj)
                 gp->gv.corneria.x10C = grCn_804D69A0->x28;
                 Ground_801C53EC(0x55739);
             } else {
+                s32 imax;
                 s32 imin = grCn_804D69A0->x30;
-                s32 imax = grCn_804D69A0->x34;
+                imax = grCn_804D69A0->x34;
                 if (imax > imin) {
                     s32 range = imax - imin;
                     imax = imin + (range != 0 ? HSD_Randi(range) : 0);
@@ -2182,8 +2184,8 @@ void grCorneria_801E1878(Ground_GObj* gobj)
 {
     Vec3 pos;
     Ground* gr = GET_GROUND(gobj);
-    HSD_JObj* jobj = gobj->hsd_obj;
     HSD_JObj* target_jobj = gr->gv.corneria.x128->hsd_obj;
+    HSD_JObj* jobj = gobj->hsd_obj;
 
     HSD_JObjGetTranslation(jobj, &pos);
     HSD_JObjSetTranslate(target_jobj, &pos);

--- a/src/melee/gr/grfourside.c
+++ b/src/melee/gr/grfourside.c
@@ -443,21 +443,21 @@ bool grFourside_801F388C(Ground_GObj* arg)
 void grFourside_801F3894(Ground_GObj* arg0)
 {
     Ground* gp = arg0->user_data;
-    HSD_JObj* jobj = arg0->hsd_obj;
     u8 state = gp->gv.foursideUfo.x0;
     u8 prev_building = gp->gv.foursideUfo.x1;
+    HSD_JObj* jobj = arg0->hsd_obj;
+    PAD_STACK(8);
     switch (state) {
     case 0: {
         s32 timer = gp->gv.foursideUfo.x4;
         if (timer <= 0) {
-            s16 prob = 0;
+            s32 prob = 0;
             if (gp->gv.foursideUfo.x8 != 0) {
-                prob = grFs_804D69D8->x46;
+                prob = (s16) grFs_804D69D8->x46;
             }
-            if ((s16) gp->gv.foursideUfo.x2 >=
-                (s16) grFs_804D69D8->ufo_challenge)
+            if (gp->gv.foursideUfo.x2 >= (s16) grFs_804D69D8->ufo_challenge)
             {
-                prob = grFs_804D69D8->x48;
+                prob = (s16) grFs_804D69D8->x48;
             }
             if (prob != 0 && HSD_Randi(prob) == 0) {
                 s32 building;

--- a/src/melee/gr/grgreens.c
+++ b/src/melee/gr/grgreens.c
@@ -973,7 +973,7 @@ void grGreens_80215358(Ground_GObj* gobj, int col, int row, int arg3, int arg4)
     Vec vec;
     float f;
     PAD_STACK(0x10);
-    HSD_ASSERT(1305, block->status == Gr_Greens_Block_Status_None);
+    HSD_ASSERT(1305, block->status==Gr_Greens_Block_Status_None);
     for (n = 0; n < 30; n++) {
         arr[n] = 0;
     }
@@ -989,7 +989,7 @@ void grGreens_80215358(Ground_GObj* gobj, int col, int row, int arg3, int arg4)
             break;
         }
     }
-    HSD_ASSERT(1316, num < Gr_Greens_Block_Max);
+    HSD_ASSERT(1316, num<Gr_Greens_Block_Max);
     if (arg3 == 1) {
         type = 1;
     } else if (arg3 == 2) {

--- a/src/melee/gr/grgreens.c
+++ b/src/melee/gr/grgreens.c
@@ -170,6 +170,7 @@ static Vec3 grGr_803E780C[] = {
     { -1.0f, 0.0f, 0.0f },
     { 1.0f, 0.0f, 0.0f },
 };
+static u8 grGr_803E7824[0x1C] = { 0 };
 static s16 grGr_803E7840[30] = {
     5,    6,    7,    8,    9,    0xA,  0xB,  0xC,  0xD,  0xE,
     0xF,  0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
@@ -971,7 +972,8 @@ void grGreens_80215358(Ground_GObj* gobj, int col, int row, int arg3, int arg4)
     float grMaterial_801C8DE0_paramB;
     Vec vec;
     float f;
-    HSD_ASSERT(1305, block->status==Gr_Greens_Block_Status_None);
+    PAD_STACK(0x10);
+    HSD_ASSERT(1305, block->status == Gr_Greens_Block_Status_None);
     for (n = 0; n < 30; n++) {
         arr[n] = 0;
     }
@@ -987,7 +989,7 @@ void grGreens_80215358(Ground_GObj* gobj, int col, int row, int arg3, int arg4)
             break;
         }
     }
-    HSD_ASSERT(1316, num<Gr_Greens_Block_Max);
+    HSD_ASSERT(1316, num < Gr_Greens_Block_Max);
     if (arg3 == 1) {
         type = 1;
     } else if (arg3 == 2) {

--- a/src/melee/gr/gricemt.c
+++ b/src/melee/gr/gricemt.c
@@ -223,7 +223,7 @@ void grIceMt_801F686C(void)
             field30 = grIm_803E4068[row_idx].id;
             break;
         }
-        HSD_ASSERTMSG(0x258, row_idx < ICEMT_FIELD_MAX, "<ICEMT_FIELD_MAX>");
+        HSD_ASSERTMSG(0x258, row_idx < ICEMT_FIELD_MAX, "i<ICEMT_FIELD_MAX");
 
         // Second loop: find row where xAC[0], xAC[1], and field30 don't match
         for (row_idx = 0; row_idx < ICEMT_FIELD_MAX; row_idx++) {
@@ -241,7 +241,7 @@ void grIceMt_801F686C(void)
             field29 = grIm_803E4068[row_idx].id;
             break;
         }
-        HSD_ASSERTMSG(0x261, row_idx < ICEMT_FIELD_MAX, "<ICEMT_FIELD_MAX>");
+        HSD_ASSERTMSG(0x261, row_idx < ICEMT_FIELD_MAX, "i<ICEMT_FIELD_MAX");
 
         // Third loop: find row where xAC[0], xAC[1], field30, and field29
         // don't match
@@ -263,7 +263,7 @@ void grIceMt_801F686C(void)
             field28 = grIm_803E4068[row_idx].id;
             break;
         }
-        HSD_ASSERTMSG(0x26B, row_idx < ICEMT_FIELD_MAX, "<ICEMT_FIELD_MAX>");
+        HSD_ASSERTMSG(0x26B, row_idx < ICEMT_FIELD_MAX, "i<ICEMT_FIELD_MAX");
 
         // Calculate Y positions for the 3 topi platforms
         y_pos = Ground_801C0498();
@@ -1467,10 +1467,10 @@ int grIceMt_801F9ACC(Ground_GObj* gobj, float y, GrIceMtSegmentLookup ev,
     HSD_JObj* jobj;
     Ground* gp;
     HSD_JObj** ptrs;
+    HSD_JObj** new_var;
     f32 cur;
     f32 f;
     f32 f2;
-    HSD_JObj** new_var;
     s32 id;
     PAD_STACK(16);
 

--- a/src/melee/gr/gricemt.c
+++ b/src/melee/gr/gricemt.c
@@ -186,7 +186,7 @@ void grIceMt_801F686C(void)
     s32 field30;
     s32 field29;
     s32 field28;
-    u32 row_idx;
+    u32 i;
     s16* xAC;
     s32 id;
     f32 y_pos;
@@ -211,24 +211,24 @@ void grIceMt_801F686C(void)
 
     if (Stage_80225194() == 76) {
         // First loop: find row where neither xAC[0] nor xAC[1] matches
-        for (row_idx = 0; row_idx < ICEMT_FIELD_MAX; row_idx++) {
+        for (i = 0; i < ICEMT_FIELD_MAX; i++) {
             xAC = grIm_804D69F4->xAC;
-            id = grIm_803E4068[row_idx].id;
+            id = grIm_803E4068[i].id;
             if (xAC[0] == id) {
                 continue;
             }
             if (xAC[1] == id) {
                 continue;
             }
-            field30 = grIm_803E4068[row_idx].id;
+            field30 = grIm_803E4068[i].id;
             break;
         }
-        HSD_ASSERTMSG(0x258, row_idx < ICEMT_FIELD_MAX, "i<ICEMT_FIELD_MAX");
+        HSD_ASSERT(0x258, i<ICEMT_FIELD_MAX);
 
         // Second loop: find row where xAC[0], xAC[1], and field30 don't match
-        for (row_idx = 0; row_idx < ICEMT_FIELD_MAX; row_idx++) {
+        for (i = 0; i < ICEMT_FIELD_MAX; i++) {
             xAC = grIm_804D69F4->xAC;
-            id = grIm_803E4068[row_idx].id;
+            id = grIm_803E4068[i].id;
             if (xAC[0] == id) {
                 continue;
             }
@@ -238,16 +238,16 @@ void grIceMt_801F686C(void)
             if (field30 == id) {
                 continue;
             }
-            field29 = grIm_803E4068[row_idx].id;
+            field29 = grIm_803E4068[i].id;
             break;
         }
-        HSD_ASSERTMSG(0x261, row_idx < ICEMT_FIELD_MAX, "i<ICEMT_FIELD_MAX");
+        HSD_ASSERT(0x261, i<ICEMT_FIELD_MAX);
 
         // Third loop: find row where xAC[0], xAC[1], field30, and field29
         // don't match
-        for (row_idx = 0; row_idx < ICEMT_FIELD_MAX; row_idx++) {
+        for (i = 0; i < ICEMT_FIELD_MAX; i++) {
             xAC = grIm_804D69F4->xAC;
-            id = grIm_803E4068[row_idx].id;
+            id = grIm_803E4068[i].id;
             if (xAC[0] == id) {
                 continue;
             }
@@ -260,10 +260,10 @@ void grIceMt_801F686C(void)
             if (field29 == id) {
                 continue;
             }
-            field28 = grIm_803E4068[row_idx].id;
+            field28 = grIm_803E4068[i].id;
             break;
         }
-        HSD_ASSERTMSG(0x26B, row_idx < ICEMT_FIELD_MAX, "i<ICEMT_FIELD_MAX");
+        HSD_ASSERT(0x26B, i<ICEMT_FIELD_MAX);
 
         // Calculate Y positions for the 3 topi platforms
         y_pos = Ground_801C0498();

--- a/src/melee/gr/grinishie1.c
+++ b/src/melee/gr/grinishie1.c
@@ -7,6 +7,8 @@
 #include "ef/efsync.h"
 #include "gm/gm_unsplit.h"
 
+#include "m2c_macros.h"
+
 #include "gr/forward.h"
 
 #include "gr/grdisplay.h"
@@ -464,45 +466,45 @@ void grInishie1_801FAD84(HSD_GObj* gobj)
 void grInishie1_801FB0AC(HSD_GObj* gobj, u32 index)
 {
     Ground* gp = gobj->user_data;
-    if (gp->gv.inishie12.blocks[index].status == 1) {
-        grInishie1_801FBA34(gobj, gp->gv.inishie12.blocks[index].jobj);
-        gp->gv.inishie12.blocks[index].status = 0;
+    if (gp->gv.inishie1.blocks[index].status == 1) {
+        grInishie1_801FBA34(gobj, gp->gv.inishie1.blocks[index].jobj2);
+        gp->gv.inishie1.blocks[index].status = 0;
         grInishie1_801FBC4C(gobj, index);
 
-        gp->gv.inishie12.xC6 =
+        M2C_FIELD(gp, s16*, 0xC6) =
             randi_between(grI1_804D69F8->unk0, grI1_804D69F8->unk4);
-    } else if (gp->gv.inishie12.blocks[index].status == 2) {
-        grInishie1_801FBA34(gobj, gp->gv.inishie12.blocks[index].jobj);
-        gp->gv.inishie12.blocks[index].status = 0;
+    } else if (gp->gv.inishie1.blocks[index].status == 2) {
+        grInishie1_801FBA34(gobj, gp->gv.inishie1.blocks[index].jobj2);
+        gp->gv.inishie1.blocks[index].status = 0;
         grInishie1_801FBC4C(gobj, index);
 
-        gp->gv.inishie12.xC8 =
+        M2C_FIELD(gp, s16*, 0xC8) =
             randi_between(grI1_804D69F8->unk8, grI1_804D69F8->unkC);
-    } else if (gp->gv.inishie12.blocks[index].status == 3) {
-        grInishie1_801FBA34(gobj, gp->gv.inishie12.blocks[index].jobj);
-        gp->gv.inishie12.blocks[index].status = 0;
+    } else if (gp->gv.inishie1.blocks[index].status == 3) {
+        grInishie1_801FBA34(gobj, gp->gv.inishie1.blocks[index].jobj2);
+        gp->gv.inishie1.blocks[index].status = 0;
         grInishie1_801FBC4C(gobj, index);
 
         {
             int i;
             bool match = false;
             for (i = 0; i < 0x13; i++) {
-                if (gp->gv.inishie12.blocks[i].status == 3) {
+                if (gp->gv.inishie1.blocks[i].status == 3) {
                     match = true;
                     break;
                 }
             }
             if (!match) {
-                gp->gv.inishie12.xC6 =
+                M2C_FIELD(gp, s16*, 0xC6) =
                     randi_between(grI1_804D69F8->unk0, grI1_804D69F8->unk4);
-                gp->gv.inishie12.xC8 =
+                M2C_FIELD(gp, s16*, 0xC8) =
                     randi_between(grI1_804D69F8->unk8, grI1_804D69F8->unkC);
             }
         }
 
-        gp->gv.inishie12.xD8 = grI1_804D69F8->unk10;
+        gp->gv.inishie1.xD8 = grI1_804D69F8->unk10;
     } else {
-        if (gp->gv.inishie12.blocks[index].hatena_gobj != NULL) {
+        if (gp->gv.inishie1.blocks[index].hatena_gobj != NULL) {
             __assert("grinishie1.c", 0x29D, "0");
         }
     }

--- a/src/melee/gr/grinishie1.c
+++ b/src/melee/gr/grinishie1.c
@@ -7,8 +7,6 @@
 #include "ef/efsync.h"
 #include "gm/gm_unsplit.h"
 
-#include "m2c_macros.h"
-
 #include "gr/forward.h"
 
 #include "gr/grdisplay.h"
@@ -471,14 +469,14 @@ void grInishie1_801FB0AC(HSD_GObj* gobj, u32 index)
         gp->gv.inishie1.blocks[index].status = 0;
         grInishie1_801FBC4C(gobj, index);
 
-        M2C_FIELD(gp, s16*, 0xC6) =
+        gp->gv.inishie1.xC6 =
             randi_between(grI1_804D69F8->unk0, grI1_804D69F8->unk4);
     } else if (gp->gv.inishie1.blocks[index].status == 2) {
         grInishie1_801FBA34(gobj, gp->gv.inishie1.blocks[index].jobj2);
         gp->gv.inishie1.blocks[index].status = 0;
         grInishie1_801FBC4C(gobj, index);
 
-        M2C_FIELD(gp, s16*, 0xC8) =
+        gp->gv.inishie1.xC8 =
             randi_between(grI1_804D69F8->unk8, grI1_804D69F8->unkC);
     } else if (gp->gv.inishie1.blocks[index].status == 3) {
         grInishie1_801FBA34(gobj, gp->gv.inishie1.blocks[index].jobj2);
@@ -495,9 +493,9 @@ void grInishie1_801FB0AC(HSD_GObj* gobj, u32 index)
                 }
             }
             if (!match) {
-                M2C_FIELD(gp, s16*, 0xC6) =
+                gp->gv.inishie1.xC6 =
                     randi_between(grI1_804D69F8->unk0, grI1_804D69F8->unk4);
-                M2C_FIELD(gp, s16*, 0xC8) =
+                gp->gv.inishie1.xC8 =
                     randi_between(grI1_804D69F8->unk8, grI1_804D69F8->unkC);
             }
         }

--- a/src/melee/gr/grinishie2.c
+++ b/src/melee/gr/grinishie2.c
@@ -509,16 +509,16 @@ void grInishie2_801FD4F0(Ground_GObj* gobj)
 {
     Vec3 vec;
     s32 spawn_side;
-    HSD_JObj* temp_r28;
-    HSD_JObj* temp_r29;
-    void* temp_r30;
-    void* temp_r3;
     Ground* gp;
-    PAD_STACK(8);
+    HSD_JObj* jobj;
+    HSD_JObj* temp_r29;
+    HSD_JObj* temp_r30;
+    PAD_STACK(16);
 
-    temp_r29 = GET_JOBJ(gobj);
+    jobj = GET_JOBJ(gobj);
     gp = GET_GROUND(gobj);
-    temp_r28 = temp_r29;
+    temp_r29 = jobj;
+    temp_r30 = jobj;
     spawn_side = HSD_Randi(2);
     mpJointListAdd(0xE);
     if (spawn_side == 0) {
@@ -532,7 +532,7 @@ void grInishie2_801FD4F0(Ground_GObj* gobj)
     vec.z = grI2_804D6A00->unk14[spawn_side].z;
     HSD_JObjSetTranslate(temp_r29, &vec);
     gp->gv.inishie22.xC4 = it_802ECD3C(gobj, &vec, sign_inline(spawn_side));
-    Ground_801C2ED0(temp_r28, gp->map_id);
+    Ground_801C2ED0(temp_r30, gp->map_id);
 }
 
 bool grInishie2_801FD64C(Ground_GObj* gobj)
@@ -643,7 +643,7 @@ void grInishie2_801FD9EC(HSD_GObj* gobj)
     s32 var_r3;
     s32 var_r3_2;
     s16 temp_r0;
-    PAD_STACK(72);
+    PAD_STACK(48);
 
     gp = gobj->user_data;
 
@@ -682,7 +682,7 @@ void grInishie2_801FD9EC(HSD_GObj* gobj)
 
                     if (var_r3 != 0) {
                         gp->gv.inishie23.xC8_flags.b2 = 1;
-                        gp->gv.inishie23.xC8_flags.b3 = (var_r3 == 2);
+                        gp->gv.inishie23.xC8_flags.b3 = var_r3;
                         gp->gv.inishie23.xC8_flags.b0 = 1;
                     } else {
                         temp_r0 = grI2_804D6A00->unk48 + grI2_804D6A00->unk4A;
@@ -701,8 +701,8 @@ void grInishie2_801FD9EC(HSD_GObj* gobj)
         grAnime_801C8138(gobj, gp->map_id, gp->gv.inishie23.xC8_flags.b3);
 
         gp = GET_GROUND(gobj);
-        temp_vec = &gp->gv.inishie23.xD8;
         jobj = Ground_801C3FA4(gobj, 0);
+        temp_vec = &gp->gv.inishie23.xD8;
         HSD_JObjSetTranslate(jobj, temp_vec);
         HSD_JObjAddTranslationX(jobj, gp->gv.inishie23.xCC.x);
         HSD_JObjAddTranslationY(jobj, gp->gv.inishie23.xCC.y);

--- a/src/melee/gr/grkongo.c
+++ b/src/melee/gr/grkongo.c
@@ -1202,14 +1202,14 @@ void grKongo_801D7134(HSD_GObj* gobj, s32 arg1)
         gp->gv.kongo.xD8 = -angular_vel;
     }
 
-    entry = (_struct_grKg_803E188C_0x18*) ((u8*) grKg_803E16E0 + 0x1AC);
+    entry = grKg_803E188C;
     for (i = 0; i < 15; i++) {
         HSD_JObjSetRotationX(entry->unk4, entry->unkC);
         entry++;
     }
 
     mpLib_80057424(4);
-    entry = (_struct_grKg_803E188C_0x18*) ((u8*) grKg_803E16E0 + 0x1AC);
+    entry = grKg_803E188C;
     line_id = 0x28;
     for (i = 0; i < 15; i++) {
         temp = entry->unk14;

--- a/src/melee/gr/grkongo.c
+++ b/src/melee/gr/grkongo.c
@@ -1202,14 +1202,14 @@ void grKongo_801D7134(HSD_GObj* gobj, s32 arg1)
         gp->gv.kongo.xD8 = -angular_vel;
     }
 
-    entry = grKg_803E188C;
+    entry = (_struct_grKg_803E188C_0x18*) ((u8*) grKg_803E16E0 + 0x1AC);
     for (i = 0; i < 15; i++) {
         HSD_JObjSetRotationX(entry->unk4, entry->unkC);
         entry++;
     }
 
     mpLib_80057424(4);
-    entry = grKg_803E188C;
+    entry = (_struct_grKg_803E188C_0x18*) ((u8*) grKg_803E16E0 + 0x1AC);
     line_id = 0x28;
     for (i = 0; i < 15; i++) {
         temp = entry->unk14;

--- a/src/melee/gr/grmutecity.c
+++ b/src/melee/gr/grmutecity.c
@@ -460,6 +460,7 @@ void grMuteCity_801EFDF8(Ground_GObj* gobj)
     Ground* gp = GET_GROUND(gobj);
     HSD_GObj* lgobj;
     HSD_LObj* lobj;
+    HSD_LObj* next_lobj;
     PAD_STACK(12);
 
     grAnime_801C8138(gobj, gp->map_id, 0);
@@ -514,18 +515,18 @@ void grMuteCity_801EFDF8(Ground_GObj* gobj)
     lgobj = Ground_801C498C();
     gp->gv.mutecity.x110 = NULL;
     if (lgobj != NULL) {
-        lobj = (HSD_LObj*) lgobj->hsd_obj;
-        if (lobj != NULL) {
+        if ((lobj = (HSD_LObj*) lgobj->hsd_obj) != NULL) {
             while (lobj != NULL) {
                 if ((u32) (lobj->flags & 3) == LOBJ_POINT) {
                     gp->gv.mutecity.x110 = lobj;
                     HSD_LObjSetFlags(gp->gv.mutecity.x110, LOBJ_HIDDEN);
                 }
                 if (lobj == NULL) {
-                    lobj = NULL;
+                    next_lobj = NULL;
                 } else {
-                    lobj = lobj->next;
+                    next_lobj = lobj->next;
                 }
+                lobj = next_lobj;
             }
         }
     }
@@ -1327,7 +1328,7 @@ void grMuteCity_801F1A34(HSD_GObj* arg0, Ground_GObj* arg1)
     HSD_Spline* spline;
 
     Ground_801C0498();
-    PAD_STACK(8);
+    PAD_STACK(16);
     track_mid = 0.5f * (gp->gv.mutecity.xD4 + gp->gv.mutecity.xD8);
     Camera_GetTransformPosition(&spE8);
 

--- a/src/melee/gr/groldyoshi.c
+++ b/src/melee/gr/groldyoshi.c
@@ -241,8 +241,7 @@ void grOldYoshi_8020EC10(Ground_GObj* arg)
     int i = 0;
     Ground* gp = arg->user_data;
     HSD_JObj* jobj = arg->user_data;
-    PAD_STACK(8);
-    do {
+    for (i = 0; i < 3; i++) {
         // int test = HSD_Randi(3);
         switch (gp->gv.oldyoshicloud.cloud[i].xC4_0123) {
         case 0:
@@ -320,8 +319,7 @@ void grOldYoshi_8020EC10(Ground_GObj* arg)
                               gp->gv.oldyoshicloud.cloud[i].xCC -
                                   gp->gv.oldyoshicloud.cloud[i].xD0);
         gp->gv.oldyoshicloud.cloud[i].xC4_4 = 0;
-        i++;
-    } while (i < 3);
+    }
     Ground_801C2FE0(arg);
     return;
 }

--- a/src/melee/gr/gronett.c
+++ b/src/melee/gr/gronett.c
@@ -83,10 +83,10 @@ static struct grOnett_StageParam {
     /* 0x38 */ f32 x38;
     /* 0x3C */ f32 x3C;
     /* 0x40 */ f32 x40;
-    /* 0x44 */ s32 x44;
-    /* 0x48 */ s32 x48;
-    /* 0x4C */ s32 x4C;
-    /* 0x50 */ s32 x50;
+    /* 0x44 */ f32 x44;
+    /* 0x48 */ f32 x48;
+    /* 0x4C */ f32 x4C;
+    /* 0x50 */ f32 x50;
     /* 0x54 */ f32 x54;
     /* 0x58 */ f32 x58;
     /* 0x5C */ f32 x5C;
@@ -453,9 +453,8 @@ void grOnett_801E41C8(Ground_GObj* gobj)
     gp->gv.onettcar.unk_jobj2 = Ground_801C3FA4(gobj, 0x14);
 
     for (i = 0; i < 4; i++) {
-        HSD_JObj* jobj = gp->gv.onettcar.car_jobjs[i];
-        HSD_JObjSetTranslateX(jobj, 726.0f);
-        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
+        HSD_JObjSetTranslateX(gp->gv.onettcar.car_jobjs[i], 726.0f);
+        HSD_JObjSetFlagsAll(gp->gv.onettcar.car_jobjs[i], JOBJ_HIDDEN);
         gp->gv.onettcar.car_items[i] =
             grMaterial_801C8CFC(0, 0, gp, gp->gv.onettcar.car_jobjs[i],
                                 grOnett_801E5030, NULL, NULL);
@@ -482,7 +481,7 @@ bool grOnett_801E43D8(Ground_GObj* gobj)
 void grOnett_801E43E0(Ground_GObj* gobj)
 {
     Ground* gp = GET_GROUND(gobj);
-    s8 saved_car = gp->gv.onettcar.curr_car;
+    u8 saved_car = gp->gv.onettcar.curr_car;
     Vec3 pos = { 0.0f, 0.0f, 0.0f };
     f32 cam_x, cam_y, cam_z;
     PAD_STACK(32);

--- a/src/melee/gr/ground.c
+++ b/src/melee/gr/ground.c
@@ -573,23 +573,21 @@ void Ground_801C0C2C(HSD_GObj* arg0)
         if (gobj != NULL && !ftLib_8008701C(gobj)) {
             ftLib_80086644(gobj, &sp50);
             if (stage_info.unk8C.b6) {
-                bool result = false;
-                f32 x_min = -stage_info.x70C;
-                f32 y_min = -stage_info.x710;
-                f32 x_max = +stage_info.x70C;
-                f32 y_max = +stage_info.x710;
                 int i;
+                bool result = false;
+                f32 x_max = stage_info.x70C;
+                f32 y_max = stage_info.x710;
                 for (i = 0x99; i < 0xB3; i++) {
                     if (Ground_801C2D24(i, &sp44)) {
-                        bool var_r0_2 = 0;
-                        bool var_r3_2 = 0;
-                        bool var_r4_2 = 0;
+                        bool var_r0_2 = false;
+                        bool var_r3_2 = var_r0_2;
+                        bool var_r4_2 = var_r0_2;
                         f32 xpos = sp50.x - sp44.x;
                         f32 ypos = sp50.y - sp44.y;
-                        if (xpos > x_min && xpos < x_max) {
+                        if (xpos > -x_max && xpos < x_max) {
                             var_r4_2 = 1;
                         }
-                        if (var_r4_2 && ypos > y_min) {
+                        if (var_r4_2 && ypos > -y_max) {
                             var_r3_2 = 1;
                         }
                         if (var_r3_2 && ypos < y_max) {
@@ -611,23 +609,21 @@ void Ground_801C0C2C(HSD_GObj* arg0)
                 stage_info.unk8C.b6 = false;
             }
             if (stage_info.unk8C.b7) {
-                bool result = false;
-                f32 x_min = -stage_info.x718;
-                f32 y_min = -stage_info.x71C;
-                f32 x_max = +stage_info.x718;
-                f32 y_max = +stage_info.x71C;
                 int i;
+                bool result = false;
+                f32 x_max = stage_info.x718;
+                f32 y_max = stage_info.x71C;
                 for (i = 0xBD; i < 0xC7; i++) {
                     if (Ground_801C2D24(i, &sp38)) {
-                        bool var_r0_2 = 0;
-                        bool var_r3_2 = 0;
-                        bool var_r4_2 = 0;
+                        bool var_r0_2 = false;
+                        bool var_r3_2 = var_r0_2;
+                        bool var_r4_2 = var_r0_2;
                         f32 xpos = sp50.x - sp38.x;
                         f32 ypos = sp50.y - sp38.y;
-                        if (xpos > x_min && xpos < x_max) {
+                        if (xpos > -x_max && xpos < x_max) {
                             var_r4_2 = 1;
                         }
-                        if (var_r4_2 && ypos > y_min) {
+                        if (var_r4_2 && ypos > -y_max) {
                             var_r3_2 = 1;
                         }
                         if (var_r3_2 && ypos < y_max) {

--- a/src/melee/gr/grpstadium.c
+++ b/src/melee/gr/grpstadium.c
@@ -2165,19 +2165,18 @@ void grStadium_801D4548(Ground_GObj* gobj)
         if (temp_r3_6 != NULL) {
             temp_r0_2 = temp_r31->u.stadium.xDE;
 
-            var_r29 = temp_r0_2;
-            if (var_r29 == 3) {
+            if (temp_r0_2 == 3) {
                 var_r29 = 3;
-            } else if (var_r29 == 4) {
+            } else if (temp_r0_2 == 4) {
                 var_r29 = 4;
-            } else if (var_r29 == 9) {
+            } else if (temp_r0_2 == 9) {
                 var_r29 = 5;
-            } else if (var_r29 == 6) {
+            } else if (temp_r0_2 == 6) {
                 var_r29 = 6;
-            } else if (var_r29 == 5) {
+            } else if (temp_r0_2 == 5) {
                 var_r29 = 2;
             } else {
-                HSD_ASSERT(0xA44, 0);
+                HSD_ASSERT(0xA67, 0);
             }
 
             grStadium_801D2528(temp_r3_6, var_r29, 0);
@@ -2267,50 +2266,12 @@ void grStadium_801D4548(Ground_GObj* gobj)
         temp_r3_9->u.stadium.xC4_b0 = true;
         mpLib_80058560();
         if (temp_r31->u.stadium.xDE == 5) {
-            var_r28 = yaku->x4;
-            temp_r27_6 = yaku->x0;
-            if (var_r28 > temp_r27_6) {
-                temp_r3_10 = var_r28 - temp_r27_6;
-                if (temp_r3_10 != 0) {
-                    var_r3_10 = HSD_Randi(temp_r3_10);
-                } else {
-                    var_r3_10 = 0;
-                }
-                var_r28 = temp_r27_6 + var_r3_10;
-            } else if (var_r28 < temp_r27_6) {
-                temp_r3_11 = temp_r27_6 - var_r28;
-                if (temp_r3_11 != 0) {
-                    var_r3_11 = HSD_Randi(temp_r3_11);
-                } else {
-                    var_r3_11 = 0;
-                }
-                var_r28 += var_r3_11;
-            }
-            temp_r31->u.stadium.xD8 = var_r28;
+            temp_r31->u.stadium.xD8 = randi_between_2(yaku->x0, yaku->x4);
             grAnime_801C65B0((void*) temp_r31->u.stadium.xCC);
             mpLib_800575B0(0x55);
             mpLib_800575B0(0x6F);
         } else {
-            var_r28_2 = yaku->xC;
-            temp_r27_7 = yaku->x8;
-            if (var_r28_2 > temp_r27_7) {
-                temp_r3_12 = var_r28_2 - temp_r27_7;
-                if (temp_r3_12 != 0) {
-                    var_r3_12 = HSD_Randi(temp_r3_12);
-                } else {
-                    var_r3_12 = 0;
-                }
-                var_r28_2 = temp_r27_7 + var_r3_12;
-            } else if (var_r28_2 < temp_r27_7) {
-                temp_r3_13 = temp_r27_7 - var_r28_2;
-                if (temp_r3_13 != 0) {
-                    var_r3_13 = HSD_Randi(temp_r3_13);
-                } else {
-                    var_r3_13 = 0;
-                }
-                var_r28_2 += var_r3_13;
-            }
-            temp_r31->u.stadium.xD8 = var_r28_2;
+            temp_r31->u.stadium.xD8 = randi_between_2(yaku->x8, yaku->xC);
         }
         temp_r31->u.stadium.xDC = 0;
         break;

--- a/src/melee/gr/grrcruise.c
+++ b/src/melee/gr/grrcruise.c
@@ -377,7 +377,7 @@ void grRCruise_801FF924(Ground_GObj* gobj)
     HSD_ASSERT(0x2B2, gp->u.scroll.cam_jobj);
 
     gp->u.scroll.ctr_jobj = Ground_801C3FA4(gobj, 1);
-    HSD_ASSERT(0x2B2, gp->u.scroll.ctr_jobj);
+    HSD_ASSERT(0x2B4, gp->u.scroll.ctr_jobj);
 
     HSD_JObjGetTranslation(gp->u.scroll.ctr_jobj, &gp->u.scroll.x04);
     gp->u.scroll.x10.z = 0.0f;
@@ -407,9 +407,9 @@ void grRCruise_801FFADC(Ground_GObj* arg0)
     Vec3 sp18;
     Ground* gp;
     HSD_GObj* gobj;
-    HSD_JObj* temp_r29_2;
     HSD_JObj* temp_r30;
     HSD_JObj* temp_r31;
+    HSD_JObj* temp_r29_2;
     f32 temp_f31;
     f32 temp_f4;
 

--- a/src/melee/gr/grshrineroute.c
+++ b/src/melee/gr/grshrineroute.c
@@ -405,8 +405,8 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
         if (result != -1) {
             s32 ix = result - 0xBD;
             if (!(gp->gv.shrineroute.xC6 & (1 << ix))) {
-                gp->gv.shrineroute.xC8 = (u16) result;
                 HSD_ASSERT(0x213, gp->gv.shrineroute.symbols[ix]);
+                gp->gv.shrineroute.xC8 = (u16) result;
                 {
                     s32 mid =
                         ((Ground*) gp->gv.shrineroute.symbols[ix]->user_data)

--- a/src/melee/gr/grvenom.c
+++ b/src/melee/gr/grvenom.c
@@ -306,13 +306,12 @@ void grVenom_80203B18(void)
     Ground_GObj* obj;
     Ground_GObj* temp;
     Ground* gp;
-    f32 f0;
-    f32 f2;
     s32 i0;
     s32 i1;
     s32 flag;
     HSD_GObj* gobj;
     HSD_LObj* lobj;
+    HSD_LObj* next;
 
     data = (s32*) &grVe_803E5348;
     grVe_804D6A30 = Ground_801C49F8();
@@ -330,19 +329,15 @@ void grVenom_80203B18(void)
     data[10] = 0;
     data[13] = 0;
     data[16] = 0;
-    if (Stage_80225194() == 0xE9) {
-        goto skip;
+    if (Stage_80225194() != 0xE9) {
+        flag = 0;
     }
-    flag = 0;
-skip:
     grVe_804D6A40 = flag;
     if (flag == 1) {
         grVe_804D6A38 = 0x78;
     } else {
-        f0 = grVe_804D6A30->x0;
-        f2 = grVe_804D6A30->x4;
-        i0 = (s32) f0;
-        i1 = (s32) f2;
+        i0 = (s32) grVe_804D6A30->x0;
+        i1 = (s32) grVe_804D6A30->x4;
         if (i1 > i0) {
             i1 = i1 - i0;
             if (i1 != 0) {
@@ -399,10 +394,11 @@ skip:
                                     HSD_AObjSetFlags, AOBJ_ARG_AU, AOBJ_LOOP);
                 }
                 if (lobj == NULL) {
-                    lobj = NULL;
+                    next = NULL;
                 } else {
-                    lobj = lobj->next;
+                    next = lobj->next;
                 }
+                lobj = next;
             }
         }
     }
@@ -1269,11 +1265,11 @@ void grVenom_80205AD0(Ground_GObj* arg) {}
 void grVenom_80205AD4(Ground_GObj* gobj)
 {
     s32 zero;
-    u8* base;
-    HSD_JObj* jobj;
+    s32* base;
     Ground* gp;
+    HSD_JObj* jobj;
     f32 scale;
-    u8* data;
+    s32* data;
     s32 type;
     Ground_GObj* other;
     Ground* other_gp;
@@ -1282,9 +1278,9 @@ void grVenom_80205AD4(Ground_GObj* gobj)
     void* attr;
 
     zero = 0;
-    base = (u8*) &grVe_803E5348;
     gp = gobj->user_data;
     jobj = gobj->hsd_obj;
+    base = (s32*) &grVe_803E5348;
     scale = Ground_801C0498();
 
     gp->gv.venom.xC8 = grVe_804D6A34;
@@ -1293,12 +1289,12 @@ void grVenom_80205AD4(Ground_GObj* gobj)
     *(s32*) &gp->gv.venom.xE4 = zero;
     *(s32*) &gp->gv.venom.xE0 = zero;
 
-    grAnime_801C7FF8(gobj, 7, 7, 0, 0.0F, 1.0F);
-    grAnime_801C7FF8(gobj, 8, 7, 0, 0.0F, 1.0F);
-    grAnime_801C8098(gobj, 2, 7, 3, 0.0F, 1.0F);
+    grAnime_801C7FF8(gobj, 7, 7, 0, grVe_804DB740, grVe_804DB73C);
+    grAnime_801C7FF8(gobj, 8, 7, 0, grVe_804DB740, grVe_804DB73C);
+    grAnime_801C8098(gobj, 2, 7, 3, grVe_804DB740, grVe_804DB73C);
 
-    data = base + gp->gv.venom.xC8 * 4;
-    type = *(s32*) (data + 0x2C);
+    data = base + gp->gv.venom.xC8;
+    type = data[11];
 
     if (type < 8) {
         if (type >= 1) {
@@ -1312,9 +1308,9 @@ void grVenom_80205AD4(Ground_GObj* gobj)
     goto venom_80205AD4_link;
 
 venom_80205AD4_spawn: {
-    s32 idx = *(s32*) (data + 0x38);
-    u8* data2 = base + idx * 4;
-    other = (Ground_GObj*) grVenom_80203EAC(*(s32*) (data2 + 0x324));
+    s32 idx = data[14];
+    s32* data2 = base + idx;
+    other = (Ground_GObj*) grVenom_80203EAC(data2[0xC9]);
     *(s32*) &gp->gv.venom.xDC = (s32) other;
     if (other != NULL) {
         other = *(Ground_GObj**) &gp->gv.venom.xDC;
@@ -1327,7 +1323,7 @@ venom_80205AD4_spawn: {
 }
 
 venom_80205AD4_link:
-    jobj2 = Ground_801C3FA4((HSD_GObj*) *(s32*) (data + 0x20), 5);
+    jobj2 = Ground_801C3FA4((HSD_GObj*) data[8], 5);
     lb_8000C2F8(Ground_801C3FA4(gobj, 0), jobj2);
     *(s32*) &gp->gv.venom.xDC = zero;
     goto venom_80205AD4_done;
@@ -1544,12 +1540,12 @@ void grVenom_80205F30(Ground_GObj* gobj)
                                 NULL, &sp94);
                 }
                 if (*(u32*) &gp->gv.venom.xDC != 0U) {
-                    void* sub =
-                        *(void**) ((u8*) (*(u32*) &gp->gv.venom.xDC) + 0x2C);
+                    Ground* sub =
+                        ((HSD_GObj*) *(u32*) &gp->gv.venom.xDC)->user_data;
                     if (sub != NULL) {
-                        *(f32*) ((u8*) sub + 0xE0) = sp94.x;
-                        *(f32*) ((u8*) sub + 0xE4) = sp94.y;
-                        *(f32*) ((u8*) sub + 0xE8) = sp94.z;
+                        sub->gv.venom.xE0 = sp94.x;
+                        sub->gv.venom.xE4 = sp94.y;
+                        sub->gv.venom.xE8 = sp94.z;
                     }
                 }
 
@@ -1557,14 +1553,11 @@ void grVenom_80205F30(Ground_GObj* gobj)
                     s32 idx0 = base[gp->gv.venom.xC8 + 14];
                     s32 anim_id = base[idx0 * 4 + 0xD6];
                     helper = Ground_801C3FA4((HSD_GObj*) gobj, anim_id);
-                    if (helper == NULL) {
-                        __assert("jobj.h", 0x2E9, "jobj");
-                    }
                     if (*(u32*) &gp->gv.venom.xDC != 0U) {
-                        void* sub = *(
-                            void**) ((u8*) (*(u32*) &gp->gv.venom.xDC) + 0x2C);
+                        Ground* sub =
+                            ((HSD_GObj*) *(u32*) &gp->gv.venom.xDC)->user_data;
                         if (sub != NULL) {
-                            *(f32*) ((u8*) sub + 0xDC) = helper->rotate.z;
+                            sub->gv.venom.xDC = HSD_JObjGetRotationZ(helper);
                         }
                     }
                 }
@@ -1789,7 +1782,9 @@ venom_80206874_done:
     *(s32*) &gp->gv.venom.xD4 = zero;
     gp->gv.venom.xF0 = zero;
     gp->gv.venom.xF4 = zero;
-    gp->gv.venom.xF8 = (s32) * (f32*) ((u8*) grVe_804D6A30 + 0x2C);
+
+    attr = grVe_804D6A30;
+    gp->gv.venom.xF8 = (s32) * (f32*) ((u8*) attr + 0x2C);
     gp->gv.venom.xFC = zero;
 }
 

--- a/src/melee/gr/grvenom.c
+++ b/src/melee/gr/grvenom.c
@@ -1540,12 +1540,12 @@ void grVenom_80205F30(Ground_GObj* gobj)
                                 NULL, &sp94);
                 }
                 if (*(u32*) &gp->gv.venom.xDC != 0U) {
-                    Ground* sub =
-                        ((HSD_GObj*) *(u32*) &gp->gv.venom.xDC)->user_data;
+                    void* sub =
+                        *(void**) ((u8*) (*(u32*) &gp->gv.venom.xDC) + 0x2C);
                     if (sub != NULL) {
-                        sub->gv.venom.xE0 = sp94.x;
-                        sub->gv.venom.xE4 = sp94.y;
-                        sub->gv.venom.xE8 = sp94.z;
+                        *(f32*) ((u8*) sub + 0xE0) = sp94.x;
+                        *(f32*) ((u8*) sub + 0xE4) = sp94.y;
+                        *(f32*) ((u8*) sub + 0xE8) = sp94.z;
                     }
                 }
 
@@ -1553,11 +1553,14 @@ void grVenom_80205F30(Ground_GObj* gobj)
                     s32 idx0 = base[gp->gv.venom.xC8 + 14];
                     s32 anim_id = base[idx0 * 4 + 0xD6];
                     helper = Ground_801C3FA4((HSD_GObj*) gobj, anim_id);
+                    if (helper == NULL) {
+                        __assert("jobj.h", 0x2E9, "jobj");
+                    }
                     if (*(u32*) &gp->gv.venom.xDC != 0U) {
-                        Ground* sub =
-                            ((HSD_GObj*) *(u32*) &gp->gv.venom.xDC)->user_data;
+                        void* sub = *(
+                            void**) ((u8*) (*(u32*) &gp->gv.venom.xDC) + 0x2C);
                         if (sub != NULL) {
-                            sub->gv.venom.xDC = HSD_JObjGetRotationZ(helper);
+                            *(f32*) ((u8*) sub + 0xDC) = helper->rotate.z;
                         }
                     }
                 }

--- a/src/melee/gr/grvenom.c
+++ b/src/melee/gr/grvenom.c
@@ -1289,9 +1289,9 @@ void grVenom_80205AD4(Ground_GObj* gobj)
     *(s32*) &gp->gv.venom.xE4 = zero;
     *(s32*) &gp->gv.venom.xE0 = zero;
 
-    grAnime_801C7FF8(gobj, 7, 7, 0, grVe_804DB740, grVe_804DB73C);
-    grAnime_801C7FF8(gobj, 8, 7, 0, grVe_804DB740, grVe_804DB73C);
-    grAnime_801C8098(gobj, 2, 7, 3, grVe_804DB740, grVe_804DB73C);
+    grAnime_801C7FF8(gobj, 7, 7, 0, 0.0F, 1.0F);
+    grAnime_801C7FF8(gobj, 8, 7, 0, 0.0F, 1.0F);
+    grAnime_801C8098(gobj, 2, 7, 3, 0.0F, 1.0F);
 
     data = base + gp->gv.venom.xC8;
     type = data[11];

--- a/src/melee/gr/grzebes.c
+++ b/src/melee/gr/grzebes.c
@@ -314,16 +314,20 @@ void grZebes_801D8644(HSD_GObj* gobj)
     grMaterial_801C8DE0(mat_gobj, 0.0f, -7.0f, 0.0f, 0.0f, 7.0f, 0.0f, 3.0f);
     grMaterial_801C8E08(mat_gobj);
     gp->gv.zebes5.xC4 = 0;
-    gp->gv.zebes5.xC8 = 0xFF;
-    gp->gv.zebes5.xCC = HSD_JObjGetTranslationX(child_jobj);
-    gp->gv.zebes5.xD0 = 0.0f;
-    gp->gv.zebes5.xD4 = 0.0f;
-    gp->gv.zebes5.xD8 = 0.0f;
-    gp->gv.zebes5.xDC = (u32) child_jobj;
-    gp->gv.zebes5.xE0 = (u32) Ground_801C3FA4(gobj, 0x20);
-    gp->gv.zebes5.xE4 = (u32) (mat_gobj2 = mat_gobj);
+    ((grZe_AcidState*) &gp->gv.zebes5.xC8)->x00_state = 0xFF;
+    ((grZe_AcidState*) &gp->gv.zebes5.xC8)->x01_next = 0;
+    ((grZe_AcidState*) &gp->gv.zebes5.xC8)->x02_timer = 0;
+    ((grZe_AcidState*) &gp->gv.zebes5.xC8)->x04_base_x =
+        HSD_JObjGetTranslationX(child_jobj);
+    ((grZe_AcidState*) &gp->gv.zebes5.xC8)->x08_offset = 0.0f;
+    ((grZe_AcidState*) &gp->gv.zebes5.xC8)->x0C_velocity = 0.0f;
+    ((grZe_AcidState*) &gp->gv.zebes5.xC8)->x10_damage = 0.0f;
+    ((grZe_AcidState*) &gp->gv.zebes5.xC8)->x14_jobj1 = child_jobj;
+    ((grZe_AcidState*) &gp->gv.zebes5.xC8)->x18_jobj2 =
+        Ground_801C3FA4(gobj, 0x20);
+    ((grZe_AcidState*) &gp->gv.zebes5.xC8)->x1C_mat = mat_gobj2 = mat_gobj;
 
-    gp->gv.zebes5.xE8 = 0x1C;
+    ((grZe_AcidState*) &gp->gv.zebes5.xC8)->x20_anim_idx = 0x1C;
     gp->gv.zebes5.xEC = 0;
     gp->gv.zebes5.xF4 = 0;
     pos = grZe_803B7FF0.x00;
@@ -759,8 +763,7 @@ void grZebes_801D9758(Ground_GObj* gobj)
 void grZebes_801D9798(HSD_GObj* gobj)
 {
     Ground* gp = GET_GROUND(gobj);
-    grZe_AcidLevelEntry* entry;
-    s16 delay_max, delay_min;
+    s32 delay_max, delay_min;
     f32 rand;
     s32 j;
     HSD_JObj* jobj;
@@ -769,9 +772,8 @@ void grZebes_801D9798(HSD_GObj* gobj)
 
     gp->gv.zebes5.xC4 = 0;
 
-    entry = &grZe_804D6990->xA0_entries[gp->gv.zebes5.xC4];
-    delay_max = entry->x4_delay_max;
-    delay_min = entry->x2_delay_min;
+    delay_max = grZe_804D6990->xA0_entries[gp->gv.zebes5.xC4].x4_delay_max;
+    delay_min = grZe_804D6990->xA0_entries[gp->gv.zebes5.xC4].x2_delay_min;
 
     if (delay_max > delay_min) {
         s32 diff = delay_max - delay_min;
@@ -790,14 +792,14 @@ void grZebes_801D9798(HSD_GObj* gobj)
     gp->gv.zebes5.xDC = 0;
     gp->x11_flags.b012 = 1;
 
+    for (j = 0; j < 0x1D &&
+                (grZe_804D6990->xA0_entries[j + 1].x0_base != 0 ||
+                 grZe_804D6990->xA0_entries[j + 1].x2_delay_min != 0 ||
+                 grZe_804D6990->xA0_entries[j + 1].x4_delay_max != 0 ||
+                 grZe_804D6990->xA0_entries[j + 1].x6_level != 0);
+         j++)
     {
-        grZe_AcidLevelEntry* ep = &grZe_804D6990->xA0_entries[0];
-        for (j = 0; j < 0x1D && (ep->x0_base != 0 || ep->x2_delay_min != 0 ||
-                                 ep->x4_delay_max != 0 || ep->x6_level != 0);
-             j++)
-        {
-            ep = &grZe_804D6990->xA0_entries[j];
-        }
+        ;
     }
 
     rand = HSD_Randf();
@@ -1067,6 +1069,16 @@ void grZebes_801D9F84(Ground_GObj* gobj)
 }
 
 void grZebes_801DA0C0(Ground_GObj* arg) {}
+
+const grZe_BubbleConfig grZe_803B8044 = {
+    { 1.0f, 1.1f, 1.0f, 1.2f, 1.1f, 1.0f, 1.0f },
+    {
+        { 7.59f, 2.5f, 0.0f },
+        { 24.05f, 2.2f, 0.0f },
+        { 8.2f, -4.55f, 0.0f },
+        { 24.1f, -4.6f, 0.0f },
+    },
+};
 
 void grZebes_801DA0C4(f32 level)
 {
@@ -2234,16 +2246,6 @@ void grZebes_801DC744(s32 arg0, u8 arg1)
                          1.0f);
     }
 }
-
-const grZe_BubbleConfig grZe_803B8044 = {
-    { 1.0f, 1.1f, 1.0f, 1.2f, 1.1f, 1.0f, 1.0f },
-    {
-        { 7.59f, 2.5f, 0.0f },
-        { 24.05f, 2.2f, 0.0f },
-        { 8.2f, -4.55f, 0.0f },
-        { 24.1f, -4.6f, 0.0f },
-    },
-};
 
 void grZebes_801DC9DC(s32 arg0)
 {

--- a/src/melee/if/ifprize.c
+++ b/src/melee/if/ifprize.c
@@ -89,6 +89,13 @@ struct un_803F9D48 {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, { 0x43, 0x44, 0x45 },
 };
+static char lbl_803F9D84[] =
+    "ScInfPrize_scene_data\0\0"
+    "SdPrize.usd\0"
+    "SIS_PrizeData\0\0"
+    "SdPrize.dat\0\0\0\0"
+    "%2d.%2d.%04d  %02d:%02d:%02d\0\0\0"
+    "%04d.%2d.%2d  %02d:%02d:%02d\0\0\0\0\0\0\0";
 
 /// .sbss
 /* 4D6D98 */ static HSD_Archive* un_804D6D98;
@@ -242,6 +249,7 @@ void un_802FE918(int a, int b, int c)
     int k;
     int i;
     char sp1C[0x104];
+    HSD_Text** text;
     datetime sp14;
 
     lbAudioAx_800236DC();
@@ -280,14 +288,15 @@ found:
     }
     gm_801692E8(c, &sp14);
     if (lbLang_IsSavedLanguageUS()) {
-        sprintf(sp1C, "%2d.%2d.%04d  %02d:%02d:%02d", sp14.month, sp14.day,
+        sprintf(sp1C, lbl_803F9D84 + 0x40, sp14.month, sp14.day,
                 sp14.year, sp14.hour, sp14.minute, sp14.second);
     } else {
-        sprintf(sp1C, "%04d.%2d.%2d  %02d:%02d:%02d", sp14.year, sp14.month,
+        sprintf(sp1C, lbl_803F9D84 + 0x60, sp14.year, sp14.month,
                 sp14.day, sp14.hour, sp14.minute, sp14.second);
     }
-    HSD_SisLib_803A7664(un_803F9D48.x24);
-    HSD_SisLib_803A6B98(un_803F9D48.x24, 320.0f, 316.0f, sp1C);
+    text = &un_803F9D48.x24;
+    HSD_SisLib_803A7664(*text);
+    HSD_SisLib_803A6B98(*text, 320.0f, 316.0f, sp1C);
 }
 
 void un_802FEBE0_OnEnter(void* arg0_)
@@ -321,11 +330,11 @@ found:
     un_803F9D48.xC = arg0x4;
     un_803F9D48.x0a = 1;
     un_804D6D98 = lbArchive_80016DBC("IfPrize", &un_804D6D9C,
-                                     "ScInfPrize_scene_data", 0);
+                                     lbl_803F9D84, 0);
     if (lbLang_IsSavedLanguageUS()) {
-        HSD_SisLib_803A62A0(2, "SdPrize.usd", "SIS_PrizeData");
+        HSD_SisLib_803A62A0(2, lbl_803F9D84 + 0x18, lbl_803F9D84 + 0x24);
     } else {
-        HSD_SisLib_803A62A0(2, "SdPrize.dat", "SIS_PrizeData");
+        HSD_SisLib_803A62A0(2, lbl_803F9D84 + 0x34, lbl_803F9D84 + 0x24);
     }
     un_802FE6A8();
 }

--- a/src/melee/if/ifprize.c
+++ b/src/melee/if/ifprize.c
@@ -89,14 +89,6 @@ struct un_803F9D48 {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, { 0x43, 0x44, 0x45 },
 };
-static char lbl_803F9D84[] =
-    "ScInfPrize_scene_data\0\0"
-    "SdPrize.usd\0"
-    "SIS_PrizeData\0\0"
-    "SdPrize.dat\0\0\0\0"
-    "%2d.%2d.%04d  %02d:%02d:%02d\0\0\0"
-    "%04d.%2d.%2d  %02d:%02d:%02d\0\0\0\0\0\0\0";
-
 /// .sbss
 /* 4D6D98 */ static HSD_Archive* un_804D6D98;
 /* 4D6D9C */ static SceneDesc* un_804D6D9C;
@@ -288,10 +280,10 @@ found:
     }
     gm_801692E8(c, &sp14);
     if (lbLang_IsSavedLanguageUS()) {
-        sprintf(sp1C, lbl_803F9D84 + 0x40, sp14.month, sp14.day,
+        sprintf(sp1C, "%2d.%2d.%04d  %02d:%02d:%02d", sp14.month, sp14.day,
                 sp14.year, sp14.hour, sp14.minute, sp14.second);
     } else {
-        sprintf(sp1C, lbl_803F9D84 + 0x60, sp14.year, sp14.month,
+        sprintf(sp1C, "%04d.%2d.%2d  %02d:%02d:%02d", sp14.year, sp14.month,
                 sp14.day, sp14.hour, sp14.minute, sp14.second);
     }
     text = &un_803F9D48.x24;
@@ -330,11 +322,11 @@ found:
     un_803F9D48.xC = arg0x4;
     un_803F9D48.x0a = 1;
     un_804D6D98 = lbArchive_80016DBC("IfPrize", &un_804D6D9C,
-                                     lbl_803F9D84, 0);
+                                     "ScInfPrize_scene_data", 0);
     if (lbLang_IsSavedLanguageUS()) {
-        HSD_SisLib_803A62A0(2, lbl_803F9D84 + 0x18, lbl_803F9D84 + 0x24);
+        HSD_SisLib_803A62A0(2, "SdPrize.usd", "SIS_PrizeData");
     } else {
-        HSD_SisLib_803A62A0(2, lbl_803F9D84 + 0x34, lbl_803F9D84 + 0x24);
+        HSD_SisLib_803A62A0(2, "SdPrize.dat", "SIS_PrizeData");
     }
     un_802FE6A8();
 }

--- a/src/melee/if/soundtest.c
+++ b/src/melee/if/soundtest.c
@@ -52,7 +52,7 @@
     u8 x226;
     u8 x227;
 } un_803FA128;
-/* 3FA258 */ static struct un_803FA258_t {
+/* 3FA258 */ struct un_803FA258_t {
     int x0;
     int x4[4];
     int x14[4];
@@ -130,7 +130,7 @@
 /* 3FD24C */ extern char un_803FD24C[];
 /* 3FD258 */ extern char un_803FD258[];
 /* 3FD264 */ extern char un_803FD264[];
-/* 3FD274 */ extern void* un_803FD274;
+/* 3FD274 */ extern void* un_803FD274[];
 /* 3FD28C */ extern char un_803FD28C[];
 /* 3FD29C */ extern char un_803FD29C[];
 /* 3FD2AC */ extern char un_803FD2AC[];
@@ -176,7 +176,7 @@
 /* 4D590C */ extern s32 un_804D590C;
 /* 4D5910 */ extern s32 un_804D5910;
 
-/* 4D5990 */ extern char un_804D5990[];
+/* 4D5990 */ extern SDATA char un_804D5990[];
 
 /// .bss (extern)
 /* 45A6C0 */ extern u8 gmMainLib_8045A6C0[];
@@ -584,11 +584,12 @@ s32 un_80300410(s32 arg0)
     if (arg0 == 1) {
         u8* dst;
         lbAudioAx_80024030(1);
-        dst = &gmMainLib_8045A6C0[un_803FA128.x220 + 0x1868];
-        dst[0] = un_803FA128.x224;
-        dst[1] = un_803FA128.x225;
-        dst[2] = un_803FA128.x226;
-        dst[3] = un_803FA128.x227;
+        dst = gmMainLib_8045A6C0;
+        dst += un_803FA128.x220;
+        dst[0x1868] = un_803FA128.x224;
+        dst[0x1869] = un_803FA128.x225;
+        dst[0x186A] = un_803FA128.x226;
+        dst[0x186B] = un_803FA128.x227;
     }
     return 0;
 }
@@ -1413,7 +1414,7 @@ int un_80301964(int arg0)
 
             gobj = GObj_Create(0xE, 0xF, 0);
             GObj_SetupGXLink(gobj, HSD_SObjLib_803A49E0, 0x12, 0);
-            un_803FD274 = un_804D6E04;
+            un_803FD274[0] = un_804D6E04;
             sobj =
                 HSD_SObjLib_803A477C(gobj, (int) un_804D5990, 0, 0, 0x80, 0);
             sobj->x10 = un_804DDC4C;

--- a/src/melee/it/itcoll.c
+++ b/src/melee/it/itcoll.c
@@ -621,6 +621,8 @@ void it_802706D0(Item_GObj* arg_item_gobj)
 {
     Item* arg_item;
     HSD_GObj* item_gobj;
+    Item* item;
+    HitCapsule* hit;
     s32 count;
     bool chk;
     u32 hit_index;
@@ -631,7 +633,7 @@ void it_802706D0(Item_GObj* arg_item_gobj)
     for (item_gobj = HSD_GObj_Entities->items; item_gobj != NULL;
          item_gobj = item_gobj->next)
     {
-        Item* item = item_gobj->user_data;
+        item = item_gobj->user_data;
         if (arg_item_gobj == item_gobj) {
             chk = true;
         } else if (((arg_item->owner == NULL) && (item->owner == NULL) &&
@@ -650,7 +652,7 @@ void it_802706D0(Item_GObj* arg_item_gobj)
             count = it_802706D0_sub2(item, arg_item);
         }
         for (hit_index = 0; hit_index < 4; hit_index++) {
-            HitCapsule* hit = &item->x5D4_hitboxes[hit_index].hit;
+            hit = &item->x5D4_hitboxes[hit_index].hit;
             if ((hit->state == HitCapsule_Disabled) || (hit->x42_b7 != 1) ||
                 ((!hit->x40_b2 || (arg_item->ground_or_air != GA_Air)) &&
                  (!hit->x40_b3 || (arg_item->ground_or_air != GA_Ground))) ||
@@ -798,7 +800,7 @@ void it_80270E30(Item_GObj* arg_item_gobj)
                     hit2 = var_r29->x8;
                     arg_item2 = arg_item_gobj->user_data;
                     hurt_coll_pos = &hit2->hurt_coll_pos;
-                    element = *(&it_803F1384[hit2->element]);
+                    element = it_803F1384[hit2->element];
                     switch (element) {
                     case 0x3E8:
                         efSync_Spawn(0x3E8, arg_item_gobj, hurt_coll_pos,

--- a/src/melee/it/items/itarwinglaser.c
+++ b/src/melee/it/items/itarwinglaser.c
@@ -251,7 +251,9 @@ void it_802E7654(Item_GObj* owner, HSD_JObj* bone, Vec3* target, s32 type,
 
     lb_8000B1CC(bone, NULL, &sp28);
     spawn.kind = It_Kind_Arwing_Laser;
-    spawn.prev_pos = sp28;
+    *(u32*) &spawn.prev_pos.x = *(u32*) &sp28.x;
+    *(u32*) &spawn.prev_pos.y = *(u32*) &sp28.y;
+    *(u32*) &spawn.prev_pos.z = *(u32*) &sp28.z;
     *(u32*) &spawn.prev_pos.y = *(u32*) &sp28.y;
     spawn.facing_dir = 0.0f;
     spawn.x3C_damage = 0;

--- a/src/melee/it/items/itdosei.c
+++ b/src/melee/it/items/itdosei.c
@@ -343,7 +343,8 @@ static inline void itDosei_SetupWalk_FC(Item_GObj* gobj)
     ip->owner = NULL;
     it_802762B0(ip);
     Item_80268E5C(gobj, 1, 0xB);
-    itDosei_SetSpeed(gobj, ip, 1.0f);
+    ip->x5D0_animFrameSpeed = 1.0f;
+    lb_8000BA0C(jobj, 1.0f);
     {
         HSD_JObj* j = gobj->hsd_obj;
         itDosei_SetRotX(j, 0.0f);
@@ -359,6 +360,7 @@ static inline void itDosei_SetupWalk_FC(Item_GObj* gobj)
 bool itDosei_UnkMotion2_Coll(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
+    PAD_STACK(16);
     it_8026D62C(gobj, it_80282074);
     if (ip->xDD4_itemVar.dosei.xDD8 == 2) {
         itDosei_SetupWalk_FC(gobj);
@@ -653,6 +655,7 @@ void itDosei_UnkMotion9_Phys(Item_GObj* gobj) {}
 bool itDosei_UnkMotion9_Coll(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
+    PAD_STACK(16);
     it_8026D62C(gobj, it_80282074);
     if (ip->xDD4_itemVar.dosei.xDD8 == 2) {
         f32 frame = ip->x5CC_currentAnimFrame;

--- a/src/melee/it/items/itkusudama.c
+++ b/src/melee/it/items/itkusudama.c
@@ -171,8 +171,8 @@ void it_80289BE8(Item_GObj* gobj, s32 arg1, s32 arg2, s32 arg3)
     Vec3 vel;
     itKusudamaAttributes* attr;
     Item* ip = GET_ITEM(gobj);
-    s32 count;
     int i;
+    s32 count;
     PAD_STACK(8);
 
     attr = ip->xC4_article_data->x4_specialAttributes;

--- a/src/melee/it/items/itkyasarin.c
+++ b/src/melee/it/items/itkyasarin.c
@@ -521,9 +521,11 @@ bool it_802EDDC0(Item_GObj* gobj)
         ip->x5D0_animFrameSpeed = attr->x24;
         itKyasarin_TurnAround(gobj);
     } else {
-        Item* ip = GET_ITEM(gobj);
-        if (ip->xDD4_itemVar.kyasarin.x20 != NULL) {
-            grInishie2_801FD4CC(ip->xDD4_itemVar.kyasarin.x20);
+        {
+            Item* ip = GET_ITEM(gobj);
+            if (ip->xDD4_itemVar.kyasarin.x20 != NULL) {
+                grInishie2_801FD4CC(ip->xDD4_itemVar.kyasarin.x20);
+            }
         }
         ip->xDCC_flag.b3 = 1;
         if (HSD_Randf() < it_804D6D40->x8) {

--- a/src/melee/it/items/itlinkarrow.c
+++ b/src/melee/it/items/itlinkarrow.c
@@ -421,7 +421,7 @@ static void inline itLinkarrow_UnkMotion1_Anim_inline(HSD_GObj* gobj, int i,
     Item* item;
     HSD_JObj* jobj;
     item = GET_ITEM(gobj);
-    jobj = HSD_GObjGetHSDObj(gobj);
+    jobj = gobj->hsd_obj;
     if (item->xDD4_itemVar.linkarrow.xB4[i] != NULL) {
         it_80272A18(item->xDD4_itemVar.linkarrow.xB4[i]);
         HSD_JObjSetTranslateWithMtxDirty(item->xDD4_itemVar.linkarrow.xB4[i],
@@ -460,6 +460,7 @@ bool itLinkarrow_UnkMotion1_Anim(HSD_GObj* gobj)
     u8 _pad[4];
     Vec3 scale1;
     Vec3 scale2;
+    PAD_STACK(16);
     {
         HSD_JObj* jobj = HSD_GObjGetHSDObj(gobj);
         scale.x = scale.y = scale.z = ip->xDD4_itemVar.linkarrow.xC0;

--- a/src/melee/it/items/itlinkboomerang.c
+++ b/src/melee/it/items/itlinkboomerang.c
@@ -215,7 +215,7 @@ HSD_GObj* it_802A013C(f32 facing_dir, Fighter_GObj* owner_gobj, Vec3* pos,
                 anim_bundle = &attrs->x4C_anim;
             } else {
                 joint = attrs->x48;
-                anim_bundle = &attrs->x58_anim;
+                anim_bundle = (AnimBundle*) &attrs->x50_matanim;
             }
             jobj = HSD_JObjLoadJoint(joint);
             HSD_JObjAddAnimAll(jobj, anim_bundle->anim, anim_bundle->matanim,
@@ -708,14 +708,16 @@ void it_802A1948(Item_GObj* gobj, s32 arg1)
 void it_802A19E0(Item_GObj* gobj)
 {
     HSD_JObj* hobj;
+    HSD_JObj* hobj_tmp;
     HSD_JObj* child;
     Item* ip;
     itLinkBoomerangAttributes* attrs;
     Quaternion quat;
     s32 i;
 
-    hobj = gobj->hsd_obj;
-    child = HSD_JObjGetChild(hobj);
+    hobj_tmp = gobj->hsd_obj;
+    hobj = hobj_tmp;
+    child = HSD_JObjGetChild(hobj_tmp);
     ip = gobj->user_data;
     attrs = ip->xC4_article_data->x4_specialAttributes;
     HSD_JObjGetRotation(child, &quat);

--- a/src/melee/it/items/itlinkhookshot.c
+++ b/src/melee/it/items/itlinkhookshot.c
@@ -242,7 +242,7 @@ HSD_JObj* it_802A2568(Item* arg0, HSD_JObj* arg1, s32 arg2, f32 arg8)
             mpColl_80041EE4(temp_r18);
             temp_r18->x34_flags.b1234 = 5;
             mpColl_SetECBSource_Fixed(temp_r18, NULL, arg8, arg8, arg8, arg8);
-            HSD_GObjObject_80390A70(temp_r3_2, (u8) HSD_GObj_804D7849,
+            HSD_GObjObject_80390A70(temp_r3_2, HSD_GObj_804D7849,
                                     it_link_get_joint(arg0, var_r31));
             GObj_SetupGXLink(temp_r3_2, it_802A24A0, 6U, 0U);
         } else if (var_r31 == (s32) (attr->x2C - 1)) {
@@ -266,7 +266,7 @@ HSD_JObj* it_802A2568(Item* arg0, HSD_JObj* arg1, s32 arg2, f32 arg8)
             mpColl_80041EE4(temp_r21);
             temp_r21->x34_flags.b1234 = 5;
             mpColl_SetECBSource_Fixed(temp_r21, NULL, arg8, arg8, arg8, arg8);
-            HSD_GObjObject_80390A70(temp_r3_2, (u8) HSD_GObj_804D7849,
+            HSD_GObjObject_80390A70(temp_r3_2, HSD_GObj_804D7849,
                                     it_link_get_joint_c(arg0));
             GObj_SetupGXLink(temp_r3_2, HSD_GObj_JObjCallback, 6U, 0U);
             var_r21 = temp_r3_2->hsd_obj;
@@ -280,9 +280,9 @@ HSD_JObj* it_802A2568(Item* arg0, HSD_JObj* arg1, s32 arg2, f32 arg8)
             temp_r3_3->gobj = temp_r3_2;
             temp_r3_3->vel = pos;
             temp_r3_3->pos = pos;
-            temp_r3_3->x2C_b0 = 1;
-            temp_r3_3->x2C_b1 = 1;
-            temp_r3_3->x2C_b2 = 1;
+            temp_r3_3->x2C_b0 = 0;
+            temp_r3_3->x2C_b1 = 0;
+            temp_r3_3->x2C_b2 = 0;
             // it_802A43B8(temp_r3_3);
             temp_r3_3->coll_data.cur_pos = temp_r3_3->pos;
             temp_r3_3->coll_data.last_pos = temp_r3_3->coll_data.cur_pos;
@@ -290,7 +290,7 @@ HSD_JObj* it_802A2568(Item* arg0, HSD_JObj* arg1, s32 arg2, f32 arg8)
             mpColl_80041EE4(temp_r17);
             temp_r17->x34_flags.b1234 = 5;
             mpColl_SetECBSource_Fixed(temp_r17, NULL, arg8, arg8, arg8, arg8);
-            HSD_GObjObject_80390A70(temp_r3_2, (u8) HSD_GObj_804D7849,
+            HSD_GObjObject_80390A70(temp_r3_2, HSD_GObj_804D7849,
                                     it_link_get_joint(arg0, var_r31));
             GObj_SetupGXLink(temp_r3_2, it_802A24A0, 6U, 0U);
         }
@@ -756,17 +756,17 @@ void itLinkhookshot_UnkMotion6_Phys(Item_GObj* arg0)
 void it_802A3828(Item_GObj* gobj)
 {
     Item* item = GET_ITEM(gobj);
-    Fighter* fp = GET_FIGHTER(item->owner);
     itLinkHookshotAttributes* attr =
         item->xC4_article_data->x4_specialAttributes;
-    ftLk_DatAttrs* lk_attr = fp->dat_attrs;
+    Fighter* fp = GET_FIGHTER(item->owner);
     ItemLink* item_link = item->xDD4_itemVar.linkhookshot.x4;
+    ftLk_DatAttrs* lk_attr = fp->dat_attrs;
     Vec3 pos;
     u8 _padA[16];
     Mtx m;
     u8 _padB[4];
-    f32 temp_f30;
     f32 temp_f31;
+    f32 temp_f30;
 
     it_802A2EE4_inline((MtxPtr) &m, item_link, &pos);
 
@@ -790,7 +790,7 @@ void it_802A3828(Item_GObj* gobj)
     } else {
         fp->cur_pos.x = pos.x + temp_f31;
         fp->cur_pos.y = pos.y + temp_f30;
-        it_802A7168(item, &pos, fp->x34_scale.y);
+        it_802A7384(item, &pos, fp->x34_scale.y);
         if (fp->ground_or_air != 1) {
             it_802A77DC(gobj);
         }
@@ -1403,7 +1403,8 @@ void it_802A5770_inline(ItemLink* link_1, itLinkHookshotAttributes* arg2,
                         Fighter* arg3, s32 var_r29)
 {
     if (var_r29 == arg2->x2C / 2) {
-        it_802A3E50(link_1, arg3->kind, arg2->x30);
+        f32 width = arg2->x30;
+        it_802A3E50(link_1, arg3->kind, width);
     } else {
         it_802A40D0(link_1, arg2->x30);
     }
@@ -2072,14 +2073,14 @@ void it_802A7384(Item* item, Vec3* arg1, f32 arg8)
     jobj = link->gobj->hsd_obj;
     cur_pos = link->pos;
     HSD_JObjSetTranslate(jobj, &cur_pos);
-    if (fp->facing_dir > 0.0f) {
-        dir.x = 1.0f;
-        dir.y = 0.0f;
-        dir.z = 0.0f;
+    if (fp->facing_dir > (f64) 0.0F) {
+        dir.x = 1.0F;
+        dir.y = 0.0F;
+        dir.z = 0.0F;
     } else {
-        dir.x = -1.0f;
-        dir.y = 0.0f;
-        dir.z = 0.0f;
+        dir.x = -1.0F;
+        dir.y = 0.0F;
+        dir.z = 0.0F;
     }
     it_802A6F80(jobj, &cur_pos, &dir, arg8);
 }
@@ -2218,6 +2219,25 @@ void it_802A7AF0(HSD_GObj* arg0)
     }
 }
 
+static inline void it_802A7B34_6944_inline(Item* item)
+{
+    Mtx m;
+    f32 zero = 0.0F;
+    HSD_JObj* jobj;
+    ItemLink* item_link = item->xDD4_itemVar.linkhookshot.x0;
+    jobj = item_link->gobj->hsd_obj;
+
+    HSD_JObjSetupMatrix(item_link->jobj);
+    PSMTXIdentity(m);
+    m[0][3] = zero;
+    m[1][3] = zero;
+    m[2][3] = it_804D6D48;
+    PSMTXConcat(item_link->jobj->mtx, m, m);
+    HSD_JObjCopyMtx(jobj, m);
+    jobj->flags |= 0x03800000;
+    HSD_JObjSetMtxDirty(jobj);
+}
+
 void it_802A7B34(HSD_GObj* arg0)
 {
     Vec3 vec;
@@ -2233,7 +2253,7 @@ void it_802A7B34(HSD_GObj* arg0)
         it_802A2EE4_inline_alt(item_link, &vec);
 
         if (it_802A6A78(item_link, &vec, attr, fp) != 0) {
-            it_802A6944(item, fp->x34_scale.y);
+            it_802A7B34_6944_inline(item);
         } else {
             it_802A7168(item, &vec, fp->x34_scale.y);
         }

--- a/src/melee/it/items/itmewtwoshadowball.c
+++ b/src/melee/it/items/itmewtwoshadowball.c
@@ -248,7 +248,7 @@ void it_802C53F0(Item_GObj* gobj, Vec3* pos, float angle, float charge,
     ip->xDD4_itemVar.mewtwoshadowball.x18 = charge;
     ip->xDD4_itemVar.mewtwoshadowball.x1C = max_charge;
 
-    if (ip->xDD4_itemVar.mewtwoshadowball.x2C != NULL &&
+    if (NULL != ip->xDD4_itemVar.mewtwoshadowball.x2C &&
         ip->owner == ip->xDD4_itemVar.mewtwoshadowball.x2C)
     {
         it_802C5B18(gobj);

--- a/src/melee/it/items/itsamusgrapple.c
+++ b/src/melee/it/items/itsamusgrapple.c
@@ -141,8 +141,10 @@ void it_802B7160(Fighter_GObj* gobj, itSamusGrapple_HitboxData* data)
 
     fp = GET_FIGHTER(gobj);
     hit_group = data->create_hitbox.create_hitbox_0.hit_group;
-    hitbox = &fp->x914[data->create_hitbox.create_hitbox_0.id];
-    if (hitbox->state == HitCapsule_Disabled || hitbox->x4 != hit_group) {
+    if (((hitbox = &fp->x914[data->create_hitbox.create_hitbox_0.id])->state ==
+         HitCapsule_Disabled) ||
+        hitbox->x4 != hit_group)
+    {
         hitbox->x4 = hit_group;
         hitbox->state = HitCapsule_Enabled;
         fp->x2219_b3 = 1;
@@ -543,11 +545,10 @@ void itSamusgrapple_UnkMotion0_Phys(Item_GObj* gobj)
 void fn_802B805C(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
-    Fighter* fp = ip->owner->user_data;
-    itSamusGrappleAttributes* attrs =
-        ip->xC4_article_data->x4_specialAttributes;
+    Fighter_GObj* owner;
+    itSamusGrappleAttributes* attrs;
     ItemLink* link;
-    Fighter* fp2;
+    Fighter* fp;
     Vec3 pos;
     Vec3 normal;
     Vec3 pos2;
@@ -555,11 +556,13 @@ void fn_802B805C(Item_GObj* gobj)
     Mtx m;
     PAD_STACK(28);
 
-    fp2 = fp;
-    samus_grapple_state_sync(fp2);
+    owner = ip->owner;
+    attrs = ip->xC4_article_data->x4_specialAttributes;
+    fp = owner->user_data;
+    samus_grapple_state_sync(fp);
 
     link = ip->xDD4_itemVar.samusgrapple.x0;
-    if (!samus_grapple_fighter_compare(fp2->motion_id) &&
+    if (!samus_grapple_fighter_compare(fp->motion_id) &&
         !(link->next->x2C_b0))
     {
         it_802B7B84(gobj);
@@ -570,7 +573,7 @@ void fn_802B805C(Item_GObj* gobj)
 
     switch (it_802B9328(link, &pos, attrs, ip->owner->user_data)) {
     case 1:
-        if (fp2->motion_id == 0x165) {
+        if (fp->motion_id == 0x165) {
             ftCo_800C3CC0(ip->owner);
             it_802BAB40(gobj);
             {
@@ -580,14 +583,14 @@ void fn_802B805C(Item_GObj* gobj)
                     HSD_GObj* link_gobj =
                         ip->xDD4_itemVar.samusgrapple.x0->gobj;
                     efSync_Spawn(0x41C, link_gobj, &pos2, link2);
-                    efSync_Spawn(0x3F1, link_gobj, &pos2, &fp2->facing_dir);
+                    efSync_Spawn(0x3F1, link_gobj, &pos2, &fp->facing_dir);
                 }
             }
             return;
         }
         link->vel.x *= -attrs->x0;
         it_802BAA08(gobj);
-        ftCommon_8007E2F4(fp2, 0);
+        ftCommon_8007E2F4(fp, 0);
         break;
     case 2: {
         normal = link->coll_data.floor.normal;
@@ -595,15 +598,15 @@ void fn_802B805C(Item_GObj* gobj)
         lbVector_Mirror(&link->vel, &normal);
         link->vel.y *= attrs->x0;
         it_802BAA08(gobj);
-        ftCommon_8007E2F4(fp2, 0);
+        ftCommon_8007E2F4(fp, 0);
         break;
     }
     case 3:
         it_802BA9B8(gobj);
-        ftCommon_8007E2F4(fp2, 0);
+        ftCommon_8007E2F4(fp, 0);
         break;
     }
-    it_802A7168(ip, &pos, fp2->x34_scale.y);
+    it_802A7168(ip, &pos, fp->x34_scale.y);
     samus_grapple_anim(gobj);
 }
 
@@ -814,42 +817,46 @@ void itSamusgrapple_UnkMotion6_Phys(Item_GObj* gobj)
 void fn_802B8B54(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
-    Fighter* fp = ip->owner->user_data;
     itSamusGrappleAttributes* attrs =
         ip->xC4_article_data->x4_specialAttributes;
-    ItemLink* link = ip->xDD4_itemVar.samusgrapple.x4;
+    Fighter* fp = ip->owner->user_data;
+    ItemLink* link;
     Vec3 pos;
-    ftSs_DatAttrs* da = fp->dat_attrs;
+    ftSs_DatAttrs* da;
+    Fighter* fp2;
     u8 _pad[4];
     f32 dx, dy;
     u8 _pad2[24];
     Mtx m;
     PAD_STACK(28);
 
+    da = fp->dat_attrs;
+    link = ip->xDD4_itemVar.samusgrapple.x4;
+    fp2 = fp;
     samus_grapple_setup_pos(link, &pos, m);
-    dx = fp->cur_pos.x - pos.x;
-    dy = fp->cur_pos.y - pos.y;
+    dx = fp2->cur_pos.x - pos.x;
+    dy = fp2->cur_pos.y - pos.y;
 
     if (it_802BA3BC(ip->xDD4_itemVar.samusgrapple.x4,
                     ip->xDD4_itemVar.samusgrapple.x0, &pos, attrs,
                     attrs->x4C) != 0)
     {
-        fp->cur_pos.x = pos.x + dx;
-        fp->cur_pos.y = pos.y + dy;
+        fp2->cur_pos.x = pos.x + dx;
+        fp2->cur_pos.y = pos.y + dy;
         if (ftCo_800C3A14(ip->owner) && ft_80082E3C(ip->owner) == NULL) {
             ftCliffCommon_80081370(ip->owner);
         } else {
-            fp->self_vel.x = 0.0f;
+            fp2->self_vel.x = 0.0f;
             ftCo_8009B390(ip->owner, da->xCC);
         }
         it_802B7B84(gobj);
         return;
     }
-    fp->cur_pos.x = pos.x + dx;
-    fp->cur_pos.y = pos.y + dy;
-    it_802A7168(ip, &pos, fp->x34_scale.y);
+    fp2->cur_pos.x = pos.x + dx;
+    fp2->cur_pos.y = pos.y + dy;
+    it_802A7168(ip, &pos, fp2->x34_scale.y);
     samus_grapple_anim(gobj);
-    if (fp->ground_or_air != GA_Air) {
+    if (fp2->ground_or_air != GA_Air) {
         it_802BAA58(gobj);
     }
 }
@@ -997,6 +1004,7 @@ void it_802B91C4(ItemLink* link, Vec3* pos, itSamusGrappleAttributes* attrs,
 static inline void it_802B9328_attach(ItemLink* link, Mtx m)
 {
     Vec3 pos;
+    PAD_STACK(0xE4);
 
     PSMTXIdentity(m);
     HSD_JObjSetupMatrix(link->jobj);

--- a/src/melee/it/items/itsamusmissile.c
+++ b/src/melee/it/items/itsamusmissile.c
@@ -152,12 +152,14 @@ void it_802B64FC(Item_GObj* gobj)
         goto block_4;
     }
     temp_ret = it_8026C258(&ip->pos, ip->facing_dir);
-    // var_f1 = M2C_BITWISE(f32, temp_ret);
     temp_r3 = temp_ret;
     if (temp_r3 == NULL) {
-        goto block_18;
+        goto block_17;
     }
     it_8026BB88(temp_r3, &vec3);
+    goto block_4;
+block_17:
+    goto block_18;
 block_4:
     var_f1 = 0.0f;
     if (vec3.x != 0.0f) {
@@ -182,7 +184,7 @@ block_6:
     vec0 = vec1;
     lbVector_Sub(&vec0, &vec2);
     if ((vec0.y > 0.001f)) {
-        ip->xDD4_itemVar.samusmissile.x8 -= M2C_FIELD(sa, f32*, 0x18);
+        ip->xDD4_itemVar.samusmissile.x8 -= sa->x18;
         goto block_11;
     }
     if (!(vec0.y < 0.001f)) {
@@ -193,7 +195,6 @@ block_11:
     itSamusMissile_ClampTurn(ip, sa);
 block_18:
     return;
-    // return M2C_BITWISE(Item_GObj*, var_f1);
 }
 
 void* it_802B66A8(Item_GObj* gobj)

--- a/src/melee/it/items/itseakneedlethrown.c
+++ b/src/melee/it/items/itseakneedlethrown.c
@@ -22,6 +22,25 @@
 #include <MSL/math.h>
 #include <MSL/trigf.h>
 
+itSeakNeedleThrownData it_803F6F50 = {
+    {
+        { 0, NULL, NULL, NULL },
+        { 1, NULL, NULL, NULL },
+        { 2, NULL, NULL, NULL },
+        { 3, NULL, NULL, NULL },
+        { 4, NULL, NULL, NULL },
+    },
+    { -2.0f, -2.1f, -2.2f, -2.3f, -2.4f, -2.5f, -2.6f, -2.7f },
+    { -0.1f, -0.12f, -0.14f, -0.18f, -0.2f, -0.22f, -0.24f, -0.26f },
+    { 0.20943952f, 0.2443461f, 0.27925268f, 0.31415927f, 0.34906584f,
+      0.38397244f, 0.41887903f, 0.4537856f },
+    { 0.0f, 0.2f, 0.4f, 0.6f, 0.8f, 1.0f, 1.2f, 1.4f },
+    { -2.0f, -2.1f, -2.2f, -2.3f, -2.4f, -2.5f, -2.6f, -2.7f },
+    { -0.1f, -0.12f, -0.14f, -0.18f, -0.2f, -0.22f, -0.24f, -0.26f },
+    { 0.5235988f, 0.61086524f, 0.6981317f, 0.7853982f, 0.87266463f,
+      0.9599311f, 1.0471976f, 1.134464f },
+};
+
 Item_GObj* it_802AFD8C(Item_GObj* parent, Vec3* pos, u32 kind,
                        float facing_dir)
 {
@@ -328,9 +347,9 @@ bool itSeakneedlethrown_UnkMotion0_Coll(Item_GObj* gobj)
 bool itSeakneedlethrown_UnkMotion1_Coll(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
+    itSeakNeedleThrownData* data = &it_803F6F50;
     itSeakNeedleThrownAttributes* attr =
         ip->xC4_article_data->x4_specialAttributes;
-    itSeakNeedleThrownData* data = &it_803F6F50;
     if (itSeakNeedleThrown_CheckGroundHit(gobj)) {
         it_80275158(gobj, attr->x4);
         ip->x40_vel.y = ABS(ip->x40_vel.y);
@@ -529,9 +548,9 @@ bool it_2725_Logic109_HitShield(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
     itSeakNeedleThrownData* data = &it_803F6F50;
-    itSeakNeedleThrownAttributes* attr =
-        ip->xC4_article_data->x4_specialAttributes;
+    itSeakNeedleThrownAttributes* attr;
 
+    attr = ip->xC4_article_data->x4_specialAttributes;
     if (HSD_Randi(3) == 0) {
         it_80272560(gobj, 0);
         it_80275158(gobj, attr->x4);

--- a/src/melee/it/itspawn.c
+++ b/src/melee/it/itspawn.c
@@ -203,7 +203,7 @@ void fn_8026C88C(HSD_GObj* gobj)
                     spawn.x3C_damage = 0;
                     spawn.vel.x = spawn.vel.y = spawn.vel.z = 0.0F;
                     spawn.x0_parent_gobj = NULL;
-                    spawn.x4_parent_gobj2 = NULL;
+                    spawn.x4_parent_gobj2 = spawn.x0_parent_gobj;
                     spawn.x44_flag.b0 = 1;
                     spawn.x40 = 0;
                     chk = true;
@@ -219,10 +219,9 @@ void fn_8026C88C(HSD_GObj* gobj)
                 }
             } ///< @todo Make a FLT_RAND(min, max) define or inline
             {
-                s32* temp_r29 =
-                    ((s32*) it_804D6D28) + (gm_8016AE80() * 2) + 0x3F;
+                s32* range = &it_804D6D28->xFC[gm_8016AE80() * 2];
                 f32 randf = HSD_Randf();
-                *alloc_x0 = (temp_r29[1] - temp_r29[0]) * randf + temp_r29[0];
+                *alloc_x0 = (range[1] - range[0]) * randf + range[0];
                 *alloc_x0 *= Ground_801C2AE8(Stage_80225194());
             }
         }

--- a/src/melee/lb/lb_00F9.c
+++ b/src/melee/lb/lb_00F9.c
@@ -1237,7 +1237,7 @@ int lb_80011E24(HSD_JObj* root, HSD_JObj** result, ...)
                         break;
                     }
                     if (HSD_JObjGetNext(HSD_JObjGetParent(saved)) != NULL) {
-                        next_node = HSD_JObjGetNext(HSD_JObjGetParent(saved));
+                        next_node = saved = HSD_JObjGetNext(HSD_JObjGetParent(saved));
                         break;
                     }
                     saved = HSD_JObjGetParent(saved);
@@ -1717,8 +1717,8 @@ void fn_80013614(HSD_GObj* gobj)
     struct CameraBlurData* data = gobj->user_data;
     Mtx view_mtx;
     Mtx view_mtx2;
-    GXTexObj tex_obj;
     GXColor color;
+    GXTexObj tex_obj;
     PAD_STACK(16);
 
     if (data->x18 != NULL) {
@@ -1727,14 +1727,23 @@ void fn_80013614(HSD_GObj* gobj)
 
     if (data->x12 == 1) {
         HSD_CObj* cobj = (HSD_CObj*) gobj->hsd_obj;
-        f32 alpha = data->x20;
-        u8 x11 = data->x11;
-        u8 x10 = data->x10;
-        f32 xC = data->xC;
-        f32 x8 = data->x8;
-        f32 x4 = data->x4;
-        f32 x0 = data->x0;
-        HSD_ImageDesc* image = data->x1C;
+        HSD_ImageDesc* image;
+        f32 x0;
+        f32 x4;
+        f32 x8;
+        f32 xC;
+        u8 x10;
+        u8 x11;
+        f32 alpha;
+
+        alpha = data->x20;
+        x11 = data->x11;
+        x10 = data->x10;
+        xC = data->xC;
+        x8 = data->x8;
+        x4 = data->x4;
+        x0 = data->x0;
+        image = data->x1C;
 
         HSD_CObjSetCurrent(cobj);
         HSD_StateSetZMode(0, 7, 0);
@@ -1754,14 +1763,21 @@ void fn_80013614(HSD_GObj* gobj)
         lb_80012994(image, x10, x11, x0, x4, x8, xC, alpha);
     } else {
         HSD_CObj* cobj = (HSD_CObj*) gobj->hsd_obj;
-        u8 x10 = data->x10;
-        f32 xC = data->xC;
-        f32 x8 = data->x8;
-        f32 x4 = data->x4;
-        f32 x0 = data->x0;
-        HSD_ImageDesc* image = data->x1C;
+        HSD_ImageDesc* image;
+        f32 x0;
+        f32 x4;
+        f32 x8;
+        f32 xC;
+        u8 x10;
         u16 width;
         u16 height;
+
+        x10 = data->x10;
+        xC = data->xC;
+        x8 = data->x8;
+        x4 = data->x4;
+        x0 = data->x0;
+        image = data->x1C;
 
         HSD_CObjSetCurrent(cobj);
         HSD_StateSetZMode(0, 7, 0);

--- a/src/melee/lb/lbaudio_ax.c
+++ b/src/melee/lb/lbaudio_ax.c
@@ -1265,162 +1265,212 @@ ret_true:
 bool fn_800253D8(HSD_GObj* gobj)
 {
     lbAudioAx_UserData* ud;
+    s32 target;
+    s32 current;
+    s32 end_frame;
+    s32 current_frame;
+    s32 result;
+    f32 f_result;
 
-    if (gobj != NULL) {
-        ud = gobj->user_data;
-        if (ud != NULL) {
-            if (ud->x3C == 1.0f) {
-                int end_frame = ud->end_frame;
-                int cur_frame = ud->current_frame;
-                int pan_right = ud->pan_right;
-                int pan_left = ud->pan_left;
-                int result;
-                float val;
-
-                if (cur_frame > end_frame) {
-                    cur_frame = end_frame;
-                }
-                if (pan_left != pan_right) {
-                    if (pan_left <= pan_right) {
-                        val = (float) pan_left +
-                              ((float) cur_frame *
-                               ((float) pan_right - (float) pan_left)) /
-                                  (float) end_frame;
-                    } else {
-                        val = (float) pan_right +
-                              ((float) cur_frame *
-                               ((float) pan_left - (float) pan_right)) /
-                                  (float) end_frame;
-                    }
-                    if (val < 0.0f) {
-                        val = 0.0f;
-                    }
-                    if (val > 127.0f) {
-                        val = 127.0f;
-                    }
-                    result = (int) val;
-                } else {
-                    result = 0x40;
-                }
-                ud->x2C.pan = result;
-            } else {
-                int end_frame = ud->end_frame;
-                int cur_frame = ud->current_frame;
-                int pan_right = ud->pan_right;
-                int pan_left = ud->pan_left;
-                int result;
-                float val;
-
-                if (cur_frame > end_frame) {
-                    cur_frame = end_frame;
-                }
-                if (pan_left != pan_right) {
-                    if (pan_left <= pan_right) {
-                        val = (float) pan_left +
-                              ((float) cur_frame *
-                               ((float) pan_right - (float) pan_left)) /
-                                  (float) end_frame;
-                    } else {
-                        val = (float) pan_right +
-                              ((float) cur_frame *
-                               ((float) pan_left - (float) pan_right)) /
-                                  (float) end_frame;
-                    }
-                    if (val < 0.0f) {
-                        val = 0.0f;
-                    }
-                    if (val > 127.0f) {
-                        val = 127.0f;
-                    }
-                    result = (int) val;
-                } else {
-                    result = 0x40;
-                }
-                ud->x2C.pan = 0x7F - result;
-            }
-        }
+    if (gobj == NULL) {
+        goto end;
     }
+
+    gobj = gobj->user_data;
+    if (gobj == NULL) {
+        goto end;
+    }
+    ud = (lbAudioAx_UserData*) gobj;
+
+    if (ud->x3C == 1.0f) {
+        end_frame = ud->end_frame;
+        current_frame = ud->current_frame;
+        if (ud && ud) {
+        }
+        target = ud->pan_right;
+        current = ud->pan_left;
+
+        if (current_frame > end_frame) {
+            current_frame = end_frame;
+        }
+
+        if (ud->pan_left != target) {
+            if (current <= target) {
+                f_result =
+                    (f32) current +
+                    ((f32) current_frame * ((f32) target - (f32) current)) /
+                        (f32) end_frame;
+            } else {
+                f_result =
+                    (f32) target +
+                    ((f32) current_frame * ((f32) current - (f32) target)) /
+                        (f32) end_frame;
+            }
+            if (f_result < 0.0f) {
+                f_result = 0.0f;
+            }
+            if (f_result > 127.0f) {
+                f_result = 127.0f;
+            }
+            result = (s32) f_result;
+        } else {
+            result = 0x40;
+        }
+
+        ud->x2C.pan = result;
+    } else {
+        s32 target2;
+        s32 current2;
+        s32 end_frame2;
+        s32 current_frame2;
+        s32 result2;
+        f32 f_result2;
+
+        end_frame2 = ud->end_frame;
+        current_frame2 = ud->current_frame;
+        if (ud && ud) {
+        }
+        target2 = ud->pan_right;
+        current2 = ud->pan_left;
+
+        if (current_frame2 > end_frame2) {
+            current_frame2 = end_frame2;
+        }
+
+        if (ud->pan_left != target2) {
+            if (current2 <= target2) {
+                f_result2 =
+                    (f32) current2 +
+                    ((f32) current_frame2 *
+                     ((f32) target2 - (f32) current2)) /
+                        (f32) end_frame2;
+            } else {
+                f_result2 =
+                    (f32) target2 +
+                    ((f32) current_frame2 *
+                     ((f32) current2 - (f32) target2)) /
+                        (f32) end_frame2;
+            }
+            if (f_result2 < 0.0f) {
+                f_result2 = 0.0f;
+            }
+            if (f_result2 > 127.0f) {
+                f_result2 = 127.0f;
+            }
+            result2 = (s32) f_result2;
+        } else {
+            result2 = 0x40;
+        }
+
+        ud->x2C.pan = 0x7F - result2;
+    }
+end:
     return false;
 }
 
 bool fn_800256BC(HSD_GObj* gobj)
 {
     lbAudioAx_UserData* ud;
+    s32 target;
+    s32 current;
+    s32 end_frame;
+    s32 current_frame;
+    s32 result;
+    f32 f_result;
 
-    if (gobj != NULL) {
-        ud = gobj->user_data;
-        if (ud != NULL) {
-            if (ud->x3C == 1.0f) {
-                int end_frame = ud->end_frame;
-                int cur_frame = ud->current_frame;
-                int pan_right = ud->pan_right;
-                int pan_left = ud->pan_left;
-                int result;
-                float val;
-
-                if (cur_frame > end_frame) {
-                    cur_frame = end_frame;
-                }
-                if (pan_left != pan_right) {
-                    if (pan_left <= pan_right) {
-                        val = (float) pan_left +
-                              ((float) cur_frame *
-                               ((float) pan_right - (float) pan_left)) /
-                                  (float) end_frame;
-                    } else {
-                        val = (float) pan_right +
-                              ((float) cur_frame *
-                               ((float) pan_left - (float) pan_right)) /
-                                  (float) end_frame;
-                    }
-                    if (val < 0.0f) {
-                        val = 0.0f;
-                    }
-                    if (val > 127.0f) {
-                        val = 127.0f;
-                    }
-                    result = (int) val;
-                } else {
-                    result = 0x40;
-                }
-                ud->x2C.pan = result;
-            } else {
-                int end_frame = ud->end_frame;
-                int cur_frame = ud->current_frame;
-                int pan_right = ud->pan_right;
-                int pan_left = ud->pan_left;
-                int result;
-                float val;
-
-                if (cur_frame > end_frame) {
-                    cur_frame = end_frame;
-                }
-                if (pan_left != pan_right) {
-                    if (pan_left <= pan_right) {
-                        val = (float) pan_left +
-                              ((float) cur_frame *
-                               ((float) pan_right - (float) pan_left)) /
-                                  (float) end_frame;
-                    } else {
-                        val = (float) pan_right +
-                              ((float) cur_frame *
-                               ((float) pan_left - (float) pan_right)) /
-                                  (float) end_frame;
-                    }
-                    if (val < 0.0f) {
-                        val = 0.0f;
-                    }
-                    if (val > 127.0f) {
-                        val = 127.0f;
-                    }
-                    result = (int) val;
-                } else {
-                    result = 0x40;
-                }
-                ud->x2C.pan = 0x7F - result;
-            }
-        }
+    if (gobj == NULL) {
+        goto end;
     }
+
+    gobj = gobj->user_data;
+    if (gobj == NULL) {
+        goto end;
+    }
+    ud = (lbAudioAx_UserData*) gobj;
+
+    if (ud->x3C == 1.0f) {
+        end_frame = ud->end_frame;
+        current_frame = ud->current_frame;
+        if (ud && ud) {
+        }
+        target = ud->pan_right;
+        current = ud->pan_left;
+
+        if (current_frame > end_frame) {
+            current_frame = end_frame;
+        }
+
+        if (ud->pan_left != target) {
+            if (current <= target) {
+                f_result =
+                    (f32) current +
+                    ((f32) current_frame * ((f32) target - (f32) current)) /
+                        (f32) end_frame;
+            } else {
+                f_result =
+                    (f32) target +
+                    ((f32) current_frame * ((f32) current - (f32) target)) /
+                        (f32) end_frame;
+            }
+            if (f_result < 0.0f) {
+                f_result = 0.0f;
+            }
+            if (f_result > 127.0f) {
+                f_result = 127.0f;
+            }
+            result = (s32) f_result;
+        } else {
+            result = 0x40;
+        }
+
+        ud->x2C.pan = result;
+    } else {
+        s32 target2;
+        s32 current2;
+        s32 end_frame2;
+        s32 current_frame2;
+        s32 result2;
+        f32 f_result2;
+
+        end_frame2 = ud->end_frame;
+        current_frame2 = ud->current_frame;
+        if (ud && ud) {
+        }
+        target2 = ud->pan_right;
+        current2 = ud->pan_left;
+
+        if (current_frame2 > end_frame2) {
+            current_frame2 = end_frame2;
+        }
+
+        if (ud->pan_left != target2) {
+            if (current2 <= target2) {
+                f_result2 =
+                    (f32) current2 +
+                    ((f32) current_frame2 *
+                     ((f32) target2 - (f32) current2)) /
+                        (f32) end_frame2;
+            } else {
+                f_result2 =
+                    (f32) target2 +
+                    ((f32) current_frame2 *
+                     ((f32) current2 - (f32) target2)) /
+                        (f32) end_frame2;
+            }
+            if (f_result2 < 0.0f) {
+                f_result2 = 0.0f;
+            }
+            if (f_result2 > 127.0f) {
+                f_result2 = 127.0f;
+            }
+            result2 = (s32) f_result2;
+        } else {
+            result2 = 0x40;
+        }
+
+        ud->x2C.pan = 0x7F - result2;
+    }
+end:
     return false;
 }
 
@@ -2446,7 +2496,7 @@ s32 lbAudioAx_8002785C(void)
         result = lbAudioAx_80026E84(Player_GetPlayerCharacter(0));
         for (i = 0; i < 3; i++) {
             if ((s8) gm_80169370(i) != (s8) CHKIND_MAX) {
-                s8 opp = (s8) gm_80169370(i);
+                s32 opp = (s8) gm_80169370(i);
                 result |= lbAudioAx_80026E84(opp);
                 if (opp == 4) {
                     result |= 0x200004000ULL;
@@ -2472,7 +2522,7 @@ s32 lbAudioAx_8002785C(void)
     lbl_804D38D8 = (s32) s32_arr_803BB6B0[Stage_8022519C(stage)][1];
     result |= lbAudioAx_80026EBC(stage);
 
-    if (result != 0) {
+    if (result) {
         lbAudioAx_80026F2C(0xC);
         lbAudioAx_8002702C(0xC, result);
         lbAudioAx_80027168();

--- a/src/melee/lb/lbbgflash.c
+++ b/src/melee/lb/lbbgflash.c
@@ -586,11 +586,10 @@ void lbBgFlash_80020E38(HSD_JObj* jobj, Vec3* dir, f32 max_angle,
     f32 dy = dir->y;
     f32 dz = dir->z;
     f32 mag_sq;
-    f32 len;
     f32 angle;
-    f32 z_col_z;
     f32 z_col_y;
     f32 z_col_x;
+    f32 z_col_z;
     f32 dx2 = dx * dx;
     f32 dy2 = dy * dy;
     f32 dz2 = dz * dz;
@@ -601,24 +600,23 @@ void lbBgFlash_80020E38(HSD_JObj* jobj, Vec3* dir, f32 max_angle,
 
     HSD_JObjSetupMatrix(jobj);
 
-    z_col_x = jobj->mtx[0][2];
     z_col_y = jobj->mtx[1][2];
+    z_col_x = jobj->mtx[0][2];
     z_col_z = jobj->mtx[2][2];
-    mag_sq = z_col_x * z_col_x;
-    mag_sq = z_col_y * z_col_y + mag_sq;
+    mag_sq = z_col_y * z_col_y;
+    mag_sq = z_col_x * z_col_x + mag_sq;
     mag_sq = z_col_z * z_col_z + mag_sq;
-    len = mag_sq;
     if (mag_sq > 0.0f) {
         f64 e = __frsqrte(mag_sq);
         e = 0.5 * e * -(((f64) mag_sq * (e * e)) - 3.0);
         e = 0.5 * e * -(((f64) mag_sq * (e * e)) - 3.0);
         e = 0.5 * e * -(((f64) mag_sq * (e * e)) - 3.0);
         tmp = (f32) ((f64) mag_sq * e);
-        len = tmp;
+        mag_sq = tmp;
     }
 
-    if (len != 0.0f) {
-        angle = atan2f(-dir->x * (z_col_z / len), dir->y);
+    if (mag_sq != 0.0f) {
+        angle = atan2f(-dir->x * (z_col_z / mag_sq), dir->y);
 
         if (angle > max_angle) {
             angle = max_angle;

--- a/src/melee/lb/lbdvd.c
+++ b/src/melee/lb/lbdvd.c
@@ -407,7 +407,7 @@ struct lbDvd_803B72C0_t {
     int x8;
 };
 
-static void inline1(void)
+static inline void inline1(void)
 {
     struct lbDvd_803B72C0_t spA0 = { 2, "LbRb.dat" };
     if (preloadCache.new_scene.is_heap_persistent[0]) {
@@ -419,7 +419,7 @@ static void inline1(void)
     }
 }
 
-static void inline2(void)
+static inline void inline2(void)
 {
     int i;
     int temp_r3_6;
@@ -471,7 +471,7 @@ void lbDvd_80018254(void)
     struct lbDvd_803B72C0_t* var_r26;
     int i;
 
-    u8 _[0x18];
+    PAD_STACK(0x18);
 
     if (memcmp(&preloadCache.new_scene, &preloadCache.scene,
                sizeof(PreloadCacheScene)) == 0)

--- a/src/melee/lb/lbmthp.c
+++ b/src/melee/lb/lbmthp.c
@@ -125,8 +125,8 @@ s32 fn_8001EB14(THPDecComp* data, const char* path)
 s32 fn_8001EBF0(THPDecComp* data)
 {
     s32 size = 0;
-    u32 aligned_100;
     u32 unk_104_val;
+    u32 aligned_100;
     u32 width;
     u32 height;
     u32 wh;
@@ -196,7 +196,7 @@ void fn_8001ECF4(THPDecComp* data, void* buf)
     width = data->width;
     height = data->height;
     data->frame_buffers = (u32*) buf;
-    y_size = width * height;
+    y_size = height * width;
     count = data->unk_104;
     data->unk_64 = 0;
     uv_size = y_size >> 2U;

--- a/src/melee/lb/lbrefract.c
+++ b/src/melee/lb/lbrefract.c
@@ -111,9 +111,10 @@ extern float MSL_TrigF_80400770[], MSL_TrigF_80400774[];
 void lbRefract_80021CE8(void* arg0, s32 arg1)
 {
     lbRefract_CallbackData* cb = arg0;
+    u32 param_idx;
     u32 col, row;
     f32 x_step, y_step;
-    f32 x, y, y_sq;
+    f32 y, x, y_sq;
     f32 dist_sq;
     f32 dist;
     f32 param0;
@@ -123,6 +124,7 @@ void lbRefract_80021CE8(void* arg0, s32 arg1)
 
     PAD_STACK(20);
 
+    param_idx = arg1 * 2;
     x_step = 2.0f / (f32) (u32) (cb->width - 1);
     y_step = 2.0f / (f32) (u32) (cb->height - 1);
     y = -1.0f;
@@ -146,7 +148,7 @@ void lbRefract_80021CE8(void* arg0, s32 arg1)
                 dist = 1.0f;
             }
             params = *(f32**) (lbl_804D63E8 + 4);
-            param0 = params[arg1 * 2];
+            param0 = params[param_idx];
             if (param0 != 0.0f) {
                 f32 rem;
                 if (__fabsf(param0) > __fabsf(dist)) {
@@ -159,7 +161,7 @@ void lbRefract_80021CE8(void* arg0, s32 arg1)
                 param0 = dist;
             }
             params = *(f32**) (lbl_804D63E8 + 4);
-            param0 *= params[arg1 * 2 + 1];
+            param0 *= params[param_idx + 1];
             if (param0 > 1.0f) {
                 param0 = 1.0f;
             }

--- a/src/melee/mn/mncharsel.c
+++ b/src/melee/mn/mncharsel.c
@@ -4142,8 +4142,8 @@ s32 mnCharSel_802640A0(void)
     }
 
     gobj = GObj_Create(2, 3, 0x80);
-    mnCharSel_804D6CB8 = gobj;
     MenMain_cam = MODELS->cam;
+    mnCharSel_804D6CB8 = gobj;
     HSD_GObjObject_80390A70(gobj, HSD_GObj_804D784B,
                             HSD_CObjLoadDesc(MODELS->cam));
     GObj_SetupGXLinkMax(gobj, HSD_GObj_803910D8, 0);
@@ -4955,7 +4955,7 @@ s32 mnCharSel_802640A0(void)
 #undef MODELS
 #undef ANIM
 
-static u8 data_pad[0x138] = { 0 };
+static u8 data_pad[0x18] = { 0 };
 
 void mnCharSel_8026688C_OnEnter(void* arg0)
 {

--- a/src/melee/mn/mndatadel.c
+++ b/src/melee/mn/mndatadel.c
@@ -160,18 +160,15 @@ void mnDataDel_8024EBC8(HSD_JObj* root, u8 unused, u8 a, u8 b)
 /// @brief animates the warning modal
 void fn_8024ECCC(HSD_GObj* arg0)
 {
+    struct WarnCmnData* data;
     HSD_JObj* root;
     HSD_JObj* panel;
-    HSD_JObj* exclaim;
-    HSD_JObj* cursor_no;
-    HSD_JObj* cursor_yes;
     u8 _pad[10];
     f32 curr_frame;
     HSD_Text* text;
     s32 sis_id;
     u8 visible;
     u8 cursor_idx;
-    struct WarnCmnData* data;
     PAD_STACK(16);
 
     root = GET_JOBJ(arg0);
@@ -182,6 +179,7 @@ void fn_8024ECCC(HSD_GObj* arg0)
         if ((mnDataDel_803EF8A0.start_frame <= curr_frame) &&
             (curr_frame < mnDataDel_803EF8A0.end_frame))
         {
+            HSD_JObj* exclaim;
             curr_frame = mn_8022EFD8(panel, &mnDataDel_803EF8A0);
             lb_80011E24(root, &exclaim, WARN_JOINT_EXCLAIM, -1);
             mn_8022EFD8(exclaim, &mnDataDel_803EF8A0);
@@ -205,6 +203,8 @@ void fn_8024ECCC(HSD_GObj* arg0)
                 HSD_SisLib_803A6368(text, sis_id);
             }
         } else {
+            HSD_JObj* cursor_no;
+            HSD_JObj* cursor_yes;
             cursor_idx = data->cursor_idx;
             lb_80011E24(root, &cursor_yes, WARN_JOINT_CURSOR_YES, -1);
             lb_80011E24(root, &cursor_no, WARN_JOINT_CURSOR_NO, -1);
@@ -233,9 +233,6 @@ void mnDataDel_8024EEC0(void)
     HSD_JObj* no;
     HSD_JObj* yes;
     HSD_JObj* root;
-    f32 no_pos;
-    f32 yes_pos;
-    s32 is_english;
     s32 cursor;
     HSD_GObj* wrn_modal;
     struct WarnCmnData* data;
@@ -268,14 +265,15 @@ void mnDataDel_8024EEC0(void)
     HSD_JObjAnimAll(yes);
     HSD_JObjAnimAll(no);
 
-    is_english = lbLang_IsSavedLanguageUS();
-    if (is_english != false) {
+    if (lbLang_IsSavedLanguageUS() != false) {
         lb_80011E24(root, &cursor_yes, WARN_JOINT_CURSOR_YES, -1);
         lb_80011E24(root, &cursor_no, WARN_JOINT_CURSOR_NO, -1);
-        yes_pos = HSD_JObjGetTranslationX(cursor_yes);
-        no_pos = HSD_JObjGetTranslationX(cursor_no);
-        HSD_JObjSetTranslateX(cursor_yes, no_pos);
-        HSD_JObjSetTranslateX(cursor_no, yes_pos);
+        {
+            f32 yes_pos = HSD_JObjGetTranslationX(cursor_yes);
+            f32 no_pos = HSD_JObjGetTranslationX(cursor_no);
+            HSD_JObjSetTranslateX(cursor_yes, no_pos);
+            HSD_JObjSetTranslateX(cursor_no, yes_pos);
+        }
     }
 }
 
@@ -674,6 +672,7 @@ void mnDataDel_8024FE4C(u8 arg0)
     u16 sis_id;
     u8 is_enabled;
     struct MnDataDelGObjUserData* user_data;
+    PAD_STACK(0x18);
 
     gobj = GObj_Create(6U, 7U, 0x80U);
     mnDataDel_804D6C68 = gobj;
@@ -708,8 +707,8 @@ void mnDataDel_8024FE4C(u8 arg0)
         HSD_JObjReqAnimAll(joint, (f32) i);
         HSD_JObjAnimAll(joint);
         HSD_JObjAddChild(user_data->x10[mnDataDel_803EF8AC[i]], joint);
-        mnDataDel_8024EBC8(joint, i, user_data->x0 == i, 1U);
-        is_enabled = ((u8*) &user_data->x3)[i];
+        mnDataDel_8024EBC8(joint, i, i == user_data->x0, 1U);
+        is_enabled = user_data->x3[i];
         lb_80011E24(joint, &child, 1, -1);
         frame = mn_8022F298(child);
         if (is_enabled != 0) {

--- a/src/melee/mn/mndiagram.c
+++ b/src/melee/mn/mndiagram.c
@@ -1496,7 +1496,7 @@ inline void mnDiagram_FormatPopupNumber(char* buf, u32 val)
 void mnDiagram_80240D94(void* arg0, s32 arg1, s32 arg2, s32 arg3)
 {
     mnDiagram_PopupData* data = ((HSD_GObj*) arg0)->user_data;
-    mnDiagram_AnimTable* tbl;
+    mnDiagram_AnimTable* tbl = (mnDiagram_AnimTable*) &mnDiagram_803EE728;
     Point3d pos;
     char buf[8];
     u32 kos;
@@ -1504,7 +1504,6 @@ void mnDiagram_80240D94(void* arg0, s32 arg1, s32 arg2, s32 arg3)
 
     HSD_Text* text = HSD_SisLib_803A6754(0, 1);
     PAD_STACK(24);
-    tbl = (mnDiagram_AnimTable*) &mnDiagram_803EE728;
     data->text[0] = text;
     lb_8000B1CC(data->jobjs[8], &tbl->points[0], &pos);
     text->font_size.x = 0.0521f;

--- a/src/melee/mn/mndiagram.c
+++ b/src/melee/mn/mndiagram.c
@@ -1496,7 +1496,7 @@ inline void mnDiagram_FormatPopupNumber(char* buf, u32 val)
 void mnDiagram_80240D94(void* arg0, s32 arg1, s32 arg2, s32 arg3)
 {
     mnDiagram_PopupData* data = ((HSD_GObj*) arg0)->user_data;
-    mnDiagram_AnimTable* tbl = (mnDiagram_AnimTable*) &mnDiagram_803EE728;
+    mnDiagram_AnimTable* tbl;
     Point3d pos;
     char buf[8];
     u32 kos;
@@ -1504,6 +1504,7 @@ void mnDiagram_80240D94(void* arg0, s32 arg1, s32 arg2, s32 arg3)
 
     HSD_Text* text = HSD_SisLib_803A6754(0, 1);
     PAD_STACK(24);
+    tbl = (mnDiagram_AnimTable*) &mnDiagram_803EE728;
     data->text[0] = text;
     lb_8000B1CC(data->jobjs[8], &tbl->points[0], &pos);
     text->font_size.x = 0.0521f;
@@ -1652,7 +1653,7 @@ void mnDiagram_80241310(s32 arg0, s32 arg1, s32 arg2)
     HSD_JObjReqAnimAll(jobj, 0.0f);
     HSD_JObjAnimAll(jobj);
 
-    user_data = HSD_MemAlloc(sizeof(mnDiagram_PopupData));
+    user_data = HSD_MemAlloc(sizeof(mnDiagram_PopupData) - sizeof(HSD_Text*));
     HSD_ASSERTREPORT(0x5F8, user_data, "Can't get user_data\n");
 
     GObj_InitUserData(gobj, 0, mnDiagram_PopupCleanup, user_data);
@@ -1977,8 +1978,10 @@ void mnDiagram_OnFrame(HSD_GObj* gobj)
     Diagram* data = gobj->user_data;
     Diagram* data2;
     HSD_GObjProc* proc;
-    u8 col_idx;
+    HSD_JObj* jobj;
+    f32 anim_frame;
     s32 row_idx;
+    u8 col_idx;
     int count;
     PAD_STACK(8);
 
@@ -1997,10 +2000,10 @@ void mnDiagram_OnFrame(HSD_GObj* gobj)
     }
 
     if (data->anim_state == 1) {
-        if (mn_8022ED6C(data->jobjs[1], &mnDiagram_803EE768) >=
-            mnDiagram_803EE768.end_frame)
-        {
-            HSD_JObjClearFlagsAll(data->jobjs[2], 0x10);
+        anim_frame = mn_8022ED6C(data->jobjs[1], &mnDiagram_803EE768);
+        jobj = data->jobjs[2];
+        if (anim_frame >= mnDiagram_803EE768.end_frame) {
+            HSD_JObjClearFlagsAll(jobj, 0x10);
             data->anim_state = 0;
             mnDiagram_802433AC();
             if (data->is_name_mode != 0) {
@@ -2037,7 +2040,7 @@ void mnDiagram_OnFrame(HSD_GObj* gobj)
             }
             mnDiagram_UpdateScrollArrowVisibility(gobj, count);
         } else {
-            HSD_JObjSetFlagsAll(data->jobjs[2], 0x10);
+            HSD_JObjSetFlagsAll(jobj, 0x10);
         }
     }
     mnDiagram_802417D0(gobj);

--- a/src/melee/mn/mnitemsw.c
+++ b/src/melee/mn/mnitemsw.c
@@ -309,13 +309,13 @@ HSD_JObj* mnItemSw_8023405C(MnItemSwData* data, u8 idx)
 
 void mnItemSw_80234104(HSD_GObj* gobj)
 {
-    MnItemSwData* data = gobj->user_data;
     HSD_JObj* sp38;
     u8* order;
     s32 i;
     u8 cursor;
     HSD_JObj* cjobj;
     f32 y_spacing;
+    MnItemSwData* data = gobj->user_data;
 
     HSD_JObjClearFlagsAll(data->jobjs[4], 0x10);
     HSD_JObjClearFlagsAll(data->jobjs[6], 0x10);
@@ -367,14 +367,14 @@ void mnItemSw_80234104(HSD_GObj* gobj)
 
 void mnItemSw_8023453C(HSD_GObj* gobj, u8 arg1, u8 arg2)
 {
-    MnItemSwData* data = gobj->user_data;
-    struct MnItemSwTable* tbl = &mnItemSw_803ED340;
-    HSD_JObj* sp44;
     s32 sp40;
+    HSD_JObj* sp44;
     HSD_JObj* sp3C;
     f32 anim_val;
     u8 new_cursor;
     HSD_JObj* cjobj;
+    MnItemSwData* data = gobj->user_data;
+    struct MnItemSwTable* tbl = &mnItemSw_803ED340;
 
     if (arg1 != 0) {
         u8 old_cursor = data->cursor;
@@ -502,13 +502,13 @@ void mnItemSw_8023453C(HSD_GObj* gobj, u8 arg1, u8 arg2)
 void fn_80234C24(HSD_GObj* gobj)
 {
     MnItemSwData* data;
+    struct MnItemSwTable* tbl = &mnItemSw_803ED340;
     f32* anims;
     HSD_JObj* jobj;
     HSD_Text* text;
     s32 menu_changed;
     s32 hovered_changed;
     s32 confirmed_changed;
-    struct MnItemSwTable* tbl = &mnItemSw_803ED340;
 
     PAD_STACK(0x18);
 

--- a/src/melee/mn/mnmain.c
+++ b/src/melee/mn/mnmain.c
@@ -1016,8 +1016,9 @@ void mn_8022A440(HSD_GObj* gp, HSD_JObj* root, MainMenuSelection selection)
     mn_8022F3D8(r29, 0x12, TOBJ_MASK);
     mn_8022F3D8(r29, 0x13, TOBJ_MASK);
     HSD_JObjAnim(r29);
-    f = (mn_8022F298(sp24[0]) - mn_803EB360[1].start_frame);
-    HSD_JObjReqAnimAll(sp24[0], f + mn_803EB360[0].start_frame);
+    f = mn_8022F298(sp24[0]);
+    HSD_JObjReqAnimAll(sp24[0], (f - mn_803EB360[1].start_frame) +
+                                     mn_803EB360[0].start_frame);
     HSD_JObjAnimAll(sp24[0]);
     mn_8022F298(sp24[2]);
     HSD_JObjReqAnimAll(sp24[2], mn_803EB378[0].start_frame);
@@ -1217,19 +1218,20 @@ void fn_8022AF10(HSD_GObj* gp)
 void fn_8022AFEC(HSD_GObj* gp)
 {
     /// @todo figure out the inlines
+    AnimLoopSettings* anim_loop;
+    HSD_JObj* jobj;
     MainMenuData* data;
     MainMenuData* data2;
     HSD_GObjProc* think;
     bool selection_changed;
-    HSD_JObj* jobj;
     HSD_JObj* temp_jobj;
     u8 var_r26;
-    AnimLoopSettings* anim_loop;
     MainMenuSelection hovered_selection;
     u8 state;
     u8 option_count;
+    u8 pad[0x20];
     HSD_JObj* sp20[4];
-    PAD_STACK(50);
+    PAD_STACK(18);
 
     var_r26 = 0;
     selection_changed = false;
@@ -1637,9 +1639,9 @@ void fn_8022BDB4(HSD_GObj* gobj, int unused)
 
 HSD_GObj* mn_8022BE34(void)
 {
-    Vec3 pos;
     HSD_GObj* gobj = GObj_Create(2, 3, 0x80);
     HSD_CObj* cobj;
+    Vec3 pos;
 
     mn_804D6BAC = gobj;
     cobj = HSD_CObjLoadDesc(MenMain_cam);

--- a/src/melee/mn/mnname.c
+++ b/src/melee/mn/mnname.c
@@ -1406,9 +1406,9 @@ void mnName_8023A290(void)
 
 HSD_GObj* mnName_8023A59C(u8 arg0)
 {
+    HSD_JObj* root_jobj;
     char* base = (char*) &mnName_803ED538;
     HSD_GObj* gobj;
-    HSD_JObj* root_jobj;
     MnName_GObj* user_data;
     HSD_JObj* jobj5;
     MnNameArchive* archive = &mnName_804A06E0;

--- a/src/melee/mn/mnnamenew.c
+++ b/src/melee/mn/mnnamenew.c
@@ -49,7 +49,7 @@ extern u8 mn_804D6BB4;
 extern u8 mn_804D6BB5;
 extern u8 mnNameNew_804D4F7C[4];
 extern char mnNameNew_SpaceCharacter[2];
-extern GlyphRow* mnNameNew_803EDCE4;
+extern GlyphRow mnNameNew_803EDCE4[];
 extern void* mnNameNew_804A06F0[];
 extern void* mnNameNew_804A0700[];
 extern void* mnNameNew_804A0710[];
@@ -592,7 +592,7 @@ void mnNameNew_GlyphVariantInput(void)
     u16 old_hover;
     u8 old_sel;
     u8 cur_pos;
-    GlyphRow* table;
+    char** table;
     s32 total;
     s8 null_ch;
 
@@ -639,8 +639,8 @@ void mnNameNew_GlyphVariantInput(void)
             return;
         }
         null_ch = (s8) mnNameNew_NullCharacter;
-        table = &mnNameNew_803EDCE4[data->x1 * 4];
-        while (null_ch != (s8) * **table) {
+        table = (char**) &mnNameNew_803EDCE4[data->x1];
+        while (null_ch != (s8) **table) {
             table++;
             count++;
         }

--- a/src/melee/mn/mnsnap.c
+++ b/src/melee/mn/mnsnap.c
@@ -876,8 +876,11 @@ void fn_802545C4(void)
             HSD_JObjReqAnim(mnSnap_804A0A10.dlg_pos,
                             (f32) (9 - mnSnap_804A0A10.dlg_timer));
             HSD_JObjAnim(mnSnap_804A0A10.dlg_pos);
-            mnSnap_804A0A10.dlg_text->pos_x =
-                HSD_JObjGetTranslationX(mnSnap_804A0A10.dlg_pos) - 6.0F;
+            jobj = mnSnap_804A0A10.dlg_pos;
+            if (jobj == NULL) {
+                __assert("jobj.h", 0x3E1, "jobj");
+            }
+            mnSnap_804A0A10.dlg_text->pos_x = jobj->translate.x - 6.0F;
         }
     }
     state = mnSnap_804A0A10.state;

--- a/src/melee/mn/mnsnap.c
+++ b/src/melee/mn/mnsnap.c
@@ -876,11 +876,8 @@ void fn_802545C4(void)
             HSD_JObjReqAnim(mnSnap_804A0A10.dlg_pos,
                             (f32) (9 - mnSnap_804A0A10.dlg_timer));
             HSD_JObjAnim(mnSnap_804A0A10.dlg_pos);
-            jobj = mnSnap_804A0A10.dlg_pos;
-            if (jobj == NULL) {
-                __assert("jobj.h", 0x3E1, "jobj");
-            }
-            mnSnap_804A0A10.dlg_text->pos_x = jobj->translate.x - 6.0F;
+            mnSnap_804A0A10.dlg_text->pos_x =
+                HSD_JObjGetTranslationX(mnSnap_804A0A10.dlg_pos) - 6.0F;
         }
     }
     state = mnSnap_804A0A10.state;

--- a/src/melee/mn/mnsound.c
+++ b/src/melee/mn/mnsound.c
@@ -35,9 +35,9 @@ static void mnSound_VolumeAnim(HSD_JObj* jobj, s32 sound_music_mix,
 {
     Vec3 pos_0;
     Vec3 pos_1;
-    HSD_JObj* jobj_anim_2;
-    HSD_JObj* jobj_anim_1;
     HSD_JObj* jobj_anim_0;
+    HSD_JObj* jobj_anim_1;
+    HSD_JObj* jobj_anim_2;
     lb_80011E24(jobj, &jobj_anim_0, 6, -1);
     lb_80011E24(jobj, &jobj_anim_1, 3, -1);
     lb_80011E24(jobj, &jobj_anim_2, 4, -1);
@@ -102,9 +102,8 @@ void mnSound_802492CC(HSD_GObj* gobj)
         }
         {
             Menu* menu = GET_MENU(mnSound_804D6C30);
-            HSD_Text* text = menu->text;
-            if (text != NULL) {
-                HSD_SisLib_803A5CC4(text);
+            if (menu->text != NULL) {
+                HSD_SisLib_803A5CC4(menu->text);
             }
             Menu_InitCenterText(menu, (menu->unk2 == 0) ? 0xBB : 0xBC);
         }
@@ -206,7 +205,7 @@ void mnSound_80249C08(int unused)
 {
     HSD_GObj* gobj = GObj_Create(HSD_GOBJ_CLASS_ITEM, 7U, 0x80U);
     HSD_JObj* jobj;
-    Menu* menu;
+    Menu* user_data;
     HSD_GObjProc* proc;
     PAD_STACK(24);
     mnSound_804D6C30 = gobj;
@@ -217,31 +216,27 @@ void mnSound_80249C08(int unused)
                        mnSound_804A08A8.matanim_joint,
                        mnSound_804A08A8.shapeanim_joint);
     HSD_JObjReqAnimAll(jobj, 0.0F);
-    menu = HSD_MemAlloc(8);
-    if (menu == NULL) {
-        OSReport("Can't get user_data.\n");
-        __assert("mnsound.c", 0x22CU, "user_data");
-    }
+    user_data = HSD_MemAlloc(8);
+    HSD_ASSERTREPORT(0x22CU, user_data, "Can't get user_data.\n");
     gmMainLib_8015CC34();
-    menu->cursor = 0x14;
-    menu->unk1 = lbAudioAx_80024BD0();
-    menu->unk2 = 0U;
-    menu->unk3 = gmMainLib_8015ED74();
-    menu->text = NULL;
-    GObj_InitUserData(gobj, 0U, HSD_Free, menu);
+    user_data->cursor = 0x14;
+    user_data->unk1 = lbAudioAx_80024BD0();
+    user_data->unk2 = 0U;
+    user_data->unk3 = gmMainLib_8015ED74();
+    user_data->text = NULL;
+    GObj_InitUserData(gobj, 0U, HSD_Free, user_data);
     proc = HSD_GObj_SetupProc(gobj, fn_80249A1C, 0U);
     proc->flags_3 = HSD_GObj_804D783C;
 
     {
         Menu* menu = GET_MENU(mnSound_804D6C30);
-        HSD_Text* text = menu->text;
-        if (text != NULL) {
-            HSD_SisLib_803A5CC4(text);
+        if (menu->text != NULL) {
+            HSD_SisLib_803A5CC4(menu->text);
         }
         Menu_InitCenterText(menu, (menu->unk2 == 0) ? 0xBB : 0xBC);
     }
 
-    mnSound_ChannelAnim(GET_JOBJ(gobj), menu->unk1);
+    mnSound_ChannelAnim(GET_JOBJ(gobj), user_data->unk1);
 
     {
         HSD_JObj* sp5C;
@@ -250,16 +245,16 @@ void mnSound_80249C08(int unused)
         HSD_JObjAnimAll(sp5C);
     }
 
-    mnSound_VolumeAnim(GET_JOBJ(gobj), menu->unk3, -1);
+    mnSound_VolumeAnim(GET_JOBJ(gobj), user_data->unk3, -1);
 
     {
         HSD_JObj* sp64;
         HSD_JObj* sp60;
-        gm_801602C0(menu->unk3);
+        gm_801602C0(user_data->unk3);
         lb_80011E24(jobj, &sp64, 0xE, -1);
-        mn_8022ED6C(sp64, &mnSound_803EEED8[menu->unk2 + 1]);
+        mn_8022ED6C(sp64, &mnSound_803EEED8[user_data->unk2 + 1]);
         lb_80011E24(jobj, &sp60, 0xB, -1);
-        HSD_JObjReqAnimAll(sp60, mnSound_803EEED8[menu->unk1 + 4].start_frame);
+        HSD_JObjReqAnimAll(sp60, mnSound_803EEED8[user_data->unk1 + 4].start_frame);
         HSD_JObjAnimAll(sp60);
         HSD_JObjSetFlagsAll(jobj, 0x10U);
     }

--- a/src/melee/mp/mpcoll.c
+++ b/src/melee/mp/mpcoll.c
@@ -2167,14 +2167,14 @@ bool mpColl_80046224_LeftWall(CollData* coll)
 
         line_id = mpLineNextNonLeftWall(wall_id);
         if (line_id != -1 && mpLib_80054ED8(line_id) &&
-            mpLineGetKind(line_id) & CollLine_Ceiling)
+            (mpLineGetKind(line_id) & CollLine_Ceiling))
         {
             Vec3 vec;
             mpLeftWallGetTop(wall_id, &vec);
             if (pos.y > vec.y) {
                 line_id = mpLinePrevNonCeiling(line_id);
                 if (line_id != -1 && mpLib_80054ED8(line_id) &&
-                    mpLineGetKind(line_id) & CollLine_LeftWall)
+                    (mpLineGetKind(line_id) & CollLine_LeftWall))
                 {
                     Vec3 nrm;
                     PAD_STACK(0x44);

--- a/src/melee/mp/mplib.c
+++ b/src/melee/mp/mplib.c
@@ -920,7 +920,7 @@ void mpLibLoad(MapCollData* coll_data)
 
     count = coll_data->floor_count;
     start = coll_data->floor_start;
-    while (count-- > 0) {
+    for (; count > 0; count--) {
         groundCollLine[start].flags =
             coll_data->lines[start].hi_flags | LINE_FLAG_ENABLED;
         groundCollLine[start].x0 = &coll_data->lines[start];
@@ -1582,6 +1582,7 @@ bool mpCheckFloor(float ax, float ay, float bx, float by, float y_offset,
     int i_r28;
     bool result_r27;
     bool already_checked;
+    PAD_STACK(8);
 
     result_r27 = false;
     min_dist2_f30 = F32_MAX;
@@ -5947,8 +5948,7 @@ void mpLib_DrawSnapping(void)
         }
     }
 
-    item_r28 = HSD_GObj_Entities->items;
-    if (item_r28 != NULL) {
+    if ((item_r28 = HSD_GObj_Entities->items) != NULL) {
         if (!var_r31) {
             Mtx sp7C;
             PAD_STACK(0x40);

--- a/src/melee/pl/plbonus.c
+++ b/src/melee/pl/plbonus.c
@@ -572,7 +572,10 @@ void fn_80039618(int player)
     {
         int hit_count = 0;
         for (i = 1; i < 100; i++) {
-            if (hit_counts[i] != 0 && i >= 0x11 && i <= 0x30) {
+            if (hit_counts[i] != 0) {
+                if (i < 0x11 || i > 0x30) {
+                    goto skip_hit_count;
+                }
                 hit_count++;
             }
         }
@@ -583,6 +586,7 @@ void fn_80039618(int player)
                 setFlag(player, 0x17);
             }
         }
+    skip_hit_count:;
     }
     if (hits_total != 0) {
         if (pl_CalculateAverage(stats->x56C, hits_total) >= pl_804D6470->x8) {

--- a/src/melee/pl/pltrick.c
+++ b/src/melee/pl/pltrick.c
@@ -222,12 +222,14 @@ void pl_80038144(HSD_GObj* attacker_gobj, HSD_GObj* victim_gobj, s32 x18d4_int,
     s32 h_player;
     s32 x18d4_x3;
     s32 var_r0;
+    volatile s32 x18d4_word;
     union Struct2070 ev;
     union Struct2070 ev_reload;
     union Struct2070 ev_best;
     union Struct2070 ev_hits;
     PAD_STACK(16);
 
+    x18d4_word = x18d4_int;
     if (attacker_gobj != NULL) {
         attacker_fp = GET_FIGHTER(attacker_gobj);
     } else {
@@ -236,7 +238,7 @@ void pl_80038144(HSD_GObj* attacker_gobj, HSD_GObj* victim_gobj, s32 x18d4_int,
 
     victim_fp = GET_FIGHTER(victim_gobj);
     attacked_from_behind = 0;
-    ev.x2070_int = x18d4_int;
+    ev.x2070_int = x18d4_word;
 
     if (attacker_fp != NULL && ev.x2073 != 0) {
         f32 facing_dir = victim_fp->facing_dir;
@@ -338,9 +340,10 @@ void pl_80038144(HSD_GObj* attacker_gobj, HSD_GObj* victim_gobj, s32 x18d4_int,
                 pl_8003ED0C(attacker_fp->player_id, attacker_fp->x221F_b4,
                             victim_fp->player_id, victim_fp->x221F_b4,
                             victim_fp->dmg.x1830_percent);
+                x18d4_x3 = ev_data->xC;
                 pl_8003EA40(attacker_fp->player_id, attacker_fp->x221F_b4,
                             victim_fp->player_id, victim_fp->x221F_b4,
-                            ev_data->xC);
+                            x18d4_x3);
                 pl_800403FC(attacker_fp->player_id, attacker_fp->x221F_b4,
                             victim_fp->player_id, victim_fp->x221F_b4,
                             victim_fp->dmg.x18d4.x3);

--- a/src/melee/ty/toy.c
+++ b/src/melee/ty/toy.c
@@ -2105,25 +2105,28 @@ void fn_80307E84(HSD_GObj* gobj)
 void un_80307F64(s32 arg0, s32 arg1)
 {
     s8 idx;
+    s32 kind = arg0;
     char* data;
+    s32* base;
     ToyAnimState* state;
     HSD_JObj* jobj1;
     HSD_JObj* jobj2;
 
     data = un_803FDD18;
-    state = (ToyAnimState*) ((u8*) un_804A26B8 + 0x3F0);
+    base = (s32*) un_804A26B8;
+    state = (ToyAnimState*) ((u8*) base + 0x3F0);
     idx = state->x0E;
-    jobj1 = state->jobj[idx];
-    jobj2 = state->jobj[idx ^ 1];
+    jobj1 = (HSD_JObj*) base[idx + (0x3F4 / 4)];
+    jobj2 = (HSD_JObj*) base[(idx ^ 1) + (0x3F4 / 4)];
 
     if (state->x0F == 0) {
         if (arg1 != 0) {
-            if (arg0 != state->x11) {
+            if (kind != state->x11) {
                 HSD_JObjRemoveAnimAll(jobj1);
                 HSD_JObjRemoveAnimAll(jobj2);
-                state->x11 = arg0;
-                state->x10 = arg0;
-                if (arg0 == 1) {
+                state->x11 = kind;
+                state->x10 = kind;
+                if (kind == 1) {
                     un_80306A48(jobj1, 0, data + 0x438, 0, un_804D6EC8, 0);
                     un_80306A48(jobj2, 0, data + 0x438, 0, un_804D6EC8, 0);
                 } else {
@@ -2136,7 +2139,7 @@ void un_80307F64(s32 arg0, s32 arg1)
                 HSD_GObj_80390CD4(state->gobj);
             }
         } else {
-            if (arg0 == 1) {
+            if (kind == 1) {
                 un_80306A48(jobj1, 0, data + 0x438, 0, un_804D6EC8, 0xA);
                 un_80306A48(jobj2, 0, data + 0x438, 0, un_804D6EC8, 0xA);
             } else {
@@ -2771,7 +2774,7 @@ void fn_80309404(HSD_GObj* gobj)
     Vec3 transition_interest;
     ToyCameraControl* ed4;
     HSD_CObj* cobj;
-    u8* base;
+    Toy26B8* base;
     void* ed8;
     Toy6E68* state;
     ToyAnimState* anim;
@@ -2791,10 +2794,10 @@ void fn_80309404(HSD_GObj* gobj)
     PAD_STACK(264);
 
     cobj = gobj->hsd_obj;
-    base = (u8*) un_804A26B8;
+    base = (Toy26B8*) un_804A26B8;
     ed8 = un_804D6ED8;
     state = (Toy6E68*) un_804D6E68;
-    anim = (ToyAnimState*) (base + 0x3F0);
+    anim = &base->anim;
     ed4 = un_804D6ED4;
     rotate_update = 0.0f;
     movement_update = 0.0f;
@@ -2893,7 +2896,7 @@ void fn_80309404(HSD_GObj* gobj)
         un_80310660(1);
         HSD_GObj_80390CD4(gobj);
         mn_8022F268();
-        ((Toy26B8*) base)->x198 = 1;
+        base->x198 = 1;
         return;
     }
 
@@ -2912,7 +2915,7 @@ void fn_80309404(HSD_GObj* gobj)
         }
 
         if ((gm_8016B498() != 0) || (gm_801A4310() == 0xC)) {
-            trophy_count = ((Toy26B8*) base)->trophy_count;
+            trophy_count = base->trophy_count;
         } else {
             trophy_count = *gmMainLib_8015CC90();
         }
@@ -3030,11 +3033,11 @@ void fn_80309404(HSD_GObj* gobj)
             HSD_CObjGetEyePosition(cobj, &eye_pos);
             transition_eye.y = 8.0f;
             HSD_CObjGetInterest(cobj, &transition_interest);
-            ((Toy26B8*) base)->x0.x =
+            base->x0.x =
                 (transition_eye.x - transition_interest.x) / 10.0f;
-            ((Toy26B8*) base)->x0.y =
+            base->x0.y =
                 (transition_eye.y - transition_interest.y) / 10.0f;
-            ((Toy26B8*) base)->x0.z =
+            base->x0.z =
                 (transition_eye.z - transition_interest.z) / 10.0f;
             un_804D6E90 = (state->x20 - 38.0f) / 10.0f;
             un_804D6E94 = state->x18 / 10.0f;
@@ -3172,7 +3175,7 @@ void fn_80309404(HSD_GObj* gobj)
             s16 trophy_count;
 
             if ((gm_8016B498() != 0) || (gm_801A4310() == 0xC)) {
-                trophy_count = ((Toy26B8*) base)->trophy_count;
+                trophy_count = base->trophy_count;
             } else {
                 trophy_count = *gmMainLib_8015CC90();
             }
@@ -3194,7 +3197,7 @@ void fn_80309404(HSD_GObj* gobj)
                         if (new_idx < 0) {
                             if ((gm_8016B498() != 0) || (gm_801A4310() == 0xC))
                             {
-                                total = ((Toy26B8*) base)->trophy_count;
+                                total = base->trophy_count;
                             } else {
                                 total = *gmMainLib_8015CC90();
                             }
@@ -3202,7 +3205,7 @@ void fn_80309404(HSD_GObj* gobj)
                                 (s16) (total - 1);
                         }
                         if ((gm_8016B498() != 0) || (gm_801A4310() == 0xC)) {
-                            total = ((Toy26B8*) base)->trophy_count;
+                            total = base->trophy_count;
                         } else {
                             total = *gmMainLib_8015CC90();
                         }
@@ -3218,7 +3221,7 @@ void fn_80309404(HSD_GObj* gobj)
                                 if ((gm_8016B498() != 0) ||
                                     (gm_801A4310() == 0xC))
                                 {
-                                    cnt = ((Toy26B8*) base)->trophy_count;
+                                    cnt = base->trophy_count;
                                 } else {
                                     cnt = *gmMainLib_8015CC90();
                                 }
@@ -3288,7 +3291,7 @@ void fn_80309404(HSD_GObj* gobj)
                         display->selectedIdx =
                             display->selectedIdx + 1;
                         if ((gm_8016B498() != 0) || (gm_801A4310() == 0xC)) {
-                            total = ((Toy26B8*) base)->trophy_count;
+                            total = base->trophy_count;
                         } else {
                             total = *gmMainLib_8015CC90();
                         }
@@ -3296,7 +3299,7 @@ void fn_80309404(HSD_GObj* gobj)
                             display->selectedIdx = 0;
                         }
                         if ((gm_8016B498() != 0) || (gm_801A4310() == 0xC)) {
-                            total = ((Toy26B8*) base)->trophy_count;
+                            total = base->trophy_count;
                         } else {
                             total = *gmMainLib_8015CC90();
                         }
@@ -3305,7 +3308,7 @@ void fn_80309404(HSD_GObj* gobj)
 
                             if ((gm_8016B498() != 0) || (gm_801A4310() == 0xC))
                             {
-                                cnt = ((Toy26B8*) base)->trophy_count;
+                                cnt = base->trophy_count;
                             } else {
                                 cnt = *gmMainLib_8015CC90();
                             }
@@ -3321,7 +3324,7 @@ void fn_80309404(HSD_GObj* gobj)
                                 if ((gm_8016B498() != 0) ||
                                     (gm_801A4310() == 0xC))
                                 {
-                                    cnt2 = ((Toy26B8*) base)->trophy_count;
+                                    cnt2 = base->trophy_count;
                                 } else {
                                     cnt2 = *gmMainLib_8015CC90();
                                 }
@@ -5137,7 +5140,7 @@ void un_803102D0(void)
 
 void un_80310324(void)
 {
-    char* toy;
+    Toy26B8* toy;
     char* data;
     ToyGlobalsS_* tg;
     ToyGlobalsS_* tg2;
@@ -5160,11 +5163,11 @@ void un_80310324(void)
     PAD_STACK(4);
 
     data = un_803FDD18;
-    toy = (char*) un_804A26B8;
+    toy = TOY_DATA;
     tg = un_804D6ED8;
 
     un_8030663C();
-    un_803067BC((s8) toy[0x195], (s8) toy[0x196]);
+    un_803067BC(toy->x195, toy->x196);
 
     if (tg->x50 == NULL) {
         if (lbLang_IsSavedLanguageJP() != 0) {
@@ -5215,13 +5218,13 @@ void un_80310324(void)
     }
 
     if (gm_8016B498() != 0 || (u8) gm_801A4310() == 0xC) {
-        var_r0 = *(s16*) (toy + 0x3EC);
+        var_r0 = toy->trophy_count;
     } else {
         var_r0 = *gmMainLib_8015CC90();
     }
 
     if (var_r0 != 0) {
-        memzero(toy + 0x3F0, 0x14);
+        memzero(&toy->anim, 0x14);
         un_8030FE48(un_804D6EE0, 0);
         tg6 = un_804D6EE0;
         un_803087F4(tg6->x140);
@@ -5230,7 +5233,7 @@ void un_80310324(void)
         idx = un_804D6EDC[tg6->x154];
 
         if (gm_8016B498() != 0 || (u8) gm_801A4310() == 0xC) {
-            flags = (u16*) (toy + 0x19E);
+            flags = toy->trophy_flags;
         } else {
             flags = gmMainLib_8015CC78();
         }
@@ -5240,7 +5243,7 @@ void un_80310324(void)
             idx = un_804D6EDC[tg6->x154];
 
             if (gm_8016B498() != 0 || (u8) gm_801A4310() == 0xC) {
-                flags = (u16*) (toy + 0x19E);
+                flags = toy->trophy_flags;
             } else {
                 flags = gmMainLib_8015CC78();
             }

--- a/src/melee/ty/tyfigupon.c
+++ b/src/melee/ty/tyfigupon.c
@@ -217,10 +217,9 @@ void tyFigupon_80314BE4(HSD_GObj* gobj, int unused)
 
 void tyFigupon_80314C5C(HSD_GObj* gobj)
 {
-    // 3-way regswap (r29-r30-r31) to 100%
     Toy* tp1 = GET_TOY(gobj);
-    struct un_804D6EF4_t* temp_r29 = un_804D6EF4;
     HSD_JObj* jobj = GET_JOBJ(gobj);
+    struct un_804D6EF4_t* temp_r29 = un_804D6EF4;
     PAD_STACK(40);
     if (tp1 != NULL) {
         if (tp1->x8 % 30 == 0) {

--- a/src/melee/ty/tylist.c
+++ b/src/melee/ty/tylist.c
@@ -470,61 +470,11 @@ loop:
     if (i == 2) {
         goto next;
     }
-    {
-        float pos = arg->x30;
-        if (jobj == NULL) {
-            __assert(&un_804D5A78, 0x3B3, &un_804D5A80);
-        }
-        jobj->translate.y = pos;
-    }
-
-    if ((jobj->flags & 0x02000000) == 0) {
-        if (jobj == NULL) {
-            goto skip_dirty;
-        }
-        if (jobj == NULL) {
-            __assert(&un_804D5A78, 0x234, &un_804D5A80);
-        }
-        {
-            u32 flags = jobj->flags;
-            s32 skip = 0;
-            if ((flags & 0x800000) == 0 && (flags & 0x40)) {
-                skip = 1;
-            }
-            if (skip == 0) {
-                HSD_JObjSetMtxDirtySub(jobj);
-            }
-        }
-    }
-skip_dirty:
+    HSD_JObjSetTranslateY(jobj, arg->x30);
 
     if (arg->idx == un_GetTrophyTotal() - 1) {
-        float pos;
         jobj = ((TyListState*) data)->jobj;
-        pos = arg->x30;
-        if (jobj == NULL) {
-            __assert(&un_804D5A78, 0x3B3, &un_804D5A80);
-        }
-        jobj->translate.y = pos;
-
-        if ((jobj->flags & 0x02000000) == 0) {
-            if (jobj == NULL) {
-                goto next;
-            }
-            if (jobj == NULL) {
-                __assert(&un_804D5A78, 0x234, &un_804D5A80);
-            }
-            {
-                u32 flags = jobj->flags;
-                s32 skip = 0;
-                if ((flags & 0x800000) == 0 && (flags & 0x40)) {
-                    skip = 1;
-                }
-                if (skip == 0) {
-                    HSD_JObjSetMtxDirtySub(jobj);
-                }
-            }
-        }
+        HSD_JObjSetTranslateY(jobj, arg->x30);
     }
 
 next:
@@ -859,13 +809,11 @@ void un_80312BAC(TyListState* state, s8 arg1);
 void fn_80313BD8(HSD_GObj* gobj)
 {
     TyListState* state = (TyListState*) un_804A2AC0;
+    TyListArg* p;
     s8* g = ((s8*) state) + 0x2AC;
     f32 f30;
     f32 f31;
-    HSD_JObj* jobj;
-    f32 ftmp;
     s32 i;
-    TyListArg* p;
     s8 v;
 
     if (un_GetTrophyTotal() > 10) {
@@ -1055,24 +1003,7 @@ void fn_80313BD8(HSD_GObj* gobj)
                 state->selectedIdx = p->idx;
                 state->entries[10].links[0] = (TyListArg*) p;
                 lbAudioAx_80024030(2);
-                jobj = state->jobj;
-                ftmp = p->x30;
-                if (jobj == NULL) {
-                    __assert(&un_804D5A78, 0x3B3, &un_804D5A80);
-                }
-                jobj->translate.y = ftmp;
-                if (!(jobj->flags & 0x02000000)) {
-                    if (jobj != NULL) {
-                        u32 flags = jobj->flags;
-                        s32 skip = 0;
-                        if (!(flags & 0x800000) && (flags & 0x40)) {
-                            skip = 1;
-                        }
-                        if (skip == 0) {
-                            HSD_JObjSetMtxDirtySub(jobj);
-                        }
-                    }
-                }
+                HSD_JObjSetTranslateY(state->jobj, p->x30);
             }
             un_80312904(p, state->x2B8);
         }

--- a/src/melee/vi/vi1201v1.c
+++ b/src/melee/vi/vi1201v1.c
@@ -227,7 +227,7 @@ static void HSD_JObjSetTranslateZ_2(HSD_JObj* jobj, f32 z)
 void un_8031FD18_OnEnter(void* arg)
 {
     u8* input = arg;
-    s32 i = 0;
+    s32 i;
     u8 char_index;
     HSD_CObj* cobj;
     HSD_GObj* gobj;
@@ -240,7 +240,7 @@ void un_8031FD18_OnEnter(void* arg)
 
     un_804D6FFC = input[0];
     un_804D6FFD = input[1];
-    un_804D7000 = (void*) i;
+    un_804D7000 = (void*) 0U;
 
     lbAudioAx_800236DC();
     efLib_Init();
@@ -268,7 +268,7 @@ void un_8031FD18_OnEnter(void* arg)
     HSD_CObjAnim(cobj);
     HSD_GObj_SetupProc(gobj, fn_8031FC30, 0);
 
-    for (; un_804D6FE0->models[i] != NULL; i++) {
+    for (i = 0; un_804D6FE0->models[i] != NULL; i++) {
         gobj = GObj_Create(0xE, 0xF, 0);
         jobj = HSD_JObjLoadJoint(un_804D6FE0->models[i]->joint);
         HSD_GObjObject_80390A70(gobj, HSD_GObj_804D7849, jobj);

--- a/src/melee/vi/vi1201v2.c
+++ b/src/melee/vi/vi1201v2.c
@@ -241,60 +241,6 @@ static void HSD_JObjSetRotationY_2(HSD_JObj* jobj, f32 y)
     }
 }
 
-static void HSD_JObjSetScaleX_2(HSD_JObj* jobj, f32 x)
-{
-    ((jobj) ? ((void) 0) : __assert("jobj.h", 776, "jobj"));
-    jobj->scale.x = x;
-    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
-        (HSD_JObjSetMtxDirty)(jobj);
-    }
-}
-
-static void HSD_JObjSetScaleY_2(HSD_JObj* jobj, f32 y)
-{
-    ((jobj) ? ((void) 0) : __assert("jobj.h", 791, "jobj"));
-    jobj->scale.y = y;
-    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
-        (HSD_JObjSetMtxDirty)(jobj);
-    }
-}
-
-static void HSD_JObjSetScaleZ_2(HSD_JObj* jobj, f32 z)
-{
-    ((jobj) ? ((void) 0) : __assert("jobj.h", 806, "jobj"));
-    jobj->scale.z = z;
-    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
-        (HSD_JObjSetMtxDirty)(jobj);
-    }
-}
-
-static void HSD_JObjSetTranslateX_2(HSD_JObj* jobj, f32 x)
-{
-    ((jobj) ? ((void) 0) : __assert("jobj.h", 932, "jobj"));
-    jobj->translate.x = x;
-    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
-        (HSD_JObjSetMtxDirty)(jobj);
-    }
-}
-
-static void HSD_JObjSetTranslateY_2(HSD_JObj* jobj, f32 y)
-{
-    ((jobj) ? ((void) 0) : __assert("jobj.h", 947, "jobj"));
-    jobj->translate.y = y;
-    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
-        (HSD_JObjSetMtxDirty)(jobj);
-    }
-}
-
-static void HSD_JObjSetTranslateZ_2(HSD_JObj* jobj, f32 z)
-{
-    ((jobj) ? ((void) 0) : __assert("jobj.h", 962, "jobj"));
-    jobj->translate.z = z;
-    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
-        (HSD_JObjSetMtxDirty)(jobj);
-    }
-}
-
 void un_80320A40_OnEnter(void* arg)
 {
     u8* input = arg;
@@ -305,8 +251,9 @@ void un_80320A40_OnEnter(void* arg)
     HSD_GObj* gobj;
     HSD_JObj* child;
     HSD_JObj* jobj;
+    HSD_LObj* lobj;
     f32 scale;
-    PAD_STACK(24);
+    char pad[24];
 
     efLib_Init();
     efAsync_LoadSync(0);
@@ -361,16 +308,16 @@ void un_80320A40_OnEnter(void* arg)
         child = jobj->child;
     }
 
-    HSD_JObjSetTranslateX_2(child, -un_803060BC(0x1E, 0));
-    HSD_JObjSetTranslateY_2(child, -un_803060BC(0x1E, 1));
-    HSD_JObjSetTranslateZ_2(child, -un_803060BC(0x1E, 2));
+    HSD_JObjSetTranslateXWithMtxDirty(child, -un_803060BC(0x1E, 0));
+    HSD_JObjSetTranslateYWithMtxDirty(child, -un_803060BC(0x1E, 1));
+    HSD_JObjSetTranslateZWithMtxDirty(child, -un_803060BC(0x1E, 2));
     HSD_JObjSetRotationY_2(child, -un_803060BC(0x1E, 5));
 
     scale = 0.55f * (un_803060BC(0x1E, 4) * (1.0f / un_803060BC(0x1E, 3)));
 
-    HSD_JObjSetScaleX_2(child, scale);
-    HSD_JObjSetScaleY_2(child, scale);
-    HSD_JObjSetScaleZ_2(child, scale);
+    HSD_JObjSetScaleXWithMtxDirty(child, scale);
+    HSD_JObjSetScaleYWithMtxDirty(child, scale);
+    HSD_JObjSetScaleZWithMtxDirty(child, scale);
 
     lb_8000C1C0(jobj, un_804D7024);
     lb_8000C290(jobj, un_804D7024);
@@ -387,8 +334,8 @@ void un_80320A40_OnEnter(void* arg)
     un_804D702C = 0;
 
     gobj = GObj_Create(0xB, 3, 0);
-    HSD_GObjObject_80390A70(gobj, HSD_GObj_804D784A,
-                            lb_80011AC4(un_804D7010->lights));
+    lobj = lb_80011AC4(un_804D7010->lights);
+    HSD_GObjObject_80390A70(gobj, HSD_GObj_804D784A, lobj);
     GObj_SetupGXLink(gobj, HSD_GObj_LObjCallback, 0, 0);
 
     lbAudioAx_80024E50(0);

--- a/src/sysdolphin/baselib/axdriver.c
+++ b/src/sysdolphin/baselib/axdriver.c
@@ -194,7 +194,7 @@ u32 AXDriver_8038C678(u32 param_type, u32 param_value)
 
 void AXDriver_8038BF6C(HSD_SM* v)
 {
-    int flag;
+    u32 flag;
     int i;
 
     for (i = 0; i <= 9; i++) {
@@ -262,7 +262,7 @@ void AXDriver_8038BF6C(HSD_SM* v)
                 float right_inv_sqrt = sqrtf(1.0F - right_vol);
 
                 HSD_SynthSFXSetMix(
-                    v->vID, left_inv_sqrt * left_inv_sqrt * right_inv_sqrt,
+                    v->vID, left_inv_sqrt * (left_inv_sqrt * right_inv_sqrt),
                     left_sqrt, right_sqrt * left_inv_sqrt);
                 break;
             }
@@ -290,6 +290,7 @@ void AXDriver_8038C6C0(HSD_SM* v)
     u32 cmd_type;
     u32 cmd_word;
     int cmd_size;
+    int cmd_val;
     PAD_STACK(8);
 
     while (v->x30 == (s32) AXDriver_804D778C) {
@@ -310,7 +311,7 @@ void AXDriver_8038C6C0(HSD_SM* v)
             break;
         case 3:
             if ((v->flags & 0x100000) || v->x2A != 0) {
-                v->cmd_stream -= *v->cmd_stream;
+                v->cmd_stream -= *v->cmd_stream & 0xFFFFFF;
                 v->x2A--;
             }
             break;
@@ -324,7 +325,8 @@ void AXDriver_8038C6C0(HSD_SM* v)
             break;
         case 5:
             v->flags |= 2;
-            v->pri = CLAMP(5, v->pri + (s8) (u8) *v->cmd_stream, 0x1C);
+            cmd_val = v->pri + (s8) (u8) *v->cmd_stream;
+            v->pri = CLAMP(5, cmd_val, 0x1C);
             break;
         case 6:
             v->flags |= 4;

--- a/src/sysdolphin/baselib/cobj.c
+++ b/src/sysdolphin/baselib/cobj.c
@@ -646,7 +646,7 @@ static float upvec2roll(HSD_CObj* cobj, Vec3* up)
     return dot;
 }
 
-static inline f64 fabsf_p(f32* v)
+static inline f64 cobj_fabsf_p(f32* v)
 {
     return __fabsf(*v);
 }
@@ -662,7 +662,7 @@ static int roll2upvec(HSD_CObj* cobj, Vec3* up, float roll)
     if (res != 0) {
         return res;
     }
-    if (1.0 - fabsf_p(&eye.y) < 0.0001) {
+    if (1.0 - cobj_fabsf_p(&eye.y) < 0.0001) {
         v0.x = sqrtf(eye.y * eye.y + eye.z * eye.z);
         v0.y = eye.y * (-eye.x / v0.x);
         v0.z = eye.z * (-eye.x / v0.x);
@@ -807,7 +807,7 @@ MtxPtr HSD_CObjGetInvViewingMtxPtr(HSD_CObj* cobj)
 void HSD_CObjSetRoll(HSD_CObj* cobj, float roll)
 {
     Vec3 up;
-    PAD_STACK(8);
+    PAD_STACK(4);
 
     if (!cobj) {
         return;

--- a/src/sysdolphin/baselib/hsd_3A94.c
+++ b/src/sysdolphin/baselib/hsd_3A94.c
@@ -32,7 +32,7 @@ typedef struct CardBlock {
 #define CMD_PTR(off) ((void*) CMD_S32(off))
 #define CMD_TYPE (((CardBufEntry*) hsd_804D1138)[hsd_804D7980].x10)
 
-static s32 hsd_803A949C_Close(CardState* state)
+static inline s32 hsd_803A949C_Close(CardState* state)
 {
     s32 i;
     s32 result;
@@ -49,7 +49,7 @@ static s32 hsd_803A949C_Close(CardState* state)
     return result;
 }
 
-static s32 hsd_803A949C_IconSize(CardState* state)
+static inline s32 hsd_803A949C_IconSize(CardState* state)
 {
     switch (state->x3B0) {
     case 2:
@@ -61,7 +61,7 @@ static s32 hsd_803A949C_IconSize(CardState* state)
     }
 }
 
-static s32 hsd_803A949C_FileId(CardBlock* block)
+static inline s32 hsd_803A949C_FileId(CardBlock* block)
 {
     return (block->x10 << 8) | block->x11;
 }

--- a/src/sysdolphin/baselib/hsd_3AA7.c
+++ b/src/sysdolphin/baselib/hsd_3AA7.c
@@ -1238,12 +1238,12 @@ s32 fn_803ACD58(CardState* state, void* icon_data, void* file_data)
 
     {
         s32 retries;
+        u8* buf;
+        s32 offset;
         s32 size;
         for (i = 0; size = state->x8, i < (0x2F + state->x24 + size) / size;
              i++)
         {
-            s32 offset;
-            u8* buf;
             s32 result;
 
             offset = i * size;

--- a/src/sysdolphin/baselib/leak.c
+++ b/src/sysdolphin/baselib/leak.c
@@ -28,21 +28,21 @@ extern HSD_LeakChecker HSD_Leak_80407B58;
 static char HSD_Leak_804D6000[] = " ";
 static char HSD_Leak_804D6004[] = "done.\n";
 
-/* @todo Currently ~97.2% match - register allocation differences
- * remain: r28/r29 swap (scan_copy/cap_ptr), r21/r23 swap (heap_start_phys),
- * and r22/r27 swap (ofs/loop counter) in second half. */
+/* @todo Currently ~97.3% match - register allocation differences
+ * remain: r28/r29 swap (scan_copy/cap_ptr) and loop/local register swaps
+ * in the allocation table scan and report indentation loops. */
 int HSD_Leak_80387DF8(int indent)
 {
     u32 val;
     HSD_LeakChecker* lc;
-    u32* cap_ptr;
     u32* scan;
+    u32* heap_start_phys;
+    u32* cap_ptr;
     u32 heap_start_align;
     int leak_count;
     u32 i;
     u32 j;
     u32 ofs;
-    u32* heap_start_phys;
 
     scan = (u32*) lbCommand_803B9840;
     lc = &HSD_Leak_80407B58;
@@ -85,7 +85,7 @@ int HSD_Leak_80387DF8(int indent)
                     if (phys_addr >= heap_start_align && val > phys_addr) {
                         u32 virt = phys_addr | 0x80000000;
                         u32* hdr = (u32*) (virt - 0x20);
-                        if ((u32) (*hdr + 0xFEDD0000) == 0x4567) {
+                        if (*hdr == HEAP_MAGIC) {
                             u32 reg_idx = hdr[1];
                             if ((u32) (reg_idx + 0x10000) != 0xFFFF &&
                                 reg_idx < *cap_ptr)
@@ -120,7 +120,7 @@ int HSD_Leak_80387DF8(int indent)
         } else if ((u32*) val <= heap_start_phys && heap_start_phys < scan) {
         } else if (heap_start_phys != NULL) {
             u32* block = (u32*) heap_start_phys;
-            if ((u32) (block[0] + 0xFEDD0000) == 0x4567) {
+            if (block[0] == HEAP_MAGIC) {
                 u32 reg_idx = block[1];
                 if ((u32) (reg_idx + 0x10000) != 0xFFFF && reg_idx < *cap_ptr)
                 {

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -294,21 +294,21 @@ static inline int hexval(int ch)
 {
     if (ch < 0x47) {
         if (ch < 0x0A) {
-            if (ch < 0) {
-                goto ret_zero;
+            if (ch >= 0) {
+                goto sub_30;
             }
-            goto sub_30;
-        }
-        if (ch < 0x41) {
             goto ret_zero;
         }
-        goto sub_37;
+        if (ch >= 0x41) {
+            goto sub_37;
+        }
+        goto ret_zero;
     }
     if (ch < 0x67) {
-        if (ch < 0x61) {
-            goto ret_zero;
+        if (ch >= 0x61) {
+            goto sub_57;
         }
-        goto sub_57;
+        goto ret_zero;
     }
     goto ret_zero;
 sub_30:
@@ -2246,14 +2246,17 @@ void hsd_80394950(OSContext* ctx)
     OSRestoreInterrupts(irq);
 }
 
+extern u8 lbl_8040AB00[];
+
 // @TODO: Currently 99.94% match - minor relocation difference
 void Exception_ReportStackTrace(OSContext* ctx, int max_depth)
 {
     u32 i;
     u32* sp;
+    char* strings = (char*) lbl_8040AB00;
 
-    OSReport("- STACK ---------------------------------\n");
-    OSReport(" Address:  Back Chain  LR Save\n");
+    OSReport(strings + 0x8CC);
+    OSReport(strings + 0x904);
 
     sp = (u32*) ctx->gpr[1];
     i = 0;
@@ -2266,7 +2269,7 @@ void Exception_ReportStackTrace(OSContext* ctx, int max_depth)
         if ((s64) (u32) sp >= (s64) OSGetPhysicalMemSize() + 0x800000000) {
             break;
         }
-        OSReport("%08X:   %08X   %08X\n", sp, sp[0], sp[1]);
+        OSReport(strings + 0x924, sp, sp[0], sp[1]);
         sp = (u32*) sp[0];
         i++;
     }
@@ -2969,8 +2972,8 @@ static inline void ps_remove_node(struct ParticleScreenState* sp, void* node)
 // allocation
 s32 hsd_80395D88(void* data)
 {
-    struct ParticleScreenState* sp = &hsd_804CF810;
     char* msg = (char*) lbl_8040AB00;
+    struct ParticleScreenState* sp = &hsd_804CF810;
     s32 result;
 
     result = hsd_80395550(data);
@@ -3001,13 +3004,16 @@ s32 hsd_80395D88(void* data)
         remove_return_0:
             ps_remove_node(sp, data);
             return 0;
-        case 6:
-            if (sp->xD4 != NULL) {
-                OSContext* ctx = sp->xD4;
-                s32 saved;
-                s32 i;
+        case 6: {
+            OSContext* ctx;
+            OSContext** ctx_ptr;
+            s32 saved;
+            s32 i;
 
+            ctx_ptr = &sp->xD4;
+            if (*ctx_ptr != NULL) {
                 saved = hsd_80393D2C(1);
+                ctx = *ctx_ptr;
                 OSReport(msg + 0x728);
                 i = 0;
                 do {
@@ -3016,7 +3022,8 @@ s32 hsd_80395D88(void* data)
                              ((u32*) ctx)[i + 0x10]);
                     i++;
                 } while (i < 0x10);
-                hsd_80394950(ctx);
+                hsd_80394950(*ctx_ptr);
+                ctx = *ctx_ptr;
                 OSReport(msg + 0x828);
                 OSReport(msg + 0x860, ((u32*) ctx)[0x198 / 4],
                          ((u32*) ctx)[0x19C / 4]);
@@ -3035,6 +3042,7 @@ s32 hsd_80395D88(void* data)
             }
             ps_remove_node(sp, data);
             return 1;
+        }
         case 7:
             hsd_80394E8C(lbl_8040BEC4);
             return 1;
@@ -3373,10 +3381,7 @@ s32 hsd_80396A20(void* data)
                 hsd_80394E8C(lbl_8040BC3C.x18);
                 return 1;
             }
-            /* fallthrough */
-        default:
-            bit <<= 1;
-            break;
+            goto default_case;
         case 0x400:
             lbl_8040BC3C.x10 = val & ~mask;
             return 1;
@@ -3385,18 +3390,21 @@ s32 hsd_80396A20(void* data)
             return 1;
         case 0x1000: {
             extern u8 lbl_8040BD74[];
-            ExcptNode* node = (ExcptNode*) lbl_8040BD74;
-            if (node != NULL) {
-                fn_80394DF4(node);
-                node->next = sp->xD0;
-                sp->xD0 = node;
-                if (node->callback != NULL) {
-                    node->callback(node);
+            data = (ExcptNode*) lbl_8040BD74;
+            if (data != NULL) {
+                fn_80394DF4(data);
+                ((ExcptNode*) data)->next = sp->xD0;
+                sp->xD0 = data;
+                if (((ExcptNode*) data)->callback != NULL) {
+                    ((ExcptNode*) data)->callback(data);
                 }
                 sp->x0_b5 = 1;
             }
             return 1;
         }
+        default: default_case:
+            bit <<= 1;
+            break;
         }
     }
     return 0;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -2246,17 +2246,14 @@ void hsd_80394950(OSContext* ctx)
     OSRestoreInterrupts(irq);
 }
 
-extern u8 lbl_8040AB00[];
-
 // @TODO: Currently 99.94% match - minor relocation difference
 void Exception_ReportStackTrace(OSContext* ctx, int max_depth)
 {
     u32 i;
     u32* sp;
-    char* strings = (char*) lbl_8040AB00;
 
-    OSReport(strings + 0x8CC);
-    OSReport(strings + 0x904);
+    OSReport("- STACK ---------------------------------\n");
+    OSReport(" Address:  Back Chain  LR Save\n");
 
     sp = (u32*) ctx->gpr[1];
     i = 0;
@@ -2269,7 +2266,7 @@ void Exception_ReportStackTrace(OSContext* ctx, int max_depth)
         if ((s64) (u32) sp >= (s64) OSGetPhysicalMemSize() + 0x800000000) {
             break;
         }
-        OSReport(strings + 0x924, sp, sp[0], sp[1]);
+        OSReport("%08X:   %08X   %08X\n", sp, sp[0], sp[1]);
         sp = (u32*) sp[0];
         i++;
     }

--- a/src/sysdolphin/baselib/particle.static.h
+++ b/src/sysdolphin/baselib/particle.static.h
@@ -41,7 +41,7 @@ struct ParticleScreenState {
     /* 0xC8 */ s32 xC8;
     /* 0xCC */ s32 xCC;
     /* 0xD0 */ void* xD0;
-    /* 0xD4 */ void* xD4;
+    /* 0xD4 */ OSContext* xD4;
 };
 
 struct ParticleConsoleState {

--- a/src/sysdolphin/baselib/synth.c
+++ b/src/sysdolphin/baselib/synth.c
@@ -1203,7 +1203,7 @@ extern u32 HSD_Synth_804D7774;
 void HSD_Synth_8038ADD0(void)
 {
     struct HSD_SynthSFXNode* node = getNode(HSD_Synth_804D7760);
-    s32 pos;
+    u32 pos;
     s32 i;
     BOOL intr;
     s32 src;
@@ -1243,8 +1243,8 @@ void HSD_Synth_8038ADD0(void)
                         (i * lbl_804C4540[HSD_Synth_804D7770].x0 + 2));
                 AXSetVoiceAdpcmLoop(
                     node->voice[i],
-                    (AXPBADPCMLOOP*) ((u8*) &lbl_804C4540[HSD_Synth_804D7770] +
-                                      0xC + i * 8));
+                    (AXPBADPCMLOOP*) ((u32*) &lbl_804C4540[HSD_Synth_804D7770] +
+                                      (i * 2 + 3)));
             }
         }
     }

--- a/src/sysdolphin/baselib/texpdag.c
+++ b/src/sysdolphin/baselib/texpdag.c
@@ -252,7 +252,7 @@ int HSD_TExpMakeDag(HSD_TExp* root, HSD_TExpDag* list)
     j = 0;
 loop_22:
     if (j < num) {
-        HSD_ASSERT(0xF6U, j < HSD_TEXP_MAX_NUM);
+        HSD_ASSERT(0xF6U, j<HSD_TEXP_MAX_NUM);
         cur = *p;
         i = 0;
         tmp = cur;
@@ -534,8 +534,6 @@ void make_full_dependancy_mtx(int num, u32* dep, u32* full)
     } while (changed != false);
 }
 
-static u8 pad[0x44] = { 0 };
-
 void HSD_TExpSchedule(int num, HSD_TExpDag* list, HSD_TExp** result,
                       HSD_TExpRes* resource)
 {
@@ -599,6 +597,8 @@ int SimplifySrc(HSD_TExp* arg0)
     HSD_TEArg* a_arg;
     HSD_TExp* src;
     HSD_TObj* tobj;
+    u32 clear_arg;
+    HSD_TExp* clear_exp;
     int result;
     int i;
     u8 sel;
@@ -617,8 +617,10 @@ int SimplifySrc(HSD_TExp* arg0)
                 case 0xFF:
                     HSD_TExpUnref(src, sel);
                     result = 1;
-                    *(u32*) c_arg = HSD_TExpDag_804D5FF8;
-                    c_arg->exp = HSD_TExpDag_804D5FFC;
+                    clear_exp = HSD_TExpDag_804D5FFC;
+                    clear_arg = HSD_TExpDag_804D5FF8;
+                    *(u32*) c_arg = clear_arg;
+                    c_arg->exp = clear_exp;
                     break;
                 case GX_TEV_ADD:
                     if (src->tev.c_in[0].sel == HSD_TE_0 &&
@@ -679,8 +681,10 @@ int SimplifySrc(HSD_TExp* arg0)
                 case 0xFF:
                     HSD_TExpUnref(src, sel);
                     result = 1;
-                    *(u32*) c_arg = HSD_TExpDag_804D5FF8;
-                    c_arg->exp = HSD_TExpDag_804D5FFC;
+                    clear_exp = HSD_TExpDag_804D5FFC;
+                    clear_arg = HSD_TExpDag_804D5FF8;
+                    *(u32*) c_arg = clear_arg;
+                    c_arg->exp = clear_exp;
                     break;
                 }
             }
@@ -698,8 +702,10 @@ int SimplifySrc(HSD_TExp* arg0)
             case 0xFF:
                 HSD_TExpUnref(src, sel);
                 result = 1;
-                *(u32*) a_arg = HSD_TExpDag_804D5FF8;
-                a_arg->exp = HSD_TExpDag_804D5FFC;
+                clear_exp = HSD_TExpDag_804D5FFC;
+                clear_arg = HSD_TExpDag_804D5FF8;
+                *(u32*) a_arg = clear_arg;
+                a_arg->exp = clear_exp;
                 break;
             case GX_TEV_ADD:
                 if (src->tev.a_in[0].sel == HSD_TE_0 &&


### PR DESCRIPTION
## Summary

- Improves matching across multiple Melee source files.
- Applies PR review cleanup while keeping the generated code regression-free against current `origin/master`.
- Keeps `decomp-orchestrator/` and local orchestrator artifacts out of this Melee PR.

## Current report

Compared against current `origin/master` baseline `5d2393e4bf9e085e7e911af3a0f17081e7cf1b56`.

- Head SHA: `a81d8f8f5c863031fd24e05bda3c4bdbe47c14fd`
- Changed units: `85`
- New matches: `36` (`34` functions, `2` sections)
- Broken matches: `0`
- Improvements in unmatched items: `117` (`114` functions, `3` sections)
- Regressions in unmatched items: `0`
- Metric progressions: `354`
- Metric regressions: `0`

## Progress deltas

- Fuzzy match: `97.428474 -> 97.461624` (`+0.033150`)
- Matched code: `70.79643 -> 71.48751` (`+0.69108`, `+26,828 bytes`)
- Matched data: `41.350536 -> 41.43838` (`+0.087844`, `+1,064 bytes`)
- Matched functions: `18,714 -> 18,748` (`+34`)
- Linked/complete code: unchanged at `42.35421%`
- Linked/complete data: unchanged at `34.995697%`
- Complete units: unchanged at `836 / 1031`

## Largest new matches

| Unit | Item | Bytes | Before | After |
| - | - | -: | -: | -: |
| `main/sysdolphin/baselib/axdriver` | `.data` | `+632` | `0.00%` | `100.00%` |
| `main/melee/ft/ft_0852` | `.bss` | `+62` | `85.71%` | `100.00%` |
| `main/melee/gr/groldyoshi` | `grOldYoshi_8020EC10` | `+39` | `95.86%` | `100.00%` |
| `main/melee/gm/gm_1601` | `fn_80165AC0` | `+24` | `96.38%` | `100.00%` |
| `main/melee/lb/lbaudio_ax` | `fn_800253D8` | `+22` | `97.00%` | `100.00%` |
| `main/melee/lb/lbaudio_ax` | `fn_800256BC` | `+22` | `97.00%` | `100.00%` |

## Largest unmatched improvements

| Unit | Item | Bytes | Before | After |
| - | - | -: | -: | -: |
| `main/melee/it/items/itseakneedlethrown` | `.data` | `+256` | `0.00%` | `74.45%` |
| `main/melee/gm/gm_1832` | `fn_8018325C` | `+163` | `95.47%` | `99.74%` |
| `main/dolphin/thp/THPDec` | `__THPDecompressiMCURow640x480` | `+92` | `96.06%` | `97.45%` |
| `main/melee/gr/gronett` | `grOnett_801E43E0` | `+76` | `95.27%` | `97.68%` |
| `main/melee/gm/gmregclear` | `.bss` | `+64` | `12.57%` | `13.11%` |

## Verification

- `ninja`: passed, `build/GALE01/main.dol: OK`
- `ninja changes_all`: passed with `0` broken matches, `0` fuzzy regressions, and `0` metric regressions
- GitHub CI: `tests`, `Issues`, `Ninja (GALE01, diff)`, `Ninja (GALE01, link)`, and `Nix` all passed
- Review threads: all current and outdated review threads are resolved

Note: the older bot report comment for `d65ac60` is stale and was superseded by the current `a81d8f8` report above.
