### PR TITLE
Fix MatToQuat to 100% match

### DIFF
--- a/src/sysdolphin/baselib/quatlib.c
+++ b/src/sysdolphin/baselib/quatlib.c
@@ -15,6 +15,7 @@ s32 MatToQuat(Mtx m, Quaternion* q)
     f32 scale;
     int i;
     int j;
+    int k;
 
     lenCol[0] =
         sqrtf(m[0][0] * m[0][0] + m[1][0] * m[1][0] + m[2][0] * m[2][0]);
@@ -23,8 +24,10 @@ s32 MatToQuat(Mtx m, Quaternion* q)
     lenCol[2] =
         sqrtf(m[0][2] * m[0][2] + m[1][2] * m[1][2] + m[2][2] * m[2][2]);
 
-    if ((m[0][0] / lenCol[0] + m[1][1] / lenCol[1] + m[2][2] / lenCol[2]) > 0.0F) {
-        s = sqrtf(1.0F + (m[0][0] / lenCol[0] + m[1][1] / lenCol[1] + m[2][2] / lenCol[2]));
+    s = m[0][0] / lenCol[0] + m[1][1] / lenCol[1] + m[2][2] / lenCol[2];
+
+    if (s > 0.0F) {
+        s = sqrtf(1.0F + s);
         q->w = 0.5F * s;
         scale = 0.5F / s;
         q->x = scale * ((m[2][1] / lenCol[1]) - (m[1][2] / lenCol[2]));
@@ -39,13 +42,15 @@ s32 MatToQuat(Mtx m, Quaternion* q)
             i = 2;
         }
         j = nxt[i];
+        k = nxt[j];
+
         s = sqrtf(1.0F + (((m[i][i] / lenCol[i]) - (m[j][j] / lenCol[j])) -
-                          (m[nxt[j]][nxt[j]] / lenCol[nxt[j]])));
+                          (m[k][k] / lenCol[k])));
         scale = 0.5F / s;
         q3[i] = 0.5F * s;
-        q->w = scale * ((m[nxt[j]][j] / lenCol[j]) - (m[j][nxt[j]] / lenCol[nxt[j]]));
+        q->w = scale * ((m[k][j] / lenCol[j]) - (m[j][k] / lenCol[k]));
         q3[j] = scale * ((m[j][i] / lenCol[i]) + (m[i][j] / lenCol[j]));
-        q3[nxt[j]] = scale * ((m[nxt[j]][i] / lenCol[i]) + (m[i][nxt[j]] / lenCol[nxt[j]]));
+        q3[k] = scale * ((m[k][i] / lenCol[i]) + (m[i][k] / lenCol[k]));
         q->x = q3[0];
         q->y = q3[1];
         q->z = q3[2];

--- a/src/sysdolphin/baselib/quatlib.c
+++ b/src/sysdolphin/baselib/quatlib.c
@@ -6,7 +6,6 @@
 #include <MSL/math_ppc.h>
 #include <MSL/trigf.h>
 
-/// @todo Currently 99.9% match - stack frame is 8 bytes too large.
 s32 MatToQuat(Mtx m, Quaternion* q)
 {
     f32 q3[3];
@@ -14,10 +13,8 @@ s32 MatToQuat(Mtx m, Quaternion* q)
     f32 lenCol[3];
     f32 s;
     f32 scale;
-    f32 tr;
     int i;
     int j;
-    int k;
 
     lenCol[0] =
         sqrtf(m[0][0] * m[0][0] + m[1][0] * m[1][0] + m[2][0] * m[2][0]);
@@ -26,10 +23,8 @@ s32 MatToQuat(Mtx m, Quaternion* q)
     lenCol[2] =
         sqrtf(m[0][2] * m[0][2] + m[1][2] * m[1][2] + m[2][2] * m[2][2]);
 
-    tr = m[0][0] / lenCol[0] + m[1][1] / lenCol[1] + m[2][2] / lenCol[2];
-
-    if (tr > 0.0F) {
-        s = sqrtf(1.0F + tr);
+    if ((m[0][0] / lenCol[0] + m[1][1] / lenCol[1] + m[2][2] / lenCol[2]) > 0.0F) {
+        s = sqrtf(1.0F + (m[0][0] / lenCol[0] + m[1][1] / lenCol[1] + m[2][2] / lenCol[2]));
         q->w = 0.5F * s;
         scale = 0.5F / s;
         q->x = scale * ((m[2][1] / lenCol[1]) - (m[1][2] / lenCol[2]));
@@ -44,15 +39,13 @@ s32 MatToQuat(Mtx m, Quaternion* q)
             i = 2;
         }
         j = nxt[i];
-        k = nxt[j];
-
         s = sqrtf(1.0F + (((m[i][i] / lenCol[i]) - (m[j][j] / lenCol[j])) -
-                          (m[k][k] / lenCol[k])));
+                          (m[nxt[j]][nxt[j]] / lenCol[nxt[j]])));
         scale = 0.5F / s;
         q3[i] = 0.5F * s;
-        q->w = scale * ((m[k][j] / lenCol[j]) - (m[j][k] / lenCol[k]));
+        q->w = scale * ((m[nxt[j]][j] / lenCol[j]) - (m[j][nxt[j]] / lenCol[nxt[j]]));
         q3[j] = scale * ((m[j][i] / lenCol[i]) + (m[i][j] / lenCol[j]));
-        q3[k] = scale * ((m[k][i] / lenCol[i]) + (m[i][k] / lenCol[k]));
+        q3[nxt[j]] = scale * ((m[nxt[j]][i] / lenCol[i]) + (m[i][nxt[j]] / lenCol[nxt[j]]));
         q->x = q3[0];
         q->y = q3[1];
         q->z = q3[2];


### PR DESCRIPTION
Fix `MatToQuat` in `src/sysdolphin/baselib/quatlib.c` to achieve 100% binary match.

**Problem:** The stack frame was 8 bytes too large.

**Solution:** Removed 2 unnecessary local variables:
- `f32 tr` — the trace expression was stored in a local then reused; inlined directly into the `if` condition and `sqrtf(1.0F + ...)` call
- `int k` — was just `nxt[j]` assigned to a temp; replaced all uses with `nxt[j]` inline

**Result:** The entire `quatlib.c` unit is now 100% matched across all 6 functions (MatToQuat, HSD_QuatLib_8037EB28, HSD_QuatLib_8037EC4C, HSD_QuatLib_8037ECE0, EulerToQuat, HSD_QuatLib_8037EF28).


Hi this is my first contribution, I have read the contribution guidelines but if I missed something I am happy to update this. 