### PR TITLE
Improvements to split up: MN

### DIFF
--- a/src/melee/mn/mnmain.c
+++ b/src/melee/mn/mnmain.c
@@ -1337,7 +1337,7 @@ void fn_8022AFEC(HSD_GObj* gp)
             mn_8022A440(gp,
                         sp20[mn_80229A04_dontinline(mn_804A04F0.cur_menu,
                                                     data->hovered_selection)],
-                        mn_804A04F0.prev_menu);
+                        data->hovered_selection);
         }
         if ((u8) selection_changed != false) {
             hovered_selection = mn_804A04F0.hovered_selection;
@@ -1386,9 +1386,10 @@ HSD_GObj* mn_8022B3A0(u8 state)
 {
     HSD_JObj* sp48[12];
     HSD_JObj* sp2C[7];
+    StaticModelDesc* top = &MenMainConTop_Top;
+    HSD_GObj* gobj;
     HSD_JObj* cursor_jobj;
     int temp_r31;
-    HSD_GObj* gobj;
     HSD_JObj* temp_r16_2;
     u8 hovered_selection;
     int idx;
@@ -1405,7 +1406,6 @@ HSD_GObj* mn_8022B3A0(u8 state)
     u8 var_r17;
     u32 var_r17_int;
     HSD_JObj* root_jobj;
-    StaticModelDesc* top = &MenMainConTop_Top;
     PAD_STACK(16);
 
     cur_menu = mn_804A04F0.cur_menu;


### PR DESCRIPTION
Split from #2617 by directory/subsystem so the matching improvements are easier to review.

## Scope

`src/melee/mn`

## Preliminary Report

This slice was applied to a fresh branch from `origin/master` (07bb71f) using only its planned pathspecs from source 26fb91f. The full source branch report before the split was:

- Matched code: 71.86% (+0.31%, +11944 bytes)
- Linked code: 46.50% (+0.02%, +640 bytes)
- Matched data: 41.67% (+0.04%, +448 bytes)
- New matches: 26
- Improvements in unmatched items: 79
- Broken matches/regressions: none in the current post-rebase report

Per-PR CI/decomp-dev reporting on this draft is the authoritative slice score once it completes.

## Local Checks

- Created from `origin/master` as an isolated path slice
- `git diff --check origin/master...HEAD` passed for this slice
- The full unsplit source branch had green CI before the directory split

## Files

- `src/melee/mn/mncount.c`
- `src/melee/mn/mndiagram.c`
- `src/melee/mn/mnitemsw.c`
- `src/melee/mn/mnmain.c`
- `src/melee/mn/mnnamenew.c`
- `src/melee/mn/mnsnap.c`
