### PR TITLE
Auto-regenerate the wiki Translation Units page in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -252,3 +252,62 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix-build
     - run: nix-shell --run "echo OK"
+
+  update-wiki:
+    name: Update wiki TU list
+    runs-on: ubuntu-latest
+    needs: build-ninja
+    if: >-
+      github.event_name == 'push' &&
+      github.ref_name == github.event.repository.default_branch &&
+      github.repository == 'doldecomp/melee'
+    permissions:
+      contents: write
+      actions: read
+    concurrency:
+      group: update-wiki
+      cancel-in-progress: false
+    steps:
+    - name: Checkout Melee repository
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          tools
+          reqs
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install generator dependencies
+      run: pip install -r reqs/misc.txt
+    - name: Download report
+      uses: actions/download-artifact@v4
+      with:
+        name: GALE01_report
+        path: report
+    - name: Regenerate and push the Translation Units page
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        repo='${{ github.repository }}'
+        page='Translation-Units.md'
+
+        # GITHUB_TOKEN with `contents: write` can push to this repo's own wiki.
+        git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/${repo}.wiki.git" wiki
+
+        python tools/wiki_tu.py write report/report.json "wiki/${page}" > "wiki/${page}.new"
+        mv "wiki/${page}.new" "wiki/${page}"
+
+        cd wiki
+        if git diff --quiet -- "${page}"; then
+          echo 'Translation Units page already up to date.'
+          exit 0
+        fi
+
+        git config user.name 'github-actions[bot]'
+        git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+        git add "${page}"
+        git commit -m "Update Translation Units list for ${{ github.sha }}"
+        git push origin HEAD:master


### PR DESCRIPTION
Follow-up to #2584. `tools/wiki_tu.py` generates the Translation Units wiki page, but nothing regenerates it automatically — it drifts until someone runs the tool by hand. This wires it into CI.

## What

A new `update-wiki` job in `build.yml`:
- runs after a successful build (`needs: build-ninja`) on **push to the default branch** of `doldecomp/melee` (skipped on PRs and forks);
- reuses the existing `GALE01_report` artifact (no extra build);
- regenerates `Translation-Units.md` with `tools/wiki_tu.py`, preserving assignees by reading the current page first; and
- commits + pushes to the wiki **only if the page changed**, as `github-actions[bot]`.

It runs in its own `concurrency` group so master pushes can't race the wiki push.

## No secret needed

The job authenticates with the built-in `GITHUB_TOKEN`, granted `contents: write` at the job level — sufficient to push to **this repository's own wiki**. No PAT, machine user, or GitHub App required, and nothing to configure before merging.

Verified end-to-end on a fork: a job using only `${{ github.token }}` with `permissions: contents: write` cloned and pushed to the repo's own `.wiki.git` successfully.

## Notes
- Dependencies are installed from `reqs/misc.txt`.
- Independent of #2584 — works with the current generator and the sectioned one; merge order doesn't matter.
- `actionlint`-clean; the pre-existing `actions/checkout@v3` / `docker/login-action@v2` warnings are unrelated and left untouched.
