### PR TITLE
Match grInishie2_801FD4F0

### DIFF
--- a/src/melee/gr/grinishie2.c
+++ b/src/melee/gr/grinishie2.c
@@ -513,7 +513,7 @@ void grInishie2_801FD4F0(Ground_GObj* gobj)
     HSD_JObj* jobj;
     HSD_JObj* temp_r29;
     HSD_JObj* temp_r30;
-    PAD_STACK(16);
+    PAD_STACK(12);
 
     jobj = GET_JOBJ(gobj);
     gp = GET_GROUND(gobj);


### PR DESCRIPTION
## Summary
- Matches `grInishie2_801FD4F0` (was 99.91% fuzzy): the stack pad was 4 bytes too large, `PAD_STACK(16)` -> `PAD_STACK(12)`, which moves the local `Vec3` from `0x24(r1)` to the expected `0x20(r1)`.

Verified with objdiff: target=100.0, current=100.0.