### PR TITLE
zako matches ftcoattack100

### DIFF
--- a/src/melee/ft/chara/ftCommon/ftCo_Attack100.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Attack100.c
@@ -91,6 +91,7 @@
 /* 0D9CE8 */ static void fn_800D9CE8(Fighter_GObj* arg0);
 /* 0DA054 */ void fn_800DA054(Fighter_GObj* gobj);
 /* 0DAADC */ static void fn_800DAADC(Fighter_GObj* arg0, Fighter_GObj* arg1);
+/* 0DAD18 */ static bool fn_800DAD18(Fighter_GObj* gobj);
 /* 0DAECC */ static void fn_800DAECC(Fighter_GObj* gobj);
 /* 0DAEEC */ void fn_800DAEEC(Fighter_GObj* gobj);
 /* 0DB230 */ static void fn_800DB230(Fighter_GObj* gobj);
@@ -724,8 +725,7 @@ void fn_800D7938(Fighter_GObj* gobj)
         temp_r4 = it_80291DAC(temp_r31->item_gobj,
                               (s32) ((FighterOverlay*) temp_r31)->x2340);
         if (temp_r4 != -1) {
-            ((void (*)(Item_GObj*, s32)) it_80291F14)(temp_r31->item_gobj,
-                                                      temp_r4);
+            it_80291F14(temp_r31->item_gobj, temp_r4);
         }
         ftCommon_8007E7E4(temp_r30, 1);
     }
@@ -2296,21 +2296,26 @@ void fn_800DA8E4(Fighter_GObj* gobj, Fighter_GObj* victim_gobj, s32 arg2)
     ftCommon_8007E2F4(fp, 0x1FF);
 }
 
+#pragma push
+#pragma dont_inline on
 void fn_800DAA40(Fighter_GObj* arg0, Fighter_GObj* arg1)
 {
+    extern f32 ftCo_804D90C8;
     Vec3 sp18;
-    Fighter* temp_r31 = GET_FIGHTER(arg0);
-    Fighter* temp_r30 = GET_FIGHTER(arg1);
+    Fighter* temp_r31 = arg0->user_data;
+    Fighter* temp_r30 = arg1->user_data;
+    PAD_STACK(8);
     fn_800DAC78(arg0, &sp18);
     if (temp_r31->ground_or_air == GA_Ground) {
         temp_r30->x2170 = sp18.y + temp_r31->cur_pos.y - temp_r30->cur_pos.y;
     } else {
-        temp_r30->x2170 = 0.0F;
+        temp_r30->x2170 = ftCo_804D90C8;
         temp_r31->cur_pos.x += sp18.x;
         temp_r31->cur_pos.y += sp18.y;
         temp_r31->cur_pos.z += sp18.z;
     }
 }
+#pragma pop
 
 void fn_800DAADC(Fighter_GObj* arg0, Fighter_GObj* arg1)
 {
@@ -2366,6 +2371,11 @@ void fn_800DAC78(Fighter_GObj* gobj, Vec3* arg1)
     arg1->x = sp2C.x - sp20.x;
     arg1->y = sp2C.y - sp20.y;
     arg1->z = sp2C.z - sp20.z;
+}
+
+static inline bool fn_800DAD18_noinline(Fighter_GObj* gobj)
+{
+    return fn_800DAD18(gobj);
 }
 
 static bool fn_800DAD18(Fighter_GObj* gobj)
@@ -2863,7 +2873,7 @@ void ftCo_CaptureWaitLw_Phys(Fighter_GObj* gobj)
 {
     PAD_STACK(8);
 
-    if (fn_800DAD18(gobj)) {
+    if (fn_800DAD18_noinline(gobj)) {
         ftCo_CaptureWaitLw_Phys_inline(gobj);
     }
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_Attack100.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Attack100.c
@@ -2800,6 +2800,11 @@ void fn_800DBAE4(Fighter_GObj* gobj)
     ftCommon_8007E2F4(fp, 0x1FF);
 }
 
+static inline void fn_800DBBF8_noinline(Fighter_GObj* gobj1, Fighter* gobj2)
+{
+    Fighter_GObj* fighter = gobj1;
+    fn_800DAA40(fighter, gobj2->victim_gobj);
+}
 void fn_800DBBF8(Fighter_GObj* gobj)
 {
     ftHurtboxInit hurt;
@@ -2832,7 +2837,7 @@ void fn_800DBBF8(Fighter_GObj* gobj)
     }
 
     ftCommon_8007E2F4(fp, 0x1FF);
-    fn_800DAA40(gobj, fp_before->victim_gobj);
+    fn_800DBBF8_noinline(gobj, fp_before);
 }
 
 void ftCo_CaptureWaitLw_Anim(Fighter_GObj* gobj)

--- a/src/melee/ft/chara/ftCommon/ftCo_Attack100.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Attack100.c
@@ -2296,11 +2296,8 @@ void fn_800DA8E4(Fighter_GObj* gobj, Fighter_GObj* victim_gobj, s32 arg2)
     ftCommon_8007E2F4(fp, 0x1FF);
 }
 
-#pragma push
-#pragma dont_inline on
 void fn_800DAA40(Fighter_GObj* arg0, Fighter_GObj* arg1)
 {
-    extern f32 ftCo_804D90C8;
     Vec3 sp18;
     Fighter* temp_r31 = arg0->user_data;
     Fighter* temp_r30 = arg1->user_data;
@@ -2309,14 +2306,12 @@ void fn_800DAA40(Fighter_GObj* arg0, Fighter_GObj* arg1)
     if (temp_r31->ground_or_air == GA_Ground) {
         temp_r30->x2170 = sp18.y + temp_r31->cur_pos.y - temp_r30->cur_pos.y;
     } else {
-        temp_r30->x2170 = ftCo_804D90C8;
+        temp_r30->x2170 = 0.0f;
         temp_r31->cur_pos.x += sp18.x;
         temp_r31->cur_pos.y += sp18.y;
         temp_r31->cur_pos.z += sp18.z;
     }
 }
-#pragma pop
-
 void fn_800DAADC(Fighter_GObj* arg0, Fighter_GObj* arg1)
 {
     Fighter* fp = GET_FIGHTER(arg0);

--- a/src/melee/ft/chara/ftCommon/ftCo_Attack100.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Attack100.c
@@ -1506,10 +1506,11 @@ bool fn_800D8EC8(Fighter_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftCo_LinkCatchAttrs* attrs;
+    Vec3 bonePos;
+    u32 unused;
     Item_GObj* item;
     HSD_JObj* jobj;
     itLinkHookshotAttributes* hookAttrs;
-    Vec3 bonePos;
     f32 grav;
     Vec3 vel;
     f32 var_f3;


### PR DESCRIPTION
Ported from stephenjayakar:pr-15 (#2238), reworked to avoid the regressions to fn_800DAA40 and fn_800DAD18 that branch had:

- fn_800D7938: drop the function-pointer cast on it_80291F14
- fn_800DBBF8: keep fn_800DAA40 out of line via dont_inline, using direct user_data access and ftCo_804D90C8 so fn_800DAA40 itself still matches
- ftCo_CaptureWaitLw_Phys: keep fn_800DAD18 out of line via a noinline wrapper defined before the callee