### PR TITLE
Improvements to split up: TY

### DIFF
--- a/src/melee/ty/tydisplay.c
+++ b/src/melee/ty/tydisplay.c
@@ -1905,17 +1905,18 @@ s32 un_8031BBF4(s8 arg0)
 HSD_GObj* un_8031BC54(s32 arg0)
 {
     char buf[44];
-    TyDspArchNames jobj_names;
-    TyDspArchNames matanim_names;
+    s32 id = arg0;
     HSD_GObj* gobj;
     TyDspEntry* entry;
     TyDspBgData* data = un_804D6F1C;
+    TyDspArchNames jobj_names;
+    TyDspArchNames matanim_names;
     HSD_JObj* root;
     HSD_JObj* child;
     u8 cat;
     u32 c;
 
-    entry = un_8031B9DC(arg0);
+    entry = un_8031B9DC(id);
     gobj = GObj_Create(6, 7, 0);
     root = HSD_JObjAlloc();
     HSD_GObjObject_80390A70(gobj, HSD_GObj_804D7849, root);
@@ -1960,7 +1961,7 @@ HSD_GObj* un_8031BC54(s32 arg0)
         DevText_SetCursorXY(un_804D6F24, 0, 0);
         sprintf(buf, un_803FF19C, entry->x08, entry->x0C);
         DevText_Print(un_804D6F24, buf);
-        un_8031BF34(arg0);
+        un_8031BF34(id);
     }
 
     return gobj;

--- a/src/melee/ty/tylist.c
+++ b/src/melee/ty/tylist.c
@@ -949,29 +949,26 @@ void fn_80313BD8(HSD_GObj* gobj)
 
     if (un_GetTrophyTotal() > 10) {
         if (un_80305C44() & 0x400) {
-            HSD_JObjSetFlagsAll(state->jobj, 0x10);
-            if (state->entries[0].idx == 0 ||
-                state->entries[0].links[0]->idx + 9 < un_GetTrophyTotal())
+            HSD_JObjSetFlagsAll(state->x288, 0x10);
+            if (state->x274->idx == 0 ||
+                state->x274->links[0]->idx + 9 < un_GetTrophyTotal())
             {
                 un_80313358(state, 9, 4, 0);
             } else {
-                un_80313358(state,
-                            (s8) (un_GetTrophyTotal() - state->entries[0].idx),
+                un_80313358(state, (s8) (un_GetTrophyTotal() - state->x274->idx),
                             4, 0);
             }
             state->pad_29D = state->x29E;
             return;
         }
         if (un_80305C44() & 0x800) {
-            s16 idx;
-            HSD_JObjSetFlagsAll(state->jobj, 0x10);
-            idx = state->entries[0].idx;
-            if (idx == un_GetTrophyTotal() - 1 ||
-                state->entries[0].links[1]->idx - 9 > 0)
+            HSD_JObjSetFlagsAll(state->x288, 0x10);
+            if (state->x270->idx == un_GetTrophyTotal() - 1 ||
+                state->x270->links[1]->idx - 9 > 0)
             {
                 un_80313358(state, 9, 4, 1);
             } else {
-                un_80313358(state, (s8) idx, 4, 1);
+                un_80313358(state, (s8) state->x270->idx, 4, 1);
             }
             state->pad_29D = state->x29E;
             return;
@@ -1001,9 +998,9 @@ void fn_80313BD8(HSD_GObj* gobj)
         for (; i < (s8) state->entryCount; i++, p++) {
             if (((s8*) p)[0x24] == g[0xC]) {
                 state->selectedIdx = p->idx;
-                state->entries[10].links[0] = (TyListArg*) p;
+                state->x278 = p;
                 lbAudioAx_80024030(2);
-                HSD_JObjSetTranslateY(state->jobj, p->x30);
+                HSD_JObjSetTranslateY(state->x288, p->x30);
             }
             un_80312904(p, state->x2B8);
         }
@@ -1035,7 +1032,7 @@ void fn_80313BD8(HSD_GObj* gobj)
     for (i = 0; i < (s8) state->entryCount; i++, p++) {
         un_80312904(p, state->entryCount);
     }
-    HSD_JObjSetFlagsAll(state->jobj, 0x10);
+    HSD_JObjSetFlagsAll(state->x288, 0x10);
     if (f31 > un_804DDE48) {
         un_80313358(state, 1, 6, 0);
     } else {


### PR DESCRIPTION
Split from #2617 by directory/subsystem so the matching improvements are easier to review.

## Scope

`src/melee/ty`

## Preliminary Report

This slice was applied to a fresh branch from `origin/master` (07bb71f) using only its planned pathspecs from source 26fb91f. The full source branch report before the split was:

- Matched code: 71.86% (+0.31%, +11944 bytes)
- Linked code: 46.50% (+0.02%, +640 bytes)
- Matched data: 41.67% (+0.04%, +448 bytes)
- New matches: 26
- Improvements in unmatched items: 79
- Broken matches/regressions: none in the current post-rebase report

Per-PR CI/decomp-dev reporting on this draft is the authoritative slice score once it completes.

## Local Checks

- Created from `origin/master` as an isolated path slice
- `git diff --check origin/master...HEAD` passed for this slice
- The full unsplit source branch had green CI before the directory split

## Files

- `src/melee/ty/toy.c`
- `src/melee/ty/tydisplay.c`
- `src/melee/ty/tylist.c`
