### PR TITLE
Split-up improvements across common, GM/MN, TY, and baselib

### DIFF
--- a/src/melee/cm/camera.c
+++ b/src/melee/cm/camera.c
@@ -4667,9 +4667,10 @@ bool Camera_80030CFC(CmSubject* cam_box, f32 tolerance)
     Vec3 eye_pos;
     Vec3 interest;
     Vec3 sp38;
+    u8 _PAD[12];
     Vec3 sp20;
     f32 range;
-    PAD_STACK(14);
+    PAD_STACK(2);
 
     cobj = GET_COBJ(cm_80452C68.gobj);
     HSD_CObjGetEyePosition(cobj, &eye_pos);

--- a/src/melee/ft/chara/ftCommon/ftCo_Bury.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Bury.c
@@ -54,6 +54,13 @@
 #include <baselib/gobj.h>
 #include <baselib/jobj.h>
 
+#pragma force_active on
+const double ftCo_804D8C28 = 4503599627370496.0;
+const double ftCo_804D8C30 = 4503601774854144.0;
+const float ftCo_804D8C38 = 0.0F;
+const float ftCo_804D8C3C = 1.0F;
+#pragma force_active reset
+
 void ftCo_800C0874(Fighter_GObj* gobj, UNK_T arg1, ftCommon_BuryType arg2)
 {
     switch (arg2) {
@@ -221,7 +228,6 @@ bool ftCo_800C0CB8(Fighter_GObj* gobj)
 
 void ftCo_800C0D0C(Fighter_GObj* gobj)
 {
-    u8 _[8] = { 0 };
     Vec3 joint_pos;
     Vec3 hip_pos;
     Fighter* fp = GET_FIGHTER(gobj);

--- a/src/melee/gm/gm_1832.c
+++ b/src/melee/gm/gm_1832.c
@@ -197,6 +197,8 @@ void fn_8018325C(HSD_GObj* arg0, int arg1)
     HSD_JObj* src = lbl_804735A8.x4[0];
     int i;
 
+    PAD_STACK(4);
+
     HSD_JObjGetTranslation(src, &pos);
     HSD_JObjSetTranslate(jobj, &pos);
 
@@ -1957,14 +1959,15 @@ inline int fn_801884F8_inline(void)
 int fn_801884F8(void)
 {
     int result;
+    int* ptr = (int*) &lbl_80473700;
 
     result = pl_80041300(0);
     if (result != 0) {
-        lbl_80473700.result_cache[0] = result;
-        lbl_80473700.result_cache[1] = 1;
+        ptr[65] = result;
+        ptr[66] = 1;
     }
-    if (lbl_80473700.result_cache[1] != 0) {
-        result = lbl_80473700.result_cache[0];
+    if (ptr[66] != 0) {
+        result = ptr[65];
     }
     return result;
 }

--- a/src/melee/gm/gmregclear.c
+++ b/src/melee/gm/gmregclear.c
@@ -1902,8 +1902,8 @@ s32 fn_8017F2A4(HSD_Text** arg0, f32 farg0, f32 farg1)
     u8* data;
     f32 y;
     f32 x_end;
-    s32 temp;
     s32 i;
+    s32 temp;
 
     temp = HSD_SisLib_803A611C(3, NULL, 9U, 0xDU, 0U, 0x14U, 0U, 0x13U);
     if (lbLang_IsSavedLanguageUS()) {

--- a/src/melee/gm/gmstaffroll.c
+++ b/src/melee/gm/gmstaffroll.c
@@ -952,8 +952,8 @@ void fn_801AC67C(HSD_GObj* gobj)
 void gm_801AC6D8_OnEnter(void* unused)
 {
     HSD_JObj* jobj_arr[2];
-    HSD_GObj* gobj;
     HSD_CObj* cobj;
+    HSD_GObj* gobj;
     int i;
     int const gx_link = 11;
     PAD_STACK(0x10);

--- a/src/melee/mn/mncount.c
+++ b/src/melee/mn/mncount.c
@@ -318,63 +318,66 @@ static inline bool mnCount_8025092C_inline(void)
 
 s32 mnCount_8025092C(s32 rank, u32 (*getVal)(s32), bool mode)
 {
-    CountEntry entries[NUM_CHARACTERS];
-    CountEntry tmp;
-    int i, j, min;
-    if (mnCount_8025092C_inline()) {
-        return NUM_CHARACTERS;
-    }
-    for (i = 0; i < NUM_CHARACTERS; i++) {
-        entries[i].id = i;
-        entries[i].val = getVal(i);
-    }
-    for (i = 0; i < NUM_CHARACTERS; i++) {
-        min = i;
-        for (j = i + 1; j < NUM_CHARACTERS; j++) {
-            if (entries[min].val < entries[j].val) {
-                min = j;
-            }
+    PAD_STACK(4);
+    {
+        CountEntry entries[NUM_CHARACTERS];
+        CountEntry tmp;
+        int i, j, min;
+        if (mnCount_8025092C_inline()) {
+            return NUM_CHARACTERS;
         }
-        if (min != i) {
-            tmp = entries[min];
-            for (j = min; j > i; j--) {
-                entries[j] = entries[j - 1];
-            }
-            entries[i] = tmp;
+        for (i = 0; i < NUM_CHARACTERS; i++) {
+            entries[i].id = i;
+            entries[i].val = getVal(i);
         }
-    }
-    for (i = 0; i < NUM_CHARACTERS; i++) {
-        if (!gm_80164840(gm_8016400C(entries[i].id))) {
-            continue;
-        }
-        if (rank != 0) {
-            rank--;
+        for (i = 0; i < NUM_CHARACTERS; i++) {
+            min = i;
             for (j = i + 1; j < NUM_CHARACTERS; j++) {
-                if (!gm_80164840(gm_8016400C(entries[j].id))) {
-                    continue;
+                if (entries[min].val < entries[j].val) {
+                    min = j;
                 }
-                if (getVal(entries[i].id) == getVal(entries[j].id)) {
-                    i++;
-                    if (rank != 0) {
-                        rank--;
-                    } else {
-                        return NUM_CHARACTERS;
+            }
+            if (min != i) {
+                tmp = entries[min];
+                for (j = min; j > i; j--) {
+                    entries[j] = entries[j - 1];
+                }
+                entries[i] = tmp;
+            }
+        }
+        for (i = 0; i < NUM_CHARACTERS; i++) {
+            if (!gm_80164840(gm_8016400C(entries[i].id))) {
+                continue;
+            }
+            if (rank != 0) {
+                rank--;
+                for (j = i + 1; j < NUM_CHARACTERS; j++) {
+                    if (!gm_80164840(gm_8016400C(entries[j].id))) {
+                        continue;
+                    }
+                    if (getVal(entries[i].id) == getVal(entries[j].id)) {
+                        i++;
+                        if (rank != 0) {
+                            rank--;
+                        } else {
+                            return NUM_CHARACTERS;
+                        }
                     }
                 }
-            }
-        } else {
-            for (j = i + 1; j < NUM_CHARACTERS; j++) {
-                if (!gm_80164840(gm_8016400C(entries[j].id))) {
-                    continue;
+            } else {
+                for (j = i + 1; j < NUM_CHARACTERS; j++) {
+                    if (!gm_80164840(gm_8016400C(entries[j].id))) {
+                        continue;
+                    }
+                    if (getVal(entries[i].id) == getVal(entries[j].id)) {
+                        return mnCount_8025072C(entries, i, mode);
+                    }
                 }
-                if (getVal(entries[i].id) == getVal(entries[j].id)) {
-                    return mnCount_8025072C(entries, i, mode);
-                }
+                return entries[i].id;
             }
-            return entries[i].id;
         }
+        return NUM_CHARACTERS;
     }
-    return NUM_CHARACTERS;
 }
 
 static inline int mnCount_CountUnlockedChars(void)

--- a/src/melee/mn/mnitemsw.c
+++ b/src/melee/mn/mnitemsw.c
@@ -367,7 +367,6 @@ void mnItemSw_80234104(HSD_GObj* gobj)
 
 void mnItemSw_8023453C(HSD_GObj* gobj, u8 arg1, u8 arg2)
 {
-    s32 sp40;
     HSD_JObj* sp44;
     HSD_JObj* sp3C;
     f32 anim_val;
@@ -375,8 +374,10 @@ void mnItemSw_8023453C(HSD_GObj* gobj, u8 arg1, u8 arg2)
     HSD_JObj* cjobj;
     MnItemSwData* data = gobj->user_data;
     struct MnItemSwTable* tbl = &mnItemSw_803ED340;
+    u8 arg1_ = arg1;
+    u8 arg2_ = arg2;
 
-    if (arg1 != 0) {
+    if (arg1_ != 0) {
         u8 old_cursor = data->cursor;
 
         if (old_cursor == 0x1F || old_cursor == 0x20) {
@@ -457,7 +458,7 @@ void mnItemSw_8023453C(HSD_GObj* gobj, u8 arg1, u8 arg2)
         }
     }
 
-    if (arg2 != 0) {
+    if (arg2_ != 0) {
         if (mn_804A04F0.hovered_selection == 0x1F ||
             mn_804A04F0.hovered_selection == 0x20)
         {

--- a/src/melee/mn/mnmain.c
+++ b/src/melee/mn/mnmain.c
@@ -1337,7 +1337,7 @@ void fn_8022AFEC(HSD_GObj* gp)
             mn_8022A440(gp,
                         sp20[mn_80229A04_dontinline(mn_804A04F0.cur_menu,
                                                     data->hovered_selection)],
-                        mn_804A04F0.prev_menu);
+                        data->hovered_selection);
         }
         if ((u8) selection_changed != false) {
             hovered_selection = mn_804A04F0.hovered_selection;
@@ -1386,9 +1386,10 @@ HSD_GObj* mn_8022B3A0(u8 state)
 {
     HSD_JObj* sp48[12];
     HSD_JObj* sp2C[7];
+    StaticModelDesc* top = &MenMainConTop_Top;
+    HSD_GObj* gobj;
     HSD_JObj* cursor_jobj;
     int temp_r31;
-    HSD_GObj* gobj;
     HSD_JObj* temp_r16_2;
     u8 hovered_selection;
     int idx;
@@ -1405,7 +1406,6 @@ HSD_GObj* mn_8022B3A0(u8 state)
     u8 var_r17;
     u32 var_r17_int;
     HSD_JObj* root_jobj;
-    StaticModelDesc* top = &MenMainConTop_Top;
     PAD_STACK(16);
 
     cur_menu = mn_804A04F0.cur_menu;

--- a/src/melee/mp/mplib.c
+++ b/src/melee/mp/mplib.c
@@ -1615,10 +1615,12 @@ bool mpCheckFloor(float ax, float ay, float bx, float by, float y_offset,
         for (; i_r28 < var_r25; i_r28 += 1, line_r26 += 1) {
             float px_sp54;
             float py_sp50;
+            u8 pad[4];
             float x0_sp48;
             float y0_sp44;
             float x1_sp40;
             float y1_sp3C;
+            float dist2;
         block_8:
             if (cb != NULL && !cb(gobj, line_r26 - groundCollLine)) {
                 continue;
@@ -1643,11 +1645,7 @@ bool mpCheckFloor(float ax, float ay, float bx, float by, float y_offset,
                 if (mpLineIntersection(x0_sp48, y0_sp44, x1_sp40, y1_sp3C, ax,
                                        ay, bx, by, &px_sp54, &py_sp50))
                 {
-                    float dx = px_sp54 - ax;
-                    float dy = py_sp50 - ay;
-                    float dx2 = dx * dx;
-                    float dy2 = dy * dy;
-                    float dist2 = dx2 + dy2;
+                    dist2 = SQ(px_sp54 - ax) + SQ(py_sp50 - ay);
                     if (min_dist2_f30 > dist2) {
                         min_dist2_f30 = dist2;
                         if (vec_out != NULL) {
@@ -1675,11 +1673,7 @@ bool mpCheckFloor(float ax, float ay, float bx, float by, float y_offset,
                     mpLineIntersectionH(&px_sp54, &py_sp50, x0_sp48, y0_sp44,
                                         x1_sp40, ax, ay, bx, by))
                 {
-                    float dx = px_sp54 - ax;
-                    float dx2 = dx * dx;
-                    float dy = py_sp50 - ay;
-                    float dy2 = dy * dy;
-                    float dist2 = dx2 + dy2;
+                    dist2 = SQ(px_sp54 - ax) + SQ(py_sp50 - ay);
                     if (min_dist2_f30 > dist2) {
                         min_dist2_f30 = dist2;
                         if (vec_out != NULL) {

--- a/src/melee/ty/tydisplay.c
+++ b/src/melee/ty/tydisplay.c
@@ -1905,8 +1905,8 @@ s32 un_8031BBF4(s8 arg0)
 HSD_GObj* un_8031BC54(s32 arg0)
 {
     char buf[44];
-    s32 id = arg0;
     HSD_GObj* gobj;
+    s32 id = arg0;
     TyDspEntry* entry;
     TyDspBgData* data = un_804D6F1C;
     TyDspArchNames jobj_names;
@@ -1915,6 +1915,7 @@ HSD_GObj* un_8031BC54(s32 arg0)
     HSD_JObj* child;
     u8 cat;
     u32 c;
+    u32 c2;
 
     entry = un_8031B9DC(id);
     gobj = GObj_Create(6, 7, 0);
@@ -1936,16 +1937,17 @@ HSD_GObj* un_8031BC54(s32 arg0)
 
     HSD_JObjAddChild(root, child);
 
-    c = (cat = entry->x04);
+    c2 = entry->x04;
+    cat = c2;
     matanim_names = un_803B8A34;
-    if ((s8) c == -1) {
+    if ((s8) c2 == -1) {
         cat = 0;
     }
 
     {
         char* temp2;
         temp2 = (char*) matanim_names.entries[(s8) cat];
-        un_80306A48(child, NULL, temp2, NULL, data->archives[c],
+        un_80306A48(child, NULL, temp2, NULL, data->archives[c2],
                     (long) entry->x05);
     }
     HSD_JObjRemoveAnimAll(child);

--- a/src/sysdolphin/baselib/axdriver.c
+++ b/src/sysdolphin/baselib/axdriver.c
@@ -209,7 +209,7 @@ void AXDriver_8038BF6C(HSD_SM* v)
                 float left_inv_sqrt = sqrtf(1.0F - left_vol);
                 float right_sqrt = sqrtf(right_vol);
                 float right_inv_sqrt = sqrtf(1.0F - right_vol);
-                float tmp2 = left_inv_sqrt * right_sqrt;
+                float tmp2 = left_inv_sqrt * right_inv_sqrt;
                 float pitch1 = powf(2.0F, v->x20 / 1200.0F);
                 float pitch2 = powf(2.0F, v->fadetime / 1200.0F);
 
@@ -217,7 +217,7 @@ void AXDriver_8038BF6C(HSD_SM* v)
                     v->fid, v->x1A, v->volume,
                     (v->flags & 0x20000) ? v->pan : v->x1C, v->pri, v->itdflag,
                     v->track, pitch1, pitch2, left_inv_sqrt * tmp2, left_sqrt,
-                    left_inv_sqrt * right_inv_sqrt);
+                    right_sqrt * left_inv_sqrt);
 
                 if (v->vID != -1) {
                     AXDriver_804C5920[v->vID & 0x3F] = v;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1695,7 +1695,8 @@ s32 hsd_80393D2C(s32 enable)
 void hsd_80393DA0(u8* buf, size_t size)
 {
     PAD_STACK(4);
-    memset(&hsd_804CF7E8, 0, sizeof(hsd_804CF7E8));
+    memset(&hsd_804CF7E8, 0,
+           sizeof(hsd_804CF7E8) - sizeof(hsd_804CF7E8.x24));
     hsd_804CF7E8.out_buf = buf;
     hsd_804CF7E8.buf_size = size;
     memset(buf, 0, size);


### PR DESCRIPTION
## Summary

This continues the split-up matching work with a small set of exact-match and near-match improvements across common fighter code, camera, GM/MN, TY display, map collision, and sysdolphin/baselib.

New exact matches from the local regression gate:

- `main/melee/ft/chara/ftCommon/ftCo_Bury` `.sdata2`
- `main/melee/ty/tydisplay` `un_8031BC54`
- `main/melee/ft/chara/ftCommon/ftCo_Bury` `ftCo_800C0D0C`
- `main/melee/cm/camera` `Camera_80030CFC`
- `main/melee/gm/gm_1832` `fn_801884F8`

Also improves several still-unmatched items, including `AXDriver_8038BF6C`, `mpCheckFloor`, `gm_801AC6D8_OnEnter`, `mn_8022B3A0`, `mnItemSw_8023453C`, `fn_8017F2A4`, `mnCount_8025092C`, and `hsd_80393DA0`.

## Reviewer Notes

- The earlier `tydisplay` string-base/assert reshaping for `un_8031B1FC` was dropped; this PR keeps the source string literals and `HSD_ASSERT` form there.
- `ftCo_Bury` adds tightly scoped `force_active` `.sdata2` literals. These correspond to existing `symbols.txt` entries and the `ftCo_Bury.c` split-owned `.sdata2` range.
- `gm_1832` uses local pointer indexing for `fn_801884F8` to match codegen, mirroring nearby pointer-style access in `fn_8018846C`.
- Stack/local-shape tweaks are kept narrow and are backed by the regression report below.

## Verification

- `git diff --check origin/master`
- `ninja`
  - `build/GALE01/main.dol: OK`
- Decomp Orchestrator regression gate:
  - PR-ready
  - 5 new exact matches
  - +1608 matched code bytes
  - +24 matched data bytes
  - 8 improvements in unmatched items
  - 0 broken matches
  - 0 fuzzy regressions
  - 0 metric regressions
