### PR TITLE
Improvements to split up: Dolphin support

### DIFF
--- a/extern/dolphin/src/dolphin/thp/THPDec.c
+++ b/extern/dolphin/src/dolphin/thp/THPDec.c
@@ -1925,42 +1925,53 @@ static void __THPDecompressiMCURowNxN(void)
     u32 x_pos, x;
     THPComponent* comp;
     THPFileInfo* info = __THPInfo;
-    THPCoeff** mcuBuffer = (THPCoeff**) ((u8*) info + 0x10);
 
-    x = __THPInfo->xPixelSize;
+    x = info->xPixelSize;
 
     LCQueueWait(3);
 
     for (cl_num = 0; cl_num < ((THPMCURowFields*) info)->MCUsPerRow;
          cl_num++) {
-        __THPHuffDecodeDCTCompY(info, mcuBuffer[0]);
-        __THPHuffDecodeDCTCompY(info, mcuBuffer[1]);
-        __THPHuffDecodeDCTCompY(info, mcuBuffer[2]);
-        __THPHuffDecodeDCTCompY(info, mcuBuffer[3]);
-        __THPHuffDecodeDCTCompU(info, mcuBuffer[4]);
-        __THPHuffDecodeDCTCompV(info, mcuBuffer[5]);
+        __THPHuffDecodeDCTCompY(
+            info, ((THPFileInfoMCUBufferView*) info)->mcuBuffer[0]);
+        __THPHuffDecodeDCTCompY(
+            info, ((THPFileInfoMCUBufferView*) info)->mcuBuffer[1]);
+        __THPHuffDecodeDCTCompY(
+            info, ((THPFileInfoMCUBufferView*) info)->mcuBuffer[2]);
+        __THPHuffDecodeDCTCompY(
+            info, ((THPFileInfoMCUBufferView*) info)->mcuBuffer[3]);
+        __THPHuffDecodeDCTCompU(
+            info, ((THPFileInfoMCUBufferView*) info)->mcuBuffer[4]);
+        __THPHuffDecodeDCTCompV(
+            info, ((THPFileInfoMCUBufferView*) info)->mcuBuffer[5]);
 
-        comp = &__THPInfo->components[0];
+        comp = &info->components[0];
         Gbase = __THPLCWork672[0];
         Gwid = x;
-        Gq = __THPInfo->quantTabs[comp->quantizationTableSelector];
+        Gq = info->quantTabs[comp->quantizationTableSelector];
         x_pos = (u32) (cl_num * 16);
-        __THPInverseDCTNoYPos(mcuBuffer[0], x_pos);
-        __THPInverseDCTNoYPos(mcuBuffer[1], x_pos + 8);
-        __THPInverseDCTY8(mcuBuffer[2], x_pos);
-        __THPInverseDCTY8(mcuBuffer[3], x_pos + 8);
+        __THPInverseDCTNoYPos(
+            ((THPFileInfoMCUBufferView*) info)->mcuBuffer[0], x_pos);
+        __THPInverseDCTNoYPos(
+            ((THPFileInfoMCUBufferView*) info)->mcuBuffer[1], x_pos + 8);
+        __THPInverseDCTY8(
+            ((THPFileInfoMCUBufferView*) info)->mcuBuffer[2], x_pos);
+        __THPInverseDCTY8(
+            ((THPFileInfoMCUBufferView*) info)->mcuBuffer[3], x_pos + 8);
 
-        comp = &__THPInfo->components[1];
+        comp = &info->components[1];
         Gbase = __THPLCWork672[1];
         Gwid = x / 2;
-        Gq = __THPInfo->quantTabs[comp->quantizationTableSelector];
+        Gq = info->quantTabs[comp->quantizationTableSelector];
         x_pos /= 2;
-        __THPInverseDCTNoYPos(mcuBuffer[4], x_pos);
+        __THPInverseDCTNoYPos(
+            ((THPFileInfoMCUBufferView*) info)->mcuBuffer[4], x_pos);
 
-        comp = &__THPInfo->components[2];
+        comp = &info->components[2];
         Gbase = __THPLCWork672[2];
-        Gq = __THPInfo->quantTabs[comp->quantizationTableSelector];
-        __THPInverseDCTNoYPos(mcuBuffer[5], x_pos);
+        Gq = info->quantTabs[comp->quantizationTableSelector];
+        __THPInverseDCTNoYPos(
+            ((THPFileInfoMCUBufferView*) info)->mcuBuffer[5], x_pos);
 
         if (((THPRestartFields*) info)->RST != 0) {
             ((THPRestartFields*) info)->currMCU--;

--- a/src/sysdolphin/baselib/cobj.c
+++ b/src/sysdolphin/baselib/cobj.c
@@ -699,7 +699,6 @@ int HSD_CObjGetUpVector(HSD_CObj* cobj, Vec3* up)
 void HSD_CObjSetUpVector(HSD_CObj* cobj, Vec3* up)
 {
     Vec3 v;
-
     if (!cobj || !up) {
         return;
     }

--- a/src/sysdolphin/baselib/hsd_3B34.c
+++ b/src/sysdolphin/baselib/hsd_3B34.c
@@ -983,10 +983,10 @@ void hsd_803B46D4(void)
     u8* temp_r4_8;
     u8* temp_r4_9;
 
-    jmp_buf = &hsd_804D2648;
-    temp_r4 = hsd_804D79A0;
     sp8 = *(s32*) lbl_804DEB88;
     spC = lbl_804DEB88[4];
+    jmp_buf = &hsd_804D2648;
+    temp_r4 = hsd_804D79A0;
     if (temp_r4 < &hsd_804D79A4[hsd_804D79A8]) {
         hsd_804D79A0 = temp_r4 + 1;
         *temp_r4 = 0xFF;

--- a/src/sysdolphin/baselib/synth.c
+++ b/src/sysdolphin/baselib/synth.c
@@ -1228,7 +1228,7 @@ void HSD_Synth_8038ADD0(void)
         }
     }
     if (pos == HSD_Synth_804D7770 && pos != HSD_Synth_804D776C) {
-        if ((u32) (lbl_804C4540[HSD_Synth_804D7770].x8 + 0x10000) == -1U) {
+        if (lbl_804C4540[HSD_Synth_804D7770].x8 == -0x10001) {
             HSD_Synth_804D7770 = (HSD_Synth_804D7770 + 1) % 3;
             for (i = 0; i < node->voice_count; i++) {
                 AXSetVoiceLoop(node->voice[i], 0);


### PR DESCRIPTION
Split from #2617 by support directory so the matching improvements are easier to review.

## Scope

`extern/dolphin/src/dolphin/thp` and `src/sysdolphin/baselib` support code.

## Preliminary Report

This slice was applied to a fresh branch from `origin/master` (07bb71f) using only its planned pathspecs from source 26fb91f. The full source branch report before the split was:

- Matched code: 71.86% (+0.31%, +11944 bytes)
- Linked code: 46.50% (+0.02%, +640 bytes)
- Matched data: 41.67% (+0.04%, +448 bytes)
- New matches: 26
- Improvements in unmatched items: 79
- Broken matches/regressions: none in the current post-rebase report

Per-PR CI/decomp-dev reporting on this draft is the authoritative slice score once it completes.

## Local Checks

- Created from `origin/master` as an isolated path slice
- `git diff --check origin/master...HEAD` passed for this slice
- The full unsplit source branch had green CI before the directory split

## Files

- `extern/dolphin/src/dolphin/thp/THPDec.c`
- `src/sysdolphin/baselib/cobj.c`
- `src/sysdolphin/baselib/hsd_3B34.c`
- `src/sysdolphin/baselib/particle.c`
- `src/sysdolphin/baselib/sislib.c`
- `src/sysdolphin/baselib/synth.c`
