### PR TITLE
Improvements to split up: IF

### DIFF
--- a/src/melee/if/soundtest.c
+++ b/src/melee/if/soundtest.c
@@ -91,7 +91,7 @@
     u8 _pad13C[0x8];
     u8 x144[0x44];
     s32 x188;
-} un_803FA258;
+} un_803FA258 = { 0 };
 /* 3FA348 */ static u16 un_803FA348;
 /* 3FA34C */ static u8 un_803FA34C;
 /* 3FA32C */ static u8 un_803FA32C;


### PR DESCRIPTION
Split from #2617 by directory/subsystem so the matching improvements are easier to review.

## Scope

`src/melee/if`

## Preliminary Report

This slice was applied to a fresh branch from `origin/master` (07bb71f) using only its planned pathspecs from source 26fb91f. The full source branch report before the split was:

- Matched code: 71.86% (+0.31%, +11944 bytes)
- Linked code: 46.50% (+0.02%, +640 bytes)
- Matched data: 41.67% (+0.04%, +448 bytes)
- New matches: 26
- Improvements in unmatched items: 79
- Broken matches/regressions: none in the current post-rebase report

Per-PR CI/decomp-dev reporting on this draft is the authoritative slice score once it completes.

## Local Checks

- Created from `origin/master` as an isolated path slice
- `git diff --check origin/master...HEAD` passed for this slice
- The full unsplit source branch had green CI before the directory split

## Files

- `src/melee/if/soundtest.c`
- `src/melee/if/textlib.c`
