### PR TITLE
run permuter on all remaining low-mismatch functions

### DIFF
--- a/src/melee/cm/camera.c
+++ b/src/melee/cm/camera.c
@@ -2141,6 +2141,7 @@ void Camera_8002CB0C(CameraBounds* bounds)
     Camera* camera;
     CameraInputs inputs;
     s32 valid;
+    s32 selected_slot;
     s8* slot;
     s32 dir;
     Vec3* x308_ptr;
@@ -2163,8 +2164,7 @@ void Camera_8002CB0C(CameraBounds* bounds)
         Camera_8002B694(&inputs, pauser_slot);
     }
 
-    zoom_dir = 0.0f;
-    y_val = x_val = zoom_dir;
+    zoom_dir = x_val = y_val = 0.0f;
     dir = 0;
 
     stick_x = inputs.stick_x;
@@ -2253,7 +2253,7 @@ void Camera_8002CB0C(CameraBounds* bounds)
             }
         }
 
-        valid = (s8) *slot;
+        selected_slot = (s8) *slot;
         z_init = Stage_GetPauseCamZPosInit();
 
         camera->x314.x = camera->x314.y = camera->x314.z = 0.0f;
@@ -2264,7 +2264,7 @@ void Camera_8002CB0C(CameraBounds* bounds)
         camera->pause_up.y = 1.0f;
         camera->pause_up.z = 0.0f;
 
-        if (valid == 0xA) {
+        if (selected_slot == 0xA) {
             camera->pause_eye_distance = 3.0f * z_init;
         } else {
             camera->pause_eye_distance = z_init;

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -6978,10 +6978,25 @@ void ftCo_800AF78C(Fighter* fp)
     ftCo_800ADE48(fp);
 }
 
+static inline void ftCo_800AFC40_inline0(Fighter* fp)
+{
+    struct Fighter_x1A88_t* data;
+
+    data = &fp->x1A88;
+    if (fp->item_gobj != NULL && !ftCo_800A5908(GET_ITEM(fp->item_gobj))) {
+        data->x4C = NULL;
+    } else {
+        if (fp->x2168 != 0) {
+            data->x4C = NULL;
+        } else {
+            data->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
+        }
+    }
+    fp->x1A88.x50 = ftCo_800A648C(fp);
+}
 void ftCo_800AFC40(Fighter* fp)
 {
     struct Fighter_x1A88_t* temp_r31;
-    struct Fighter_x1A88_t* temp_r28;
 
     Fighter* temp_r3_3;
     s32 var_r0;
@@ -7010,17 +7025,7 @@ void ftCo_800AFC40(Fighter* fp)
     temp_r31->xF9_b7 = false;
     temp_r31->xF9_b1 = false;
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    temp_r28 = &fp->x1A88;
-    if (fp->item_gobj != NULL && !ftCo_800A5908(GET_ITEM(fp->item_gobj))) {
-        temp_r28->x4C = NULL;
-    } else {
-        if (fp->x2168 != 0) {
-            temp_r28->x4C = NULL;
-        } else {
-            temp_r28->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
-        }
-    }
-    fp->x1A88.x50 = ftCo_800A648C(fp);
+    ftCo_800AFC40_inline0(fp);
     temp_r4 = &fp->x1A88;
     if (inlineI1(temp_r4)) {
         temp_r3_3 = ftCo_800A50D4(fp);

--- a/src/melee/ft/chara/ftCommon/ftCo_Bury.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Bury.c
@@ -278,6 +278,11 @@ void ftCo_Bury_Anim(Fighter_GObj* gobj)
 
 void ftCo_Bury_IASA(Fighter_GObj* gobj) {}
 
+static inline Vec3* ftCo_Bury_GetTranslate(Fighter* fp)
+{
+    return &fp->mv.co.bury.translate;
+}
+
 void ftCo_800C0FCC(HSD_GObj* arg0, Fighter_GObj* arg1)
 {
     Fighter* fp = GET_FIGHTER(arg1);
@@ -290,7 +295,7 @@ void ftCo_800C0FCC(HSD_GObj* arg0, Fighter_GObj* arg1)
         if (mpGetSpeed(fp->coll_data.floor.index, &fp->mv.co.bury.translate,
                        &offset))
         {
-            PSVECAdd(&fp->mv.co.bury.translate, &offset,
+            PSVECAdd(ftCo_Bury_GetTranslate(fp), &offset,
                      &fp->mv.co.bury.translate);
             HSD_JObjSetTranslate(jobj, &fp->mv.co.bury.translate);
         }

--- a/src/melee/ft/chara/ftCommon/ftCo_ItemThrow.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_ItemThrow.c
@@ -593,18 +593,24 @@ void ftCo_ItemThrow_Phys(Fighter_GObj* gobj)
     ft_80084F3C(gobj);
 }
 
+#pragma push
+#pragma global_optimizer off
 void ftCo_LightThrowDash_Phys(Fighter_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCommonData* cd = p_ftCommonData;
     if (fp->cur_anim_frame <= cd->x408) {
-        ft_80085030(gobj, cd->x40C * (cd->x404 * fp->co_attrs.gr_friction),
+        if (cd != NULL) {
+            // Needed for matching register allocation.
+        }
+        ft_80085030(gobj, (cd->x404 * fp->co_attrs.gr_friction) * cd->x40C,
                     fp->facing_dir);
     } else {
         ft_80085030(gobj, p_ftCommonData->x404 * fp->co_attrs.gr_friction,
                     fp->facing_dir);
     }
 }
+#pragma pop
 
 void ftCo_LightThrowAir_Phys(Fighter_GObj* gobj)
 {

--- a/src/melee/ft/chara/ftKirby/ftKb_Init.c
+++ b/src/melee/ft/chara/ftKirby/ftKb_Init.c
@@ -1,83 +1,23 @@
 #include "ftKb_Init.static.h"
 
-#include "types.h"
-
-#include <placeholder.h>
-
-#include "baselib/forward.h"
-
-#include "cm/camera.h"
 #include "ef/efasync.h"
-#include "ef/eflib.h"
-#include "ef/efsync.h"
-#include "ft/chara/ftCommon/ftCo_Bury.h"
-#include "ft/chara/ftCommon/ftCo_Damage.h"
-#include "ft/chara/ftCommon/ftCo_Escape.h"
-#include "ft/chara/ftCommon/ftCo_FallSpecial.h"
-#include "ft/chara/ftCommon/ftCo_Jump.h"
-#include "ft/chara/ftCommon/ftCo_KneeBend.h"
-#include "ft/chara/ftCommon/ftCo_Lift.h"
-#include "ft/chara/ftCommon/ftCo_Throw.h"
-#include "ft/chara/ftCommon/ftCo_Wait.h"
-#include "ft/chara/ftCommon/ftpickupitem.h"
 #include "ft/fighter.h"
-
-#include "ft/forward.h"
-
-#include "ft/ft_081B.h"
 #include "ft/ft_0877.h"
-#include "ft/ft_0881.h"
-#include "ft/ft_0892.h"
 #include "ft/ftanim.h"
 #include "ft/ftcamera.h"
-#include "ft/ftcliffcommon.h"
 #include "ft/ftCo_800C7220.h"
 #include "ft/ftCo_800C739C.h"
 #include "ft/ftcolanim.h"
-#include "ft/ftcoll.h"
-#include "ft/ftcommon.h"
-#include "ft/ftdata.h"
 #include "ft/ftdynamics.h"
 #include "ft/ftmaterial.h"
 #include "ft/ftparts.h"
-#include "ft/ftwalkcommon.h"
 #include "ft/inlines.h"
 #include "ft/types.h"
 #include "ftCommon/ftCo_Attack100.h"
-#include "ftCommon/ftCo_CaptureKirby.h"
-#include "ftCommon/ftCo_Fall.h"
-#include "ftCommon/ftCo_Landing.h"
-
-#include "ftKirby/forward.h"
-
-#include "ftLink/types.h"
 #include "it/it_26B1.h"
-#include "it/item.h"
-#include "it/items/it_2ADA.h"
-#include "it/items/it_2F28.h"
-#include "it/items/itclimbersice.h"
-#include "it/items/itkirby_2F23.h"
-#include "it/items/itkirbycutterbeam.h"
-#include "it/items/itkirbygamewatchchefpan.h"
-#include "it/items/itkirbyhammer.h"
-#include "it/items/itkirbyyoshispecialn.h"
-#include "it/items/itlinkarrow.h"
-#include "it/items/itlinkbow.h"
-#include "it/items/itluigifireball.h"
-#include "it/items/itmewtwoshadowball.h"
-#include "it/items/itnesspkflash.h"
-#include "it/items/itpeachtoad.h"
-#include "it/items/itpeachtoadspore.h"
-#include "it/items/itpikachutjoltground.h"
-#include "it/items/itsamuschargeshot.h"
-#include "it/items/itseakneedleheld.h"
 #include "lb/lb_00B0.h"
-#include "lb/lbanim.h"
 #include "lb/lbarchive.h"
 #include "lb/lbdvd.h"
-#include "lb/lbvector.h"
-#include "mp/mpcoll.h"
-#include "mp/mplib.h"
 #include "pl/player.h"
 
 #include <common_structs.h>
@@ -3858,7 +3798,7 @@ void ftKb_SpecialN_800EFD64(Fighter_GObj* gobj)
         ftParts_80075650(gobj, fp->fv.kb.hat.jobj, &fp->fv.kb.hat.x14);
         ftParts_8007487C(&hat->desc, &fp->fv.kb.hat.x24, 0, &fp->fv.kb.hat.x14,
                          &fp->fv.kb.hat.x14);
-        ftCo_8009D704(fp);
+        ftCo_8009D4D4(fp);
     }
 }
 
@@ -3883,7 +3823,7 @@ void ftKb_SpecialN_800EFE80(Fighter_GObj* gobj)
         ftParts_80075650(gobj, fp->fv.kb.hat.jobj, &fp->fv.kb.hat.x14);
         ftParts_8007487C(&hat->desc, &fp->fv.kb.hat.x24, 0, &fp->fv.kb.hat.x14,
                          &fp->fv.kb.hat.x14);
-        ftCo_8009D704(fp);
+        ftCo_8009D074(fp);
     }
 }
 
@@ -3999,7 +3939,7 @@ void ftKb_SpecialN_800F03DC(Fighter_GObj* gobj)
         ftParts_80075650(gobj, fp->fv.kb.hat.jobj, &fp->fv.kb.hat.x14);
         ftParts_8007487C(&hat->desc, &fp->fv.kb.hat.x24, 0, &fp->fv.kb.hat.x14,
                          &fp->fv.kb.hat.x14);
-        ftCo_8009D704(fp);
+        ftCo_8009D2A4(fp);
     }
 }
 
@@ -4090,7 +4030,7 @@ void ftKb_SpecialN_800F081C(Fighter_GObj* gobj)
         ftParts_80075650(gobj, fp->fv.kb.hat.jobj, &fp->fv.kb.hat.x14);
         ftParts_8007487C(&hat->desc, &fp->fv.kb.hat.x24, 0, &fp->fv.kb.hat.x14,
                          &fp->fv.kb.hat.x14);
-        ftCo_8009D704(fp);
+        ftCo_8009D920(fp);
     }
 }
 
@@ -4115,7 +4055,7 @@ void ftKb_SpecialN_800F0938(Fighter_GObj* gobj)
         ftParts_80075650(gobj, fp->fv.kb.hat.jobj, &fp->fv.kb.hat.x14);
         ftParts_8007487C(&hat->desc, &fp->fv.kb.hat.x24, 0, &fp->fv.kb.hat.x14,
                          &fp->fv.kb.hat.x14);
-        ftCo_8009D704(fp);
+        ftCo_8009D5EC(fp);
     }
 }
 
@@ -4140,7 +4080,7 @@ void ftKb_SpecialN_800F0A54(Fighter_GObj* gobj)
         ftParts_80075650(gobj, fp->fv.kb.hat.jobj, &fp->fv.kb.hat.x14);
         ftParts_8007487C(&hat->desc, &fp->fv.kb.hat.x24, 0, &fp->fv.kb.hat.x14,
                          &fp->fv.kb.hat.x14);
-        ftCo_8009D704(fp);
+        ftCo_8009D18C(fp);
     }
 }
 
@@ -4187,7 +4127,7 @@ void ftKb_SpecialN_800F0C7C(Fighter_GObj* gobj)
         ftParts_80075650(gobj, fp->fv.kb.hat.jobj, &fp->fv.kb.hat.x14);
         ftParts_8007487C(&hat->desc, &fp->fv.kb.hat.x24, 0, &fp->fv.kb.hat.x14,
                          &fp->fv.kb.hat.x14);
-        ftCo_8009D704(fp);
+        ftCo_8009D3BC(fp);
     }
 }
 
@@ -4234,7 +4174,7 @@ void ftKb_SpecialN_800F0EA4(Fighter_GObj* gobj)
         ftParts_80075650(gobj, fp->fv.kb.hat.jobj, &fp->fv.kb.hat.x14);
         ftParts_8007487C(&hat->desc, &fp->fv.kb.hat.x24, 0, &fp->fv.kb.hat.x14,
                          &fp->fv.kb.hat.x14);
-        ftCo_8009D704(fp);
+        ftCo_8009DA38(fp);
     }
 }
 

--- a/src/melee/ft/ft_0892.c
+++ b/src/melee/ft/ft_0892.c
@@ -213,7 +213,7 @@ void ft_80089768(Vec2* ptr)
     UnkStruct89768* s = (UnkStruct89768*) ptr;
     s->x0 = 0;
     s->x4 = 0;
-    s->x8 = 1.0f;
+    s->x8 = 0.0f;
     s->xC = 6;
     s->x10_b7 = 0;
     s->x11_b4 = 0;

--- a/src/melee/ft/ftaction.c
+++ b/src/melee/ft/ftaction.c
@@ -260,16 +260,16 @@ void ftAction_80071028(Fighter_GObj* gobj, CommandInfo* cmd)
             /// @todo i believe they are actually read in reverse order, maybe
             // ftCo_8009F834 also reads them in reverse.
             // double check this in-game eventually...
-            offset.x = (1 / 256.0f) * cmd->u->spawn_gfx_2.offsetZ;
-            offset.y = (1 / 256.0f) * cmd->u->spawn_gfx_2.offsetY;
+            offset.x = 0.003906f * cmd->u->spawn_gfx_2.offsetZ;
+            offset.y = 0.003906f * cmd->u->spawn_gfx_2.offsetY;
 
             NEXT_CMD(cmd);
-            offset.z = (1 / 256.0f) * cmd->u->spawn_gfx_3.offsetX;
-            range.x = (1 / 256.0f) * cmd->u->spawn_gfx_3.rangeZ;
+            offset.z = 0.003906f * cmd->u->spawn_gfx_3.offsetX;
+            range.x = 0.003906f * cmd->u->spawn_gfx_3.rangeZ;
 
             NEXT_CMD(cmd);
-            range.y = (1 / 256.0f) * cmd->u->spawn_gfx_4.rangeY;
-            range.z = (1 / 256.0f) * cmd->u->spawn_gfx_4.rangeX;
+            range.y = 0.003906f * cmd->u->spawn_gfx_4.rangeY;
+            range.z = 0.003906f * cmd->u->spawn_gfx_4.rangeX;
 
             NEXT_CMD(cmd);
             ftCo_8009F834(gobj, gfx_id, bone, use_common_bone_id,
@@ -400,7 +400,7 @@ void ftAction_8007169C(Fighter_GObj* gobj, CommandInfo* cmd)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     HitCapsule* hit = &fp->x914[cmd->u->set_hitbox_scale.idx];
-    hit->scale = (1 / 256.0f) * cmd->u->set_hitbox_scale.value;
+    hit->scale = 0.003906f * cmd->u->set_hitbox_scale.value;
     NEXT_CMD(cmd);
 }
 
@@ -1253,7 +1253,7 @@ void ftAction_80073008(Fighter_GObj* gobj, CommandInfo* cmd)
 
     charge_rate = cmd->u->smash_charge_0.charge_rate;
     charge_frames = cmd->u->smash_charge_0.charge_frames;
-    dmg_mult = (1 / 256.0f) * charge_rate;
+    dmg_mult = 0.003906f * charge_rate;
     NEXT_CMD(cmd);
     color_anim = cmd->u->smash_charge_1.color_anim;
     NEXT_CMD(cmd);

--- a/src/melee/ft/ftcpuattack.c
+++ b/src/melee/ft/ftcpuattack.c
@@ -703,7 +703,7 @@ int ftCo_800B6208(ftCo_AttackEntry* arr)
         }
         p++;
     }
-    HSD_ASSERT(0x28A, NULL);
+    HSD_ASSERT(0x28A, 0);
 }
 
 /// Return true if the fighter is currently in any attacking motion state

--- a/src/melee/gm/gm_1601.c
+++ b/src/melee/gm/gm_1601.c
@@ -1493,7 +1493,7 @@ void gm_80162B4C(s32 amount)
 void gm_IncrementPowerCount(void)
 {
     u32 result;
-    u32 val;
+    s32 val;
     u32* ptr;
 
     ptr = gmMainLib_GetPowerCount();

--- a/src/melee/gm/gm_16AE.c
+++ b/src/melee/gm/gm_16AE.c
@@ -1425,7 +1425,8 @@ static inline void fn_8016D634_inline(struct lbl_8046B6A0_24C_t* dst)
 void fn_8016D634(void)
 {
     lbl_8046B6A0_t* tmp = &lbl_8046B6A0;
-    struct lbl_8046B6A0_24C_t* temp_r6;
+    struct lbl_8046B6A0_24C_t* dst;
+    struct lbl_8046B6A0_24C_t* copied_dst;
 
     PAD_STACK(8);
 
@@ -1444,22 +1445,23 @@ void fn_8016D634(void)
         gm_801A4674(4);
         gm_801A4634(5);
         lbl_8046B6A0.unk_9 = 1;
-        temp_r6 = &tmp->x24C;
+        dst = &tmp->x24C;
+        copied_dst = dst;
         if (lbl_8046B6A0.match_over == 0) {
-            *temp_r6 = tmp->x24C;
-            temp_r6->is_teams = lbl_8046B6A0.x24C8.is_teams;
-            temp_r6->x4 = tmp->match_result;
-            gm_80166378(temp_r6);
-            fn_8016C46C_dontinline((int) temp_r6);
+            *copied_dst = tmp->x24C;
+            copied_dst->is_teams = lbl_8046B6A0.x24C8.is_teams;
+            copied_dst->x4 = tmp->match_result;
+            gm_80166378(copied_dst);
+            fn_8016C46C_dontinline((int) copied_dst);
             if (tmp->match_result != 7 && tmp->match_result != 8) {
-                fn_8016C4F4(temp_r6);
+                fn_8016C4F4(copied_dst);
             }
             tmp->match_over = 1;
         } else {
-            *temp_r6 = tmp->x24C;
+            *copied_dst = tmp->x24C;
         }
         fn_80180630(tmp->x24C8.x18, 0, tmp->x24C8.x9, tmp->x24C8.x4_5,
-                    temp_r6);
+                    copied_dst);
         lbl_8046B6A0.unk_0 = 2;
     } else {
         lbl_8046B6A0.unk_0 = 3;

--- a/src/melee/gm/gm_1832.c
+++ b/src/melee/gm/gm_1832.c
@@ -93,6 +93,15 @@ static struct {
     u8 pad_104[0x54];
 } lbl_804735E8;
 
+typedef struct gm_1832_8047368C_t {
+    /* 0x00 */ s32 model_scale_kind;
+    /* 0x04 */ s32 game_type;
+    /* 0x08 */ u8 pad_8[0x1C];
+} gm_1832_8047368C_t;
+STATIC_ASSERT(sizeof(gm_1832_8047368C_t) == 0x24);
+
+extern gm_1832_8047368C_t lbl_8047368C;
+
 static HSD_Archive* lbl_804D65F4;
 static HSD_Archive* lbl_804D65F8;
 static HSD_GObj* lbl_804D65F0;
@@ -953,19 +962,19 @@ void fn_80186080(void)
     HSD_SisLib_803A62A0(0, "SdIntro.dat", "SIS_IntroData");
     lbl_804735A8.x4[6] = (HSD_JObj*) HSD_SisLib_803A5ACC(
         0, temp_r31, 0.0f, 0.0f, 0.0f, 640.0f, 480.0f);
-    if (lbl_804735E8.xE8 == 1) {
+    if (lbl_8047368C.game_type == 1) {
         if (lbLang_IsSavedLanguageUS()) {
             HSD_SisLib_803A6368((HSD_Text*) lbl_804735A8.x4[6], 5);
             return;
         }
         HSD_SisLib_803A6368((HSD_Text*) lbl_804735A8.x4[6], 2);
-    } else if (lbl_804735E8.xE8 == 3) {
+    } else if (lbl_8047368C.game_type == 3) {
         if (lbLang_IsSavedLanguageUS()) {
             HSD_SisLib_803A6368((HSD_Text*) lbl_804735A8.x4[6], 6);
             return;
         }
         HSD_SisLib_803A6368((HSD_Text*) lbl_804735A8.x4[6], 3);
-    } else if (lbl_804735E8.xE8 == 2) {
+    } else if (lbl_8047368C.game_type == 2) {
         if (lbLang_IsSavedLanguageUS()) {
             HSD_SisLib_803A6368((HSD_Text*) lbl_804735A8.x4[6], 7);
             return;
@@ -1268,14 +1277,16 @@ void fn_80186EFC(HSD_GObj* gobj)
     }
 }
 
-static struct {
+typedef struct gm_80186F6C_Entry {
     /* 0x00 */ f32 x0;
     /* 0x04 */ f32 x4;
     /* 0x08 */ f32 x8;
     /* 0x0C */ f32 xC;
     /* 0x10 */ f32 x10;
     /* 0x14 */ f32 x14;
-} lbl_803D9498[] = {
+} gm_80186F6C_Entry;
+
+static gm_80186F6C_Entry lbl_803D9498[] = {
     { 0.0f, -4.5f, 0.0f, 1.0f, 1.0f, 1.0f },
     { 0.0f, 1.5f, 0.0f, 0.6f, 0.6f, 0.6f },
     { 0.0f, -5.3f, 0.0f, 1.3f, 1.3f, 1.3f },
@@ -1311,20 +1322,21 @@ void fn_80186F6C(HSD_GObj* arg0)
     Vec3 pos;
     HSD_JObj* jobj = arg0->hsd_obj;
     HSD_JObj* child = lbl_804736B0.x8;
+    gm_80186F6C_Entry* entry = lbl_803D9498;
     PAD_STACK(4);
 
     HSD_JObjGetTranslation(child, &pos);
 
     pos.x -= 7.0f;
-    pos.x += lbl_803D9498[lbl_804D6618.x0].x0;
-    pos.y += lbl_803D9498[lbl_804D6618.x0].x4;
-    pos.z += lbl_803D9498[lbl_804D6618.x0].x8;
+    pos.x += entry[lbl_804D6618.x0].x0;
+    pos.y += entry[lbl_804D6618.x0].x4;
+    pos.z += entry[lbl_804D6618.x0].x8;
 
     HSD_JObjSetTranslate(jobj, &pos);
 
-    HSD_JObjSetScaleX(jobj, lbl_803D9498[lbl_804D6618.x0].xC);
-    HSD_JObjSetScaleY(jobj, lbl_803D9498[lbl_804D6618.x0].x10);
-    HSD_JObjSetScaleZ(jobj, lbl_803D9498[lbl_804D6618.x0].x14);
+    HSD_JObjSetScaleX(jobj, entry[lbl_804D6618.x0].xC);
+    HSD_JObjSetScaleY(jobj, entry[lbl_804D6618.x0].x10);
+    HSD_JObjSetScaleZ(jobj, entry[lbl_804D6618.x0].x14);
 
     {
         HSD_GObj* entity2 = Player_GetEntityAtIndex(0, 1);

--- a/src/melee/gm/gm_18A5.c
+++ b/src/melee/gm/gm_18A5.c
@@ -3633,24 +3633,24 @@ void fn_80193230(void)
 }
 #pragma pop
 
-static s32 lbl_804DA78C = 0x46DC46FF;
+/// .sdata2
+/* 4DA78C */ extern s32 lbl_804DA78C;
 
 void fn_80193308(void)
 {
-    // Extra vars are permuter slop, but 100% is 100%
-    HSD_Text* new_var3;
-    s32* new_var4;
+    HSD_Text* created_text2;
+    s32* text_color_word;
     s32 color;
     TmData* tm;
     HSD_Text* text;
-    GXColor* new_var5;
+    GXColor* text_color;
     HSD_Text** ptr;
     f32 y;
     s32 i;
     s32 idx;
-    s32* new_var;
+    s32* color_word;
     s32 count;
-    HSD_Text* new_var2;
+    HSD_Text* created_text;
 
     color = lbl_804DA78C;
     tm = gm_8018F634();
@@ -3695,17 +3695,17 @@ void fn_80193308(void)
     idx = 1;
     if ((!tm) && (!tm)) {
     }
-    new_var = &color;
+    color_word = &color;
     do {
-        new_var2 = HSD_SisLib_803A6754(0, (s32) lbl_804D663C);
+        created_text = HSD_SisLib_803A6754(0, (s32) lbl_804D663C);
         ptr = &tm->x518[idx];
-        *ptr = new_var2;
+        *ptr = created_text;
         text = *ptr;
         text->font_size.x = 0.58f;
         text->font_size.y = 0.55f;
         (*ptr)->default_kerning = 1;
         if (count != 0) {
-            *(new_var4 = (s32*) (&(*ptr)->text_color)) = *new_var;
+            *(text_color_word = (s32*) (&(*ptr)->text_color)) = *color_word;
         }
         count += 1;
         idx = 2;
@@ -3714,16 +3714,16 @@ void fn_80193308(void)
     count = 0;
     idx = 3;
     do {
-        new_var3 = HSD_SisLib_803A6754(0, (s32) lbl_804D663C);
+        created_text2 = HSD_SisLib_803A6754(0, (s32) lbl_804D663C);
         ptr = &tm->x518[idx];
-        *ptr = new_var3;
+        *ptr = created_text2;
         text = *ptr;
         text->font_size.x = 0.85f;
         text->font_size.y = 1.35f;
         (*ptr)->default_kerning = 1;
         (*ptr)->default_alignment = 1;
         if (count) {
-            *((s32*) (new_var5 = &(*ptr)->text_color)) = *new_var;
+            *((s32*) (text_color = &(*ptr)->text_color)) = *color_word;
             ;
         }
         count += 1;

--- a/src/melee/gm/gmmain_lib.c
+++ b/src/melee/gm/gmmain_lib.c
@@ -679,8 +679,9 @@ bool gmMainLib_8015D984(u32 arg0)
     PAD_STACK(16);
 
     if (gmMainLib_8015DA90(arg0) == 0) {
-        u32* base = &gmMainLib_804D3EE0->unk_6C[0];
-        u32* temp_r31 = &base[arg0];
+        u32* temp_r31 = (u32*) gmMainLib_804D3EE0;
+        temp_r31 += arg0;
+        temp_r31 = (u32*) ((u8*) temp_r31 + 0x6C);
         *temp_r31 = lbTime_8000AFBC();
 
         gmMainLib_8015D9F4(arg0);

--- a/src/melee/gm/gmresultplayer.c
+++ b/src/melee/gm/gmresultplayer.c
@@ -917,22 +917,10 @@ int fn_80179350_inline(void)
     return fn_801791E4();
 }
 
-void fn_80179350(HSD_GObj* arg0)
+static inline void fn_80179350_update(ResultsData* data, MatchEnd* match_end,
+                                      HSD_GObj* arg0)
 {
-    ResultsData* data = &lbl_8046DBE8;
-    MatchEnd* match_end;
-    int i;
-
     PAD_STACK(8);
-
-    match_end = fn_80174274();
-
-    for (i = 0; i < 6; i++) {
-        if (data->player_data[i].jobjs[12] != NULL) {
-            lb_8000B1CC(data->player_data[i].jobjs[12], NULL,
-                        &data->player_data[i].stats_position);
-        }
-    }
 
     if ((u32) data->x8 == 0 && data->x0_4) {
         gm_801A4634(0);
@@ -996,6 +984,21 @@ void fn_80179350(HSD_GObj* arg0)
             break;
         }
     }
+}
+void fn_80179350(HSD_GObj* arg0)
+{
+    ResultsData* data = &lbl_8046DBE8;
+    MatchEnd* match_end;
+    int i;
+    PAD_STACK(8);
+    match_end = fn_80174274();
+    for (i = 0; i < 6; i++) {
+        if (data->player_data[i].jobjs[12] != NULL) {
+            lb_8000B1CC(data->player_data[i].jobjs[12], NULL,
+                        &data->player_data[i].stats_position);
+        }
+    }
+    fn_80179350_update(data, match_end, arg0);
 
     if ((u32) data->x8 < (u32) -1) {
         data->x8++;

--- a/src/melee/gm/gmtou.c
+++ b/src/melee/gm/gmtou.c
@@ -470,10 +470,9 @@ void fn_8019CDBC(HSD_GObj* gobj)
     TmData* tmd = gm_8018F634();
     HSD_JObj* jobj = HSD_GObjGetHSDObj(gobj);
     u32 idx = fn_8018F62C(gobj);
-    PAD_STACK(20);
+    PAD_STACK(12);
 
-    HSD_ASSERT(993, jobj);
-    sp28 = jobj->translate.x;
+    sp28 = HSD_JObjGetTranslationX(jobj);
     temp_r27 = tmd->x37[idx].xE;
     sp24 = (5.999997f * temp_r27) - 21.5f;
     mn_8022F410(&sp28, &sp24, 0.4f);

--- a/src/melee/gr/granime.c
+++ b/src/melee/gr/granime.c
@@ -630,7 +630,7 @@ void grAnime_801C752C(HSD_JObj* obj, s32 arg1, s32 flags, void* func,
         arg.d = va_arg(ap, u32);
         break;
     default:
-        HSD_ASSERTREPORT(0x36F, NULL, "not match arg_type\n");
+        HSD_ASSERTREPORT(0x36F, 0, "unexpected argument format.\n");
         break;
     }
     if (grAnime_801C6F50_wrapped(obj_tmp, flags, func, type, &arg)) {

--- a/src/melee/gr/gricemt.c
+++ b/src/melee/gr/gricemt.c
@@ -1050,7 +1050,9 @@ void grIceMt_801F8B10(Ground_GObj* arg0)
     f32 cur;
     mul = 0.3f * gp->gv.icemt2.xC4;
     jobj = Ground_801C3FA4(arg0, 8);
-    HSD_ASSERT(0x78F, jobj);
+    if (jobj == NULL) {
+        __assert(grIm_803E46F8, 0x78F, &grIm_804D4718);
+    }
     cur = HSD_JObjGetTranslationY(jobj);
     cur = cur - mul;
     if (cur > 0.5f * (3500.0f * Ground_801C0498())) {

--- a/src/melee/gr/grkongo.c
+++ b/src/melee/gr/grkongo.c
@@ -43,28 +43,28 @@ S16Vec3 grKg_803E16E0[6] = {
 
 StageCallbacks grKg_803E1704[12] = {
     { NULL, NULL, NULL, NULL, 0 },
-    { grKongo_801D6074, grKongo_801D6190, grKongo_801D6198,
-      grKongo_801D6378, 0 },
-    { grKongo_801D6074, grKongo_801D6190, grKongo_801D6198,
-      grKongo_801D6378, 0 },
-    { grKongo_801D6038, grKongo_801D6064, grKongo_801D606C,
-      grKongo_801D6070, 0 },
-    { grKongo_801D5FA8, grKongo_801D5FD4, grKongo_801D5FDC,
-      grKongo_801D5FE0, 0 },
-    { grKongo_801D55D8, grKongo_801D5774, grKongo_801D577C,
-      grKongo_801D5FA4, 0 },
-    { grKongo_801D5FE4, grKongo_801D6028, grKongo_801D6030,
-      grKongo_801D6034, 0 },
-    { grKongo_801D637C, grKongo_801D64B4, grKongo_801D64BC,
-      grKongo_801D6518, 0 },
-    { grKongo_801D637C, grKongo_801D64B4, grKongo_801D64BC,
-      grKongo_801D6518, 0 },
-    { grKongo_801D637C, grKongo_801D64B4, grKongo_801D64BC,
-      grKongo_801D6518, 0 },
-    { grKongo_801D5490, grKongo_801D5574, grKongo_801D557C,
-      grKongo_801D55D4, 0xC0000000 },
-    { grKongo_801D651C, grKongo_801D6660, grKongo_801D6668,
-      grKongo_801D69AC, 0 },
+    { grKongo_801D6074, grKongo_801D6190, grKongo_801D6198, grKongo_801D6378,
+      0 },
+    { grKongo_801D6074, grKongo_801D6190, grKongo_801D6198, grKongo_801D6378,
+      0 },
+    { grKongo_801D6038, grKongo_801D6064, grKongo_801D606C, grKongo_801D6070,
+      0 },
+    { grKongo_801D5FA8, grKongo_801D5FD4, grKongo_801D5FDC, grKongo_801D5FE0,
+      0 },
+    { grKongo_801D55D8, grKongo_801D5774, grKongo_801D577C, grKongo_801D5FA4,
+      0 },
+    { grKongo_801D5FE4, grKongo_801D6028, grKongo_801D6030, grKongo_801D6034,
+      0 },
+    { grKongo_801D637C, grKongo_801D64B4, grKongo_801D64BC, grKongo_801D6518,
+      0 },
+    { grKongo_801D637C, grKongo_801D64B4, grKongo_801D64BC, grKongo_801D6518,
+      0 },
+    { grKongo_801D637C, grKongo_801D64B4, grKongo_801D64BC, grKongo_801D6518,
+      0 },
+    { grKongo_801D5490, grKongo_801D5574, grKongo_801D557C, grKongo_801D55D4,
+      0xC0000000 },
+    { grKongo_801D651C, grKongo_801D6660, grKongo_801D6668, grKongo_801D69AC,
+      0 },
 };
 
 char grKg_803E17F4[] = "/GrKg.dat";
@@ -482,8 +482,7 @@ void grKongo_801D577C(Ground_GObj* arg0)
         }
         temp_r31->gv.kongo3.xC6 = 2;
     case 2: /* switch 2 */
-    block_124:
-        ;
+    block_124:;
         hit = grKg_803B7FB0;
         hit.state = 1;
         hit.damage = *(u32*) &grKg_804D6980->unk6C;
@@ -492,8 +491,7 @@ void grKongo_801D577C(Ground_GObj* arg0)
         hit.unk10 = *(u32*) &grKg_804D6980->unk78;
         hit.unk14 = *(u32*) &grKg_804D6980->unk7C;
         hit.element = *(u32*) &grKg_804D6980->unk80;
-        angle = (f32) (1.5707963267948966 +
-                       (f64) temp_r31->gv.kongo3.xD8);
+        angle = (f32) (1.5707963267948966 + (f64) temp_r31->gv.kongo3.xD8);
         if (angle < 0.0f) {
             angle = (f32) ((f64) angle + M_TAU);
         } else if (angle > (f32) M_TAU) {
@@ -661,7 +659,7 @@ void grKongo_801D828C(HSD_GObj* gobj)
         return;
     }
     if (gp->gv.kongo.u.taru.keep == NULL) {
-        __assert(grKg_803E1858, 1719, grKg_803E1A00);
+        __assert(grKg_803E1858, 1719, "gp->u.taru.keep");
     }
     if (((u8*) gp->gv.kongo.u.taru.keep)[2] == 8) {
         gp->gv.kongo3.xC6 = 0;
@@ -1138,8 +1136,8 @@ void grKongo_801D7134(HSD_GObj* gobj, s32 arg1)
     grKongo_801D6AFC();
 
     i = 0U;
-    entry = (_struct_grKg_803E188C_0x18*) ((u8*) grKg_803E16E0 +
-                                           (i * 0x18) + 0x1AC);
+    entry = (_struct_grKg_803E188C_0x18*) ((u8*) grKg_803E16E0 + (i * 0x18) +
+                                           0x1AC);
     table = entry;
     do {
         entry->unk14 = (f32) (37.8 * tanf(-entry->unkC));
@@ -1147,17 +1145,16 @@ void grKongo_801D7134(HSD_GObj* gobj, s32 arg1)
         entry++;
     } while (i < 15U);
 
-    displacement = grKg_803E188C[2].unkC *
-                   (((deg_to_rad * grKg_804D6980->unkA8) /
-                     (deg_to_rad * grKg_804D6980->unk90)) -
-                    1.0f);
+    displacement =
+        grKg_803E188C[2].unkC * (((deg_to_rad * grKg_804D6980->unkA8) /
+                                  (deg_to_rad * grKg_804D6980->unk90)) -
+                                 1.0f);
     angle = (f32) (0.7853981633974483 *
-                   (0.5 * (f64) (((grKg_803E188C[2].unk14 -
-                                    grKg_803E188C[1].unk14) /
-                                   6.0f) +
-                                  ((grKg_803E188C[3].unk14 -
-                                    grKg_803E188C[2].unk14) /
-                                   6.0f))));
+                   (0.5 *
+                    (f64) (((grKg_803E188C[2].unk14 - grKg_803E188C[1].unk14) /
+                            6.0f) +
+                           ((grKg_803E188C[3].unk14 - grKg_803E188C[2].unk14) /
+                            6.0f))));
     limit = deg_to_rad * grKg_804D6980->unkAC;
     if (angle > limit) {
         angle = limit;
@@ -1173,17 +1170,17 @@ void grKongo_801D7134(HSD_GObj* gobj, s32 arg1)
         gp->gv.kongo.xC8 = -angular_vel;
     }
 
-    displacement = grKg_803E188C[12].unkC *
-                   (((deg_to_rad * grKg_804D6980->unkA8) /
-                     (deg_to_rad * grKg_804D6980->unk90)) -
-                    1.0f);
-    angle = (f32) (0.7853981633974483 *
-                   (0.5 * (f64) (((grKg_803E188C[12].unk14 -
-                                    grKg_803E188C[11].unk14) /
-                                   6.0f) +
-                                  ((grKg_803E188C[13].unk14 -
-                                    grKg_803E188C[12].unk14) /
-                                   6.0f))));
+    displacement =
+        grKg_803E188C[12].unkC * (((deg_to_rad * grKg_804D6980->unkA8) /
+                                   (deg_to_rad * grKg_804D6980->unk90)) -
+                                  1.0f);
+    angle =
+        (f32) (0.7853981633974483 *
+               (0.5 *
+                (f64) (((grKg_803E188C[12].unk14 - grKg_803E188C[11].unk14) /
+                        6.0f) +
+                       ((grKg_803E188C[13].unk14 - grKg_803E188C[12].unk14) /
+                        6.0f))));
     limit = deg_to_rad * grKg_804D6980->unkAC;
     if (angle > limit) {
         angle = limit;
@@ -1350,8 +1347,7 @@ HSD_GObj* grKongo_801D5340(s32 gobj_id)
             HSD_GObj_SetupProc(gobj, callbacks->callback2, 4);
         }
     } else {
-        OSReport((char*) grKg_803E16E0 + 0x154, grKg_803E1858, 0x10E,
-                 gobj_id);
+        OSReport((char*) grKg_803E16E0 + 0x154, grKg_803E1858, 0x10E, gobj_id);
     }
     return gobj;
 }

--- a/src/melee/gr/grmaterial.c
+++ b/src/melee/gr/grmaterial.c
@@ -41,9 +41,25 @@ static inline ColorOverlay* grMaterial_GetOverlay(Ground* gp)
     return (ColorOverlay*) ((u8*) gp + 0x40);
 }
 
-/* 3E0A20 */ static HSD_MObjInfo grMaterial_803E0A20 = { 0 };
+struct grMaterial_MObjInfo {
+    /*   +0 */ HSD_ClassInfo parent;
+    /*  +3C */ HSD_MObjSetupFunc setup;
+    /*  +40 */ int (*load)(HSD_MObj* mobj, HSD_MObjDesc* desc);
+    /*  +44 */ HSD_TExp* (*make_texp)(HSD_MObj* mobj, HSD_TObj* tobj_top,
+                                      HSD_TExp** list);
+    /*  +48 */ void (*setup_tev)(HSD_MObj* mobj, HSD_TObj* tobj,
+                                 u32 rendermode);
+    /*  +4C */ void (*unset)(HSD_MObj* mobj, u32 rendermode);
+    /*  +50 */ u8 pad_x50[0xDC - 0x50];
+    /*  +DC */ char library_name[0xF4 - 0xDC];
+};
+
+/* 3E0A20 */ static struct grMaterial_MObjInfo grMaterial_803E0A20 = { 0 };
+/* 4D4560 */ static char grMaterial_804D4560[] = "gr_mobj";
 /* 4D4568 */ static char grMaterial_804D4568[] = "0";
-/* 4D456C */ static ItCmd grMaterial_804D456C[1];
+/* 4D456C */ static ItCmd grMaterial_804D456C[1] = {
+    grMaterial_801C9470,
+};
 
 static u32 data_section_pad[35] = { 0 };
 
@@ -248,7 +264,8 @@ void grMaterial_801C8E68(HSD_GObj* gobj, GroundOrAir ground_or_air)
 void grMaterial_801C8E74(void)
 {
     hsdInitClassInfo(HSD_CLASS_INFO(&grMaterial_803E0A20),
-                     HSD_CLASS_INFO(&hsdMObj), "sysdolphin_base_library",
+                     HSD_CLASS_INFO(&hsdMObj),
+                     grMaterial_803E0A20.library_name,
                      "gr_mobj", sizeof(HSD_MObjInfo), sizeof(HSD_MObj));
     HSD_CLASS_INFO(&grMaterial_803E0A20)->release =
         HSD_CLASS_INFO(&hsdMObj)->release;

--- a/src/melee/gr/grmutecity.c
+++ b/src/melee/gr/grmutecity.c
@@ -392,7 +392,8 @@ static s32 grMc_804D69D4;
 
 static f32 light_ref_br = 40000.0f;
 static f32 light_ref_dist = 0.99f;
-static s32 light_dist_func = 0x1;
+static s32 grMc_804D46CC = 0x1;
+#define light_dist_func grMc_804D46CC
 
 void grMuteCity_801EFC68(bool arg) {}
 
@@ -542,8 +543,8 @@ void grMuteCity_801F0120(Ground_GObj* gobj)
 
     ground = GET_GROUND(gobj);
     if (ground->gv.mutecity.x110 != NULL) {
-        HSD_LObjSetDistAttn(ground->gv.mutecity.x110, light_ref_dist,
-                            light_ref_br, light_dist_func);
+        HSD_LObjSetDistAttn(ground->gv.mutecity.x110, light_ref_br,
+                            light_ref_dist, light_dist_func);
     }
     grMuteCity_801F04B8(gobj);
     grMuteCity_801F0948(gobj);
@@ -580,10 +581,15 @@ bool grMuteCity_801F0288(Ground_GObj* arg)
     return false;
 }
 
+static inline f32 grMuteCity_801F0290_get_target(Ground* gp)
+{
+    return gp->gv.mutecity2.xCC;
+}
+
 void grMuteCity_801F0290(Ground_GObj* gobj)
 {
     Ground* gp = GET_GROUND(gobj);
-    f32 target = gp->gv.mutecity2.xCC;
+    f32 target = grMuteCity_801F0290_get_target(gp);
     f32 current = gp->gv.mutecity2.xD0;
     f32 diff = target - current;
 
@@ -591,7 +597,7 @@ void grMuteCity_801F0290(Ground_GObj* gobj)
         if (diff < 0.001f) {
             gp->gv.mutecity2.xD0 = target;
         } else {
-            gp->gv.mutecity2.xD0 = current + 0.001f;
+            gp->gv.mutecity2.xD0 += 0.001f;
         }
     } else if (diff < 0.0f) {
         if (diff > -0.001f) {
@@ -1655,7 +1661,9 @@ DynamicModelDesc* grMuteCity_801F28A8(void)
 {
     UnkArchiveStruct* archive = grDatFiles_801C6330(0x26);
     UnkStageDat* dat;
-    HSD_ASSERT(2135, archive);
+    if (archive == NULL) {
+        __assert(grMc_803E3434, 2135, "archive");
+    }
     dat = archive->unk4;
     if (dat != NULL) {
         return (DynamicModelDesc*) ((char*) dat->unk8 + 0x7B8);

--- a/src/melee/gr/groldkongo.c
+++ b/src/melee/gr/groldkongo.c
@@ -741,7 +741,9 @@ void grOldKongo_802105C8(HSD_GObj* gobj)
     if (gp->gv.oldkongo.xC6 != 1) {
         return;
     }
-    HSD_ASSERT(751, gp->gv.oldkongo.xD4);
+    if (gp->gv.oldkongo.xD4 == NULL) {
+        __assert(grOk_803E6640, 751, "gp->u.taru.keep");
+    }
     if (((u8*) gp->gv.oldkongo.xD4)[2] == 8) {
         gp->gv.oldkongo.xC6 = 0;
         gp->gv.oldkongo.xD4 = NULL;

--- a/src/melee/gr/grpstadium.c
+++ b/src/melee/gr/grpstadium.c
@@ -1135,14 +1135,14 @@ void grStadium_801D2A60(Ground_GObj* gobj)
         do {
             val =
                 HSD_Randf() * (yaku->x48 + yaku->x4A + yaku->x4C + yaku->x4E);
-            if (val - yaku->x48 < 0) {
+            val -= yaku->x48;
+            if (val < 0) {
                 var_r4 = 8;
-            } else if (val - yaku->x48 - yaku->x4C < 0) {
+            } else if ((val -= yaku->x4C) < 0) {
                 var_r4 = 7;
-            } else if (val - yaku->x48 - yaku->x4C - yaku->x4A < 0) {
+            } else if ((val -= yaku->x4A) < 0) {
                 var_r4 = 1;
-            } else if (val - yaku->x48 - yaku->x4C - yaku->x4A - yaku->x4E < 0)
-            {
+            } else if ((val -= yaku->x4E) < 0) {
                 var_r4 = 15;
             } else {
                 var_r4 = 1;

--- a/src/melee/if/ifcoget.c
+++ b/src/melee/if/ifcoget.c
@@ -28,6 +28,9 @@
 #include <MSL/stdio.h>
 #include <MSL/string.h>
 
+/* 4DDC28 */ extern float un_804DDC28;
+/* 4DDC2C */ extern float un_804DDC2C;
+
 /// .data
 /* 3F9E08 */ static struct {
     struct {
@@ -68,6 +71,9 @@ struct un_804A1F58_x8_t {
 /// .sbss
 /* 4D6DA0 */ static void* un_804D6DA0;
 /* 4D6DA4 */ static SceneDesc* un_804D6DA4;
+
+/// .sdata2
+/* 4DDC20 */ extern float un_804DDC20;
 
 void fn_802FED14(HSD_GObj* gobj)
 {
@@ -122,7 +128,7 @@ void un_802FEFAC(void)
     HSD_GObj_SetupProc(gobj_ui, fn_802FED14, 17);
     gm_8016895C(jobj_ui, un_804D6DA4->models[0], 0);
     HSD_JObjSetFlagsAll(jobj_ui, 0x10);
-    HSD_JObjReqAnimAll(jobj_ui, 0.0);
+    HSD_JObjReqAnimAll(jobj_ui, un_804DDC20);
     HSD_JObjAnimAll(jobj_ui);
     un_803F9E08.xC = gobj_ui;
 }
@@ -222,8 +228,9 @@ void un_802FF364(int slot)
         s = 9999;
     }
     thing->x8 =
-        HSD_SisLib_803A6B98(thing->x4, ifAll->x, ifAll->y + 3.2f, "%d", s);
-    HSD_SisLib_803A7548(thing->x4, thing->x8, 0.06, 0.06);
+        HSD_SisLib_803A6B98(thing->x4, ifAll->x, un_804DDC28 + ifAll->y, "%d",
+                            s);
+    HSD_SisLib_803A7548(thing->x4, thing->x8, un_804DDC2C, un_804DDC2C);
     thing->x4->render_callback = fn_802FF360;
     thing->x0 = GObj_Create(HSD_GOBJ_CLASS_UI, 15, 0);
     HSD_GObj_SetupProc(thing->x0, fn_802FF218, 17);

--- a/src/melee/if/soundtest.c
+++ b/src/melee/if/soundtest.c
@@ -95,35 +95,35 @@
 /* 3FA348 */ static u16 un_803FA348;
 /* 3FA34C */ static u8 un_803FA34C;
 /* 3FA32C */ static u8 un_803FA32C;
-/* 3FA658 */ static u8 un_803FA658[0x290];
-/* 3FA8E8 */ static u8 un_803FA8E8[0x15C];
-/* 3FAA44 */ static u8 un_803FAA44[0xC0];
-/* 3FB168 */ static u8 un_803FB168[0x4A4];
-/* 3FB60C */ static u8 un_803FB60C[0xE0];
-/* 3FB728 */ static u8 un_803FB728[0xC0];
-/* 3FB870 */ static u8 un_803FB870[0xE0];
-/* 3FB98C */ static u8 un_803FB98C[0xC0];
-/* 3FBA9C */ static u8 un_803FBA9C[0xC0];
-/* 3FBB98 */ static u8 un_803FBB98[0xC0];
-/* 3FBCAC */ static u8 un_803FBCAC[0xC0];
-/* 3FBDC0 */ static u8 un_803FBDC0[0xC0];
-/* 3FBFFC */ static u8 un_803FBFFC[0xC0];
-/* 3FC0FC */ static u8 un_803FC0FC[0xC0];
-/* 3FC22C */ static u8 un_803FC22C[0x1F4];
-/* 3FC63C */ static u8 un_803FC63C[0x80];
-/* 3FC70C */ static u8 un_803FC70C[0x11C];
-/* 3FC828 */ static u8 un_803FC828[0xA0];
-/* 3FC8C8 */ static u8 un_803FC8C8[0x168];
-/* 3FCA40 */ static u8 un_803FCA40[0x1A0];
-/* 3FCC38 */ static u8 un_803FCC38[0xFC];
-/* 3FCD34 */ static u8 un_803FCD34[0x118];
-/* 3FCE4C */ static u8 un_803FCE4C[0xE0];
-/* 3FD064 */ static u8 un_803FD064[0x1C0];
-/* 3FD310 */ static u8 un_803FD310[0x27C];
-/* 3FD58C */ static u8 un_803FD58C[0x2D8];
-/* 3FD864 */ static u8 un_803FD864[0x294];
-/* 3FDAF8 */ static u8 un_803FDAF8[0x80];
-/* 3FDB9C */ static u8 un_803FDB9C[0x84];
+/* 3FA658 */ static u8 un_803FA658[0x290] = { 0 };
+/* 3FA8E8 */ static u8 un_803FA8E8[0x15C] = { 0 };
+/* 3FAA44 */ static u8 un_803FAA44[0xC0] = { 0 };
+/* 3FB168 */ static u8 un_803FB168[0x4A4] = { 0 };
+/* 3FB60C */ static u8 un_803FB60C[0xE0] = { 0 };
+/* 3FB728 */ static u8 un_803FB728[0xC0] = { 0 };
+/* 3FB870 */ static u8 un_803FB870[0xE0] = { 0 };
+/* 3FB98C */ static u8 un_803FB98C[0xC0] = { 0 };
+/* 3FBA9C */ static u8 un_803FBA9C[0xC0] = { 0 };
+/* 3FBB98 */ static u8 un_803FBB98[0xC0] = { 0 };
+/* 3FBCAC */ static u8 un_803FBCAC[0xC0] = { 0 };
+/* 3FBDC0 */ static u8 un_803FBDC0[0xC0] = { 0 };
+/* 3FBFFC */ static u8 un_803FBFFC[0xC0] = { 0 };
+/* 3FC0FC */ static u8 un_803FC0FC[0xC0] = { 0 };
+/* 3FC22C */ static u8 un_803FC22C[0x1F4] = { 0 };
+/* 3FC63C */ static u8 un_803FC63C[0x80] = { 0 };
+/* 3FC70C */ static u8 un_803FC70C[0x11C] = { 0 };
+/* 3FC828 */ static u8 un_803FC828[0xA0] = { 0 };
+/* 3FC8C8 */ static u8 un_803FC8C8[0x168] = { 0 };
+/* 3FCA40 */ static u8 un_803FCA40[0x1A0] = { 0 };
+/* 3FCC38 */ static u8 un_803FCC38[0xFC] = { 0 };
+/* 3FCD34 */ static u8 un_803FCD34[0x118] = { 0 };
+/* 3FCE4C */ static u8 un_803FCE4C[0xE0] = { 0 };
+/* 3FD064 */ static u8 un_803FD064[0x1C0] = { 0 };
+/* 3FD310 */ static u8 un_803FD310[0x27C] = { 0 };
+/* 3FD58C */ static u8 un_803FD58C[0x2D8] = { 0 };
+/* 3FD864 */ static u8 un_803FD864[0x294] = { 0 };
+/* 3FDAF8 */ static u8 un_803FDAF8[0x80] = { 0 };
+/* 3FDB9C */ static u8 un_803FDB9C[0x84] = { 0 };
 /* 3FD224 */ extern char un_803FD224[];
 /* 3FD230 */ extern char un_803FD230[];
 /* 3FD23C */ extern char un_803FD23C[];
@@ -182,6 +182,8 @@
 /* 45A6C0 */ extern u8 gmMainLib_8045A6C0[];
 
 /// .sdata2 (extern)
+/* 4DDC38 */ extern float un_804DDC38;
+/* 4DDC3C */ extern float un_804DDC3C;
 /* 4DDC48 */ extern float un_804DDC48;
 /* 4DDC4C */ extern float un_804DDC4C;
 /* 4DDC50 */ extern float un_804DDC50;
@@ -222,8 +224,8 @@ int un_802FF88C(void)
     }
     {
         un_80304138_objalloc_t* x = un_80302DF0();
-        x->x4->scale_x = 16.0f;
-        x->x4->scale_y = 32.0f;
+        x->x4->scale_x = un_804DDC38;
+        x->x4->scale_y = un_804DDC3C;
     }
     return 1;
 }

--- a/src/melee/if/textdraw.c
+++ b/src/melee/if/textdraw.c
@@ -55,15 +55,18 @@
 /* 4A1FD8 */ static DevText devtext_pool[32];
 
 /// .sbss
-/* 4D6E18 */ static DevText* devtext_drawlist;
-/* 4D6E1C */ static HSD_GObj* devtext_gobj;
+/* 4D6E18 */ static DevText* un_804D6E18;
+#define devtext_drawlist un_804D6E18
+/* 4D6E1C */ static HSD_GObj* un_804D6E1C;
+#define devtext_gobj un_804D6E1C
 /* 4D6E20 */ static HSD_CObj* devtext_cobj;
 /* 4D6E24 */ static int devtext_setup_classifier;
 /* 4D6E28 */ static int devtext_setup_p_link;
 /* 4D6E2C */ static int devtext_setup_priority;
 /* 4D6E30 */ static int devtext_setup_gx_link;
 /* 4D6E34 */ static int devtext_setup_render_priority;
-/* 4D6E38 */ static DevText* devtext_poolhead;
+/* 4D6E38 */ static DevText* un_804D6E38;
+#define devtext_poolhead un_804D6E38
 
 int DevText_StrLen(char* str)
 {
@@ -134,17 +137,17 @@ void DevText_InitPool(void)
 void DevText_Remove(DevText** ptext)
 {
     DevText* text = *ptext;
-    struct DevText* new_var; // Permuter slop
-    DevText* new_var3;       // Permuter slop
-    new_var = text->next;
-    if (new_var) {
-        new_var->prev = text->prev;
+    DevText* next;
+    DevText* cur;
+    next = text->next;
+    if (next) {
+        next->prev = text->prev;
     }
-    new_var3 = *ptext;
+    cur = *ptext;
     if ((*ptext)->prev) {
         (*ptext)->prev->next = (*ptext)->next;
     } else {
-        if (new_var3->next != 0) {
+        if (cur->next != 0) {
             *ptext = (*ptext)->next;
         } else {
             *ptext = NULL;

--- a/src/melee/lb/lbcollision.c
+++ b/src/melee/lb/lbcollision.c
@@ -2580,7 +2580,6 @@ bool lbColl_8000A584(HurtCapsule* hurt, u32 arg1, u32 arg2, Mtx arg3, f32 arg8)
         Vec3 sp88;
         f32 temp_f31;
         GXColor* temp_r31_2;
-        MtxPtr var_r28;
         u32 var_r0;
         u32 var_r4;
         GXColor* temp_r3;
@@ -2613,12 +2612,12 @@ bool lbColl_8000A584(HurtCapsule* hurt, u32 arg1, u32 arg2, Mtx arg3, f32 arg8)
             sp88 = hurt->b_pos;
             sp94 = hurt->a_pos;
             if (arg3 != NULL) {
-                var_r28 = spA0;
+                hurt = (HurtCapsule*) spA0;
             } else {
-                var_r28 = HSD_JObjGetMtxPtr(hurt->bone);
+                hurt = (HurtCapsule*) HSD_JObjGetMtxPtr(hurt->bone);
             }
-            lbColl_DrawHitResult(var_r28, &sp94, &sp88, temp_r3, temp_r31_2,
-                                 temp_f31);
+            lbColl_DrawHitResult((MtxPtr) hurt, &sp94, &sp88, temp_r3,
+                                 temp_r31_2, temp_f31);
             return true;
         }
         return false;

--- a/src/melee/lb/lbsnap.c
+++ b/src/melee/lb/lbsnap.c
@@ -283,6 +283,8 @@ static inline int lbSnap_GetSaveDataOffset(struct Unk80433380_0* snap)
     return snap->xC + ((int) &snap->x38 - (int) snap);
 }
 
+#pragma push
+#pragma global_optimizer off
 int lbSnap_8001DF20(void)
 {
     struct Unk80433380_0* snap = lbSnap_80433380.x0;
@@ -291,6 +293,7 @@ int lbSnap_8001DF20(void)
     lbSnap_803BACC8.x1C = snap;
     return lb_8001C4A8(&lbSnap_803BACC8.x14, &lbSnap_803BACC8);
 }
+#pragma pop
 
 int lbSnap_8001DF6C(int chan)
 {

--- a/src/melee/mn/mnmain.c
+++ b/src/melee/mn/mnmain.c
@@ -1651,6 +1651,22 @@ HSD_GObj* mn_8022BE34(void)
     return gobj;
 }
 
+static inline HSD_GObj* mn_8022BE34_OnEnter(void)
+{
+    Vec3 pos;
+    HSD_GObj* gobj = GObj_Create(2, 3, 0x80);
+    HSD_CObj* cobj;
+
+    mn_804D6BAC = gobj;
+    cobj = HSD_CObjLoadDesc(MenMain_cam);
+    HSD_CObjGetEyePosition(cobj, (Vec3*) ((u8*) &pos + 0x14));
+    HSD_GObjObject_80390A70(gobj, HSD_GObj_804D784B, cobj);
+    GObj_SetupGXLinkMax(gobj, fn_8022BDB4, 0);
+    gobj->gxlink_prios = 0x7F;
+    HSD_GObj_SetupProc(gobj, mn_8022BA1C, 0);
+    return gobj;
+}
+
 void mn_8022BEDC(HSD_GObj* gobj)
 {
     HSD_GObj* temp_r3;
@@ -2889,7 +2905,7 @@ void mn_8022DDA8_OnEnter(MenuEnterData* data)
 
     mn_8022DDA8_inline(hovered_selection);
     mn_8022BCF8();
-    mn_8022BEDC(mn_8022BE34());
+    mn_8022BEDC(mn_8022BE34_OnEnter());
     mn_80229B2C();
     mn_80229DC0();
 

--- a/src/melee/mn/mnname.c
+++ b/src/melee/mn/mnname.c
@@ -1516,23 +1516,41 @@ HSD_GObj* mnName_8023A59C(u8 arg0)
     return gobj;
 }
 
-void mnName_8023A9B4(u8 arg0)
+static inline struct mn_80231634_t* mnName_8023A9B4_GetUserData(
+    MnName_GObj* gobj2)
+{
+    return (struct mn_80231634_t*) gobj2->gobj.user_data_remove_func;
+}
+
+static inline void mnName_8023A9B4_ResetDisplayOrder(void)
 {
     u32 i;
-    MnName_GObj* gobj2;
-    HSD_JObj* jobj;
-    mn_804A04F0.hovered_selection = 0x18;
-    mn_804A04F0.x10 = (i = 0);
     PAD_STACK(0x8);
 
     for (i = 0; i < 0x78; i++) {
         mnName_NameDisplayOrder[i] = (u8) i;
     }
     HSD_GObj_80390CD4(mnName_8023A59C(3));
-    gobj2 = (0, (MnName_GObj*) ((HSD_GObj*) mnName_804D6BF8)->user_data);
+}
+
+static inline MnName_GObj* mnName_8023A9B4_GetGObj(void)
+{
+    return (MnName_GObj*) ((HSD_GObj*) mnName_804D6BF8)->user_data;
+}
+
+void mnName_8023A9B4(u8 arg0)
+{
+    u32 i;
+    MnName_GObj* gobj2;
+    HSD_JObj* jobj;
+
+    mn_804A04F0.hovered_selection = 0x18;
+    mn_804A04F0.x10 = (i = 0);
+    mnName_8023A9B4_ResetDisplayOrder();
+    gobj2 = (0, mnName_8023A9B4_GetGObj());
     if ((u8) mn_804A04F0.x10 == 1) {
         struct mn_80231634_t* p =
-            (struct mn_80231634_t*) gobj2->gobj.user_data_remove_func;
+            mnName_8023A9B4_GetUserData(gobj2);
         if (p == NULL) {
             jobj = NULL;
         } else {

--- a/src/melee/mp/mpisland.c
+++ b/src/melee/mp/mpisland.c
@@ -31,7 +31,7 @@
     { -1, { 0x00, 0x00, 0x00, 0x00 } },
 } };
 
-/* 4D8158 */ static float mpIsland_804D8158;
+/* 4D8158 */ const float mpIsland_804D8158 = 0.0F;
 /* 458E88 */ struct mpIsland_80458E88_t mpIsland_80458E88;
 
 void mpIsland_8005A6F8(void)

--- a/src/melee/mp/mplib.c
+++ b/src/melee/mp/mplib.c
@@ -4391,12 +4391,10 @@ void mpJointUnhide(int joint_id)
         line++;
     }
 
-    count = joint->inner->vtx_count;
     vtx = &groundCollVtx[joint->inner->vtx_start];
-    while (count-- > 0) {
+    for (i = joint->inner->vtx_count; i > 0; i--, vtx++) {
         vtx->x10 = vtx->pos.x;
         vtx->x14 = vtx->pos.y;
-        vtx++;
     }
 }
 

--- a/src/melee/pl/pltrick.h
+++ b/src/melee/pl/pltrick.h
@@ -12,7 +12,7 @@ struct plAttackStats;
 /* 037B2C */ int pl_80037B2C(struct plActionStats* arg0, int arg1, int arg2);
 /* 037BC0 */ void pl_80037BC0(struct plAttackStats* stats,
                               union Struct2070* ev);
-/* 037C60 */ void pl_80037C60(Fighter_GObj*, s32 prev2070_int);
+/* 037C60 */ void pl_80037C60(Fighter_GObj*, volatile s32 prev2070_int);
 /* 037DF4 */ void pl_80037DF4(HSD_GObj*, union Struct2070*);
 /* 037ECC */ void pl_80037ECC(HSD_GObj*);
 /* 038144 */ void pl_80038144(HSD_GObj*, HSD_GObj*, s32, ft_800898B4_t*, u16,

--- a/src/melee/vi/vi1201v1.c
+++ b/src/melee/vi/vi1201v1.c
@@ -137,10 +137,10 @@ void fn_8031FC30(HSD_GObj* gobj)
 {
     HSD_CObj* cobj = GET_COBJ(gobj);
     HSD_CObjAnim(cobj);
-    if (cobj->aobj->curr_frame == 1.0F) {
+    if (cobj->aobj->curr_frame == 120.0F) {
         vi_8031C9B4(0xD, 0);
     }
-    if (cobj->aobj->curr_frame == 30.0F) {
+    if (cobj->aobj->curr_frame == 100.0F) {
         un_8031F9D8(un_804D6FFC, un_804D6FFD);
     }
     if (cobj->aobj->curr_frame == cobj->aobj->end_frame) {
@@ -151,7 +151,7 @@ void fn_8031FC30(HSD_GObj* gobj)
 
 void fn_8031FCBC(HSD_GObj* gobj)
 {
-    if ((f32) un_804D6FF8 >= 30.0F) {
+    if ((f32) un_804D6FF8 >= 100.0F) {
         HSD_GObjPLink_80390228(gobj);
     } else {
         un_804D6FF8 = un_804D6FF8 + 1;

--- a/src/melee/vi/vi1201v2.c
+++ b/src/melee/vi/vi1201v2.c
@@ -146,7 +146,7 @@ void un_8032074C(HSD_GObj* gobj)
     HSD_JObj* jobj = GET_JOBJ(gobj);
     char pad[24];
     HSD_JObjAnimAll(jobj);
-    if (mn_8022F298(jobj) == 1.0F) {
+    if (mn_8022F298(jobj) == 251.0F) {
         if (un_804D7030 != NULL) {
             HSD_GObjPLink_80390228(un_804D7030);
             un_804D7030 = NULL;


### PR DESCRIPTION
I wrote a script to sort all the remaining functions by mismatch count, and had Codex run my permuter on a bunch of them.

Many of the new matches it found were data-layout-related, like swapping an inline string for an explicitly-defined variable. I reverted those; that stuff should wait until the whole TU is ready to be linked, imo.

Even so, this seems to be a fruitful approach, so I'm going to keep chugging away at it over the weekend and hopefully get some easy wins.