### PR TITLE
Replace raw 0x10 with JOBJ_HIDDEN in HSD_JObj flag calls

### DIFF
--- a/src/melee/ef/eflib.c
+++ b/src/melee/ef/eflib.c
@@ -1298,9 +1298,9 @@ void efLib_Cb_ftMr_SpecialLw(EF_Effect* effect)
     fighter = GET_FIGHTER(effect->parent_gobj);
 
     if (fighter->motion_id == 349) {
-        HSD_JObjClearFlagsAll(eff_child_nxt_jobj, 0x10U);
+        HSD_JObjClearFlagsAll(eff_child_nxt_jobj, JOBJ_HIDDEN);
     } else {
-        HSD_JObjSetFlagsAll(eff_child_nxt_jobj, 0x10U);
+        HSD_JObjSetFlagsAll(eff_child_nxt_jobj, JOBJ_HIDDEN);
     }
     if ((fighter->cmd_vars[3] != 0U) &&
         (*(s32*) &fighter->mv.co.common.x4.z != 0))
@@ -1328,9 +1328,9 @@ void efLib_Cb_ftLg_SpecialLw(EF_Effect* effect)
     fighter = GET_FIGHTER(effect->parent_gobj);
 
     if (fighter->motion_id == 357) {
-        HSD_JObjClearFlagsAll(eff_child_nxt_jobj, 0x10U);
+        HSD_JObjClearFlagsAll(eff_child_nxt_jobj, JOBJ_HIDDEN);
     } else {
-        HSD_JObjSetFlagsAll(eff_child_nxt_jobj, 0x10U);
+        HSD_JObjSetFlagsAll(eff_child_nxt_jobj, JOBJ_HIDDEN);
     }
 
     if ((fighter->cmd_vars[3] != 0U) &&
@@ -1355,9 +1355,9 @@ void efLib_Cb_ftKp_SpecialHi(EF_Effect* effect)
     jobj_1 = GET_JOBJ(effect->gobj);
     jobj_2 = GET_JOBJ(effect->next->gobj);
     if ((fighter = GET_FIGHTER(effect->parent_gobj))->motion_id == 359) {
-        HSD_JObjClearFlagsAll(jobj_2, 0x10U);
+        HSD_JObjClearFlagsAll(jobj_2, JOBJ_HIDDEN);
     } else {
-        HSD_JObjSetFlagsAll(jobj_2, 0x10U);
+        HSD_JObjSetFlagsAll(jobj_2, JOBJ_HIDDEN);
     }
     if ((fighter->cmd_vars[2] & 1) && ((s32) fighter->mv.co.common.x10 != 0)) {
         rotate_z = -atan2f(fighter->coll_data.floor.normal.x,

--- a/src/melee/gm/gm_1832.c
+++ b/src/melee/gm/gm_1832.c
@@ -2216,9 +2216,9 @@ void fn_80188EE8(HSD_GObj* gobj)
 
     if (gm_801A45E8(2) != 0) {
         HSD_SisLib_803A6368(sub->text, 0x1E);
-        HSD_JObjSetFlagsAll(sub->jobjs[3], 0x10);
+        HSD_JObjSetFlagsAll(sub->jobjs[3], JOBJ_HIDDEN);
     } else {
-        HSD_JObjClearFlagsAll(sub->jobjs[3], 0x10);
+        HSD_JObjClearFlagsAll(sub->jobjs[3], JOBJ_HIDDEN);
     }
 
     {
@@ -2276,7 +2276,7 @@ void fn_80188EE8(HSD_GObj* gobj)
 
     fn_80188D3C(sub->jobjs[27]);
 
-    HSD_JObjSetFlags(sub->jobjs[25], 0x10);
+    HSD_JObjSetFlags(sub->jobjs[25], JOBJ_HIDDEN);
 
     val = sub->menu_values[6];
     jobj = sub->jobjs[26];

--- a/src/melee/gm/gm_18A5.c
+++ b/src/melee/gm/gm_18A5.c
@@ -2974,11 +2974,11 @@ void fn_80191A54(HSD_GObj* gobj)
     jobj_copy = jobj;
 
     if (td->cur_option <= 9) {
-        HSD_JObjSetFlagsAll(jobj_copy, 0x10);
+        HSD_JObjSetFlagsAll(jobj_copy, JOBJ_HIDDEN);
         return;
     }
 
-    HSD_JObjClearFlagsAll(jobj_copy, 0x10);
+    HSD_JObjClearFlagsAll(jobj_copy, JOBJ_HIDDEN);
 
     if (jobj == NULL) {
         child = NULL;
@@ -3158,11 +3158,11 @@ void fn_80191FD4(HSD_GObj* gobj)
     idx = fn_8018F62C(gobj);
 
     if ((s32) tm->cur_option <= 9) {
-        HSD_JObjSetFlagsAll(jobj, 0x10U);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         return;
     }
 
-    HSD_JObjClearFlagsAll(jobj, 0x10U);
+    HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
 
     if ((s32) idx == 0x19) {
         if (jobj == NULL) {
@@ -3189,7 +3189,7 @@ void fn_80191FD4(HSD_GObj* gobj)
         {
             u8 chr = tm->x37[lbl_804799B8.x2 + lbl_804799B8.x3].x2;
             if (lbl_803D9D20.x72[chr] != 0) {
-                HSD_JObjClearFlagsAll(sibling, 0x10U);
+                HSD_JObjClearFlagsAll(sibling, JOBJ_HIDDEN);
                 return;
             }
             if (fn_8018F3D0(fn_8018F310(fn_8018F6FC((enum CSSIconHud) chr))) ==
@@ -3198,13 +3198,13 @@ void fn_80191FD4(HSD_GObj* gobj)
                 fn_8019044C(sibling, 200.0f);
                 return;
             }
-            HSD_JObjSetFlagsAll(sibling, 0x10U);
+            HSD_JObjSetFlagsAll(sibling, JOBJ_HIDDEN);
             return;
         }
     }
 
     if ((s32) tm->cur_option != 0xB) {
-        HSD_JObjSetFlagsAll(jobj, 0x10U);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         return;
     }
 
@@ -3231,7 +3231,7 @@ void fn_80191FD4(HSD_GObj* gobj)
                 flag = 0;
             }
             if (flag == 0) {
-                HSD_JObjSetFlagsAll(child, 0x10U);
+                HSD_JObjSetFlagsAll(child, JOBJ_HIDDEN);
             } else {
                 fn_8019044C(child, 0.0f);
             }
@@ -3243,7 +3243,7 @@ void fn_80191FD4(HSD_GObj* gobj)
     } else {
         sibling = child->next;
     }
-    HSD_JObjClearFlagsAll(sibling, 0x10U);
+    HSD_JObjClearFlagsAll(sibling, JOBJ_HIDDEN);
 
     hud = fn_8018F6DC(fn_8018F3BC((s32) idx));
     if (lbl_803D9D20.x72[hud] != 0) {
@@ -3261,7 +3261,7 @@ void fn_80191FD4(HSD_GObj* gobj)
         fn_8019044C(sibling, 200.0f);
         return;
     }
-    HSD_JObjSetFlagsAll(sibling, 0x10U);
+    HSD_JObjSetFlagsAll(sibling, JOBJ_HIDDEN);
 }
 
 extern f32 lbl_804DA750; // -1.8f
@@ -3581,7 +3581,7 @@ void fn_80192E6C(void)
     HSD_JObjSetFlagsAll((HSD_JObj*) fn_8019035C(1, lbl_804D6650->models[2], 0,
                                                 0x1A, 2, 1, fn_80192758, 0.0f)
                             ->hsd_obj,
-                        0x10U);
+                        JOBJ_HIDDEN);
 
     for (i = 0; i < 0x40; i++) {
         gobj = fn_8019035C(1, lbl_804D6650->models[8], 0, 0x1A, 2, 1,
@@ -3593,7 +3593,7 @@ void fn_80192E6C(void)
         gobj = fn_8019035C(1, lbl_804D6650->models[3], 0, 0x1A, 2, 1,
                            fn_80191E9C, 0.0f);
         jobj = (HSD_JObj*) gobj->hsd_obj;
-        HSD_JObjSetFlagsAll(jobj, 0x10U);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         fn_8018FDC4(jobj, -12.300001f, 666.0f, 666.0f);
         fn_8018FBD8((void*) gobj, i);
     }
@@ -6058,21 +6058,21 @@ void fn_80197AF0(HSD_GObj* gobj)
     }
 
     if (in_range == 0) {
-        HSD_JObjSetFlagsAll(jobj, 0x10U);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         return;
     }
 
-    HSD_JObjClearFlagsAll(jobj, 0x10U);
+    HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
 
     if (((s8) HSD_PadMasterStatus[(u8) pnum].err != 0) &&
         ((u8) tm->x4B8[pnum].x0 != 1))
     {
-        HSD_JObjSetFlagsAll(jobj, 0x10U);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         return;
     }
 
     if ((u8) tm->x4B8[pnum].x0 == 1) {
-        HSD_JObjSetFlagsAll(jobj, 0x10U);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     }
 
     players = tm->x30;
@@ -6090,7 +6090,7 @@ void fn_80197AF0(HSD_GObj* gobj)
     if (lbl_804799D8.x44[pnum] != 6 || lbl_804799D8.x2A[pnum].state == 1 ||
         lbl_804799D8.x2A[pnum].state == 2 || lbl_804799D8.x2A[pnum].state == 4)
     {
-        HSD_JObjSetFlagsAll(jobj, 0x10U);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     }
 
     counter = &lbl_804799D8.x12[pnum];
@@ -7817,7 +7817,7 @@ void fn_8019B458(s32* arg0)
                                          0x1A, 3, 1, fn_80196EEC, 0.0f);
 
             if ((s32) td2->pad_x34[0] == match) {
-                HSD_JObjSetFlagsAll(gobj->hsd_obj, 0x10U);
+                HSD_JObjSetFlagsAll(gobj->hsd_obj, JOBJ_HIDDEN);
             }
         }
 

--- a/src/melee/gm/gm_19EF.c
+++ b/src/melee/gm/gm_19EF.c
@@ -133,9 +133,9 @@ static void fn_8019EFC4(HSD_PadStatus* pad)
             s32 i;
             for (i = 10; i > 0; i--) {
                 if (i > lbl_80479A98.x70) {
-                    HSD_JObjSetFlags(lbl_80479A98.x2C[i - 1], 0x10U);
+                    HSD_JObjSetFlags(lbl_80479A98.x2C[i - 1], JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjClearFlags(lbl_80479A98.x2C[i - 1], 0x10U);
+                    HSD_JObjClearFlags(lbl_80479A98.x2C[i - 1], JOBJ_HIDDEN);
                 }
             }
         }
@@ -327,7 +327,7 @@ static void fn_8019F810(void)
         HSD_JObjReqAnimAll(lbl_804D66B0.x0, (f32) lbl_804D66B0.x4);
         HSD_JObjAnimAll(lbl_804D66B0.x0);
     } else {
-        HSD_JObjSetFlagsAll(lbl_804D66B0.x0, 0x10U);
+        HSD_JObjSetFlagsAll(lbl_804D66B0.x0, JOBJ_HIDDEN);
     }
     if (lbl_80479A98.x0 == 9) {
         if ((u32) lbl_80479A98.x8 == (u32) lbl_80479A98.xC) {
@@ -442,9 +442,9 @@ void fn_8019F9C4(u32 arg0)
     lb_80011E24(jobj, &lbl_804D66C8.x0, 0x35, -1);
     lb_80011E24(jobj, &lbl_804D66C0.x0, 0x37, -1);
     if ((u8) lbl_80479A98.x20 != 0) {
-        HSD_JObjSetFlagsAll(lbl_804D66B0.x0, 0x10);
-        HSD_JObjSetFlagsAll(lbl_804D66C8.x0, 0x10);
-        HSD_JObjSetFlagsAll(lbl_804D66C0.x0, 0x10);
+        HSD_JObjSetFlagsAll(lbl_804D66B0.x0, JOBJ_HIDDEN);
+        HSD_JObjSetFlagsAll(lbl_804D66C8.x0, JOBJ_HIDDEN);
+        HSD_JObjSetFlagsAll(lbl_804D66C0.x0, JOBJ_HIDDEN);
     }
 
     gobj = GObj_Create(0xE, 0xF, 0);
@@ -517,9 +517,9 @@ void fn_8019F9C4(u32 arg0)
     HSD_JObjReqAnimAll(lbl_80479A98.x54, (f32) lbl_80479A98.x64);
     for (i = 10; i > 0; i--) {
         if (i > lbl_80479A98.x70) {
-            HSD_JObjSetFlags(lbl_80479A98.x2C[i - 1], 0x10);
+            HSD_JObjSetFlags(lbl_80479A98.x2C[i - 1], JOBJ_HIDDEN);
         } else {
-            HSD_JObjClearFlags(lbl_80479A98.x2C[i - 1], 0x10);
+            HSD_JObjClearFlags(lbl_80479A98.x2C[i - 1], JOBJ_HIDDEN);
         }
     }
     HSD_JObjAnimAll(jobj);

--- a/src/melee/gm/gmcamera.c
+++ b/src/melee/gm/gmcamera.c
@@ -596,7 +596,7 @@ void gmCamera_801A31FC(void)
     gm_8016895C(jobj_b, mdl_b, 0);
     HSD_JObjReqAnimAll(jobj_b, 0.0f);
     HSD_JObjAnimAll(jobj_b);
-    HSD_JObjSetFlagsAll(jobj_b, 0x10);
+    HSD_JObjSetFlagsAll(jobj_b, JOBJ_HIDDEN);
     HSD_GObj_SetupProc(gobj_b, fn_801A31D8, 0);
     gcus->x20 = 2;
     HSD_SisLib_803A62A0(3, "SdVsCam", "SIS_VsCameraData");

--- a/src/melee/gm/gmpause.c
+++ b/src/melee/gm/gmpause.c
@@ -97,7 +97,7 @@ void fn_801A1134(void)
     gm_8016895C(jobj, scene->models[0], 0);
     HSD_JObjReqAnimAll(jobj, 1.0f);
     HSD_JObjAnimAll(jobj);
-    HSD_JObjSetFlagsAll(jobj, 0x10U);
+    HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     HSD_GObj_SetupProc(gobj, fn_801A0E34, 0U);
     lbl_80479B10.slot = 99;
 }

--- a/src/melee/gm/gmregclear.c
+++ b/src/melee/gm/gmregclear.c
@@ -2415,7 +2415,7 @@ void fn_8017FF1C(HSD_GObj* gobj)
         (s32) (0.5f * (f32) (state->x110 - 0x14)) > (s32) state->x11D)
     {
         lb_80011E24(jobj, &sp28, state->x11D + 7, -1);
-        HSD_JObjClearFlagsAll(sp28, 0x10);
+        HSD_JObjClearFlagsAll(sp28, JOBJ_HIDDEN);
         state->x11D = (u8) (state->x11D + 1);
     }
 
@@ -2448,15 +2448,15 @@ void fn_8017FF1C(HSD_GObj* gobj)
     }
 
     if (state->x11E != 0) {
-        HSD_JObjSetFlagsAll(state->x20, 0x10);
+        HSD_JObjSetFlagsAll(state->x20, JOBJ_HIDDEN);
     } else {
-        HSD_JObjClearFlagsAll(state->x20, 0x10);
+        HSD_JObjClearFlagsAll(state->x20, JOBJ_HIDDEN);
     }
 
     if (state->x11F != 0) {
-        HSD_JObjSetFlagsAll(state->x24, 0x10);
+        HSD_JObjSetFlagsAll(state->x24, JOBJ_HIDDEN);
     } else {
-        HSD_JObjClearFlagsAll(state->x24, 0x10);
+        HSD_JObjClearFlagsAll(state->x24, JOBJ_HIDDEN);
     }
 
     if (state->x10C < 1.0f) {
@@ -2505,20 +2505,20 @@ s32 fn_801803FC(void* arg0)
         lb_8001204C(jobj, &p->x4, lbl_803D8B88, 0xA);
     }
     if (state->x117 == 0) {
-        HSD_JObjSetFlagsAll(p->x14, 0x10U);
-        HSD_JObjSetFlagsAll(p->x20, 0x10U);
-        HSD_JObjSetFlagsAll(p->x24, 0x10U);
+        HSD_JObjSetFlagsAll(p->x14, JOBJ_HIDDEN);
+        HSD_JObjSetFlagsAll(p->x20, JOBJ_HIDDEN);
+        HSD_JObjSetFlagsAll(p->x24, JOBJ_HIDDEN);
     }
     if (p->x11A != 0) {
         for (i = 0; i < 0xA; i++) {
             lb_80011E24(jobj, &sp10, i + 7, -1);
-            HSD_JObjSetFlagsAll(sp10, 0x10U);
+            HSD_JObjSetFlagsAll(sp10, JOBJ_HIDDEN);
         }
-        HSD_JObjSetFlagsAll(p->x10, 0x10U);
+        HSD_JObjSetFlagsAll(p->x10, JOBJ_HIDDEN);
     } else {
-        HSD_JObjSetFlagsAll(p->x1C, 0x10U);
+        HSD_JObjSetFlagsAll(p->x1C, JOBJ_HIDDEN);
         if (p->x118 != 0) {
-            HSD_JObjSetFlagsAll(p->x18, 0x10U);
+            HSD_JObjSetFlagsAll(p->x18, JOBJ_HIDDEN);
         }
     }
     temp = p->x4;
@@ -2740,7 +2740,7 @@ void fn_80180C14(HSD_GObj* gobj)
     HSD_JObj* jobj = gobj->hsd_obj;
 
     if ((lbl_80472E48.x0 & 3) != 0) {
-        HSD_JObjClearFlagsAll(jobj, 0x10);
+        HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         HSD_JObjAnimAll(jobj);
     }
 }
@@ -2815,7 +2815,7 @@ void fn_80180C60(HSD_GObj* gobj)
     if (!(((u8) lbl_80472E48.x0 >> 2) & 3)) {
         HSD_JObjReqAnimAll(jobj, 0.0f);
     } else if (lbl_80472E48.x0 & 3) {
-        HSD_JObjSetFlagsAll(jobj, 0x10U);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     } else if (dist > lbl_80472E48.x14[gm_80164024((u8) lbl_80472E48.unk_4)]) {
         if (lbl_804D65D4 == 0) {
             lbAudioAx_800237A8(0x9C40, 0x7F, 0x40);
@@ -2825,7 +2825,8 @@ void fn_80180C60(HSD_GObj* gobj)
             lbl_804D65D4 = 1;
         }
         HSD_JObjClearFlagsAll(
-            HSD_JObjGetNext(HSD_JObjGetChild(HSD_JObjGetChild(jobj))), 0x10U);
+            HSD_JObjGetNext(HSD_JObjGetChild(HSD_JObjGetChild(jobj))),
+            JOBJ_HIDDEN);
     }
 
     if (lbLang_IsSavedLanguageUS() != 0) {
@@ -2988,7 +2989,7 @@ void fn_80181708(void)
     gm_8016895C(jobj, *lbl_804D65CC, 0);
     HSD_JObjReqAnimAll(jobj, 0.0f);
     HSD_JObjAnimAll(jobj);
-    HSD_JObjSetFlagsAll(jobj, 0x10U);
+    HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
 
     gobj = (new_var = GObj_Create(0xEU, 0xFU, 0U));
     jobj = HSD_JObjLoadJoint((*lbl_804D65D0)->joint);
@@ -2998,13 +2999,14 @@ void fn_80181708(void)
     gm_8016895C(jobj, *lbl_804D65D0, 0);
     HSD_JObjReqAnimAll(jobj, 10.0f);
     HSD_JObjAnimAll(jobj);
-    HSD_JObjClearFlagsAll(jobj, 0x10U);
+    HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
 
     HSD_JObjSetFlagsAll(
-        HSD_JObjGetNext(HSD_JObjGetChild(HSD_JObjGetChild(jobj))), 0x10U);
+        HSD_JObjGetNext(HSD_JObjGetChild(HSD_JObjGetChild(jobj))),
+        JOBJ_HIDDEN);
     HSD_JObjClearFlagsAll(HSD_JObjGetNext(HSD_JObjGetNext(
                               HSD_JObjGetChild(HSD_JObjGetChild(jobj)))),
-                          0x10U);
+                          JOBJ_HIDDEN);
 
     gm_80168F88();
 }

--- a/src/melee/gm/gmresultplayer.c
+++ b/src/melee/gm/gmresultplayer.c
@@ -507,9 +507,11 @@ void fn_80178050(HSD_GObj* arg0)
                                 HSD_JObjAnimAll(
                                     data->player_data[k2].jobjs[1]);
                                 HSD_JObjSetFlagsAll(
-                                    data->player_data[k2].jobjs[0], 0x10U);
+                                    data->player_data[k2].jobjs[0],
+                                    JOBJ_HIDDEN);
                                 HSD_JObjSetFlagsAll(
-                                    data->player_data[k2].jobjs[4], 0x10U);
+                                    data->player_data[k2].jobjs[4],
+                                    JOBJ_HIDDEN);
                                 data->player_data[k2].x0_1 = 0;
                                 data->player_data[k2].x0_2 = 0;
                                 data->player_data[k2].x0_3 = 0;
@@ -536,9 +538,9 @@ void fn_80178050(HSD_GObj* arg0)
                             HSD_JObjAnimAll(data->player_data[k2].jobjs[6]);
                             HSD_JObjAnimAll(data->player_data[k2].jobjs[1]);
                             HSD_JObjClearFlagsAll(
-                                data->player_data[k2].jobjs[0], 0x10U);
+                                data->player_data[k2].jobjs[0], JOBJ_HIDDEN);
                             HSD_JObjClearFlagsAll(
-                                data->player_data[k2].jobjs[4], 0x10U);
+                                data->player_data[k2].jobjs[4], JOBJ_HIDDEN);
                             fn_8017435C();
                         }
                     } else if (slot == 1) {
@@ -573,31 +575,31 @@ void fn_80178050(HSD_GObj* arg0)
                     if ((u8) match_end->player_standings[k3].slot_type != 3) {
                         if (!data->player_data[k3].x0_1) {
                             HSD_JObjSetFlagsAll(data->player_data[k3].jobjs[8],
-                                                0x10U);
+                                                JOBJ_HIDDEN);
                         } else {
                             HSD_JObjClearFlagsAll(
-                                data->player_data[k3].jobjs[8], 0x10U);
+                                data->player_data[k3].jobjs[8], JOBJ_HIDDEN);
                         }
                         if (!data->player_data[k3].x0_2) {
                             HSD_JObjSetFlagsAll(data->player_data[k3].jobjs[9],
-                                                0x10U);
+                                                JOBJ_HIDDEN);
                         } else {
                             HSD_JObjClearFlagsAll(
-                                data->player_data[k3].jobjs[9], 0x10U);
+                                data->player_data[k3].jobjs[9], JOBJ_HIDDEN);
                         }
                         if (!data->player_data[k3].x0_3) {
                             HSD_JObjSetFlagsAll(
-                                data->player_data[k3].jobjs[0xA], 0x10U);
+                                data->player_data[k3].jobjs[0xA], JOBJ_HIDDEN);
                         } else {
                             HSD_JObjClearFlagsAll(
-                                data->player_data[k3].jobjs[0xA], 0x10U);
+                                data->player_data[k3].jobjs[0xA], JOBJ_HIDDEN);
                         }
                         if (!data->player_data[k3].x0_4) {
                             HSD_JObjSetFlagsAll(
-                                data->player_data[k3].jobjs[0xB], 0x10U);
+                                data->player_data[k3].jobjs[0xB], JOBJ_HIDDEN);
                         } else {
                             HSD_JObjClearFlagsAll(
-                                data->player_data[k3].jobjs[0xB], 0x10U);
+                                data->player_data[k3].jobjs[0xB], JOBJ_HIDDEN);
                         }
                     }
                     k3++;
@@ -781,12 +783,12 @@ void fn_80178BB4(HSD_GObj* gobj)
 
     i = 0;
     do {
-        HSD_JObjSetFlagsAll(data->player_data[i].jobjs[0], 0x10);
-        HSD_JObjSetFlagsAll(data->player_data[i].jobjs[4], 0x10);
-        HSD_JObjSetFlagsAll(data->player_data[i].jobjs[8], 0x10);
-        HSD_JObjSetFlagsAll(data->player_data[i].jobjs[9], 0x10);
-        HSD_JObjSetFlagsAll(data->player_data[i].jobjs[10], 0x10);
-        HSD_JObjSetFlagsAll(data->player_data[i].jobjs[11], 0x10);
+        HSD_JObjSetFlagsAll(data->player_data[i].jobjs[0], JOBJ_HIDDEN);
+        HSD_JObjSetFlagsAll(data->player_data[i].jobjs[4], JOBJ_HIDDEN);
+        HSD_JObjSetFlagsAll(data->player_data[i].jobjs[8], JOBJ_HIDDEN);
+        HSD_JObjSetFlagsAll(data->player_data[i].jobjs[9], JOBJ_HIDDEN);
+        HSD_JObjSetFlagsAll(data->player_data[i].jobjs[10], JOBJ_HIDDEN);
+        HSD_JObjSetFlagsAll(data->player_data[i].jobjs[11], JOBJ_HIDDEN);
         lbDObjSetRateAll(HSD_JObjGetDObj(data->player_data[i].jobjs[6]), 0.0f);
 
         {
@@ -863,16 +865,21 @@ void fn_80178BB4(HSD_GObj* gobj)
                     HSD_ForeachAnim(taunt_jobj, JOBJ_TYPE, ALL_TYPE_MASK,
                                     HSD_AObjSetCurrentFrame, AOBJ_ARG_AF, 0.0);
                     HSD_JObjAnimAll(taunt_jobj);
-                    HSD_JObjSetFlagsAll(data->player_data[i].jobjs[7], 0x10);
+                    HSD_JObjSetFlagsAll(data->player_data[i].jobjs[7],
+                                        JOBJ_HIDDEN);
                 }
 
                 HSD_JObjRemoveAnimAll(data->player_data[i].jobjs[3]);
-                HSD_JObjSetFlagsAll(data->player_data[i].jobjs[3], 0x10);
+                HSD_JObjSetFlagsAll(data->player_data[i].jobjs[3],
+                                    JOBJ_HIDDEN);
             } else {
-                HSD_JObjSetFlagsAll(data->player_data[i].jobjs[1], 0x10);
+                HSD_JObjSetFlagsAll(data->player_data[i].jobjs[1],
+                                    JOBJ_HIDDEN);
                 HSD_JObjRemoveAnimAll(data->player_data[i].jobjs[1]);
-                HSD_JObjSetFlagsAll(data->player_data[i].jobjs[5], 0x10);
-                HSD_JObjSetFlagsAll(data->player_data[i].jobjs[7], 0x10);
+                HSD_JObjSetFlagsAll(data->player_data[i].jobjs[5],
+                                    JOBJ_HIDDEN);
+                HSD_JObjSetFlagsAll(data->player_data[i].jobjs[7],
+                                    JOBJ_HIDDEN);
             }
         }
 

--- a/src/melee/gr/grbigblue.c
+++ b/src/melee/gr/grbigblue.c
@@ -173,9 +173,9 @@ void grBigBlue_801E57C0(void)
     grBigBlue_801E59F8(2);
     grBigBlue_801E59F8(0x22);
     grBigBlue_801E59F8(0x21);
-    HSD_JObjSetFlagsAll(grBigBlue_801E59F8(0x20)->hsd_obj, 0x10);
+    HSD_JObjSetFlagsAll(grBigBlue_801E59F8(0x20)->hsd_obj, JOBJ_HIDDEN);
     grBigBlue_801E59F8(0x23);
-    HSD_JObjSetFlagsAll(grBigBlue_801E59F8(0x24)->hsd_obj, 0x10);
+    HSD_JObjSetFlagsAll(grBigBlue_801E59F8(0x24)->hsd_obj, JOBJ_HIDDEN);
     Ground_801C39C0();
     Ground_801C3BB4();
     mpLib_80058044(0x21);
@@ -730,7 +730,7 @@ void grBigBlue_801E6C60(Ground_GObj* gobj)
                         gp->gv.bigblue.data[i].x34 = 0;
                         gp->gv.bigblue.data[i].x2C = 0;
                         gp->gv.bigblue.data[i].x1 = 3;
-                        HSD_JObjClearFlagsAll(jobj, 0x10);
+                        HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
                         gp->gv.bigblue.data[i].x50 = 0;
                         {
                             s32 chance = grBb_804D69C8->xB8;
@@ -1114,7 +1114,7 @@ void grBigBlue_801E6C60(Ground_GObj* gobj)
                     (10.0f + Stage_GetBlastZoneRightOffset()) - 50.0f)
                 {
                 reset_route:
-                    HSD_JObjSetFlagsAll(jobj, 0x10);
+                    HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
                     HSD_JObjSetRotationZ(jobj, 0.0f);
                     gp->gv.bigblue.data[i].x44.z = 0.0f;
                     gp->gv.bigblue.data[i].x44.y = 0.0f;
@@ -1540,7 +1540,7 @@ void grBigBlue_801E93D8(Ground_GObj* gobj)
                     HSD_JObjSetTranslate(jobj, &pos);
                     *(f32*) (bp + 0xD0) = pos.y;
                     *(f32*) (bp + 0xD8) = grBb_804D69C8->xD0;
-                    HSD_JObjClearFlagsAll(jobj, 0x10U);
+                    HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
                     bp[0xC4] = 1;
                 }
             }
@@ -1598,7 +1598,7 @@ void grBigBlue_801E93D8(Ground_GObj* gobj)
     }
     case 3:
         if (pos.x > (50.0f + Stage_GetBlastZoneRightOffset())) {
-            HSD_JObjSetFlagsAll(jobj, 0x10U);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
             *(f32*) (bp + 0xD8) = 0.0f;
             *(s32*) ((u8*) Ground_801C2BA4(32)->user_data + 0xCC) = 0;
             {
@@ -1864,7 +1864,7 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
                     *(f32*) ((u8*) gp + 0xE8) = 0.0f;
                     *(f32*) ((u8*) gp + 0xE4) = 0.0f;
 
-                    HSD_JObjClearFlagsAll(jobj, 0x10);
+                    HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
                     gp->gv.bigblue.x0 = 2;
                 }
             }
@@ -2022,7 +2022,7 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
              HSD_JObjGetTranslationX(jobj) >
                  Stage_GetBlastZoneRightOffset() - 50.0f))
         {
-            HSD_JObjSetFlagsAll(jobj, 0x10);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
             *(f32*) ((u8*) gp + 0xEC) = 0.0f;
             *(f32*) ((u8*) gp + 0xE8) = 0.0f;
             *(f32*) ((u8*) gp + 0xE4) = 0.0f;
@@ -2865,7 +2865,7 @@ void grBigBlue_801EC6C0(Ground_GObj* gobj)
     for (i = 0; i < 30; i++) {
         u8 val;
         mpJointSetCb1(grBb_803E2D78.x84[i], gp, (mpLib_Callback) fn_801EF60C);
-        HSD_JObjSetFlagsAll(((HSD_JObj**) gp->gv.bigblue.xC8)[i], 16);
+        HSD_JObjSetFlagsAll(((HSD_JObj**) gp->gv.bigblue.xC8)[i], JOBJ_HIDDEN);
         val = HSD_Randi(2) ? 0 : 2;
         ((u8*) gp->gv.bigblue.xCC)[i] = val;
     }
@@ -2980,7 +2980,7 @@ void grBigBlue_801EC6C0(Ground_GObj* gobj)
             *(f32*) (car + 0xEC) = 1.0F;
 
             HSD_JObjClearFlagsAll(((HSD_JObj**) gp->gv.bigblue.xC8)[line_idx],
-                                  16);
+                                  JOBJ_HIDDEN);
 
             jobj = ((HSD_JObj**) gp->gv.bigblue.xC8)[line_idx];
 
@@ -4112,7 +4112,7 @@ s32 grBigBlue_801EE398(Ground_GObj* gobj, s32 arg1, s32 arg2)
 
         HSD_JObjSetFlagsAll(
             ((HSD_JObj**) gp->gv.bigblue.xC8)[(*(u16*) car_d4 >> 4) & 0x1F],
-            0x10U);
+            JOBJ_HIDDEN);
 
         car = (u8*) gp + offset;
         if (*(f32*) (car + 0xE0) > 0.0f) {
@@ -4331,7 +4331,7 @@ s32 grBigBlue_801EE398(Ground_GObj* gobj, s32 arg1, s32 arg2)
                 {
                     HSD_JObj* jobj;
                     HSD_JObjClearFlagsAll(
-                        ((HSD_JObj**) gp->gv.bigblue.xC8)[slot], 0x10U);
+                        ((HSD_JObj**) gp->gv.bigblue.xC8)[slot], JOBJ_HIDDEN);
                     jobj = ((HSD_JObj**) gp->gv.bigblue.xC8)[slot];
                     HSD_JObjSetTranslate(jobj, (Vec3*) (car + 0xE0));
                 }
@@ -4480,7 +4480,7 @@ s32 grBigBlue_801EE398(Ground_GObj* gobj, s32 arg1, s32 arg2)
                 {
                     HSD_JObj* jobj;
                     HSD_JObjClearFlagsAll(
-                        ((HSD_JObj**) gp->gv.bigblue.xC8)[slot], 0x10U);
+                        ((HSD_JObj**) gp->gv.bigblue.xC8)[slot], JOBJ_HIDDEN);
                     jobj = ((HSD_JObj**) gp->gv.bigblue.xC8)[slot];
                     HSD_JObjSetTranslate(jobj, (Vec3*) (car + 0xE0));
                 }

--- a/src/melee/gr/grbigblueroute.c
+++ b/src/melee/gr/grbigblueroute.c
@@ -636,7 +636,7 @@ void grBigBlueRoute_8020C85C(Ground_GObj* gobj)
                     }
 
                     HSD_ASSERT(901, jobj);
-                    HSD_JObjClearFlagsAll(jobj, 16);
+                    HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
 
                     HSD_JObjSetRotationX(jobj, 0.0F);
                     HSD_JObjSetRotationY(jobj, 0.0F);
@@ -1042,7 +1042,7 @@ void grBigBlueRoute_8020DAB4(HSD_JObj** jobjs, f32 scale, int count)
             jobj = HSD_JObjGetNext(jobj);
         }
 
-        HSD_JObjClearFlagsAll(jobj, 16);
+        HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
 
         HSD_JObjSetScaleX(jobj, scale);
         HSD_JObjSetScaleY(jobj, scale);

--- a/src/melee/gr/grcastle.c
+++ b/src/melee/gr/grcastle.c
@@ -1061,7 +1061,7 @@ void grCastle_801CEACC(Ground_GObj* gobj)
     Ground_801C2ED0(jobj, gp->map_id);
     gp->x10_flags.b5 = 1;
     gp->gv.castle10.xC4 = 0;
-    HSD_JObjSetFlagsAll(jobj, 0x10);
+    HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     gp->gv.castle10.xC8 = 0;
 
     for (i = 0; i < 5; i++) {
@@ -1110,7 +1110,7 @@ void grCastle_801CEACC(Ground_GObj* gobj)
             HSD_JObjGetTranslationY(gp->gv.castle10.jobjs[1]);
         gp->gv.castle10.x120[1] = 7;
 
-        HSD_JObjSetFlagsAll(Ground_801C3FA4((HSD_GObj*) gobj, 7), 0x10);
+        HSD_JObjSetFlagsAll(Ground_801C3FA4((HSD_GObj*) gobj, 7), JOBJ_HIDDEN);
         gp->gv.castle10.jobjs[2] = NULL;
         gp->gv.castle10.effect_a[2] = NULL;
         gp->gv.castle10.effect_b[2] = NULL;
@@ -1250,7 +1250,7 @@ void grCastle_801CF0F4(Ground_GObj* gobj)
     Ground_801C2ED0(jobj, gp->map_id);
     gp->gv.castle7.xC4 = 0;
     gp->gv.castle7.xD8 = 0;
-    HSD_JObjSetFlagsAll(jobj, 0x10);
+    HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     scale = 1.5f * Ground_801C0498();
     HSD_JObjSetScaleX(jobj, scale);
     HSD_JObjSetScaleY(jobj, scale);
@@ -1290,7 +1290,7 @@ void grCastle_801CF308(Ground_GObj* gobj)
     case 1:
         gp->gv.castle.xC8 = -1;
         gp->gv.castle11.xCA = 0;
-        HSD_JObjClearFlagsAll(jobj, 0x10);
+        HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         grAnime_801C86D4(gp->map_id, (HSD_GObj*) gobj, 0);
         gp->gv.castle5.xC4 = 2;
         /* fallthrough */
@@ -1302,9 +1302,9 @@ void grCastle_801CF308(Ground_GObj* gobj)
             s8 val;
             gp->gv.castle.xC8 += 1;
             if (HSD_JObjGetFlags(jobj) & 0x10) {
-                HSD_JObjClearFlagsAll(jobj, 0x10);
+                HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
             } else {
-                HSD_JObjSetFlagsAll(jobj, 0x10);
+                HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
             }
             val = ((s8*) &tbl)[gp->gv.castle.xC8];
             if (val != -1) {
@@ -1347,14 +1347,14 @@ void grCastle_801CF308(Ground_GObj* gobj)
             s16 cnt = gp->gv.castle8.plat[0].state;
             gp->gv.castle8.plat[0].state = cnt - 1;
             if (cnt < 0) {
-                HSD_JObjSetFlagsAll(jobj, 0x10);
+                HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
             }
         }
         if ((s16) ((Ground*) ((HSD_GObj*) gp->gv.castle7.xD0)->user_data)
                 ->gv.castle5.xC4 == 0)
         {
             gp->gv.castle5.xC4 = 0;
-            HSD_JObjSetFlagsAll(jobj, 0x10);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         }
         var_r6 = 1;
         break;
@@ -1558,17 +1558,17 @@ s32 grCastle_801CFBD4(Ground_GObj* gobj, s32 arg1)
                     }
 
                     if (close == 0) {
-                        HSD_JObjClearFlags(jobj, 0x10);
+                        HSD_JObjClearFlags(jobj, JOBJ_HIDDEN);
                         if (eff_a != NULL && eff_b != NULL) {
                             if (gm_8016AE80() != -1 && gm_8016B238() == 0) {
-                                HSD_JObjClearFlags(eff_a, 0x10);
+                                HSD_JObjClearFlags(eff_a, JOBJ_HIDDEN);
                                 HSD_JObjSetScaleY(eff_a, 0.0001f);
-                                HSD_JObjSetFlags(eff_b, 0x10);
+                                HSD_JObjSetFlags(eff_b, JOBJ_HIDDEN);
                                 HSD_JObjSetScaleY(eff_b, 1.0f);
                             } else {
-                                HSD_JObjSetFlags(eff_a, 0x10);
+                                HSD_JObjSetFlags(eff_a, JOBJ_HIDDEN);
                                 HSD_JObjSetScaleY(eff_a, 1.0f);
-                                HSD_JObjClearFlags(eff_b, 0x10);
+                                HSD_JObjClearFlags(eff_b, JOBJ_HIDDEN);
                                 HSD_JObjSetScaleY(eff_b, 0.0001f);
                             }
                         } else {
@@ -1650,12 +1650,12 @@ s32 grCastle_801CFBD4(Ground_GObj* gobj, s32 arg1)
                         newScale -= grCs_804D6970->x4C;
                         if (newScale <= 0.0001f) {
                             newScale = 0.0001f;
-                            HSD_JObjSetFlags(jobj, 0x10);
+                            HSD_JObjSetFlags(jobj, JOBJ_HIDDEN);
                             if (eff_a != NULL) {
-                                HSD_JObjSetFlags(eff_a, 0x10);
+                                HSD_JObjSetFlags(eff_a, JOBJ_HIDDEN);
                             }
                             if (eff_b != NULL) {
-                                HSD_JObjSetFlags(eff_b, 0x10);
+                                HSD_JObjSetFlags(eff_b, JOBJ_HIDDEN);
                             }
                         }
                         HSD_JObjSetScaleY(target, newScale);
@@ -1703,8 +1703,10 @@ void grCastle_801D02B8(Ground_GObj* gobj)
                         vel.x = 0.0f;
                         vel.y = grCs_804D6970->x50;
                         it_8026F7C8(&pos, &vel, 1);
-                        HSD_JObjSetFlags(gp->gv.castle10.effect_a[i], 0x10);
-                        HSD_JObjClearFlags(gp->gv.castle10.effect_b[i], 0x10);
+                        HSD_JObjSetFlags(gp->gv.castle10.effect_a[i],
+                                         JOBJ_HIDDEN);
+                        HSD_JObjClearFlags(gp->gv.castle10.effect_b[i],
+                                           JOBJ_HIDDEN);
                     }
                 }
             } else {

--- a/src/melee/gr/grflatzone.c
+++ b/src/melee/gr/grflatzone.c
@@ -445,7 +445,7 @@ void grFlatzone_802176BC(Ground_GObj* gobj)
         break;
     case 4:
         HSD_JObjRemoveAnimAll(jobj);
-        HSD_JObjSetFlagsAll(jobj, 0x10U);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         gp->gv.flatzone2.xCC = 0;
         gp->gv.flatzone2.xD0 = -1;
         break;

--- a/src/melee/gr/grfourside.c
+++ b/src/melee/gr/grfourside.c
@@ -430,7 +430,7 @@ void grFourside_801F37FC(Ground_GObj* gobj)
     gp->gv.foursideUfo.x2 = 0;
     gp->gv.foursideUfo.xC = 0;
     gp->gv.foursideUfo.x3 = 0;
-    HSD_JObjSetFlagsAll(jobj, 16);
+    HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     mpLib_80057BC0(4);
     gp->x10_flags.b5 = 1;
 }
@@ -470,7 +470,7 @@ void grFourside_801F3894(Ground_GObj* arg0)
                                      gp->gv.foursideUfo.x1 * 4);
                     mpLib_80055E9C(4);
                     mpLib_80057424(4);
-                    HSD_JObjClearFlagsAll(jobj, 0x10);
+                    HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
                     mpJointListAdd(4);
                     gp->gv.foursideUfo.xC = Camera_80029020();
                     gp->gv.foursideUfo.x3 = 0;
@@ -529,7 +529,7 @@ void grFourside_801F3894(Ground_GObj* arg0)
     case 4: {
         s32 timer = gp->gv.foursideUfo.x4;
         if (timer >= 0x3C) {
-            HSD_JObjSetFlagsAll(jobj, 0x10);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
             mpLib_80057BC0(4);
             gp->gv.foursideUfo.x4 = grFs_804D69D8->ufo_wait;
             gp->gv.foursideUfo.x0 = 0;

--- a/src/melee/gr/grheal.c
+++ b/src/melee/gr/grheal.c
@@ -322,7 +322,7 @@ void grHeal_8021F4E8(s32 arg0, HSD_JObj* parent_jobj)
     jobj = GET_JOBJ(ground);
     child = HSD_JObjGetChild(jobj);
     HSD_JObjReparent(child, parent_jobj);
-    HSD_JObjClearFlagsAll(child, 0x10U);
+    HSD_JObjClearFlagsAll(child, JOBJ_HIDDEN);
     Ground_801C4A08(ground);
 }
 

--- a/src/melee/gr/gricemt.c
+++ b/src/melee/gr/gricemt.c
@@ -1071,7 +1071,7 @@ void fn_801F8C64(Item_GObj* gobj, Ground* u1, Vec3* u2, HSD_GObj* u3, f32 u4)
     Item* it = GET_ITEM(gobj);
     grMaterial_801C8E28(gobj);
 
-    HSD_JObjSetFlagsAll(it->xDD4_itemVar.mato.x4, 0x10);
+    HSD_JObjSetFlagsAll(it->xDD4_itemVar.mato.x4, JOBJ_HIDDEN);
     it_8026B294(gobj, &pos);
     efSync_Spawn(0x445, gobj, &pos);
     Ground_801C53EC(310);

--- a/src/melee/gr/grinishie1.c
+++ b/src/melee/gr/grinishie1.c
@@ -336,9 +336,9 @@ void grInishie1_801FAC58(Ground_GObj* gobj)
         if (gp->gv.inishie12.xCC == 0) {
             if (gp->gv.inishie12.xC8 > 0) {
                 if (gp->gv.inishie12.xC8 & 1) {
-                    HSD_JObjClearFlagsAll(jobj, 0x10U);
+                    HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlagsAll(jobj, 0x10U);
+                    HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
                 }
                 gp->gv.inishie12.xC8 -= 1;
             }
@@ -607,7 +607,7 @@ void grInishie1_801FB3F0(HSD_GObj* gobj)
                 lb_8000B1CC(slot->jobj, NULL, &pos);
                 if (!grLib_801C9EE8(&pos, 15.0f)) {
                     DOBJ_LOOP(slot->jobj);
-                    HSD_JObjClearFlagsAll(slot->jobj, 0x10U);
+                    HSD_JObjClearFlagsAll(slot->jobj, JOBJ_HIDDEN);
                     grMaterial_801C8E08(slot->item_gobj);
                     slot->status = 1;
                     slot->x22 = grI1_804D69F8->unk18;
@@ -617,7 +617,7 @@ void grInishie1_801FB3F0(HSD_GObj* gobj)
             if (slot->hatena_gobj != NULL) {
                 HSD_JObj* sub_jobj = ((HSD_GObj*) slot->hatena_gobj)->hsd_obj;
                 if (!(HSD_JObjGetFlags(sub_jobj) & 0x10)) {
-                    HSD_JObjSetFlagsAll(sub_jobj, 0x10U);
+                    HSD_JObjSetFlagsAll(sub_jobj, JOBJ_HIDDEN);
                 }
             }
             break;
@@ -632,9 +632,9 @@ void grInishie1_801FB3F0(HSD_GObj* gobj)
                         ((HSD_GObj*) slot->hatena_gobj)->hsd_obj;
 
                     if (slot->x22 & 1) {
-                        HSD_JObjClearFlagsAll(target, 0x10U);
+                        HSD_JObjClearFlagsAll(target, JOBJ_HIDDEN);
                     } else {
-                        HSD_JObjSetFlagsAll(target, 0x10U);
+                        HSD_JObjSetFlagsAll(target, JOBJ_HIDDEN);
                     }
 
                     DOBJ_LOOP(slot->jobj);
@@ -742,7 +742,7 @@ void grInishie1_801FBCEC(HSD_GObj* gobj, u32 index)
         it_8026F7C8(&item_spawn_offset, &grI1_803B8268, 0);
     }
 
-    HSD_JObjSetFlagsAll(gp->gv.inishie1.blocks[index].jobj, 0x10U);
+    HSD_JObjSetFlagsAll(gp->gv.inishie1.blocks[index].jobj, JOBJ_HIDDEN);
 
     it_8026B294(gp->gv.inishie1.blocks[index].item_gobj, &effect_pos);
 

--- a/src/melee/gr/grizumi.c
+++ b/src/melee/gr/grizumi.c
@@ -380,12 +380,12 @@ void grIzumi_801CC0D4(Ground_GObj* gobj)
             if (vec.y < 0.0f) {
                 u32 flags = HSD_JObjGetFlags(gp2->gv.izumi2.xC4);
                 if ((flags & 0x10) == 0) {
-                    HSD_JObjSetFlagsAll(gp2->gv.izumi2.xC4, 0x10);
+                    HSD_JObjSetFlagsAll(gp2->gv.izumi2.xC4, JOBJ_HIDDEN);
                 }
             } else {
                 u32 flags = HSD_JObjGetFlags(gp2->gv.izumi2.xC4);
                 if ((flags & 0x10) != 0) {
-                    HSD_JObjClearFlagsAll(gp2->gv.izumi2.xC4, 0x10);
+                    HSD_JObjClearFlagsAll(gp2->gv.izumi2.xC4, JOBJ_HIDDEN);
                 }
             }
         }
@@ -395,12 +395,12 @@ void grIzumi_801CC0D4(Ground_GObj* gobj)
             if (vec.y < 0.0f) {
                 u32 flags = HSD_JObjGetFlags(gp2->gv.izumi2.xC8);
                 if ((flags & 0x10) == 0) {
-                    HSD_JObjSetFlagsAll(gp2->gv.izumi2.xC8, 0x10);
+                    HSD_JObjSetFlagsAll(gp2->gv.izumi2.xC8, JOBJ_HIDDEN);
                 }
             } else {
                 u32 flags = HSD_JObjGetFlags(gp2->gv.izumi2.xC8);
                 if ((flags & 0x10) != 0) {
-                    HSD_JObjClearFlagsAll(gp2->gv.izumi2.xC8, 0x10);
+                    HSD_JObjClearFlagsAll(gp2->gv.izumi2.xC8, JOBJ_HIDDEN);
                 }
             }
         }
@@ -519,7 +519,7 @@ void grIzumi_801CC358(Ground_GObj* gobj)
         float f;
         gp->gv.izumi3.xC4 = 4;
         gp->gv.izumi3.xC6 = rand_range(grIz_804D6968->x50, grIz_804D6968->x4C);
-        HSD_JObjSetFlagsAll(jobj, 0x10);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         HSD_JObjRemoveAnimAll(jobj); ///< @todo float load order (41c)
         f = HSD_JObjGetTranslationY(jobj);
         f += -1.0;
@@ -531,7 +531,7 @@ void grIzumi_801CC358(Ground_GObj* gobj)
         if (gp->gv.izumi3.xC6-- < 0) {
             gp->gv.izumi3.xC4 = 2;
             gp->gv.izumi3.xD4 = gp->gv.izumi3.xDC;
-            HSD_JObjClearFlagsAll(jobj, 0x10);
+            HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
             grAnime_801C7FF8(gobj, 0, 7, 0, 0.0f, 1.0f);
             r29 = true;
         }
@@ -590,9 +590,9 @@ void grIzumi_801CCA64(Ground_GObj* gobj)
     HSD_GObjGXLink_8039084C(gobj);
     GObj_SetupGXLink(gobj, grDisplay_801C5DB0, 2, 0);
     gp->gv.izumi2.xC4 = Ground_801C3FA4(gobj, 2);
-    HSD_JObjSetFlagsAll(gp->gv.izumi2.xC4, 0x10);
+    HSD_JObjSetFlagsAll(gp->gv.izumi2.xC4, JOBJ_HIDDEN);
     gp->gv.izumi2.xC8 = Ground_801C3FA4(gobj, 3);
-    HSD_JObjSetFlagsAll(gp->gv.izumi2.xC8, 0x10);
+    HSD_JObjSetFlagsAll(gp->gv.izumi2.xC8, JOBJ_HIDDEN);
 }
 
 bool grIzumi_801CCB08(Ground_GObj* gobj)

--- a/src/melee/gr/grkinokoroute.c
+++ b/src/melee/gr/grkinokoroute.c
@@ -470,7 +470,7 @@ void grKinokoRoute_8020836C(Ground_GObj* gobj, int arg1)
     }
 
     if (arg1 != 0) {
-        HSD_JObjClearFlagsAll(jobj, 0x10);
+        HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         mpJointListAdd(0x3C);
         mpJointListAdd(0x33);
 
@@ -485,7 +485,7 @@ void grKinokoRoute_8020836C(Ground_GObj* gobj, int arg1)
         mpJointListAdd(0x0E);
         mpJointListAdd(0x0F);
     } else {
-        HSD_JObjSetFlagsAll(jobj, 0x10);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         mpLib_80057BC0(0x3C);
         mpLib_80057BC0(0x33);
 
@@ -520,7 +520,7 @@ void grKinokoRoute_802084B4(HSD_GObj* gobj)
         HSD_JObj* jobj;
     }* gp = gobj->user_data;
 
-    HSD_JObjSetFlagsAll(gp->jobj, 0x10);
+    HSD_JObjSetFlagsAll(gp->jobj, JOBJ_HIDDEN);
 
     gobj2 = Ground_801C2BA4(3);
     if (gobj2 != NULL) {

--- a/src/melee/gr/grkraid.c
+++ b/src/melee/gr/grkraid.c
@@ -66,9 +66,9 @@ void grKraid_OnInit(void)
     grKraid_801FE0C4(2);
     grKraid_801FE0C4(3);
     gobj = grKraid_801FE0C4(4);
-    HSD_JObjSetFlagsAll(GET_JOBJ(gobj), 0x10);
+    HSD_JObjSetFlagsAll(GET_JOBJ(gobj), JOBJ_HIDDEN);
     gobj = grKraid_801FE0C4(1);
-    HSD_JObjSetFlagsAll(GET_JOBJ(gobj), 0x10);
+    HSD_JObjSetFlagsAll(GET_JOBJ(gobj), JOBJ_HIDDEN);
     Ground_801C39C0();
     Ground_801C3BB4();
 }
@@ -403,8 +403,9 @@ void grKraid_801FEA00(Ground_GObj* gobj)
             Ground* map = Ground_801C2BA4(3)->user_data;
             if ((int) map->gv.kraid.x4 == 0) {
                 grKraid_801FEE54(gobj);
-                HSD_JObjClearFlagsAll(jobj, 0x10);
-                HSD_JObjClearFlagsAll(Ground_801C2BA4(1)->hsd_obj, 0x10);
+                HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
+                HSD_JObjClearFlagsAll(Ground_801C2BA4(1)->hsd_obj,
+                                      JOBJ_HIDDEN);
                 grKraid_801FF068(gobj, 3);
                 Ground_801C53EC(420001);
                 Ground_801C53EC(420008);
@@ -487,8 +488,8 @@ void grKraid_801FEA00(Ground_GObj* gobj)
         if (grAnime_801C83D0(gobj, 0, 7) != 0) {
             gp->gv.kraid2.xC = grKr_804D6A08->kraid_wait_time +
                                grKr_804D6A08->kraid_wait_time_add;
-            HSD_JObjSetFlagsAll(jobj, 0x10);
-            HSD_JObjSetFlagsAll(Ground_801C2BA4(1)->hsd_obj, 0x10);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
+            HSD_JObjSetFlagsAll(Ground_801C2BA4(1)->hsd_obj, JOBJ_HIDDEN);
             gp->gv.kraid2.xC =
                 grKr_804D6A08->kraid_wait_time +
                 ((s32) grKr_804D6A08->kraid_wait_time_add != 0

--- a/src/melee/gr/groldkongo.c
+++ b/src/melee/gr/groldkongo.c
@@ -615,7 +615,7 @@ void grOldKongo_8021005C(Ground_GObj* gobj)
 {
     Ground* gp = gobj->user_data;
     HSD_JObj* jobj = GET_JOBJ(gobj);
-    HSD_JObjSetFlagsAll(jobj, 0x10);
+    HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     gp->gv.unk.xC4 = rand_range(grOk_804D6A90->x2, grOk_804D6A90->x0);
 }
 
@@ -653,7 +653,7 @@ void grOldKongo_802100FC(Ground_GObj* arg0)
                     x = 200.0f;
                 }
                 HSD_JObjSetTranslateX(jobj, x);
-                HSD_JObjClearFlagsAll(Ground_801C3FA4(arg0, 3), 0x10U);
+                HSD_JObjClearFlagsAll(Ground_801C3FA4(arg0, 3), JOBJ_HIDDEN);
                 return;
             }
             if (-200.0f > left) {
@@ -662,13 +662,13 @@ void grOldKongo_802100FC(Ground_GObj* arg0)
                 x = -200.0f;
             }
             HSD_JObjSetTranslateX(jobj, x);
-            HSD_JObjClearFlagsAll(Ground_801C3FA4(arg0, 1), 0x10U);
+            HSD_JObjClearFlagsAll(Ground_801C3FA4(arg0, 1), JOBJ_HIDDEN);
         }
     } else if (grAnime_801C83D0(arg0, 0, 7) != 0) {
         s32 min;
         int max;
 
-        HSD_JObjSetFlagsAll(jobj, 0x10U);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         min = grOk_804D6A90->x2;
         max = grOk_804D6A90->x0;
         if (min > max) {

--- a/src/melee/gr/groldyoshi.c
+++ b/src/melee/gr/groldyoshi.c
@@ -287,7 +287,8 @@ void grOldYoshi_8020EC10(Ground_GObj* arg)
             if (grAnime_801C83D0(arg, grOy_803E6574[i * 2 + 1], 2)) {
                 gp->gv.oldyoshicloud.cloud[i].xC4_0123 = 2;
                 mpLib_80057BC0(grOy_803E6574[i * 2]);
-                HSD_JObjSetFlagsAll(gp->gv.oldyoshicloud.cloud[i].xC8, 16);
+                HSD_JObjSetFlagsAll(gp->gv.oldyoshicloud.cloud[i].xC8,
+                                    JOBJ_HIDDEN);
                 gp->gv.oldyoshicloud.cloud[i].xC4_567 = 0;
             }
             break;
@@ -303,7 +304,8 @@ void grOldYoshi_8020EC10(Ground_GObj* arg)
             break;
         case 3:
             if (gp->gv.oldyoshicloud.cloud[i].xC4_567 == 0) {
-                HSD_JObjClearFlagsAll(gp->gv.oldyoshicloud.cloud[i].xC8, 16);
+                HSD_JObjClearFlagsAll(gp->gv.oldyoshicloud.cloud[i].xC8,
+                                      JOBJ_HIDDEN);
             }
             if (gp->gv.oldyoshicloud.cloud[i].xC4_567 == grOy_804D6A88->x12) {
                 mpJointListAdd(grOy_803E6574[i * 2]);
@@ -356,7 +358,7 @@ void grOldYoshi_8020EFCC(Ground_GObj* arg)
 {
     HSD_JObj* jobj = arg->hsd_obj;
     Ground* gp = grOldYoshi_8020EFCC_inline(arg);
-    HSD_JObjSetFlagsAll(jobj, 0x10);
+    HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     gp->gv.oldyoshiguest.xC4 =
         rand_range(grOy_804D6A88->x16, grOy_804D6A88->x14);
     gp->gv.oldyoshiguest.xC6 = -1;
@@ -401,10 +403,10 @@ void grOldYoshi_8020F088(Ground_GObj* arg)
             return;
         }
         if ((HSD_JObjGetFlags(jobj) & 0x10) != 0) {
-            HSD_JObjClearFlagsAll(jobj, 0x10);
+            HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         }
         if (grAnime_801C83D0(arg, 0, 7) != 0) {
-            HSD_JObjSetFlagsAll(jobj, 0x10);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
             gp->gv.oldyoshiguest.xC4 =
                 rand_range(grOy_804D6A88->x16, grOy_804D6A88->x14);
             gp->gv.oldyoshiguest.xC6 = -1;

--- a/src/melee/gr/grpstadium.c
+++ b/src/melee/gr/grpstadium.c
@@ -672,9 +672,9 @@ void grStadium_801D1EF8(Ground_GObj* gobj)
             jobj = Ground_801C3FA4(gobj, 6);
             if (jobj != NULL) {
                 if (gp->u.display.xE6 & 1) {
-                    HSD_JObjClearFlags(jobj, 0x10);
+                    HSD_JObjClearFlags(jobj, JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlags(jobj, 0x10);
+                    HSD_JObjSetFlags(jobj, JOBJ_HIDDEN);
                 }
             }
         }
@@ -682,9 +682,9 @@ void grStadium_801D1EF8(Ground_GObj* gobj)
             jobj = Ground_801C3FA4(gobj, 3);
             if (jobj != NULL) {
                 if (gp->u.display.xE6 & 2) {
-                    HSD_JObjClearFlags(jobj, 0x10);
+                    HSD_JObjClearFlags(jobj, JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlags(jobj, 0x10);
+                    HSD_JObjSetFlags(jobj, JOBJ_HIDDEN);
                 }
             }
         }
@@ -692,9 +692,9 @@ void grStadium_801D1EF8(Ground_GObj* gobj)
             jobj = Ground_801C3FA4(gobj, 7);
             if (jobj != NULL) {
                 if (gp->u.display.xE6 & 8) {
-                    HSD_JObjClearFlags(jobj, 0x10);
+                    HSD_JObjClearFlags(jobj, JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlags(jobj, 0x10);
+                    HSD_JObjSetFlags(jobj, JOBJ_HIDDEN);
                 }
             }
         }
@@ -702,9 +702,9 @@ void grStadium_801D1EF8(Ground_GObj* gobj)
             jobj = Ground_801C3FA4(gobj, 9);
             if (jobj != NULL) {
                 if (gp->u.display.xE6 & 0x10) {
-                    HSD_JObjClearFlags(jobj, 0x10);
+                    HSD_JObjClearFlags(jobj, JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlags(jobj, 0x10);
+                    HSD_JObjSetFlags(jobj, JOBJ_HIDDEN);
                 }
             }
         }
@@ -712,9 +712,9 @@ void grStadium_801D1EF8(Ground_GObj* gobj)
             jobj = Ground_801C3FA4(gobj, 4);
             if (jobj != NULL) {
                 if (gp->u.display.xE6 & 4) {
-                    HSD_JObjClearFlags(jobj, 0x10);
+                    HSD_JObjClearFlags(jobj, JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlags(jobj, 0x10);
+                    HSD_JObjSetFlags(jobj, JOBJ_HIDDEN);
                 }
             }
         }
@@ -722,9 +722,9 @@ void grStadium_801D1EF8(Ground_GObj* gobj)
             jobj = Ground_801C3FA4(gobj, 8);
             if (jobj != NULL) {
                 if (gp->u.display.xE6 & 0x20) {
-                    HSD_JObjClearFlags(jobj, 0x10);
+                    HSD_JObjClearFlags(jobj, JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlags(jobj, 0x10);
+                    HSD_JObjSetFlags(jobj, JOBJ_HIDDEN);
                 }
             }
         }
@@ -732,9 +732,9 @@ void grStadium_801D1EF8(Ground_GObj* gobj)
             jobj = Ground_801C3FA4(gobj, 5);
             if (jobj != NULL) {
                 if (gp->u.display.xE6 & 0x80) {
-                    HSD_JObjClearFlags(jobj, 0x10);
+                    HSD_JObjClearFlags(jobj, JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlags(jobj, 0x10);
+                    HSD_JObjSetFlags(jobj, JOBJ_HIDDEN);
                 }
             }
         }
@@ -742,9 +742,9 @@ void grStadium_801D1EF8(Ground_GObj* gobj)
             jobj = Ground_801C3FA4(gobj, 2);
             if (jobj != NULL) {
                 if (gp->u.display.xE6 & 0x40) {
-                    HSD_JObjClearFlags(jobj, 0x10);
+                    HSD_JObjClearFlags(jobj, JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlags(jobj, 0x10);
+                    HSD_JObjSetFlags(jobj, JOBJ_HIDDEN);
                 }
             }
         }

--- a/src/melee/gr/grpura.c
+++ b/src/melee/gr/grpura.c
@@ -319,11 +319,11 @@ void grPura_8021231C(Ground_GObj* arg0)
     if ((HSD_JObjGetFlags(gp->gv.pura2.xC8) & 0x10) &&
         ((HSD_JObjGetFlags(jobj) & 0x10) == NULL))
     {
-        HSD_JObjSetFlagsAll(jobj, 0x10);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     } else if (((HSD_JObjGetFlags(gp->gv.pura2.xC8) & 0x10) == NULL) &&
                (HSD_JObjGetFlags(jobj) & 0x10))
     {
-        HSD_JObjClearFlagsAll(jobj, 0x10);
+        HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
     }
 }
 
@@ -365,7 +365,7 @@ void grPura_802125F0(HSD_GObj* arg0)
                 jobj, HSD_JObjGetTranslationZ(gp->gv.pura2.xC8));
 
             if (HSD_JObjGetFlags(gp->gv.pura2.xC8) & 0x10) {
-                HSD_JObjSetFlagsAll(jobj, 0x10);
+                HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
             }
 
             jobj = gobj->hsd_obj;

--- a/src/melee/gr/grshrineroute.c
+++ b/src/melee/gr/grshrineroute.c
@@ -436,7 +436,7 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
                         if (temp != NULL) {
                             ejobj =
                                 ((HSD_GObj*) gp->gv.shrineroute.xD4)->hsd_obj;
-                            HSD_JObjSetFlagsAll(ejobj, 0x10);
+                            HSD_JObjSetFlagsAll(ejobj, JOBJ_HIDDEN);
                             Ground_801C2D24(result, &sp88);
                             HSD_JObjSetTranslate(ejobj, &sp88);
                         }
@@ -451,7 +451,7 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
                             HSD_JObj* j =
                                 Ground_801C3FA4((HSD_GObj*) gobj, 0x13);
                             if (j != NULL) {
-                                HSD_JObjSetFlagsAll(j, 0x10);
+                                HSD_JObjSetFlagsAll(j, JOBJ_HIDDEN);
                             }
                             mpLib_80057BC0(8);
                         }
@@ -459,7 +459,7 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
                             HSD_JObj* j =
                                 Ground_801C3FA4((HSD_GObj*) gobj, 0x14);
                             if (j != NULL) {
-                                HSD_JObjSetFlagsAll(j, 0x10);
+                                HSD_JObjSetFlagsAll(j, JOBJ_HIDDEN);
                             }
                             mpLib_80057BC0(9);
                         }
@@ -467,7 +467,7 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
                             HSD_JObj* j =
                                 Ground_801C3FA4((HSD_GObj*) gobj, 0x12);
                             if (j != NULL) {
-                                HSD_JObjSetFlagsAll(j, 0x10);
+                                HSD_JObjSetFlagsAll(j, JOBJ_HIDDEN);
                             }
                             mpLib_80057BC0(0xA);
                         }
@@ -475,7 +475,7 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
                             HSD_JObj* j =
                                 Ground_801C3FA4((HSD_GObj*) gobj, 0x11);
                             if (j != NULL) {
-                                HSD_JObjSetFlagsAll(j, 0x10);
+                                HSD_JObjSetFlagsAll(j, JOBJ_HIDDEN);
                             }
                             mpLib_80057BC0(0xB);
                         }
@@ -483,7 +483,7 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
                             HSD_JObj* j =
                                 Ground_801C3FA4((HSD_GObj*) gobj, 0x10);
                             if (j != NULL) {
-                                HSD_JObjSetFlagsAll(j, 0x10);
+                                HSD_JObjSetFlagsAll(j, JOBJ_HIDDEN);
                             }
                             mpLib_80057BC0(0xC);
                         }
@@ -491,7 +491,7 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
                             HSD_JObj* j =
                                 Ground_801C3FA4((HSD_GObj*) gobj, 0xF);
                             if (j != NULL) {
-                                HSD_JObjSetFlagsAll(j, 0x10);
+                                HSD_JObjSetFlagsAll(j, JOBJ_HIDDEN);
                             }
                             mpLib_80057BC0(0xD);
                         }
@@ -517,12 +517,14 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
         track_plat = 1;
         if (grLib_801C96E8((HSD_GObj*) gobj) != 0) {
             gp->gv.shrineroute.xC4 = 2;
-            HSD_JObjSetFlagsAll(Ground_801C3FA4((HSD_GObj*) gobj, 1), 0x10);
-            HSD_JObjSetFlagsAll(Ground_801C3FA4((HSD_GObj*) gobj, 1), 0x10);
+            HSD_JObjSetFlagsAll(Ground_801C3FA4((HSD_GObj*) gobj, 1),
+                                JOBJ_HIDDEN);
+            HSD_JObjSetFlagsAll(Ground_801C3FA4((HSD_GObj*) gobj, 1),
+                                JOBJ_HIDDEN);
             {
                 HSD_GObj* gr2 = Ground_801C2BA4(2);
                 if (gr2 != NULL) {
-                    HSD_JObjSetFlagsAll(Ground_801C3FA4(gr2, 0), 0x10);
+                    HSD_JObjSetFlagsAll(Ground_801C3FA4(gr2, 0), JOBJ_HIDDEN);
                 }
             }
             grAnime_801C7A04((HSD_GObj*) gobj, 0, 7U, 0.0f);
@@ -540,7 +542,7 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
             HSD_JObj* ejobj = ((HSD_GObj*) gp->gv.shrineroute.xD4)->hsd_obj;
             if (HSD_JObjGetFlags(ejobj) & 0x10) {
                 void* anim = ((HSD_GObj*) gp->gv.shrineroute.xD4)->user_data;
-                HSD_JObjClearFlagsAll(ejobj, 0x10);
+                HSD_JObjClearFlagsAll(ejobj, JOBJ_HIDDEN);
                 grAnime_801C8138((HSD_GObj*) gp->gv.shrineroute.xD4,
                                  ((Ground*) anim)->map_id, 0);
             }
@@ -622,53 +624,54 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
         if (HSD_JObjGetFlags(j19) & 0x10) {
             HSD_GObj* gr2;
             u16 pid;
-            HSD_JObjClearFlagsAll(j19, 0x10);
-            HSD_JObjClearFlagsAll(Ground_801C3FA4((HSD_GObj*) gobj, 1), 0x10);
+            HSD_JObjClearFlagsAll(j19, JOBJ_HIDDEN);
+            HSD_JObjClearFlagsAll(Ground_801C3FA4((HSD_GObj*) gobj, 1),
+                                  JOBJ_HIDDEN);
             gr2 = Ground_801C2BA4(2);
             if (gr2 != NULL) {
-                HSD_JObjClearFlagsAll(Ground_801C3FA4(gr2, 0), 0x10);
+                HSD_JObjClearFlagsAll(Ground_801C3FA4(gr2, 0), JOBJ_HIDDEN);
             }
             grAnime_801C8138((HSD_GObj*) gobj, gp->map_id, 0);
             pid = gp->gv.shrineroute.xC8;
             if ((s32) pid != 0xBD) {
                 HSD_JObj* j = Ground_801C3FA4((HSD_GObj*) gobj, 0x13);
                 if (j != NULL) {
-                    HSD_JObjClearFlagsAll(j, 0x10);
+                    HSD_JObjClearFlagsAll(j, JOBJ_HIDDEN);
                 }
                 mpJointListAdd(8);
             }
             if ((s32) pid != 0xBE) {
                 HSD_JObj* j = Ground_801C3FA4((HSD_GObj*) gobj, 0x14);
                 if (j != NULL) {
-                    HSD_JObjClearFlagsAll(j, 0x10);
+                    HSD_JObjClearFlagsAll(j, JOBJ_HIDDEN);
                 }
                 mpJointListAdd(9);
             }
             if ((s32) pid != 0xBF) {
                 HSD_JObj* j = Ground_801C3FA4((HSD_GObj*) gobj, 0x12);
                 if (j != NULL) {
-                    HSD_JObjClearFlagsAll(j, 0x10);
+                    HSD_JObjClearFlagsAll(j, JOBJ_HIDDEN);
                 }
                 mpJointListAdd(0xA);
             }
             if ((s32) pid != 0xC0) {
                 HSD_JObj* j = Ground_801C3FA4((HSD_GObj*) gobj, 0x11);
                 if (j != NULL) {
-                    HSD_JObjClearFlagsAll(j, 0x10);
+                    HSD_JObjClearFlagsAll(j, JOBJ_HIDDEN);
                 }
                 mpJointListAdd(0xB);
             }
             if ((s32) pid != 0xC1) {
                 HSD_JObj* j = Ground_801C3FA4((HSD_GObj*) gobj, 0x10);
                 if (j != NULL) {
-                    HSD_JObjClearFlagsAll(j, 0x10);
+                    HSD_JObjClearFlagsAll(j, JOBJ_HIDDEN);
                 }
                 mpJointListAdd(0xC);
             }
             if ((s32) pid != 0xC2) {
                 HSD_JObj* j = Ground_801C3FA4((HSD_GObj*) gobj, 0xF);
                 if (j != NULL) {
-                    HSD_JObjClearFlagsAll(j, 0x10);
+                    HSD_JObjClearFlagsAll(j, JOBJ_HIDDEN);
                 }
                 mpJointListAdd(0xD);
             }

--- a/src/melee/gr/grtest.c
+++ b/src/melee/gr/grtest.c
@@ -142,9 +142,9 @@ void grTest_802071C4(Ground_GObj* gobj)
         iVar2 = Ground_801C3FA4(gobj, 0x10);
         if (iVar2) {
             if (HSD_JObjGetFlags(iVar2) & 0x10) {
-                HSD_JObjClearFlags(iVar2, 0x10);
+                HSD_JObjClearFlags(iVar2, JOBJ_HIDDEN);
             } else {
-                HSD_JObjSetFlags(iVar2, 0x10);
+                HSD_JObjSetFlags(iVar2, JOBJ_HIDDEN);
             }
             grTe_804D6A48 = 0.0f;
         }
@@ -154,9 +154,9 @@ void grTest_802071C4(Ground_GObj* gobj)
         iVar2 = Ground_801C3FA4(gobj, 0x11);
         if (iVar2) {
             if (HSD_JObjGetFlags(iVar2) & 0x10) {
-                HSD_JObjClearFlags(iVar2, 0x10);
+                HSD_JObjClearFlags(iVar2, JOBJ_HIDDEN);
             } else {
-                HSD_JObjSetFlags(iVar2, 0x10);
+                HSD_JObjSetFlags(iVar2, JOBJ_HIDDEN);
             }
             grTe_804D6A48 = 0.0f;
         }

--- a/src/melee/gr/grticeclimber.c
+++ b/src/melee/gr/grticeclimber.c
@@ -162,7 +162,7 @@ void grTIceClimber_80221208(Item_GObj* gobj, Ground* u1, Vec3* u2,
     Vec3 pos;
     Item* it = GET_ITEM(gobj);
 
-    HSD_JObjSetFlagsAll(it->xDD4_itemVar.mato.x4, 0x10);
+    HSD_JObjSetFlagsAll(it->xDD4_itemVar.mato.x4, JOBJ_HIDDEN);
     lb_8000B1CC(it->xDD4_itemVar.mato.x4, NULL, &pos);
     efSync_Spawn(0x445, gobj, &pos);
     Camera_80030E44(2, 0);

--- a/src/melee/gr/grvenom.c
+++ b/src/melee/gr/grvenom.c
@@ -710,10 +710,10 @@ void grVenom_8020454C(Ground_GObj* gobj)
             }
             if (HSD_JObjGetFlags(gp->gv.venom2.xC4) & 0x10) {
                 if (visible != 0) {
-                    HSD_JObjClearFlagsAll(gp->gv.venom2.xC4, 0x10);
+                    HSD_JObjClearFlagsAll(gp->gv.venom2.xC4, JOBJ_HIDDEN);
                 }
             } else if (visible == 0) {
-                HSD_JObjSetFlagsAll(gp->gv.venom2.xC4, 0x10);
+                HSD_JObjSetFlagsAll(gp->gv.venom2.xC4, JOBJ_HIDDEN);
             }
         }
         i++;
@@ -1239,12 +1239,12 @@ void grVenom_80205758(Ground_GObj* gobj)
                 v = -v;
             }
             if (v < grVe_804DB744) {
-                HSD_JObjClearFlagsAll(jobj, 0x10);
+                HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
             } else {
-                HSD_JObjSetFlagsAll(jobj, 0x10);
+                HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
             }
         } else {
-            HSD_JObjSetFlagsAll(jobj, 0x10);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         }
 
         HSD_JObjSetTranslate(jobj, (Vec3*) &gp->gv.venom.xE0);

--- a/src/melee/gr/grzebes.c
+++ b/src/melee/gr/grzebes.c
@@ -1390,7 +1390,7 @@ s32 grZebes_801DAA08(void)
                 parent_child = hsd_jobj->child;
             }
 
-            HSD_JObjSetFlagsAll(parent_child, 0x10);
+            HSD_JObjSetFlagsAll(parent_child, JOBJ_HIDDEN);
             HSD_JObjAddChild(parent_child, (&grZe_8049F170[selected])->x04);
 
             {
@@ -1547,7 +1547,7 @@ s32 grZebes_801DB088(Ground* gp, s32 arg1)
                     {
                         HSD_JObj* jobj = (HSD_JObj*) entry->x20_gobj->hsd_obj;
                         if (jobj != NULL) {
-                            HSD_JObjClearFlagsAll(jobj, 0x10);
+                            HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
                         }
                     }
                 }

--- a/src/melee/if/ifcoget.c
+++ b/src/melee/if/ifcoget.c
@@ -79,11 +79,11 @@ void fn_802FED14(HSD_GObj* gobj)
 {
     HSD_JObj* jobj = HSD_GObjGetHSDObj(gobj);
     if (!un_803F9E08.x0.b1) {
-        HSD_JObjSetFlagsAll(jobj, 0x10);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         return;
     }
     if (un_803F9E08.x1 <= un_803F9E08.x2) {
-        HSD_JObjClearFlagsAll(jobj, 0x10);
+        HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         if (un_803F9E08.x1 < un_803F9E08.x2) {
             if (un_803F9E08.x0.b567) {
                 un_803F9E08.x0.b567--;
@@ -127,7 +127,7 @@ void un_802FEFAC(void)
     GObj_SetupGXLink(gobj_ui, HSD_GObj_JObjCallback, 15, 0);
     HSD_GObj_SetupProc(gobj_ui, fn_802FED14, 17);
     gm_8016895C(jobj_ui, un_804D6DA4->models[0], 0);
-    HSD_JObjSetFlagsAll(jobj_ui, 0x10);
+    HSD_JObjSetFlagsAll(jobj_ui, JOBJ_HIDDEN);
     HSD_JObjReqAnimAll(jobj_ui, un_804DDC20);
     HSD_JObjAnimAll(jobj_ui);
     un_803F9E08.xC = gobj_ui;

--- a/src/melee/if/ifnametag.c
+++ b/src/melee/if/ifnametag.c
@@ -228,9 +228,9 @@ void fn_802FCC44(HSD_GObj* gobj)
         (un_804D6D70[*slot] || Player_GetNametagSlotID(*slot) != 'x' ||
          Player_80036058(*slot) || gm_8016B258(*slot)))
     {
-        HSD_JObjClearFlags(HSD_JObjGetChild(jobj), 0x10);
+        HSD_JObjClearFlags(HSD_JObjGetChild(jobj), JOBJ_HIDDEN);
     } else {
-        HSD_JObjSetFlags(HSD_JObjGetChild(jobj), 0x10);
+        HSD_JObjSetFlags(HSD_JObjGetChild(jobj), JOBJ_HIDDEN);
         if (has_nametag(*slot)) {
             HSD_SisLib_803A746C(un_804D6D78, un_804A1EF8[*slot], -5000.0f,
                                 0.0f);

--- a/src/melee/if/ifstatus.c
+++ b/src/melee/if/ifstatus.c
@@ -415,9 +415,9 @@ void ifStatus_802F4EDC(HSD_GObj* gobj)
     if ((state->damage_percent % 1000) / 100 == 0 &&
         (state->damage_percent % 100) / 10 == 0)
     {
-        HSD_JObjSetFlagsAll(state->jobjs[Tens], 0x10);
+        HSD_JObjSetFlagsAll(state->jobjs[Tens], JOBJ_HIDDEN);
     } else {
-        HSD_JObjClearFlagsAll(state->jobjs[Tens], 0x10);
+        HSD_JObjClearFlagsAll(state->jobjs[Tens], JOBJ_HIDDEN);
     }
 
     digit_jobj = state->jobjs[Hundreds];
@@ -430,9 +430,9 @@ void ifStatus_802F4EDC(HSD_GObj* gobj)
     HSD_AObjSetRate(digit_jobj->u.dobj->mobj->tobj->aobj, 0.0F);
 
     if ((state->damage_percent % 1000) / 100 == 0) {
-        HSD_JObjSetFlagsAll(state->jobjs[Hundreds], 0x10);
+        HSD_JObjSetFlagsAll(state->jobjs[Hundreds], JOBJ_HIDDEN);
     } else {
-        HSD_JObjClearFlagsAll(state->jobjs[Hundreds], 0x10);
+        HSD_JObjClearFlagsAll(state->jobjs[Hundreds], JOBJ_HIDDEN);
     }
 
     /* Update colors when damage changes */

--- a/src/melee/if/ifstock.c
+++ b/src/melee/if/ifstock.c
@@ -590,15 +590,15 @@ void ifStock_802F98E8(unsigned char player, int b)
                     break;
                 case 2:
                     HSD_JObjSetFlagsAll(ifStock_804A1378.player[player].x28,
-                                        0x10);
+                                        JOBJ_HIDDEN);
                     HSD_JObjSetFlagsAll(ifStock_804A1378.player[player].x2C,
-                                        0x10);
+                                        JOBJ_HIDDEN);
                     HSD_JObjSetFlagsAll(ifStock_804A1378.player[player].x30,
-                                        0x10);
+                                        JOBJ_HIDDEN);
                     HSD_JObjSetFlagsAll(ifStock_804A1378.player[player].x34,
-                                        0x10);
+                                        JOBJ_HIDDEN);
                     HSD_JObjSetFlagsAll(ifStock_804A1378.player[player].x3C,
-                                        0x10);
+                                        JOBJ_HIDDEN);
                     for (i = 0; i < 7; i++) {
                         jobj = ifStock_804A1378.player[player].x4[i + 1];
                         if (i == 0) {

--- a/src/melee/it/it_2725.c
+++ b/src/melee/it/it_2725.c
@@ -217,10 +217,10 @@ void it_802728C8(Item_GObj* item_gobj)
     rem = (u32) (s32) ((Item*) item_gobj->user_data)->xD44_lifeTimer %
           it_804D6D28->x44_float;
     if (rem != 0) {
-        HSD_JObjClearFlagsAll(item_jobj2, 0x10U);
+        HSD_JObjClearFlagsAll(item_jobj2, JOBJ_HIDDEN);
         return;
     }
-    HSD_JObjSetFlagsAll(item_jobj2, 0x10U);
+    HSD_JObjSetFlagsAll(item_jobj2, JOBJ_HIDDEN);
 }
 
 void it_80272940(Item_GObj* item_gobj)
@@ -230,7 +230,7 @@ void it_80272940(Item_GObj* item_gobj)
 
     item_jobj1 = GET_JOBJ(item_gobj);
     item_jobj2 = item_jobj1 == NULL ? NULL : item_jobj1->child;
-    HSD_JObjClearFlagsAll(item_jobj2, 0x10U);
+    HSD_JObjClearFlagsAll(item_jobj2, JOBJ_HIDDEN);
 }
 
 void it_80272980(Item_GObj* item_gobj)
@@ -264,12 +264,12 @@ void it_80272980(Item_GObj* item_gobj)
 
 void it_80272A18(HSD_JObj* item_jobj)
 {
-    HSD_JObjClearFlagsAll(item_jobj, 0x10U);
+    HSD_JObjClearFlagsAll(item_jobj, JOBJ_HIDDEN);
 }
 
 void it_80272A3C(HSD_JObj* item_jobj)
 {
-    HSD_JObjSetFlagsAll(item_jobj, 0x10U);
+    HSD_JObjSetFlagsAll(item_jobj, JOBJ_HIDDEN);
 }
 
 void it_80272A60(Item_GObj* item_gobj)
@@ -981,7 +981,8 @@ void it_802742F4(Item_GObj* item_gobj, HSD_GObj* gobj, Fighter_Part ftpart)
         item->x20_team_id = ftLib_80086EB4(gobj);
         item->xD50_landNum = 0;
         item->xDC8_word.flags.x13 = 1;
-        HSD_JObjClearFlagsAll(HSD_JObjGetChild(item_gobj->hsd_obj), 16U);
+        HSD_JObjClearFlagsAll(HSD_JObjGetChild(item_gobj->hsd_obj),
+                              JOBJ_HIDDEN);
         it_802756D0(item_gobj);
         it_8026B3A8(item_gobj);
         db_80225DD8(item_gobj, (Fighter_GObj*) gobj);

--- a/src/melee/it/items/itarwinglaser.c
+++ b/src/melee/it/items/itarwinglaser.c
@@ -199,7 +199,7 @@ Item_GObj* it_802E72E0(Item_GObj* parent, HSD_JObj* bone, s32 type, f32 scale,
             it_802E7A4C(new_gobj);
             switch (ip->xDD4_itemVar.arwinglaser.xE38) {
             case 0:
-                HSD_JObjSetFlagsAll(jobj, 0x10U);
+                HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
                 ip->xDD4_itemVar.arwinglaser.xE40 =
                     it_802E72E0(new_gobj, bone, 4, scale, scale_mult);
                 ip->xDD4_itemVar.arwinglaser.xE44 =

--- a/src/melee/it/items/itbombhei.c
+++ b/src/melee/it/items/itbombhei.c
@@ -636,7 +636,7 @@ void it_80280B60(Item_GObj* gobj)
         it_8027429C(gobj, &sp3C);
     }
     it_8026B3A8(gobj);
-    HSD_JObjSetFlagsAll(temp_r29, 0x10U);
+    HSD_JObjSetFlagsAll(temp_r29, JOBJ_HIDDEN);
     it_8026BD24(gobj);
     it_8027518C(gobj);
     temp_r30->x5D0_animFrameSpeed = 1.0f;

--- a/src/melee/it/items/itbox.c
+++ b/src/melee/it/items/itbox.c
@@ -430,7 +430,7 @@ void it_80286BA0(Item_GObj* gobj)
     Camera_80030E44(2, &ip->pos);
     it_80286248(gobj, attr->spawn_weight_0, attr->spawn_weight_1,
                 attr->spawn_weight_2, attr->special_spawn_weight);
-    HSD_JObjSetFlagsAll(jobj, 0x10);
+    HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     it_802756D0(gobj);
 
     ip->x40_vel.x = 0.0F;

--- a/src/melee/it/items/itcapsule.c
+++ b/src/melee/it/items/itcapsule.c
@@ -104,7 +104,7 @@ void it_8027CFE8(Item_GObj* item_gobj)
     Vec3 sp14;
 
     it_8026B3A8(item_gobj);
-    HSD_JObjSetFlagsAll(jobj, 0x10);
+    HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     it->x5D0_animFrameSpeed = 1.0F;
     it_80273454(item_gobj);
     it->xDD4_itemVar.capsule.x4 = true;

--- a/src/melee/it/items/itcoin.c
+++ b/src/melee/it/items/itcoin.c
@@ -73,20 +73,20 @@ void it_802F13B4(Item_GObj* gobj, int arg1)
             ((Camera_80031144() < attr->x48) &&
              (grFigureGet_80219C50(ip->xDD4_itemVar.coin.x14) == 0)))
         {
-            HSD_JObjSetFlagsAll(jobj, 0x10);
-            HSD_JObjClearFlagsAll(jobj->next, 0x10);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
+            HSD_JObjClearFlagsAll(jobj->next, JOBJ_HIDDEN);
         } else {
-            HSD_JObjSetFlagsAll(jobj->next, 0x10);
-            HSD_JObjClearFlagsAll(jobj, 0x10);
+            HSD_JObjSetFlagsAll(jobj->next, JOBJ_HIDDEN);
+            HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         }
     } else if (((gm_801A45E8(1) != 0) && (Ground_801C1D84() == 0)) ||
                (Camera_80031144() < attr->x48))
     {
-        HSD_JObjSetFlagsAll(jobj, 0x10);
-        HSD_JObjClearFlagsAll(jobj->next, 0x10);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
+        HSD_JObjClearFlagsAll(jobj->next, JOBJ_HIDDEN);
     } else {
-        HSD_JObjSetFlagsAll(jobj->next, 0x10);
-        HSD_JObjClearFlagsAll(jobj, 0x10);
+        HSD_JObjSetFlagsAll(jobj->next, JOBJ_HIDDEN);
+        HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
     }
     it_8026EECC(gobj, arg1);
 }
@@ -187,7 +187,7 @@ void itCoin_Logic116_PickedUp(Item_GObj* gobj)
     HSD_JObj* jobj = GET_JOBJ(gobj);
     HSD_JObj* child = HSD_JObjGetChild(jobj);
 
-    HSD_JObjClearFlagsAll(child, 0x10);
+    HSD_JObjClearFlagsAll(child, JOBJ_HIDDEN);
     Item_80268E5C(gobj, 2, ITEM_UNK_0x1);
 }
 

--- a/src/melee/it/items/itdrmariopill.c
+++ b/src/melee/it/items/itdrmariopill.c
@@ -328,9 +328,9 @@ static inline void itDrMarioPill_Motion2_Anim_flags(Item_GObj* gobj)
     jobj = HSD_JObjGetChild(jobj);
     it_8026B3A8(gobj);
     if (ip->xDAC_itcmd_var0 == 1) {
-        HSD_JObjClearFlags(jobj, 0x10U);
+        HSD_JObjClearFlags(jobj, JOBJ_HIDDEN);
     } else {
-        HSD_JObjSetFlags(jobj, 0x10U);
+        HSD_JObjSetFlags(jobj, JOBJ_HIDDEN);
     }
 }
 

--- a/src/melee/it/items/itfoods.c
+++ b/src/melee/it/items/itfoods.c
@@ -145,7 +145,7 @@ void itFoods_Logic18_PickedUp(Item_GObj* gobj)
 {
     HSD_JObj* jobj = HSD_GObjGetHSDObj(gobj);
     HSD_JObj* child = HSD_JObjGetChild(jobj);
-    HSD_JObjClearFlagsAll(child, 0x10U);
+    HSD_JObjClearFlagsAll(child, JOBJ_HIDDEN);
     Item_80268E5C(gobj, 2, ITEM_ANIM_UPDATE);
 }
 

--- a/src/melee/it/items/itfoxblaster.c
+++ b/src/melee/it/items/itfoxblaster.c
@@ -116,10 +116,10 @@ void it_802ADDD0(Item_GObj* item_gobj, s32 visibility)
     switch (item->xDD4_itemVar.foxblaster.set_sfx_var2) {
     case 0:
     case 2:
-        HSD_JObjSetFlagsAll(child_jobj, 0x10);
+        HSD_JObjSetFlagsAll(child_jobj, JOBJ_HIDDEN);
         return;
     case 1:
-        HSD_JObjClearFlagsAll(child_jobj, 0x10);
+        HSD_JObjClearFlagsAll(child_jobj, JOBJ_HIDDEN);
         break;
     }
 }

--- a/src/melee/it/items/itkabigon.c
+++ b/src/melee/it/items/itkabigon.c
@@ -139,7 +139,7 @@ void it_802CA074(Item_GObj* gobj)
     Item* ip = GET_ITEM(gobj);
     Vec3 scale;
 
-    HSD_JObjSetFlagsAll(jobj, 0x10);
+    HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     Item_80268E5C(gobj, 1, ITEM_ANIM_UPDATE);
     ip->entered_hitlag = efLib_PauseAll;
     ip->exited_hitlag = efLib_ResumeAll;
@@ -171,7 +171,7 @@ bool itKabigon_UnkMotion1_Anim(Item_GObj* gobj)
         if (ip->xDD4_itemVar.kabigon.x6C <= 0) {
             HSD_JObj* jobj = GET_JOBJ(gobj);
             ip->xDAC_itcmd_var0 = 1;
-            HSD_JObjClearFlagsAll(jobj, 0x10);
+            HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
             ip->pos.y = Stage_GetBlastZoneTopOffset();
             ip->x40_vel.y = ip->xDD4_itemVar.kabigon.x64;
             Camera_80030E44(2, NULL);

--- a/src/melee/it/items/itlinkbomb.c
+++ b/src/melee/it/items/itlinkbomb.c
@@ -542,7 +542,7 @@ void it_8029F69C(HSD_GObj* gobj)
     }
     it_8026B3A8(gobj);
     it_80273454(gobj);
-    HSD_JObjSetFlagsAll(jobj, 0x10U);
+    HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     it_8026BD24(gobj);
     it_8027518C(gobj);
     it_802756D0(gobj);

--- a/src/melee/it/items/itmarumine.c
+++ b/src/melee/it/items/itmarumine.c
@@ -351,7 +351,7 @@ void it_802D1204(Item_GObj* gobj)
         it_80274250(gobj, &vec);
     }
     it_8026B3A8(gobj);
-    HSD_JObjSetFlagsAll(jobj, 0x10);
+    HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     it_8026BD24(gobj);
     it_8027518C(gobj);
     it_80273454(gobj);

--- a/src/melee/it/items/itnessbat.c
+++ b/src/melee/it/items/itnessbat.c
@@ -151,9 +151,9 @@ bool itNessbat_UnkMotion0_Anim(Item_GObj* gobj)
     PAD_STACK(24);
 
     if (ip->xDAC_itcmd_var0 == 0) {
-        HSD_JObjClearFlagsAll(child, 0x10);
+        HSD_JObjClearFlagsAll(child, JOBJ_HIDDEN);
     } else {
-        HSD_JObjSetFlagsAll(child, 0x10);
+        HSD_JObjSetFlagsAll(child, JOBJ_HIDDEN);
     }
 
     if (ip->xDD4_itemVar.nessbat.x0 != NULL) {

--- a/src/melee/it/items/itnesspkthundertrail.c
+++ b/src/melee/it/items/itnesspkthundertrail.c
@@ -110,9 +110,9 @@ bool itNesspkthundertrail_UnkMotion0_Anim(Item_GObj* gobj)
     HSD_JObj* child = HSD_JObjGetChild(jobj);
 
     if (ip->xDD4_itemVar.nesspkthundertrail.x8 & 1) {
-        HSD_JObjSetFlagsAll(child, 0x10);
+        HSD_JObjSetFlagsAll(child, JOBJ_HIDDEN);
     } else {
-        HSD_JObjClearFlagsAll(child, 0x10);
+        HSD_JObjClearFlagsAll(child, JOBJ_HIDDEN);
     }
     ip->xDD4_itemVar.nesspkthundertrail.x8++;
 

--- a/src/melee/it/items/itpatapata.c
+++ b/src/melee/it/items/itpatapata.c
@@ -426,9 +426,9 @@ void it_802E11E0(Item_GObj* gobj)
         coll_facing = 1;
     }
     mpCollSetFacingDir(&ip->x378_itemColl, coll_facing);
-    HSD_JObjSetFlagsAll(ip->xBBC_dynamicBoneTable->bones[0], 0x10);
-    HSD_JObjClearFlagsAll(ip->xBBC_dynamicBoneTable->bones[18], 0x10);
-    HSD_JObjClearFlagsAll(ip->xBBC_dynamicBoneTable->bones[11], 0x10);
+    HSD_JObjSetFlagsAll(ip->xBBC_dynamicBoneTable->bones[0], JOBJ_HIDDEN);
+    HSD_JObjClearFlagsAll(ip->xBBC_dynamicBoneTable->bones[18], JOBJ_HIDDEN);
+    HSD_JObjClearFlagsAll(ip->xBBC_dynamicBoneTable->bones[11], JOBJ_HIDDEN);
     it_802756D0(gobj);
     it_80274C88(gobj);
     it_80275474(gobj);
@@ -469,11 +469,15 @@ bool itPatapata_UnkMotion4_Anim(Item_GObj* gobj)
         toggle = ip->xDD4_itemVar.patapata.x44 ^ 1;
         ip->xDD4_itemVar.patapata.x44 = toggle;
         if (toggle != 0) {
-            HSD_JObjSetFlagsAll(ip->xBBC_dynamicBoneTable->bones[18], 0x10);
-            HSD_JObjSetFlagsAll(ip->xBBC_dynamicBoneTable->bones[11], 0x10);
+            HSD_JObjSetFlagsAll(ip->xBBC_dynamicBoneTable->bones[18],
+                                JOBJ_HIDDEN);
+            HSD_JObjSetFlagsAll(ip->xBBC_dynamicBoneTable->bones[11],
+                                JOBJ_HIDDEN);
         } else {
-            HSD_JObjClearFlagsAll(ip->xBBC_dynamicBoneTable->bones[18], 0x10);
-            HSD_JObjClearFlagsAll(ip->xBBC_dynamicBoneTable->bones[11], 0x10);
+            HSD_JObjClearFlagsAll(ip->xBBC_dynamicBoneTable->bones[18],
+                                  JOBJ_HIDDEN);
+            HSD_JObjClearFlagsAll(ip->xBBC_dynamicBoneTable->bones[11],
+                                  JOBJ_HIDDEN);
         }
     } else {
         ip->xDD4_itemVar.patapata.x28 -= 1;

--- a/src/melee/it/items/ittarucann.c
+++ b/src/melee/it/items/ittarucann.c
@@ -657,7 +657,7 @@ bool itTarucann_UnkMotion9_Anim(Item_GObj* gobj)
         efSync_Spawn(0x427, gobj, &ip->pos);
         Item_8026AE84(ip, 0xFB, 0x7F, 0x40);
         Camera_80030E44(2, &ip->pos);
-        HSD_JObjSetFlagsAll(jobj, 0x10);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         it_8026B3A8(gobj);
         ip->xDD4_itemVar.tarucann.x4 = 0x28;
         ip->xDAC_itcmd_var0 = 2;
@@ -684,7 +684,7 @@ bool it_80297790(Item_GObj* gobj)
     Item* ip = GET_ITEM(gobj);
     itTaruCann_DatAttrs* da = ip->xC4_article_data->x4_specialAttributes;
     PAD_STACK(16);
-    HSD_JObjClearFlagsAll(gobj->hsd_obj, 0x10);
+    HSD_JObjClearFlagsAll(gobj->hsd_obj, JOBJ_HIDDEN);
     switch (ip->msid) {
     case 3:
     case 4:

--- a/src/melee/it/items/ittincle.c
+++ b/src/melee/it/items/ittincle.c
@@ -166,7 +166,7 @@ void it_802EB6DC(Item_GObj* gobj)
     ip->xDD4_itemVar.tincle.x38 = 0.0f;
     ip->xDD4_itemVar.tincle.x4C = 0.0f;
     it_802756D0(gobj);
-    HSD_JObjSetFlagsAll(GET_JOBJ(gobj), 0x10);
+    HSD_JObjSetFlagsAll(GET_JOBJ(gobj), JOBJ_HIDDEN);
     Item_80268E5C(gobj, 0, ITEM_ANIM_UPDATE);
     it_802EC9E8(gobj);
 }
@@ -205,7 +205,7 @@ void it_802EB870(Item_GObj* gobj)
     ip->xDD4_itemVar.tincle.x5C = sa->x20 + s;
     ip->x40_vel.y = -sa->x18;
     ip->x40_vel.x = 0.0f;
-    HSD_JObjClearFlagsAll(GET_JOBJ(gobj), 0x10);
+    HSD_JObjClearFlagsAll(GET_JOBJ(gobj), JOBJ_HIDDEN);
     Item_80268E5C(gobj, 1, ITEM_ANIM_UPDATE);
     it_802EC9E8(gobj);
 }
@@ -254,7 +254,7 @@ void it_802EBA00(Item_GObj* gobj)
 
     ip->xDC8_word.flags.x1A = 1;
 
-    HSD_JObjClearFlagsAll(GET_JOBJ(gobj), 0x10);
+    HSD_JObjClearFlagsAll(GET_JOBJ(gobj), JOBJ_HIDDEN);
 
     Item_80268E5C(gobj, 2, ITEM_UNK_0x1);
 

--- a/src/melee/it/items/itunknown.c
+++ b/src/melee/it/items/itunknown.c
@@ -99,7 +99,7 @@ void it_802CE8D0(Item_GObj* gobj)
     Vec3 cam_pos;
     Vec3 dir;
 
-    HSD_JObjSetFlagsAll(gobj->hsd_obj, 0x10);
+    HSD_JObjSetFlagsAll(gobj->hsd_obj, JOBJ_HIDDEN);
     ip->x40_vel.x = 0.0f;
     ip->x40_vel.y = 0.0f;
     ip->x40_vel.z = 0.0f;

--- a/src/melee/it/items/itwhispyapple.c
+++ b/src/melee/it/items/itwhispyapple.c
@@ -75,13 +75,13 @@ static bool itWhispyapple_UnkMotion0_Anim_inline(Item_GObj* gobj)
     HSD_JObj* child = HSD_JObjGetChild(jobj);
     ip->xD44_lifeTimer -= 1.0f;
     if (ip->msid == 7) {
-        HSD_JObjSetFlagsAll(child, 0x10);
+        HSD_JObjSetFlagsAll(child, JOBJ_HIDDEN);
     } else if ((ip->xD44_lifeTimer <= it_804D6D28->x34) ||
                (ABS(ip->pos.z) > 1))
     {
         it_802728C8(gobj);
     } else {
-        HSD_JObjClearFlagsAll(child, 0x10);
+        HSD_JObjClearFlagsAll(child, JOBJ_HIDDEN);
     }
     if (ip->xD44_lifeTimer <= 0.0f) {
         return true;
@@ -276,7 +276,7 @@ void it_802EEA08(Item_GObj* gobj)
 {
     HSD_JObj* jobj = GET_JOBJ(gobj);
     HSD_JObj* child = HSD_JObjGetChild(jobj);
-    HSD_JObjClearFlagsAll(child, 0x10);
+    HSD_JObjClearFlagsAll(child, JOBJ_HIDDEN);
     Item_80268E5C(gobj, 3, ITEM_ANIM_UPDATE);
 }
 
@@ -294,7 +294,7 @@ void it_802EEA70(Item_GObj* gobj)
     Vec3 pos = { 0.0f, 0.0f, 0.0f };
 
     it_8026B390(gobj);
-    HSD_JObjClearFlagsAll(child, 0x10);
+    HSD_JObjClearFlagsAll(child, JOBJ_HIDDEN);
     Item_80268E5C(gobj, 4, ITEM_ANIM_UPDATE);
     ip->x40_vel.z = 0.0f;
     ip->x40_vel.y = 0.0f;
@@ -310,7 +310,7 @@ void it_802EEB28(Item_GObj* gobj)
     PAD_STACK(8);
 
     it_8026B390(gobj);
-    HSD_JObjClearFlagsAll(child, 0x10);
+    HSD_JObjClearFlagsAll(child, JOBJ_HIDDEN);
     Item_80268E5C(gobj, 5, ITEM_ANIM_UPDATE);
     ip->x40_vel.z = 0.0f;
     ip->pos.z = 0.0f;
@@ -341,7 +341,7 @@ void it_802EED00(Item_GObj* gobj)
     Vec3 pos;
 
     it_8026B3A8(gobj);
-    HSD_JObjSetFlagsAll(jobj, 0x10);
+    HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     it_8026BD24(gobj);
     it_80275158(gobj, 20.0f);
     it_8026BDB4(gobj);

--- a/src/melee/it/items/itwstar.c
+++ b/src/melee/it/items/itwstar.c
@@ -203,7 +203,7 @@ void it_802947CC(Item_GObj* gobj, Vec3* pos)
     it_8026B3A8(gobj);
     ip->pos = *pos;
     HSD_JObjSetTranslate(jobj, &ip->pos);
-    HSD_JObjSetFlagsAll(jobj, 0x10);
+    HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     it_8026BD24(gobj);
     it_8027518C(gobj);
     efLib_DestroyAll(gobj);

--- a/src/melee/it/items/ityoshiegglay.c
+++ b/src/melee/it/items/ityoshiegglay.c
@@ -153,7 +153,7 @@ void it_802F3290(Item_GObj* item_gobj)
     item = GET_ITEM(item_gobj);
     item->x40_vel.x = item->x40_vel.y = item->x40_vel.z = 0.0f;
     item->xD44_lifeTimer = 40.0f;
-    HSD_JObjSetFlagsAll(item_jobj, 0x10U);
+    HSD_JObjSetFlagsAll(item_jobj, JOBJ_HIDDEN);
     it_802756D0(item_gobj);
     Item_80268E5C(item_gobj, 2, ITEM_ANIM_UPDATE);
 }

--- a/src/melee/mn/mncharsel.c
+++ b/src/melee/mn/mncharsel.c
@@ -1070,7 +1070,7 @@ void mnCharSel_8025DB34(u8 arg0)
         if ((u8) mnCharSel_804D6CB0->data.data.rules.is_teams == 0) {
             /* FFA mode */
             u8 port_color_idx;
-            HSD_JObjSetFlags(sp90, 0x10U);
+            HSD_JObjSetFlags(sp90, JOBJ_HIDDEN);
             port_color_idx = arg0;
             if (mnCharSel_803F0DFC.doors[arg0].p_kind != 0) {
                 port_color_idx += 4;
@@ -1094,7 +1094,7 @@ void mnCharSel_8025DB34(u8 arg0)
                             AOBJ_ARG_AOV, 0, 0);
         } else {
             /* Teams mode */
-            HSD_JObjClearFlags(sp90, 0x10U);
+            HSD_JObjClearFlags(sp90, JOBJ_HIDDEN);
             var_r23 = mnCharSel_803F0DFC.doors[arg0].team;
             temp_f31 = (f32) mnCharSel_804D50D0[var_r23];
             lb_80011E24(mnCharSel_804D6CC0, &sp3C,

--- a/src/melee/mn/mndiagram.c
+++ b/src/melee/mn/mndiagram.c
@@ -2007,9 +2007,9 @@ void mnDiagram_802417D0(HSD_GObj* gobj)
         result = sorted[i + 0x1C];
     right_done:;
         if ((u8) result != 0x78) {
-            HSD_JObjClearFlagsAll(jobj, 0x10U);
+            HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         } else {
-            HSD_JObjSetFlagsAll(jobj, 0x10U);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         }
     } else {
         // Fighter mode - check if 10 more fighters exist
@@ -2035,9 +2035,9 @@ void mnDiagram_802417D0(HSD_GObj* gobj)
         } while (count >= 0);
     fc_right_done:
         if ((u8) result != 0x19) {
-            HSD_JObjClearFlagsAll(jobj, 0x10U);
+            HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         } else {
-            HSD_JObjSetFlagsAll(jobj, 0x10U);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         }
     }
 
@@ -2050,9 +2050,9 @@ void mnDiagram_802417D0(HSD_GObj* gobj)
         result = (u8) data->fighter_cursor_pos;
     }
     if (result != 0) {
-        HSD_JObjClearFlagsAll(jobj2, 0x10U);
+        HSD_JObjClearFlagsAll(jobj2, JOBJ_HIDDEN);
     } else {
-        HSD_JObjSetFlagsAll(jobj2, 0x10U);
+        HSD_JObjSetFlagsAll(jobj2, JOBJ_HIDDEN);
     }
 
     // Up arrow (jobjs[5])
@@ -2064,9 +2064,9 @@ void mnDiagram_802417D0(HSD_GObj* gobj)
         i = data->fighter_cursor_pos >> 8;
     }
     if (i != 0) {
-        HSD_JObjClearFlagsAll(jobj2, 0x10U);
+        HSD_JObjClearFlagsAll(jobj2, JOBJ_HIDDEN);
     } else {
-        HSD_JObjSetFlagsAll(jobj2, 0x10U);
+        HSD_JObjSetFlagsAll(jobj2, JOBJ_HIDDEN);
     }
 
     // Down arrow (jobjs[6])
@@ -2094,9 +2094,9 @@ void mnDiagram_802417D0(HSD_GObj* gobj)
         result2 = sorted[i + 0x1C];
     dn_name_done:
         if (result2 != 0x78) {
-            HSD_JObjClearFlagsAll(jobj, 0x10U);
+            HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         } else {
-            HSD_JObjSetFlagsAll(jobj, 0x10U);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         }
     } else {
         // Fighter mode - check if 7 more rows exist
@@ -2122,9 +2122,9 @@ void mnDiagram_802417D0(HSD_GObj* gobj)
         } while (count >= 0);
     dn_fc_done:
         if (result2 != 0x19) {
-            HSD_JObjClearFlagsAll(jobj, 0x10U);
+            HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         } else {
-            HSD_JObjSetFlagsAll(jobj, 0x10U);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         }
     }
 }
@@ -2155,18 +2155,18 @@ void mnDiagram_UpdateScrollArrowVisibility(void* gobj, int count)
     void* data = ((HSD_GObj*) gobj)->user_data;
     PAD_STACK(8);
     if (count <= 7) {
-        HSD_JObjSetFlagsAll(((HSD_JObj**) data)[7], 0x10U);
-        HSD_JObjSetFlagsAll(((HSD_JObj**) data)[8], 0x10U);
+        HSD_JObjSetFlagsAll(((HSD_JObj**) data)[7], JOBJ_HIDDEN);
+        HSD_JObjSetFlagsAll(((HSD_JObj**) data)[8], JOBJ_HIDDEN);
     } else {
-        HSD_JObjClearFlagsAll(((HSD_JObj**) data)[7], 0x10U);
-        HSD_JObjClearFlagsAll(((HSD_JObj**) data)[8], 0x10U);
+        HSD_JObjClearFlagsAll(((HSD_JObj**) data)[7], JOBJ_HIDDEN);
+        HSD_JObjClearFlagsAll(((HSD_JObj**) data)[8], JOBJ_HIDDEN);
     }
     if (count <= 10) {
-        HSD_JObjSetFlagsAll(((HSD_JObj**) data)[6], 0x10U);
-        HSD_JObjSetFlagsAll(((HSD_JObj**) data)[5], 0x10U);
+        HSD_JObjSetFlagsAll(((HSD_JObj**) data)[6], JOBJ_HIDDEN);
+        HSD_JObjSetFlagsAll(((HSD_JObj**) data)[5], JOBJ_HIDDEN);
     } else {
-        HSD_JObjClearFlagsAll(((HSD_JObj**) data)[6], 0x10U);
-        HSD_JObjClearFlagsAll(((HSD_JObj**) data)[5], 0x10U);
+        HSD_JObjClearFlagsAll(((HSD_JObj**) data)[6], JOBJ_HIDDEN);
+        HSD_JObjClearFlagsAll(((HSD_JObj**) data)[5], JOBJ_HIDDEN);
     }
 }
 
@@ -2186,7 +2186,7 @@ void mnDiagram_OnFrame(HSD_GObj* gobj)
         HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
         proc = HSD_GObj_SetupProc(gobj, mnDiagram_ExitAnimProc, 0);
         proc->flags_3 = HSD_GObj_804D783C;
-        HSD_JObjSetFlagsAll(data->jobjs[2], 0x10);
+        HSD_JObjSetFlagsAll(data->jobjs[2], JOBJ_HIDDEN);
         mnDiagram_80241668(gobj);
         return;
     }
@@ -2200,7 +2200,7 @@ void mnDiagram_OnFrame(HSD_GObj* gobj)
         end_frame = mnDiagram_803EE768.end_frame;
         jobj = data->jobjs[2];
         if (frame >= end_frame) {
-            HSD_JObjClearFlagsAll(jobj, 0x10);
+            HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
             data->anim_state = 0;
             mnDiagram_802433AC();
             if (data->is_name_mode != 0) {
@@ -2241,7 +2241,7 @@ void mnDiagram_OnFrame(HSD_GObj* gobj)
             }
             mnDiagram_UpdateScrollArrowVisibility(gobj, count);
         } else {
-            HSD_JObjSetFlagsAll(jobj, 0x10);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         }
     }
     mnDiagram_802417D0(gobj);

--- a/src/melee/mn/mndiagram2.c
+++ b/src/melee/mn/mndiagram2.c
@@ -359,11 +359,11 @@ void mnDiagram2_HandleInput(HSD_GObj* gobj)
         x48 = data->is_name_mode;
         data2 = (d2 = mnDiagram2_804D6C18)->user_data;
         if (x48 != 0) {
-            HSD_JObjSetFlagsAll(data2->fighter_mode_header, 0x10);
-            HSD_JObjClearFlagsAll(data2->name_mode_header, 0x10);
+            HSD_JObjSetFlagsAll(data2->fighter_mode_header, JOBJ_HIDDEN);
+            HSD_JObjClearFlagsAll(data2->name_mode_header, JOBJ_HIDDEN);
         } else {
-            HSD_JObjClearFlagsAll(data2->fighter_mode_header, 0x10);
-            HSD_JObjSetFlagsAll(data2->name_mode_header, 0x10);
+            HSD_JObjClearFlagsAll(data2->fighter_mode_header, JOBJ_HIDDEN);
+            HSD_JObjSetFlagsAll(data2->name_mode_header, JOBJ_HIDDEN);
         }
         if (x48 != 0) {
             var_r5 = data2->selected_name_idx;
@@ -907,39 +907,39 @@ void mnDiagram2_UpdateScrollArrows(HSD_GObj* gobj)
     mn_8022ED6C(jobj, &base->anim[1]);
     if (data->is_name_mode) {
         if (data->scroll_offset + 10 < 0x18) {
-            HSD_JObjClearFlagsAll(jobj, 0x10);
+            HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         } else {
-            HSD_JObjSetFlagsAll(jobj, 0x10);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         }
     } else {
         if (data->scroll_offset + 10 < 0x15) {
-            HSD_JObjClearFlagsAll(jobj, 0x10);
+            HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         } else {
-            HSD_JObjSetFlagsAll(jobj, 0x10);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         }
     }
 
     jobj = data->up_arrow;
     mn_8022ED6C(jobj, &base->anim[1]);
     if (data->scroll_offset) {
-        HSD_JObjClearFlagsAll(jobj, 0x10);
+        HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
     } else {
-        HSD_JObjSetFlagsAll(jobj, 0x10);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     }
 
     jobj = data->left_arrow;
     mn_8022ED6C(jobj, &base->anim[1]);
     if (data->is_name_mode) {
         if (data->selected_name_idx) {
-            HSD_JObjClearFlagsAll(jobj, 0x10);
+            HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         } else {
-            HSD_JObjSetFlagsAll(jobj, 0x10);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         }
     } else {
         if (data->selected_fighter_idx != 0) {
-            HSD_JObjClearFlagsAll(jobj, 0x10);
+            HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         } else {
-            HSD_JObjSetFlagsAll(jobj, 0x10);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         }
     }
 
@@ -949,17 +949,17 @@ void mnDiagram2_UpdateScrollArrows(HSD_GObj* gobj)
         if (data->selected_name_idx !=
             (u8) mnDiagram_GetNextNameIndex(data->selected_name_idx))
         {
-            HSD_JObjClearFlagsAll(jobj, 0x10);
+            HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         } else {
-            HSD_JObjSetFlagsAll(jobj, 0x10);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         }
     } else {
         if (data->selected_fighter_idx !=
             (u8) mnDiagram_GetNextFighterIndex(data->selected_fighter_idx))
         {
-            HSD_JObjClearFlagsAll(jobj, 0x10);
+            HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         } else {
-            HSD_JObjSetFlagsAll(jobj, 0x10);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         }
     }
 }
@@ -985,7 +985,7 @@ void mnDiagram2_Think(HSD_GObj* gobj)
             HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
             proc = HSD_GObj_SetupProc(gobj, mnDiagram2_OnAnimComplete, 0);
             proc->flags_3 = HSD_GObj_804D783C;
-            HSD_JObjSetFlagsAll(((HSD_JObj**) data)[4], 0x10);
+            HSD_JObjSetFlagsAll(((HSD_JObj**) data)[4], JOBJ_HIDDEN);
             if (data->header_text != NULL) {
                 HSD_SisLib_803A5CC4(data->header_text);
                 data->header_text = NULL;
@@ -1101,11 +1101,11 @@ void mnDiagram2_Create(int arg0)
     is_name = user_data->is_name_mode;
     user_data2 = gobj->user_data;
     if (is_name) {
-        HSD_JObjSetFlagsAll(user_data2->fighter_mode_header, 0x10);
-        HSD_JObjClearFlagsAll(user_data2->name_mode_header, 0x10);
+        HSD_JObjSetFlagsAll(user_data2->fighter_mode_header, JOBJ_HIDDEN);
+        HSD_JObjClearFlagsAll(user_data2->name_mode_header, JOBJ_HIDDEN);
     } else {
-        HSD_JObjClearFlagsAll(user_data2->fighter_mode_header, 0x10);
-        HSD_JObjSetFlagsAll(user_data2->name_mode_header, 0x10);
+        HSD_JObjClearFlagsAll(user_data2->fighter_mode_header, JOBJ_HIDDEN);
+        HSD_JObjSetFlagsAll(user_data2->name_mode_header, JOBJ_HIDDEN);
     }
 
     if (is_name) {

--- a/src/melee/mn/mndiagram3.c
+++ b/src/melee/mn/mndiagram3.c
@@ -289,18 +289,18 @@ void mnDiagram3_80246D40(HSD_GObj* gobj)
     }
 
     if (data->scroll_offset + 10 < limit) {
-        HSD_JObjClearFlagsAll(jobj, 0x10);
+        HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
     } else {
-        HSD_JObjSetFlagsAll(jobj, 0x10);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     }
     jobj = data->jobjs[4];
     new_var = jobj;
     mn_8022ED6C(new_var, &mnDiagram3_803EEC1C);
 
     if (data->scroll_offset != 0) {
-        HSD_JObjClearFlagsAll(new_var, 0x10);
+        HSD_JObjClearFlagsAll(new_var, JOBJ_HIDDEN);
     } else {
-        HSD_JObjSetFlagsAll(new_var, 0x10);
+        HSD_JObjSetFlagsAll(new_var, JOBJ_HIDDEN);
     }
 }
 
@@ -339,7 +339,7 @@ void fn_80246E64(HSD_GObj* gobj)
             HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
             proc = HSD_GObj_SetupProc(gobj, fn_80246E04, 0);
             proc->flags_3 = HSD_GObj_804D783C;
-            HSD_JObjSetFlagsAll(data->jobjs[2], 0x10);
+            HSD_JObjSetFlagsAll(data->jobjs[2], JOBJ_HIDDEN);
         }
     } else {
         mnDiagram3_80246D40(gobj);

--- a/src/melee/mn/mninfobonus.c
+++ b/src/melee/mn/mninfobonus.c
@@ -248,16 +248,18 @@ void fn_80252E4C(HSD_GObj* arg0)
     if (o->x0 > 0) {
         HSD_JObjClearFlags(fn_80252E4C_inline_GetJObjNext(
                                fn_80252E4C_inline_GetJObjChild(temp_r30)),
-                           0x10);
+                           JOBJ_HIDDEN);
     } else {
         HSD_JObjSetFlags(fn_80252E4C_inline_GetJObjNext(
                              fn_80252E4C_inline_GetJObjChild(temp_r30)),
-                         0x10);
+                         JOBJ_HIDDEN);
     }
     if (mnInfoBonus_802528F8_wrapper() > 5) {
-        HSD_JObjClearFlags(fn_80252E4C_inline_GetJObjChild(temp_r30), 0x10U);
+        HSD_JObjClearFlags(fn_80252E4C_inline_GetJObjChild(temp_r30),
+                           JOBJ_HIDDEN);
     } else {
-        HSD_JObjSetFlags(fn_80252E4C_inline_GetJObjChild(temp_r30), 0x10U);
+        HSD_JObjSetFlags(fn_80252E4C_inline_GetJObjChild(temp_r30),
+                         JOBJ_HIDDEN);
     }
     HSD_JObjReqAnimAll(temp_r30, (f32) o->x48);
     HSD_JObjAnimAll(temp_r30);

--- a/src/melee/mn/mnitemsw.c
+++ b/src/melee/mn/mnitemsw.c
@@ -317,8 +317,8 @@ void mnItemSw_80234104(HSD_GObj* gobj)
     f32 y_spacing;
     MnItemSwData* data = gobj->user_data;
 
-    HSD_JObjClearFlagsAll(data->jobjs[4], 0x10);
-    HSD_JObjClearFlagsAll(data->jobjs[6], 0x10);
+    HSD_JObjClearFlagsAll(data->jobjs[4], JOBJ_HIDDEN);
+    HSD_JObjClearFlagsAll(data->jobjs[6], JOBJ_HIDDEN);
 
     order = mnItemSw_803ED340.item_order;
     for (i = 0; i < 0x1F; i++, order++) {
@@ -326,7 +326,7 @@ void mnItemSw_80234104(HSD_GObj* gobj)
 
         if (i != (s32) data->cursor) {
             lb_80011E24(jobj, &sp38, 8, -1);
-            HSD_JObjSetFlagsAll(sp38, 0x10);
+            HSD_JObjSetFlagsAll(sp38, JOBJ_HIDDEN);
         }
 
         lb_80011E24(jobj, &sp38, 3, -1);
@@ -341,9 +341,9 @@ void mnItemSw_80234104(HSD_GObj* gobj)
     cjobj = data->jobjs[2];
 
     if (cursor == 0x1F || cursor == 0x20) {
-        HSD_JObjSetFlagsAll(cjobj, 0x10);
+        HSD_JObjSetFlagsAll(cjobj, JOBJ_HIDDEN);
     } else {
-        HSD_JObjClearFlagsAll(cjobj, 0x10);
+        HSD_JObjClearFlagsAll(cjobj, JOBJ_HIDDEN);
         y_spacing = HSD_JObjGetTranslationY(data->jobjs[5]) -
                     HSD_JObjGetTranslationY(data->jobjs[4]);
 
@@ -362,7 +362,7 @@ void mnItemSw_80234104(HSD_GObj* gobj)
         }
     }
 
-    HSD_JObjClearFlagsAll(data->jobjs[3], 0x10);
+    HSD_JObjClearFlagsAll(data->jobjs[3], JOBJ_HIDDEN);
 }
 
 void mnItemSw_8023453C(HSD_GObj* gobj, u8 arg1, u8 arg2)
@@ -394,7 +394,7 @@ void mnItemSw_8023453C(HSD_GObj* gobj, u8 arg1, u8 arg2)
         } else {
             HSD_JObj* jobj = mnItemSw_8023405C(data, old_cursor);
             lb_80011E24(jobj, &sp44, 8, -1);
-            HSD_JObjSetFlagsAll(sp44, 0x10);
+            HSD_JObjSetFlagsAll(sp44, JOBJ_HIDDEN);
             anim_val = mn_8022F298(sp44);
             lb_80011E24(jobj, &sp44, 3, -1);
             HSD_JObjReqAnimAll(sp44, (f32) mnItemSw_80233A98(
@@ -421,7 +421,7 @@ void mnItemSw_8023453C(HSD_GObj* gobj, u8 arg1, u8 arg2)
         } else {
             HSD_JObj* jobj = mnItemSw_8023405C(data, new_cursor);
             lb_80011E24(jobj, &sp44, 8, -1);
-            HSD_JObjClearFlagsAll(sp44, 0x10);
+            HSD_JObjClearFlagsAll(sp44, JOBJ_HIDDEN);
             HSD_JObjReqAnimAll(sp44, anim_val);
             HSD_JObjAnimAll(sp44);
             lb_80011E24(jobj, &sp44, 3, -1);
@@ -435,10 +435,10 @@ void mnItemSw_8023453C(HSD_GObj* gobj, u8 arg1, u8 arg2)
 
         cjobj = data->jobjs[2];
         if ((u8) (new_cursor - 0x1F) <= 1U) {
-            HSD_JObjSetFlagsAll(cjobj, 0x10);
+            HSD_JObjSetFlagsAll(cjobj, JOBJ_HIDDEN);
         } else {
             f32 y_spacing;
-            HSD_JObjClearFlagsAll(cjobj, 0x10);
+            HSD_JObjClearFlagsAll(cjobj, JOBJ_HIDDEN);
             y_spacing = HSD_JObjGetTranslationY(data->jobjs[5]) -
                         HSD_JObjGetTranslationY(data->jobjs[4]);
 
@@ -703,7 +703,7 @@ HSD_JObj* mnItemSw_80235020(u8 arg0, MnItemSwData* arg1)
         HSD_JObjReqAnimAll(sp14, mnItemSw_803ED340.x30[3]);
         HSD_JObjAnimAll(sp14);
     } else {
-        HSD_JObjSetFlagsAll(sp14, 0x10);
+        HSD_JObjSetFlagsAll(sp14, JOBJ_HIDDEN);
     }
     return jobj;
 }
@@ -777,16 +777,16 @@ HSD_GObj* mnItemSw_802351A0(s32 arg0)
         }
     }
 
-    HSD_JObjSetFlagsAll(data->jobjs[4], 0x10);
-    HSD_JObjSetFlagsAll(data->jobjs[6], 0x10);
+    HSD_JObjSetFlagsAll(data->jobjs[4], JOBJ_HIDDEN);
+    HSD_JObjSetFlagsAll(data->jobjs[6], JOBJ_HIDDEN);
 
     cursor = data->cursor;
     cjobj = data->jobjs[2];
 
     if (cursor == 0x1F || cursor == 0x20) {
-        HSD_JObjSetFlagsAll(cjobj, 0x10);
+        HSD_JObjSetFlagsAll(cjobj, JOBJ_HIDDEN);
     } else {
-        HSD_JObjClearFlagsAll(cjobj, 0x10);
+        HSD_JObjClearFlagsAll(cjobj, JOBJ_HIDDEN);
         y_spacing = HSD_JObjGetTranslationY(data->jobjs[5]) -
                     HSD_JObjGetTranslationY(data->jobjs[4]);
 
@@ -805,7 +805,7 @@ HSD_GObj* mnItemSw_802351A0(s32 arg0)
         }
     }
 
-    HSD_JObjSetFlagsAll(data->jobjs[2], 0x10);
+    HSD_JObjSetFlagsAll(data->jobjs[2], JOBJ_HIDDEN);
 
     {
         u8 hov = (u8) mn_804A04F0.hovered_selection;
@@ -820,7 +820,7 @@ HSD_GObj* mnItemSw_802351A0(s32 arg0)
         HSD_JObjAnimAll(all_jobj);
     }
 
-    HSD_JObjSetFlagsAll(data->jobjs[3], 0x10);
+    HSD_JObjSetFlagsAll(data->jobjs[3], JOBJ_HIDDEN);
 
     return gobj;
 }

--- a/src/melee/mn/mnmain.c
+++ b/src/melee/mn/mnmain.c
@@ -1073,7 +1073,7 @@ void mn_8022A5D0(HSD_GObj* gp, MainMenuSelection selection)
             mn_8022ED6C(sp84[0], &mn_803EB360[var_r26 == selection]);
             mn_8022ED6C(sp84[2], &mn_803EB378[var_r26 == selection]);
             if (mn_8022ED6C(sp84[3], &mn_803EB390) >= mn_803EB390.end_frame) {
-                HSD_JObjSetFlagsAll(sp84[3], 0x10);
+                HSD_JObjSetFlagsAll(sp84[3], JOBJ_HIDDEN);
             }
             if (selection == var_r26) {
                 if (HSD_JObjGetScaleY(sp84[6]) == 2.0f) {

--- a/src/melee/mn/mnmainrule.c
+++ b/src/melee/mn/mnmainrule.c
@@ -330,7 +330,7 @@ void mn_8022FB88(u8 arg0, void* arg1)
         var_r27 = 0;
         var_r29 = (u8*) &sp14;
         do {
-            HSD_JObjSetFlagsAll(data->x58[*var_r29], 0x10U);
+            HSD_JObjSetFlagsAll(data->x58[*var_r29], JOBJ_HIDDEN);
             var_r27 += 1;
             var_r29 += 1;
         } while (var_r27 < 4);
@@ -342,7 +342,7 @@ void mn_8022FB88(u8 arg0, void* arg1)
     var_r28 = 0;
     var_r29_2 = (u8*) &sp14;
     do {
-        HSD_JObjClearFlagsAll(data->x58[*var_r29_2], 0x10U);
+        HSD_JObjClearFlagsAll(data->x58[*var_r29_2], JOBJ_HIDDEN);
         var_r28 += 1;
         var_r29_2 += 1;
     } while (var_r28 < 4);
@@ -383,19 +383,19 @@ void mn_8022FD18(u8 arg0)
     sp10 = mn_804DBE0C;
     if (arg0 != 0) {
         for (i = 0, ptr = (u8*) &sp14; i < 2; i++) {
-            HSD_JObjSetFlagsAll(data->x58[ptr[i]], 0x10U);
+            HSD_JObjSetFlagsAll(data->x58[ptr[i]], JOBJ_HIDDEN);
         }
         for (i = 0, ptr = (u8*) &spC; i < 5; i++) {
-            HSD_JObjSetFlagsAll(data->x58[ptr[i]], 0x10U);
+            HSD_JObjSetFlagsAll(data->x58[ptr[i]], JOBJ_HIDDEN);
         }
         mn_8022FB88(data->x3, data);
         return;
     }
     for (i = 0, ptr = (u8*) &sp14; i < 2; i++) {
-        HSD_JObjSetFlagsAll(data->x58[ptr[i]], 0x10U);
+        HSD_JObjSetFlagsAll(data->x58[ptr[i]], JOBJ_HIDDEN);
     }
     for (i = 0, ptr = (u8*) &spC; i < 5; i++) {
-        HSD_JObjSetFlagsAll(data->x58[ptr[i]], 0x10U);
+        HSD_JObjSetFlagsAll(data->x58[ptr[i]], JOBJ_HIDDEN);
     }
     val = data->x9;
     jobj = data->x58[7];
@@ -593,8 +593,8 @@ void mn_80230274(HSD_GObj* arg0, int arg1, int arg2)
     if (arg1 != 0) {
         selected = data->x1;
         lb_8001204C(option_roots[selected], roots, indices, 0x11);
-        HSD_JObjSetFlagsAll(roots[16], 0x10U);
-        HSD_JObjSetFlagsAll(roots[13], 0x10U);
+        HSD_JObjSetFlagsAll(roots[16], JOBJ_HIDDEN);
+        HSD_JObjSetFlagsAll(roots[13], JOBJ_HIDDEN);
         jobj = roots[2];
         if ((u8) (selected - 5) <= 1) {
             HSD_JObjReqAnimAll(jobj, *(f32*) (base + 0x78));
@@ -611,14 +611,14 @@ void mn_80230274(HSD_GObj* arg0, int arg1, int arg2)
             HSD_JObjReqAnim(jobj, *(f32*) (base + 0x10 + selected * 8));
         }
         HSD_JObjAnim(jobj);
-        HSD_JObjSetFlagsAll(roots[8], 0x10U);
+        HSD_JObjSetFlagsAll(roots[8], JOBJ_HIDDEN);
 
         hovered = mn_804A04F0.hovered_selection;
         lb_8001204C(option_roots[hovered], roots, indices, 0x11);
-        HSD_JObjClearFlagsAll(roots[16], 0x10U);
+        HSD_JObjClearFlagsAll(roots[16], JOBJ_HIDDEN);
         HSD_JObjReqAnimAll(roots[16], *(f32*) (base + 0x48));
         if (hovered != 5 && hovered != 6) {
-            HSD_JObjClearFlagsAll(roots[13], 0x10U);
+            HSD_JObjClearFlagsAll(roots[13], JOBJ_HIDDEN);
             HSD_JObjReqAnimAll(roots[13], *(f32*) (base + 0x54));
             HSD_JObjReqAnimAll(roots[2], *(f32*) (base + 0x6C));
             HSD_JObjAnimAll(roots[2]);
@@ -636,7 +636,7 @@ void mn_80230274(HSD_GObj* arg0, int arg1, int arg2)
         }
         HSD_JObjAnim(roots[7]);
         if ((u8) (hovered - 5) <= 1) {
-            HSD_JObjClearFlagsAll(roots[8], 0x10U);
+            HSD_JObjClearFlagsAll(roots[8], JOBJ_HIDDEN);
             HSD_JObjReqAnimAll(roots[8], *(f32*) (base + 0x90));
             HSD_JObjAnimAll(roots[8]);
         }
@@ -1027,10 +1027,10 @@ HSD_GObj* mn_80230E38(int arg0)
         }
         HSD_JObjAnim(roots[7]);
         if (hovered != i) {
-            HSD_JObjSetFlagsAll(roots[16], 0x10U);
+            HSD_JObjSetFlagsAll(roots[16], JOBJ_HIDDEN);
         }
         if (hovered != i || (u32) (i - 5) <= 1U) {
-            HSD_JObjSetFlagsAll(roots[13], 0x10U);
+            HSD_JObjSetFlagsAll(roots[13], JOBJ_HIDDEN);
         }
         if ((u32) (i - 5) <= 1U) {
             settings =
@@ -1044,7 +1044,7 @@ HSD_GObj* mn_80230E38(int arg0)
         HSD_JObjReqAnimAll(roots[2], settings->start_frame);
         HSD_JObjAnimAll(roots[2]);
         if (hovered != i || (i != 5 && i != 6)) {
-            HSD_JObjSetFlagsAll(roots[8], 0x10U);
+            HSD_JObjSetFlagsAll(roots[8], JOBJ_HIDDEN);
         }
         HSD_JObjAddChild(data->xC[indices[visible]], jobj);
 

--- a/src/melee/mn/mnname.c
+++ b/src/melee/mn/mnname.c
@@ -1375,9 +1375,9 @@ void mnName_8023A290(void)
     HSD_JObjReqAnimAll(jobj, mnName_803ED600[0]);
     HSD_JObjAnimAll(jobj);
     lb_80011E24(jobj, &sp28, 0xA, -1);
-    HSD_JObjSetFlagsAll(sp28, 0x10U);
+    HSD_JObjSetFlagsAll(sp28, JOBJ_HIDDEN);
     lb_80011E24(jobj, &sp28, 0xB, -1);
-    HSD_JObjSetFlagsAll(sp28, 0x10U);
+    HSD_JObjSetFlagsAll(sp28, JOBJ_HIDDEN);
     sel = mn_804A04F0.confirmed_selection;
     lb_80011E24(jobj, &sp14, 6, -1);
     lb_80011E24(jobj, &sp18, 7, -1);
@@ -1463,7 +1463,7 @@ HSD_GObj* mnName_8023A59C(u8 arg0)
             HSD_SisLib_803A5CC4(user_data->text);
             user_data->text = NULL;
         }
-        HSD_JObjSetFlagsAll((HSD_JObj*) user_data->gobj.hsd_obj, 0x10U);
+        HSD_JObjSetFlagsAll((HSD_JObj*) user_data->gobj.hsd_obj, JOBJ_HIDDEN);
     } else {
         HSD_JObjRemoveAll((HSD_JObj*) mn_80231634(
             (struct mn_80231634_t*) user_data->gobj.user_data_remove_func));
@@ -1561,7 +1561,7 @@ void mnName_8023A9B4(u8 arg0)
             HSD_SisLib_803A5CC4(gobj2->text);
             gobj2->text = NULL;
         }
-        HSD_JObjSetFlagsAll((HSD_JObj*) gobj2->gobj.hsd_obj, 0x10U);
+        HSD_JObjSetFlagsAll((HSD_JObj*) gobj2->gobj.hsd_obj, JOBJ_HIDDEN);
     } else {
         HSD_JObjRemoveAll((HSD_JObj*) mn_80231634(
             (struct mn_80231634_t*) gobj2->gobj.user_data_remove_func));

--- a/src/melee/mn/mnnamenew.c
+++ b/src/melee/mn/mnnamenew.c
@@ -1463,9 +1463,9 @@ void fn_8023DBE8(HSD_GObj* arg0)
     data = arg0->user_data;
 
     if ((u8) mn_804A04F0.x10 != 1) {
-        HSD_JObjSetFlagsAll(data->jobjs[16], 0x10U);
-        HSD_JObjSetFlagsAll(data->jobjs[12], 0x10U);
-        HSD_JObjSetFlagsAll(data->jobjs[13], 0x10U);
+        HSD_JObjSetFlagsAll(data->jobjs[16], JOBJ_HIDDEN);
+        HSD_JObjSetFlagsAll(data->jobjs[12], JOBJ_HIDDEN);
+        HSD_JObjSetFlagsAll(data->jobjs[13], JOBJ_HIDDEN);
         HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
         proc = HSD_GObj_SetupProc(arg0, fn_8023DAEC, 0U);
         proc->flags_3 = HSD_GObj_804D783C;

--- a/src/melee/mn/mnruleplus.c
+++ b/src/melee/mn/mnruleplus.c
@@ -270,14 +270,14 @@ void mn_802324E4(u8 time_limit, MenuRulesPlusData* data)
     local_indices = mn_804DBE40;
     if (time_limit == 0) {
         for (i = 0; i < 4; i++) {
-            HSD_JObjSetFlagsAll(jobjs[local_indices.idx[i]], 0x10U);
+            HSD_JObjSetFlagsAll(jobjs[local_indices.idx[i]], JOBJ_HIDDEN);
         }
         HSD_JObjReqAnimAll(jobjs[4], 1.0f);
         HSD_JObjAnimAll(jobjs[4]);
         return;
     }
     for (i = 0; i < 4; i++) {
-        HSD_JObjClearFlagsAll(jobjs[local_indices.idx[i]], 0x10U);
+        HSD_JObjClearFlagsAll(jobjs[local_indices.idx[i]], JOBJ_HIDDEN);
     }
     HSD_JObjReqAnimAll(jobjs[4], mn_804D6BE4);
     HSD_JObjAnimAll(jobjs[4]);
@@ -430,8 +430,8 @@ void mn_802327A4(HSD_GObj* gobj, u32 arg1, u32 arg2)
         u8 old_sel = data->hovered_selection;
         u8 new_sel;
         lb_8001204C(option_roots[old_sel], jobj_parts, jobj_map, 17);
-        HSD_JObjSetFlagsAll(jobj_parts[16], 0x10);
-        HSD_JObjSetFlagsAll(jobj_parts[13], 0x10);
+        HSD_JObjSetFlagsAll(jobj_parts[16], JOBJ_HIDDEN);
+        HSD_JObjSetFlagsAll(jobj_parts[13], JOBJ_HIDDEN);
         if (old_sel == 5) {
             HSD_JObjReqAnimAll(jobj_parts[2], mn_803ED1D0.x7C[0].start_frame);
         } else {
@@ -441,14 +441,14 @@ void mn_802327A4(HSD_GObj* gobj, u32 arg1, u32 arg2)
         HSD_JObjReqAnim(jobj_parts[7],
                         mn_803ED1D0.text_start_frames[old_sel * 2]);
         HSD_JObjAnim(jobj_parts[7]);
-        HSD_JObjSetFlagsAll(jobj_parts[8], 0x10);
+        HSD_JObjSetFlagsAll(jobj_parts[8], JOBJ_HIDDEN);
         new_sel = (u8) mn_804A04F0.hovered_selection;
         lb_8001204C(option_roots[mn_804A04F0.hovered_selection], jobj_parts,
                     jobj_map, 17);
-        HSD_JObjClearFlagsAll(jobj_parts[16], 0x10);
+        HSD_JObjClearFlagsAll(jobj_parts[16], JOBJ_HIDDEN);
         HSD_JObjReqAnimAll(jobj_parts[16], mn_803ED1D0.x4C.start_frame);
         if (new_sel != 5) {
-            HSD_JObjClearFlagsAll(jobj_parts[13], 0x10);
+            HSD_JObjClearFlagsAll(jobj_parts[13], JOBJ_HIDDEN);
             HSD_JObjReqAnimAll(jobj_parts[13], mn_803ED1D0.x58.start_frame);
             HSD_JObjReqAnimAll(jobj_parts[2], mn_803ED1D0.x64[1].start_frame);
             HSD_JObjAnimAll(jobj_parts[2]);
@@ -460,7 +460,7 @@ void mn_802327A4(HSD_GObj* gobj, u32 arg1, u32 arg2)
                         mn_803ED1D0.text_start_frames[new_sel * 2 + 1]);
         HSD_JObjAnim(jobj_parts[7]);
         if (new_sel == 5) {
-            HSD_JObjClearFlagsAll(jobj_parts[8], 0x10);
+            HSD_JObjClearFlagsAll(jobj_parts[8], JOBJ_HIDDEN);
             HSD_JObjReqAnimAll(jobj_parts[8], mn_803ED1D0.x94.start_frame);
             HSD_JObjAnimAll(jobj_parts[8]);
         }
@@ -854,18 +854,18 @@ HSD_GObj* mn_80233218(MenuState state)
             HSD_JObjAnim(jobj_parts[7]);
 
             if ((s32) selected != i) {
-                HSD_JObjSetFlagsAll(jobj_parts[16], 0x10);
+                HSD_JObjSetFlagsAll(jobj_parts[16], JOBJ_HIDDEN);
             }
 
             if (((s32) selected != i) || (i == 5)) {
-                HSD_JObjSetFlagsAll(jobj_parts[13], 0x10);
+                HSD_JObjSetFlagsAll(jobj_parts[13], JOBJ_HIDDEN);
             } else {
                 HSD_JObjReqAnimAll(jobj_parts[13],
                                    mn_803ED1D0.x58.start_frame);
             }
 
             if (((s32) selected != i) || (i != 5)) {
-                HSD_JObjSetFlagsAll(jobj_parts[8], 0x10);
+                HSD_JObjSetFlagsAll(jobj_parts[8], JOBJ_HIDDEN);
             }
 
             if (i == 5) {

--- a/src/melee/mn/mnsnap.c
+++ b/src/melee/mn/mnsnap.c
@@ -323,9 +323,9 @@ void mnSnap_80253640(s32 page)
     HSD_JObjAnimAll(snap->scroll_jobj);
 
     if (p48[*p50] <= 4) {
-        HSD_JObjSetFlagsAll(snap->arrow_jobj, 0x10);
+        HSD_JObjSetFlagsAll(snap->arrow_jobj, JOBJ_HIDDEN);
     } else {
-        HSD_JObjClearFlagsAll(snap->arrow_jobj, 0x10);
+        HSD_JObjClearFlagsAll(snap->arrow_jobj, JOBJ_HIDDEN);
     }
 }
 
@@ -557,10 +557,10 @@ void mnSnap_80254014(void)
     HSD_JObjAnimAll(*ptr);
 
     for (i = 0; i < 5; i++) {
-        HSD_JObjClearFlagsAll(snap->option_jobjs[i], 0x10);
+        HSD_JObjClearFlagsAll(snap->option_jobjs[i], JOBJ_HIDDEN);
     }
 
-    HSD_JObjSetFlagsAll(snap->move_jobj, 0x10);
+    HSD_JObjSetFlagsAll(snap->move_jobj, JOBJ_HIDDEN);
 }
 #pragma dont_inline reset
 
@@ -577,15 +577,15 @@ void mnSnap_8025409C(s32 dlg_type)
     snap->dlg_type = dlg_type;
 
     if (dlg_type == 0) {
-        HSD_JObjSetFlags(snap->yes_jobj, 0x10);
-        HSD_JObjSetFlags(snap->no_jobj, 0x10);
+        HSD_JObjSetFlags(snap->yes_jobj, JOBJ_HIDDEN);
+        HSD_JObjSetFlags(snap->no_jobj, JOBJ_HIDDEN);
         return;
     }
 
     p38 = &snap->yes_jobj;
-    HSD_JObjClearFlags(*p38, 0x10);
+    HSD_JObjClearFlags(*p38, JOBJ_HIDDEN);
     p39 = &snap->no_jobj;
-    HSD_JObjClearFlags(*p39, 0x10);
+    HSD_JObjClearFlags(*p39, JOBJ_HIDDEN);
 
     p5E = &snap->btn_idx;
     *p5E = 0;
@@ -669,7 +669,7 @@ void mnSnap_80254298(void)
     *p51 = 0;
     snap->state = 2;
 
-    HSD_JObjSetFlagsAll(snap->fullview_jobj, 0x10);
+    HSD_JObjSetFlagsAll(snap->fullview_jobj, JOBJ_HIDDEN);
     snap->dlg_active = 0;
     slot = (void**) &snap->dlg_text;
     snap->dlg_timer = 0;
@@ -684,9 +684,9 @@ void mnSnap_80254298(void)
     HSD_JObjAnimAll((HSD_JObj*) *slot);
 
     for (i = 0; i < 5; i++) {
-        HSD_JObjClearFlagsAll(snap->option_jobjs[i], 0x10);
+        HSD_JObjClearFlagsAll(snap->option_jobjs[i], JOBJ_HIDDEN);
     }
-    HSD_JObjSetFlagsAll(snap->move_jobj, 0x10);
+    HSD_JObjSetFlagsAll(snap->move_jobj, JOBJ_HIDDEN);
 
     mnSnap_80253964();
     mnSnap_80253E90(0);
@@ -828,7 +828,8 @@ void fn_802545C4(void)
                 HSD_JObjAnim(mnSnap_804A0A10.slot_b_jobj);
                 mnSnap_804A0A10.pending_loads = 0;
                 mnSnap_804A0A10.state = 2;
-                HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj, 0x10);
+                HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj,
+                                    JOBJ_HIDDEN);
                 mnSnap_804A0A10.dlg_active = 0;
                 mnSnap_804A0A10.dlg_timer = 0;
                 if (mnSnap_804A0A10.dlg_text != NULL) {
@@ -908,8 +909,8 @@ void fn_802545C4(void)
                 mnSnap_804A0A10.dlg_timer = 9;
                 mnSnap_804A0A10.dlg_active = 1;
                 mnSnap_8025409C(0);
-                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_l, 0x10);
-                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_r, 0x10);
+                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_l, JOBJ_HIDDEN);
+                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_r, JOBJ_HIDDEN);
                 mnSnap_InitDialogText();
                 HSD_SisLib_803A6368(mnSnap_804A0A10.dlg_text, 0x140);
                 HSD_JObjReqAnim(mnSnap_804A0A10.dlg_frame,
@@ -995,8 +996,10 @@ void fn_802545C4(void)
                             mnSnap_804A0A10.dlg_timer = 9;
                             mnSnap_804A0A10.dlg_active = 1;
                             mnSnap_8025409C(0);
-                            HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_l, 0x10);
-                            HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_r, 0x10);
+                            HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_l,
+                                             JOBJ_HIDDEN);
+                            HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_r,
+                                             JOBJ_HIDDEN);
                             mnSnap_InitDialogText();
                             HSD_SisLib_803A6368(mnSnap_804A0A10.dlg_text,
                                                 0x140);
@@ -1117,8 +1120,8 @@ void fn_802545C4(void)
                     mnSnap_804A0A10.dlg_timer = 9;
                     mnSnap_804A0A10.dlg_active = 1;
                     mnSnap_8025409C(0);
-                    HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_l, 0x10);
-                    HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_r, 0x10);
+                    HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_l, JOBJ_HIDDEN);
+                    HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_r, JOBJ_HIDDEN);
                     mnSnap_InitDialogText();
                     if (mnSnap_804A0A10
                             .card_status[mnSnap_804A0A10.active_slot] == (-1))
@@ -1163,8 +1166,8 @@ void fn_802545C4(void)
                     mnSnap_804A0A10.dlg_timer = 9;
                     mnSnap_804A0A10.dlg_active = 1;
                     mnSnap_8025409C(0);
-                    HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_l, 0x10);
-                    HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_r, 0x10);
+                    HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_l, JOBJ_HIDDEN);
+                    HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_r, JOBJ_HIDDEN);
                     mnSnap_InitDialogText();
                     if (mnSnap_804A0A10.active_slot == 0) {
                         HSD_SisLib_803A6368(mnSnap_804A0A10.dlg_text, 0x141);
@@ -1199,9 +1202,10 @@ void fn_802545C4(void)
                                  ->translate;
                         HSD_JObjSetTranslate(jobj, translate);
                         HSD_JObjClearFlagsAll(mnSnap_804A0A10.select_jobj,
-                                              0x10);
+                                              JOBJ_HIDDEN);
                     } else {
-                        HSD_JObjSetFlagsAll(mnSnap_804A0A10.select_jobj, 0x10);
+                        HSD_JObjSetFlagsAll(mnSnap_804A0A10.select_jobj,
+                                            JOBJ_HIDDEN);
                     }
                 }
             }
@@ -1238,8 +1242,8 @@ void fn_802545C4(void)
                 mnSnap_804A0A10.dlg_timer = 9;
                 mnSnap_804A0A10.dlg_active = 1;
                 mnSnap_8025409C(1);
-                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_l, 0x10);
-                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_r, 0x10);
+                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_l, JOBJ_HIDDEN);
+                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_r, JOBJ_HIDDEN);
                 mnSnap_InitDialogText();
                 HSD_SisLib_803A6368(mnSnap_804A0A10.dlg_text, 0x153);
                 HSD_JObjReqAnim(mnSnap_804A0A10.dlg_frame,
@@ -1276,9 +1280,11 @@ void fn_802545C4(void)
                              .thumb_jobjs[mnSnap_804A0A10.cursor_idx % 4]
                              ->translate;
                     HSD_JObjSetTranslate(jobj, translate);
-                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.select_jobj, 0x10);
+                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.select_jobj,
+                                          JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.select_jobj, 0x10);
+                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.select_jobj,
+                                        JOBJ_HIDDEN);
                 }
             } else if (result == 1) {
                 if ((mnSnap_804A0A10.cursor_idx / 4) ==
@@ -1290,9 +1296,11 @@ void fn_802545C4(void)
                              .thumb_jobjs[mnSnap_804A0A10.cursor_idx % 4]
                              ->translate;
                     HSD_JObjSetTranslate(jobj, translate);
-                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.select_jobj, 0x10);
+                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.select_jobj,
+                                          JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.select_jobj, 0x10);
+                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.select_jobj,
+                                        JOBJ_HIDDEN);
                 }
             }
         }
@@ -1342,7 +1350,7 @@ void fn_802545C4(void)
                         mnSnap_804A0A10.pending_loads = 0;
                         mnSnap_804A0A10.state = 2;
                         HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj,
-                                            0x10);
+                                            JOBJ_HIDDEN);
                         mnSnap_804A0A10.dlg_active = 0;
                         mnSnap_804A0A10.dlg_timer = 0;
                         if (mnSnap_804A0A10.dlg_text != NULL) {
@@ -1368,10 +1376,10 @@ void fn_802545C4(void)
                                      ->translate;
                             HSD_JObjSetTranslate(jobj, translate);
                             HSD_JObjClearFlagsAll(mnSnap_804A0A10.select_jobj,
-                                                  0x10);
+                                                  JOBJ_HIDDEN);
                         } else {
                             HSD_JObjSetFlagsAll(mnSnap_804A0A10.select_jobj,
-                                                0x10);
+                                                JOBJ_HIDDEN);
                         }
                         mnSnap_80253964();
                         mnSnap_804A0A10.state = 4;
@@ -1424,7 +1432,8 @@ void fn_802545C4(void)
                 void* thumb_img;
                 lbAudioAx_80024030(1);
                 mnSnap_804A0A10.state = 0xA;
-                HSD_JObjClearFlagsAll(mnSnap_804A0A10.fullview_jobj, 0x10);
+                HSD_JObjClearFlagsAll(mnSnap_804A0A10.fullview_jobj,
+                                      JOBJ_HIDDEN);
                 jobj = mnSnap_804A0A10.fullview_jobj;
                 thumb_img = mnSnap_thumb_imgs[mnSnap_804A0A10.cursor_idx % 4];
                 HSD_ASSERT(181, jobj);
@@ -1441,10 +1450,11 @@ void fn_802545C4(void)
                 HSD_JObjAnimAll(mnSnap_804A0A10.submenu_jobj);
                 mnSnap_804A0A10.timer = 4;
                 for (i = 0; i < 5; i++) {
-                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.option_jobjs[i], 0x10);
+                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.option_jobjs[i],
+                                        JOBJ_HIDDEN);
                 }
 
-                HSD_JObjClearFlagsAll(mnSnap_804A0A10.move_jobj, 0x10);
+                HSD_JObjClearFlagsAll(mnSnap_804A0A10.move_jobj, JOBJ_HIDDEN);
                 mnSnap_804A0A10.move_idx = mnSnap_804A0A10.cursor_idx;
                 if ((mnSnap_804A0A10.move_idx / 4) == mnSnap_804A0A10.cur_page)
                 {
@@ -1453,17 +1463,19 @@ void fn_802545C4(void)
                                      .thumb_jobjs[mnSnap_804A0A10.move_idx % 4]
                                      ->translate;
                     HSD_JObjSetTranslateWithMtxDirty(jobj, translate);
-                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.move_jobj, 0x10);
+                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.move_jobj,
+                                          JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.move_jobj, 0x10);
+                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.move_jobj,
+                                        JOBJ_HIDDEN);
                 }
             } else if (mnSnap_804A0A10.menu_sel == 2) {
                 lbAudioAx_80024030(1);
                 mnSnap_804A0A10.dlg_timer = 9;
                 mnSnap_804A0A10.dlg_active = 1;
                 mnSnap_8025409C(1);
-                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_l, 0x10);
-                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_r, 0x10);
+                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_l, JOBJ_HIDDEN);
+                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_r, JOBJ_HIDDEN);
                 mnSnap_InitDialogText();
                 if (mnSnap_804A0A10.active_slot == 0) {
                     HSD_SisLib_803A6368(mnSnap_804A0A10.dlg_text, 0x144);
@@ -1486,8 +1498,8 @@ void fn_802545C4(void)
                 mnSnap_804A0A10.dlg_timer = 9;
                 mnSnap_804A0A10.dlg_active = 1;
                 mnSnap_8025409C(2);
-                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_l, 0x10);
-                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_r, 0x10);
+                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_l, JOBJ_HIDDEN);
+                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_r, JOBJ_HIDDEN);
                 mnSnap_InitDialogText();
                 HSD_SisLib_803A6368(mnSnap_804A0A10.dlg_text, 0x150);
                 HSD_JObjReqAnim(mnSnap_804A0A10.dlg_frame,
@@ -1508,8 +1520,8 @@ void fn_802545C4(void)
                 mnSnap_804A0A10.dlg_timer = 9;
                 mnSnap_804A0A10.dlg_active = 1;
                 mnSnap_8025409C(1);
-                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_l, 0x10);
-                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_r, 0x10);
+                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_l, JOBJ_HIDDEN);
+                HSD_JObjSetFlags(mnSnap_804A0A10.dlg_btn_r, JOBJ_HIDDEN);
                 mnSnap_InitDialogText();
                 if (mnSnap_804A0A10.active_slot == 0) {
                     HSD_SisLib_803A6368(mnSnap_804A0A10.dlg_text, 0x152);
@@ -1536,11 +1548,11 @@ void fn_802545C4(void)
         if (buttons & 0x200) {
             mnSnap_804A0A10.state = 4;
             lbAudioAx_80024030(0);
-            HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj, 0x10);
+            HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj, JOBJ_HIDDEN);
         } else if (buttons & 0x20) {
             mnSnap_804A0A10.state = 6;
             lbAudioAx_80024030(0);
-            HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj, 0x10);
+            HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj, JOBJ_HIDDEN);
         }
         break;
 
@@ -1587,9 +1599,11 @@ void fn_802545C4(void)
                              .thumb_jobjs[mnSnap_804A0A10.cursor_idx % 4]
                              ->translate;
                     HSD_JObjSetTranslate(jobj, translate);
-                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.select_jobj, 0x10);
+                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.select_jobj,
+                                          JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.select_jobj, 0x10);
+                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.select_jobj,
+                                        JOBJ_HIDDEN);
                 }
                 if ((mnSnap_804A0A10.move_idx / 4) == mnSnap_804A0A10.cur_page)
                 {
@@ -1598,9 +1612,11 @@ void fn_802545C4(void)
                                      .thumb_jobjs[mnSnap_804A0A10.move_idx % 4]
                                      ->translate;
                     HSD_JObjSetTranslate(jobj2, translate);
-                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.move_jobj, 0x10);
+                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.move_jobj,
+                                          JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.move_jobj, 0x10);
+                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.move_jobj,
+                                        JOBJ_HIDDEN);
                 }
             } else if (result == 1) {
                 if ((mnSnap_804A0A10.move_idx / 4) == mnSnap_804A0A10.cur_page)
@@ -1610,9 +1626,11 @@ void fn_802545C4(void)
                                      .thumb_jobjs[mnSnap_804A0A10.move_idx % 4]
                                      ->translate;
                     HSD_JObjSetTranslate(jobj2, translate);
-                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.move_jobj, 0x10);
+                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.move_jobj,
+                                          JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.move_jobj, 0x10);
+                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.move_jobj,
+                                        JOBJ_HIDDEN);
                 }
             }
         }
@@ -1621,10 +1639,11 @@ void fn_802545C4(void)
             HSD_JObjReqAnimAll(mnSnap_804A0A10.submenu_jobj, 0.0F);
             HSD_JObjAnimAll(mnSnap_804A0A10.submenu_jobj);
             for (i = 0; i < 5; i++) {
-                HSD_JObjClearFlagsAll(mnSnap_804A0A10.option_jobjs[i], 0x10);
+                HSD_JObjClearFlagsAll(mnSnap_804A0A10.option_jobjs[i],
+                                      JOBJ_HIDDEN);
             }
 
-            HSD_JObjSetFlagsAll(mnSnap_804A0A10.move_jobj, 0x10);
+            HSD_JObjSetFlagsAll(mnSnap_804A0A10.move_jobj, JOBJ_HIDDEN);
             mnSnap_80253AE4(1);
             if ((mnSnap_804A0A10.cursor_idx / 4) != mnSnap_804A0A10.cur_page) {
                 mnSnap_80253640(mnSnap_804A0A10.cursor_idx / 4);
@@ -1638,9 +1657,11 @@ void fn_802545C4(void)
                              .thumb_jobjs[mnSnap_804A0A10.cursor_idx % 4]
                              ->translate;
                     HSD_JObjSetTranslate(jobj, translate);
-                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.select_jobj, 0x10);
+                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.select_jobj,
+                                          JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.select_jobj, 0x10);
+                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.select_jobj,
+                                        JOBJ_HIDDEN);
                 }
             }
         }
@@ -1680,10 +1701,10 @@ void fn_802545C4(void)
             if (result == 0) {
                 lbAudioAx_80024030(1);
                 mnSnap_804A0A10.state = 0xF;
-                HSD_JObjClearFlags(mnSnap_804A0A10.dlg_btn_r, 0x10);
+                HSD_JObjClearFlags(mnSnap_804A0A10.dlg_btn_r, JOBJ_HIDDEN);
                 HSD_JObjSetTranslateX(mnSnap_804A0A10.progress_jobj, -6.9F);
-                HSD_JObjSetFlags(mnSnap_804A0A10.yes_jobj, 0x10);
-                HSD_JObjSetFlags(mnSnap_804A0A10.no_jobj, 0x10);
+                HSD_JObjSetFlags(mnSnap_804A0A10.yes_jobj, JOBJ_HIDDEN);
+                HSD_JObjSetFlags(mnSnap_804A0A10.no_jobj, JOBJ_HIDDEN);
                 {
                     s32 ci = mnSnap_804A0A10.cursor_idx;
                     mnSnap_804A0A10.card_result =
@@ -1698,7 +1719,8 @@ void fn_802545C4(void)
                     HSD_JObjAnim(mnSnap_804A0A10.slot_b_jobj);
                     mnSnap_804A0A10.pending_loads = 0;
                     mnSnap_804A0A10.state = 2;
-                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj, 0x10);
+                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj,
+                                        JOBJ_HIDDEN);
                     mnSnap_804A0A10.dlg_active = 0;
                     mnSnap_804A0A10.dlg_timer = 0;
                     if (mnSnap_804A0A10.dlg_text != NULL) {
@@ -1720,7 +1742,8 @@ void fn_802545C4(void)
                     HSD_JObjAnim(mnSnap_804A0A10.slot_b_jobj);
                     mnSnap_804A0A10.pending_loads = 0;
                     mnSnap_804A0A10.state = 2;
-                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj, 0x10);
+                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj,
+                                        JOBJ_HIDDEN);
                     mnSnap_804A0A10.dlg_active = 0;
                     mnSnap_804A0A10.dlg_timer = 0;
                     if (mnSnap_804A0A10.dlg_text != NULL) {
@@ -1863,7 +1886,8 @@ void fn_802545C4(void)
                 HSD_JObjAnim(mnSnap_804A0A10.slot_b_jobj);
                 mnSnap_804A0A10.pending_loads = 0;
                 mnSnap_804A0A10.state = 2;
-                HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj, 0x10);
+                HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj,
+                                    JOBJ_HIDDEN);
                 mnSnap_804A0A10.dlg_active = 0;
                 mnSnap_804A0A10.dlg_timer = 0;
                 if (mnSnap_804A0A10.dlg_text != NULL) {
@@ -1887,7 +1911,8 @@ void fn_802545C4(void)
                     HSD_JObjAnim(mnSnap_804A0A10.slot_b_jobj);
                     mnSnap_804A0A10.pending_loads = 0;
                     mnSnap_804A0A10.state = 2;
-                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj, 0x10);
+                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj,
+                                        JOBJ_HIDDEN);
                     mnSnap_804A0A10.dlg_active = 0;
                     mnSnap_804A0A10.dlg_timer = 0;
                     if (mnSnap_804A0A10.dlg_text != NULL) {
@@ -1933,7 +1958,8 @@ void fn_802545C4(void)
                 HSD_JObjAnim(mnSnap_804A0A10.slot_b_jobj);
                 mnSnap_804A0A10.pending_loads = 0;
                 mnSnap_804A0A10.state = 2;
-                HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj, 0x10);
+                HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj,
+                                    JOBJ_HIDDEN);
                 mnSnap_804A0A10.dlg_active = 0;
                 mnSnap_804A0A10.dlg_timer = 0;
                 if (mnSnap_804A0A10.dlg_text != NULL) {
@@ -2018,7 +2044,7 @@ void fn_802545C4(void)
                         mnSnap_804A0A10.pending_loads = 0;
                         mnSnap_804A0A10.state = 2;
                         HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj,
-                                            0x10);
+                                            JOBJ_HIDDEN);
                         mnSnap_804A0A10.dlg_active = 0;
                         mnSnap_804A0A10.dlg_timer = 0;
                         if (mnSnap_804A0A10.dlg_text != NULL) {
@@ -2044,9 +2070,11 @@ void fn_802545C4(void)
                              .thumb_jobjs[mnSnap_804A0A10.cursor_idx % 4]
                              ->translate;
                     HSD_JObjSetTranslate(jobj, translate);
-                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.select_jobj, 0x10);
+                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.select_jobj,
+                                          JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.select_jobj, 0x10);
+                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.select_jobj,
+                                        JOBJ_HIDDEN);
                 }
                 mnSnap_80253964();
                 mnSnap_804A0A10.state = 4;
@@ -2140,9 +2168,11 @@ void fn_802545C4(void)
                              .thumb_jobjs[mnSnap_804A0A10.cursor_idx % 4]
                              ->translate;
                     HSD_JObjSetTranslate(jobj, translate);
-                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.select_jobj, 0x10);
+                    HSD_JObjClearFlagsAll(mnSnap_804A0A10.select_jobj,
+                                          JOBJ_HIDDEN);
                 } else {
-                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.select_jobj, 0x10);
+                    HSD_JObjSetFlagsAll(mnSnap_804A0A10.select_jobj,
+                                        JOBJ_HIDDEN);
                 }
             }
         } else if (mnSnap_804A0A10.dlg_result == 2) {
@@ -2239,9 +2269,10 @@ void fn_802545C4(void)
                                  ->translate;
                         HSD_JObjSetTranslate(jobj, translate);
                         HSD_JObjClearFlagsAll(mnSnap_804A0A10.select_jobj,
-                                              0x10);
+                                              JOBJ_HIDDEN);
                     } else {
-                        HSD_JObjSetFlagsAll(mnSnap_804A0A10.select_jobj, 0x10);
+                        HSD_JObjSetFlagsAll(mnSnap_804A0A10.select_jobj,
+                                            JOBJ_HIDDEN);
                     }
                 }
             }
@@ -2458,16 +2489,16 @@ void mnSnap_80257F24(void)
         *(void**) (snap->slot_a_jobj)->u.dobj->mobj->tobj->imagedesc;
 
     if (snap->photo_count[snap->active_slot] <= 4) {
-        HSD_JObjSetFlagsAll(snap->arrow_jobj, 0x10);
+        HSD_JObjSetFlagsAll(snap->arrow_jobj, JOBJ_HIDDEN);
     } else {
-        HSD_JObjClearFlagsAll(snap->arrow_jobj, 0x10);
+        HSD_JObjClearFlagsAll(snap->arrow_jobj, JOBJ_HIDDEN);
     }
 
     HSD_AObjSetFlags((snap->select_jobj)->u.dobj->mobj->tobj->aobj,
                      0x20000000);
 
     move_jobj_ptr = &snap->move_jobj;
-    HSD_JObjSetFlagsAll(*move_jobj_ptr, 0x10);
+    HSD_JObjSetFlagsAll(*move_jobj_ptr, JOBJ_HIDDEN);
     HSD_AObjSetFlags((*move_jobj_ptr)->u.dobj->mobj->tobj->aobj, 0x20000000);
 
     HSD_GObj_SetupProc(gobj, (HSD_GObjEvent) fn_802545C4, 0);
@@ -2526,7 +2557,7 @@ void mnSnap_80257F24(void)
     jobj2 = HSD_JObjLoadJoint((HSD_Joint*) snap->page_joint);
     snap->fullview_jobj = jobj2;
     HSD_JObjAddChild(snap->thumb_root, jobj2);
-    HSD_JObjSetFlagsAll(jobj2, 0x10);
+    HSD_JObjSetFlagsAll(jobj2, JOBJ_HIDDEN);
 
     /* Create 4 SIS text objects for thumbnail labels */
     for (i = 0; i < 4; i++) {

--- a/src/melee/mn/mnsound.c
+++ b/src/melee/mn/mnsound.c
@@ -171,10 +171,10 @@ void fn_80249A1C(HSD_GObj* arg0)
     if (temp_r4 != 0) {
         menu->cursor = (u8) (temp_r4 - 1);
         if ((u8) menu->cursor != 0) {
-            HSD_JObjSetFlagsAll(jobj, 0x10U);
+            HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
             return;
         }
-        HSD_JObjClearFlagsAll(jobj, 0x10U);
+        HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         return;
     }
     if ((u8) menu->unk2 == 0) {
@@ -256,7 +256,7 @@ void mnSound_80249C08(int unused)
         lb_80011E24(jobj, &sp60, 0xB, -1);
         HSD_JObjReqAnimAll(sp60, mnSound_803EEED8[user_data->unk1 + 4].start_frame);
         HSD_JObjAnimAll(sp60);
-        HSD_JObjSetFlagsAll(jobj, 0x10U);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     }
 }
 

--- a/src/melee/mn/mnsoundtest.c
+++ b/src/melee/mn/mnsoundtest.c
@@ -264,14 +264,14 @@ void mnSoundTest_8024AA70(HSD_GObj* arg0, u8 arg1)
         mn_8022EA08((char*) &string, new_var->unk4);
         temp_r3_2->default_alignment = 1;
         HSD_SisLib_803A6B98(temp_r3_2, 0.0f, 0.0f, string);
-        HSD_JObjClearFlagsAll(sp38, 0x10U);
+        HSD_JObjClearFlagsAll(sp38, JOBJ_HIDDEN);
     } else {
         temp_r3_4 = user_data->unk1C;
         if (temp_r3_4 != NULL) {
             HSD_SisLib_803A5CC4(temp_r3_4);
             user_data->unk1C = NULL;
         }
-        HSD_JObjSetFlagsAll(sp38, 0x10U);
+        HSD_JObjSetFlagsAll(sp38, JOBJ_HIDDEN);
     }
     HSD_JObjReqAnimAll(sp34, (f32) (arg1 == 1));
     mn_8022F3D8(sp34, 0xFFU, 0x420);

--- a/src/melee/mn/mnstagesel.c
+++ b/src/melee/mn/mnstagesel.c
@@ -268,7 +268,7 @@ void fn_8025A310(HSD_GObj* gobj)
 
     jobj = gobj->hsd_obj;
     if (mnStageSel_804D6CAF != 0) {
-        HSD_JObjSetFlags(jobj, 0x10);
+        HSD_JObjSetFlags(jobj, JOBJ_HIDDEN);
         return;
     }
     HSD_JObjGetTranslation(jobj, &sp1C);
@@ -503,7 +503,7 @@ void mnStageSel_8025A998_OnEnter(void* arg0)
             mnStageSel_803F06D0[i * 2].x0 = temp_r22_6->child->next;
             switch (mnStageSel_803F06D0[i * 2].x8) {
             case 0:
-                HSD_JObjSetFlags(mnStageSel_803F06D0[i * 2].x0, 0x10);
+                HSD_JObjSetFlags(mnStageSel_803F06D0[i * 2].x0, JOBJ_HIDDEN);
                 break;
             case 1:
                 HSD_JObjReqAnimAllByFlags(mnStageSel_803F06D0[i * 2].x0, 0x10,
@@ -518,7 +518,8 @@ void mnStageSel_8025A998_OnEnter(void* arg0)
             mnStageSel_803F06D0[i * 2 + 1].x0 = temp_r22_6->child;
             switch (mnStageSel_803F06D0[i * 2 + 1].x8) {
             case 0:
-                HSD_JObjSetFlags(mnStageSel_803F06D0[i * 2 + 1].x0, 0x10);
+                HSD_JObjSetFlags(mnStageSel_803F06D0[i * 2 + 1].x0,
+                                 JOBJ_HIDDEN);
                 break;
             case 1:
                 HSD_JObjReqAnimAllByFlags(mnStageSel_803F06D0[i * 2 + 1].x0,
@@ -555,7 +556,7 @@ void mnStageSel_8025A998_OnEnter(void* arg0)
                 mnStageSel_803F06D0[i + 13].x8 = 0;
                 /* fallthrough */
             case 0:
-                HSD_JObjSetFlagsAll(temp_r23_3, 0x10);
+                HSD_JObjSetFlagsAll(temp_r23_3, JOBJ_HIDDEN);
                 break;
             default:
                 temp_r22_7 = mnStageSel_803F06D0[i + 13].x9 - 0x16;
@@ -610,7 +611,7 @@ void mnStageSel_8025A998_OnEnter(void* arg0)
                 mnStageSel_803F06D0[i + 5].x8 = 0;
                 /* fallthrough */
             case 0:
-                HSD_JObjSetFlagsAll(temp_r23_6, 0x10);
+                HSD_JObjSetFlagsAll(temp_r23_6, JOBJ_HIDDEN);
                 break;
             default:
                 temp_r22_9 = mnStageSel_803F06D0[i + 5].x9 - 0x14;

--- a/src/melee/mn/mnvibration.c
+++ b/src/melee/mn/mnvibration.c
@@ -601,7 +601,7 @@ void mnVibration_8024829C(HSD_GObj* arg0)
             connected = 1;
         }
         mnVibration_802480B4(new_jobj, (u8) i, (u8) connected);
-        HSD_JObjSetFlagsAll(new_jobj, 0x10);
+        HSD_JObjSetFlagsAll(new_jobj, JOBJ_HIDDEN);
         HSD_JObjAddChild(data->jobjs[23], new_jobj);
         i += 1;
     } while (i < 4);
@@ -754,7 +754,8 @@ void fn_802487A8(HSD_GObj* gobj)
         {
             if ((s8) var_r3 != 0) {
                 HSD_JObjSetFlagsAll(
-                    ((MnVibrationData*) temp_r31)->jobjs[*var_r25], 0x10);
+                    ((MnVibrationData*) temp_r31)->jobjs[*var_r25],
+                    JOBJ_HIDDEN);
                 {
                     void* temp_jobj2;
                     temp_jobj2 =
@@ -779,7 +780,8 @@ void fn_802487A8(HSD_GObj* gobj)
                 temp_r31[var_r23 + 6] = 0;
             } else {
                 HSD_JObjClearFlagsAll(
-                    ((MnVibrationData*) temp_r31)->jobjs[*var_r25], 0x10);
+                    ((MnVibrationData*) temp_r31)->jobjs[*var_r25],
+                    JOBJ_HIDDEN);
                 var_r26 = NULL;
                 temp_r31[var_r23 + 2] = 0;
                 temp_r27 = ((MnVibrationData*) mnVibration_804D6C28->user_data)
@@ -854,9 +856,9 @@ void fn_80248A78(HSD_GObj* arg0)
                 i++;
             }
         }
-        HSD_JObjClearFlagsAll(jobj, 0x10U);
+        HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         if ((u8) temp_r30->x6[0] != 0) {
-            HSD_JObjClearFlagsAll(temp_r30->jobjs[22], 0x10U);
+            HSD_JObjClearFlagsAll(temp_r30->jobjs[22], JOBJ_HIDDEN);
         }
     } else if (frame == 11.0f) {
         jobj = ((MnVibrationData*) arg0->user_data)->jobjs[23];
@@ -870,9 +872,9 @@ void fn_80248A78(HSD_GObj* arg0)
         } else {
             jobj = jobj->next;
         }
-        HSD_JObjClearFlagsAll(jobj, 0x10U);
+        HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         if ((u8) temp_r30->x6[1] != 0) {
-            HSD_JObjClearFlagsAll(temp_r30->jobjs[21], 0x10U);
+            HSD_JObjClearFlagsAll(temp_r30->jobjs[21], JOBJ_HIDDEN);
         }
     } else if (frame == 12.0f) {
         jobj = ((MnVibrationData*) arg0->user_data)->jobjs[23];
@@ -891,9 +893,9 @@ void fn_80248A78(HSD_GObj* arg0)
         } else {
             jobj4 = jobj3->next;
         }
-        HSD_JObjClearFlagsAll(jobj4, 0x10U);
+        HSD_JObjClearFlagsAll(jobj4, JOBJ_HIDDEN);
         if ((u8) temp_r30->x6[2] != 0) {
-            HSD_JObjClearFlagsAll(temp_r30->jobjs[20], 0x10U);
+            HSD_JObjClearFlagsAll(temp_r30->jobjs[20], JOBJ_HIDDEN);
         }
     } else if (frame == 13.0f) {
         jobj = ((MnVibrationData*) arg0->user_data)->jobjs[23];
@@ -917,9 +919,9 @@ void fn_80248A78(HSD_GObj* arg0)
         } else {
             jobj = jobj4->next;
         }
-        HSD_JObjClearFlagsAll(jobj, 0x10U);
+        HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         if ((u8) temp_r30->x6[3] != 0) {
-            HSD_JObjClearFlagsAll(temp_r30->jobjs[19], 0x10U);
+            HSD_JObjClearFlagsAll(temp_r30->jobjs[19], JOBJ_HIDDEN);
         }
     } else if (frame == 14.0f) {
         if (GetNameCount() != 0) {
@@ -1016,10 +1018,10 @@ void mnVibration_80248ED4(s32 arg0)
             k += 1;
         } while (k < 0x19);
     }
-    HSD_JObjSetFlagsAll(data->jobjs[22], 0x10);
-    HSD_JObjSetFlagsAll(data->jobjs[21], 0x10);
-    HSD_JObjSetFlagsAll(data->jobjs[20], 0x10);
-    HSD_JObjSetFlagsAll(data->jobjs[19], 0x10);
+    HSD_JObjSetFlagsAll(data->jobjs[22], JOBJ_HIDDEN);
+    HSD_JObjSetFlagsAll(data->jobjs[21], JOBJ_HIDDEN);
+    HSD_JObjSetFlagsAll(data->jobjs[20], JOBJ_HIDDEN);
+    HSD_JObjSetFlagsAll(data->jobjs[19], JOBJ_HIDDEN);
     HSD_GObj_SetupProc(gobj, (void (*)(HSD_GObj*)) fn_80248A78, 0);
     mnVibration_8024829C(gobj);
     if (data->title_text != NULL) {

--- a/src/melee/ty/toy.c
+++ b/src/melee/ty/toy.c
@@ -2089,8 +2089,8 @@ void fn_80307E84(HSD_GObj* gobj)
 
     if (x0F_val <= 0) {
         if (state->x10 == 1) {
-            HSD_JObjSetFlagsAll(jobj0, 0x10);
-            HSD_JObjSetFlagsAll(jobj1, 0x10);
+            HSD_JObjSetFlagsAll(jobj0, JOBJ_HIDDEN);
+            HSD_JObjSetFlagsAll(jobj1, JOBJ_HIDDEN);
         }
         state->x10 = 0;
         HSD_JObjRemoveAnimAll(jobj0);
@@ -2261,19 +2261,19 @@ void un_803083D8(HSD_JObj* jobj, s32 arg1)
     s32 temp_r31;
 
     if (arg1 == 0x3E6) {
-        HSD_JObjClearFlagsAll(jobj, 0x10);
+        HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
         return;
     }
     if (arg1 == 0x3E7) {
-        HSD_JObjSetFlagsAll(jobj, 0x10);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         return;
     }
     temp_r31 = (s32) un_803060BC(arg1, 8);
     if (temp_r31 == 0) {
-        HSD_JObjSetFlagsAll(jobj, 0x10);
+        HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         return;
     }
-    HSD_JObjClearFlagsAll(jobj, 0x10);
+    HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
     if (temp_r31 == 1) {
         HSD_JObjReqAnim(jobj, 0.0F);
     } else {
@@ -2502,7 +2502,7 @@ HSD_GObj* un_803087F4(void* arg0)
 
     {
         HSD_JObj* child = un_80307BA0(parent_jobj, anim->xC);
-        HSD_JObjSetFlagsAll(child, 0x10);
+        HSD_JObjSetFlagsAll(child, JOBJ_HIDDEN);
         anim->x0E = 0;
     }
 
@@ -2547,17 +2547,17 @@ void un_80308DC8(HSD_CObj* cobj)
     if (temp_r30->x18 < 10.0F) {
         if (eye_pos.y < 0.0F) {
             temp_r31->x0E = 1;
-            HSD_JObjClearFlagsAll(temp_r31->jobj[1], 0x10);
-            HSD_JObjSetFlagsAll(temp_r31->jobj[0], 0x10);
+            HSD_JObjClearFlagsAll(temp_r31->jobj[1], JOBJ_HIDDEN);
+            HSD_JObjSetFlagsAll(temp_r31->jobj[0], JOBJ_HIDDEN);
         } else {
             temp_r31->x0E = 0;
-            HSD_JObjClearFlagsAll(temp_r31->jobj[0], 0x10);
-            HSD_JObjSetFlagsAll(temp_r31->jobj[1], 0x10);
+            HSD_JObjClearFlagsAll(temp_r31->jobj[0], JOBJ_HIDDEN);
+            HSD_JObjSetFlagsAll(temp_r31->jobj[1], JOBJ_HIDDEN);
         }
     } else {
         temp_r31->x0E = 1;
-        HSD_JObjClearFlagsAll(temp_r31->jobj[1], 0x10);
-        HSD_JObjSetFlagsAll(temp_r31->jobj[0], 0x10);
+        HSD_JObjClearFlagsAll(temp_r31->jobj[1], JOBJ_HIDDEN);
+        HSD_JObjSetFlagsAll(temp_r31->jobj[0], JOBJ_HIDDEN);
     }
 }
 
@@ -4732,8 +4732,8 @@ void fn_8030E110(HSD_GObj* arg0)
             }
 
             {
-                HSD_JObjSetFlagsAll(anim->jobj[0], 0x10U);
-                HSD_JObjSetFlagsAll(anim->jobj[1], 0x10U);
+                HSD_JObjSetFlagsAll(anim->jobj[0], JOBJ_HIDDEN);
+                HSD_JObjSetFlagsAll(anim->jobj[1], JOBJ_HIDDEN);
             }
 
             un_8030715C(state->x50, state->x54);

--- a/src/melee/ty/tydisplay.c
+++ b/src/melee/ty/tydisplay.c
@@ -1996,9 +1996,9 @@ void un_8031BF34(s32 arg0)
     un_80308250(base->x38, (s16) (u16) arg0, 0);
     un_804D6F2C = un_803087F4(base->x38);
 
-    HSD_JObjClearFlagsAll(anim->jobj[0], 0x10);
-    HSD_JObjSetFlagsAll(anim->jobj[1], 0x10);
-    HSD_JObjClearFlagsAll(anim->jobj[0], 0x10);
+    HSD_JObjClearFlagsAll(anim->jobj[0], JOBJ_HIDDEN);
+    HSD_JObjSetFlagsAll(anim->jobj[1], JOBJ_HIDDEN);
+    HSD_JObjClearFlagsAll(anim->jobj[0], JOBJ_HIDDEN);
 
     jobj = un_8031BF34_inline();
 

--- a/src/melee/ty/tyfigupon.c
+++ b/src/melee/ty/tyfigupon.c
@@ -598,7 +598,7 @@ void fn_80315C44(HSD_GObj* arg0)
                                    str_coin_shapeanim);
                 HSD_JObjReqAnimAll(jobj, 0.0f);
                 HSD_JObjAnimAll(jobj);
-                HSD_JObjSetFlagsAll(jobj, 0x10);
+                HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
                 HSD_GObj_SetupProc(gobj, tyFigupon_80314C5C, 0);
                 HSD_GObj_80390CD4(gobj);
                 gm_801623FC(gm_801623D8() - 0xA);
@@ -762,8 +762,8 @@ void un_80316420(s16 arg0)
     temp_r31 = un_803048C0(arg0);
     un_80308250(un_804D6EF8, arg0, 0);
     gobj = un_803087F4(un_804D6EF8);
-    HSD_JObjClearFlagsAll(aa8->jobj[0], 0x10);
-    HSD_JObjSetFlagsAll(aa8->jobj[1], 0x10);
+    HSD_JObjClearFlagsAll(aa8->jobj[0], JOBJ_HIDDEN);
+    HSD_JObjSetFlagsAll(aa8->jobj[1], JOBJ_HIDDEN);
     jobj = HSD_GObjGetHSDObj(gobj);
     HSD_JObjSetTranslateX(jobj, -1.8f);
     HSD_JObjSetTranslateY(jobj, 18.6f);
@@ -865,13 +865,13 @@ void fn_803168DC(HSD_GObj* arg0)
 
     if (data->gobj != NULL) {
         if (rot_y > 10.0f) {
-            HSD_JObjClearFlagsAll(data->jobj[0], 0x10);
-            HSD_JObjSetFlagsAll(data->jobj[1], 0x10);
+            HSD_JObjClearFlagsAll(data->jobj[0], JOBJ_HIDDEN);
+            HSD_JObjSetFlagsAll(data->jobj[1], JOBJ_HIDDEN);
             return;
         }
         if (rot_y < -10.0f) {
-            HSD_JObjClearFlagsAll(data->jobj[1], 0x10);
-            HSD_JObjSetFlagsAll(data->jobj[0], 0x10);
+            HSD_JObjClearFlagsAll(data->jobj[1], JOBJ_HIDDEN);
+            HSD_JObjSetFlagsAll(data->jobj[0], JOBJ_HIDDEN);
         }
     }
 }
@@ -1451,7 +1451,7 @@ void un_80317D80_OnEnter(void* arg0)
         GObj_InitUserData(data->x8, 0, Toy_RemoveUserData, ud);
     }
     GObj_SetupGXLink(data->x8, HSD_GObj_JObjCallback, 0x3D, 0);
-    HSD_JObjSetFlagsAll(jobj, 0x10);
+    HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
     {
         s8 var_r0;
         if (((u32) gm_801623D8() / 10u) != 0) {

--- a/src/melee/ty/tylist.c
+++ b/src/melee/ty/tylist.c
@@ -553,7 +553,7 @@ s32 un_8031305C(void* a, TyListState* state, s8 movedFlag)
                 state->x29E = (u8) (state->x29E - 1);
             }
             if ((s8) state->x29E == 0) {
-                HSD_JObjClearFlagsAll(state->x288, 0x10U);
+                HSD_JObjClearFlagsAll(state->x288, JOBJ_HIDDEN);
                 un_80312904(state->x278, (s8) state->x278->x24);
                 if (HSD_PadCopyStatus->button & 0xC00) {
                     state->pad_2A0 = 5;
@@ -932,7 +932,7 @@ void fn_80313BD8(HSD_GObj* gobj)
 
     if (un_GetTrophyTotal() > 10) {
         if (un_80305C44() & 0x400) {
-            HSD_JObjSetFlagsAll(state->x288, 0x10);
+            HSD_JObjSetFlagsAll(state->x288, JOBJ_HIDDEN);
             if (state->x274->idx == 0 ||
                 state->x274->links[0]->idx + 9 < un_GetTrophyTotal())
             {
@@ -945,7 +945,7 @@ void fn_80313BD8(HSD_GObj* gobj)
             return;
         }
         if (un_80305C44() & 0x800) {
-            HSD_JObjSetFlagsAll(state->x288, 0x10);
+            HSD_JObjSetFlagsAll(state->x288, JOBJ_HIDDEN);
             if (state->x270->idx == un_GetTrophyTotal() - 1 ||
                 state->x270->links[1]->idx - 9 > 0)
             {
@@ -1015,7 +1015,7 @@ void fn_80313BD8(HSD_GObj* gobj)
     for (i = 0; i < (s8) state->entryCount; i++, p++) {
         un_80312904(p, state->entryCount);
     }
-    HSD_JObjSetFlagsAll(state->x288, 0x10);
+    HSD_JObjSetFlagsAll(state->x288, JOBJ_HIDDEN);
     if (f31 > 0.0f) {
         un_80313358(state, 1, 6, 0);
     } else {


### PR DESCRIPTION
Split from #2670.
> Syntax-aware sweep of HSD_JObj{Set,Clear}Flags[All] call sites replacing raw hidden-flag literals (0x10 / 0x10U / 16 / 16U) in the flag argument with the named JOBJ_HIDDEN: 505 sites across 73 files. Composite masks and other flag values are untouched.
> 
> All 1046 compiled objects verified byte-identical before and after the change (per-object sha1); main.dol sha1 unchanged.