### PR TITLE
Use HSD assert macros for hand-expanded asserts

### DIFF
--- a/src/melee/cm/cmsnap.c
+++ b/src/melee/cm/cmsnap.c
@@ -16,9 +16,8 @@ static _cmsnap_data cmsnap_data;
 
 void cmSnap_800315C8(void)
 {
-    if (cmsnap_data.unk0 != 0) {
-        __assert("cmsnap.c", 0x55, "_p(status) == CmSnapStatus_Sleep");
-    }
+    HSD_ASSERTMSG(0x55, cmsnap_data.unk0 == 0,
+                  "_p(status) == CmSnapStatus_Sleep");
     cmsnap_data.unk0 = 1;
 }
 

--- a/src/melee/db/dbscreenshot.c
+++ b/src/melee/db/dbscreenshot.c
@@ -75,8 +75,7 @@ void db_TakeScreenshotIfPending(void)
         if (temp_r3 != -1) {
             var_r30 = HSD_VIData.xfb[temp_r3].buffer;
         } else {
-            OSReport("cant find xfb!\n");
-            ((0) ? ((void) 0) : __assert("dbscreenshot.c", 61, "0"));
+            HSD_ASSERTREPORT(61, 0, "cant find xfb!\n");
         }
         temp_r5 = db_ScreenshotNumber;
         db_ScreenshotNumber = temp_r5 + 1;

--- a/src/melee/ft/chara/ftCommon/ftpickupitem.c
+++ b/src/melee/ft/chara/ftCommon/ftpickupitem.c
@@ -158,10 +158,7 @@ Item_GObj* ftpickupitem_800942A0(Fighter_GObj* gobj, u32 flags)
 bool ftpickupitem_8009447C(Fighter_GObj* gobj, Item_GObj* item_gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    if (item_gobj == NULL) {
-        OSReport("ftGetImmItem item_gobj is NULL!!\n");
-        __assert(__FILE__, 174, "item_gobj");
-    }
+    HSD_ASSERTREPORT(174, item_gobj, "ftGetImmItem item_gobj is NULL!!\n");
     if (it_8026B30C(item_gobj) == 5) {
         switch (itGetKind(item_gobj)) {
         case It_Kind_Heart:
@@ -351,10 +348,7 @@ void ftpickupitem_80094B6C(Fighter_GObj* gobj, Item_GObj* item_gobj)
     Vec3 vec;
     Fighter* fp = gobj->user_data;
     PAD_STACK(4);
-    if (item_gobj == NULL) {
-        OSReport("ftGetImmItem item_gobj is NULL!!\n");
-        __assert(__FILE__, 399, "item_gobj");
-    }
+    HSD_ASSERTREPORT(399, item_gobj, "ftGetImmItem item_gobj is NULL!!\n");
     if (it_8026B30C(item_gobj) == 5) {
         switch (itGetKind(item_gobj)) {
         case It_Kind_Heart:

--- a/src/melee/ft/chara/ftYoshi/ftYs_Init.c
+++ b/src/melee/ft/chara/ftYoshi/ftYs_Init.c
@@ -398,8 +398,7 @@ void ftYs_Init_8012B6E8(Fighter* fp, struct S_UNK_YOSHI1* unk_struct_arg)
             attr_r26->xC = HSD_AObjGetEndFrame(aobj_r24);
         } else {
             if (attr_r26->xC != HSD_AObjGetEndFrame(aobj_r24)) {
-                OSReport("yoshi matanim frame not same\n");
-                __assert(__FILE__, 97, "0");
+                HSD_ASSERTREPORT(97, 0, "yoshi matanim frame not same\n");
             }
         }
     }
@@ -483,8 +482,7 @@ void ftYs_Init_OnLoad(HSD_GObj* gobj)
     other_attr = ft->ext_attr;
 
     if (!temp) {
-        OSReport("yoshi parts_model NULL!!\n");
-        __assert(__FILE__, 113, "0");
+        HSD_ASSERTREPORT(113, 0, "yoshi parts_model NULL!!\n");
     }
 
     other_attr->xC = 0.0f;

--- a/src/melee/ft/fighter.c
+++ b/src/melee/ft/fighter.c
@@ -716,8 +716,7 @@ void Fighter_UnkInitLoad_80068914(Fighter_GObj* gobj,
     fp->x2229_b1 = Player_GetFlagsAEBit0(fp->player_id);
 
     if (fp->x61A_controller_index > 4) {
-        OSReport("fighter sub color num over!\n");
-        __assert(__FILE__, 0x33C, "0");
+        HSD_ASSERTREPORT(0x33C, 0, "fighter sub color num over!\n");
     }
 
     if (fp->x61A_controller_index != 0) {
@@ -932,8 +931,7 @@ Fighter_GObj* Fighter_Create(struct plAllocInfo* input)
         if (!fp->no_normal_motion) {
             ftCommon_8007D92C(gobj);
         } else {
-            OSReport("ellegal flag fp->no_normal_motion\n");
-            __assert(__FILE__, 1065, "0");
+            HSD_ASSERTREPORT(1065, 0, "ellegal flag fp->no_normal_motion\n");
         }
     }
     ftLib_800867E8(gobj);
@@ -2415,9 +2413,9 @@ void Fighter_procUpdate(Fighter_GObj* gobj)
                               fpclassify(fp->cur_pos.y) == FP_NAN ||
                               fpclassify(fp->cur_pos.z) == FP_NAN))
     {
-        OSReport("fighter procUpdate pos error.\tpos.x=%f\tpos.y=%f\n",
-                 fp->cur_pos.x, fp->cur_pos.y);
-        __assert(__FILE__, /*line*/ 2517, "0");
+        HSD_ASSERTREPORT(/*line*/ 2517, 0,
+                         "fighter procUpdate pos error.\tpos.x=%f\tpos.y=%f\n",
+                         fp->cur_pos.x, fp->cur_pos.y);
     }
 }
 
@@ -2489,9 +2487,9 @@ void Fighter_procMap(Fighter_GObj* gobj)
             {
                 float x = Fighter_GetPosX(fp);
                 float y = Fighter_GetPosY(fp);
-                OSReport("fighter procMap pos error.\tpos.x=%f\tpos.y=%f\n", x,
-                         y);
-                __assert("fighter.c", 2590, "0");
+                HSD_ASSERTREPORT(
+                    2590, 0,
+                    "fighter procMap pos error.\tpos.x=%f\tpos.y=%f\n", x, y);
             }
         }
 
@@ -2883,8 +2881,8 @@ void Fighter_ProcessHit_8006D1EC(Fighter_GObj* gobj)
                     ftCh_Init_80156014(gobj);
                     break;
                 default:
-                    OSReport("ellegal flag fp->no_reaction_always\n");
-                    __assert(__FILE__, 3085, "0");
+                    HSD_ASSERTREPORT(3085, 0,
+                                     "ellegal flag fp->no_reaction_always\n");
                 }
                 ftCo_8008E9D0(gobj);
             }

--- a/src/melee/ft/ftattacks4combo.c
+++ b/src/melee/ft/ftattacks4combo.c
@@ -36,8 +36,7 @@ void ftCo_800CED30(Fighter_GObj* gobj)
             }
         } else {
         second:
-            OSReport("don't have smash42 motion!!!\n");
-            __assert("ftattacks4combo.c", 0x36, "0");
+            HSD_ASSERTREPORT(0x36, 0, "don't have smash42 motion!!!\n");
         }
     }
 third:

--- a/src/melee/ft/ftcamera.c
+++ b/src/melee/ft/ftcamera.c
@@ -104,9 +104,8 @@ void ftCamera_80076320(HSD_GObj* gobj)
     ftCamera_UpdateCameraBox(gobj); // Fighter_UpdateCameraBox
     Stage_UnkSetVec3TCam_Offset(&center_pos);
 
-    if (!(Stage_GetBlastZoneTopOffset() - center_pos.y != 0.0F)) {
-        __assert("ftcamera.c", 137, "stGetPlyDeadUp() - center_pos.y != 0.0F");
-    }
+    HSD_ASSERTMSG(137, Stage_GetBlastZoneTopOffset() - center_pos.y != 0.0F,
+                  "stGetPlyDeadUp() - center_pos.y != 0.0F");
 
     temp_f31 = Stage_GetBlastZoneTopOffset() - center_pos.y;
     temp_f1 = Stage_GetCamBoundsTopOffset() - center_pos.y;

--- a/src/melee/ft/ftchangeparam.c
+++ b/src/melee/ft/ftchangeparam.c
@@ -7,6 +7,7 @@
 
 float ftCo_CalcYScaledKnockback(float arg0, float scale, float arg2)
 {
+    /// @todo Convert to @c HSD_ASSERT once a byte-matching form is found.
     if (scale == 0.0F) {
         __assert("ftchangeparam.c", 0x1E, "scale != 0.0F");
     }
@@ -229,11 +230,8 @@ void ftCo_800D105C(Fighter_GObj* fgp)
         fp->co_attrs.weight *= Fighter_804D6518->x4;
     }
 
-    if (ftKindCalcIndiviParamTable[fp->kind] == NULL) {
-        OSReport("don\'t set ftKindCalcIndiviParamTable!!\n");
-        __assert("ftchangeparam.c", 0x10d,
-                 "ftKindCalcIndiviParamTable[fp->kind] != NULL");
-    }
+    HSD_ASSERTREPORT(0x10d, ftKindCalcIndiviParamTable[fp->kind] != NULL,
+                     "don\'t set ftKindCalcIndiviParamTable!!\n");
     ftKindCalcIndiviParamTable[fp->kind](fgp);
 
     if (fp->x2D0 != NULL) {

--- a/src/melee/ft/ftdata.c
+++ b/src/melee/ft/ftdata.c
@@ -1717,15 +1717,13 @@ void ftData_80085A14(FighterKind kind)
     if (ftData_Table_Unk0[kind].data == NULL) {
         lbFile_800168A0(1, ftData_803C23E4[kind], &sp18, &sp10);
         a_head = sp18;
-        if (a_head == 0) {
-            __assert("ftdata.c", 0x974, "a_head");
-        }
+        HSD_ASSERT(0x974, a_head);
         for (i = 0; i < (u32) ftData_Table_Unk0[kind].count; i++) {
             temp_r0 = temp_r27->xC[i].x8;
             if (temp_r0 != 0) {
                 if (temp_r0 > 0x8000) {
-                    OSReport("fighter figatree over! %x\n", temp_r0);
-                    __assert("ftdata.c", 0x9AF, "0");
+                    HSD_ASSERTREPORT(0x9AF, 0, "fighter figatree over! %x\n",
+                                     temp_r0);
                 }
                 temp_r27->xC[i].x14 = (a_head + temp_r27->xC[i].x4);
             }
@@ -1759,8 +1757,7 @@ void ftData_80085B98(Fighter* fp, int arg1, int arg2)
     fp->x5A8 = 0;
     fp->x58C = ftData_UnkIntPairs[fp->kind].count;
     if (arg2 >= fp->x58C) {
-        OSReport("Demo Status error! %d\n", arg2);
-        __assert("ftdata.c", 0x9D2, "0");
+        HSD_ASSERTREPORT(0x9D2, 0, "Demo Status error! %d\n", arg2);
     }
     if (temp_r30 != 0U) {
         for (i = arg1; i <= arg2; i++) {
@@ -1768,8 +1765,8 @@ void ftData_80085B98(Fighter* fp, int arg1, int arg2)
             temp_r0 = temp_r3->x8;
             if (temp_r3->x8 != 0U) {
                 if (temp_r0 > 0xB000) {
-                    OSReport("fighter figatree over! %x\n", temp_r0);
-                    __assert("ftdata.c", 0x9DC, "0");
+                    HSD_ASSERTREPORT(0x9DC, 0, "fighter figatree over! %x\n",
+                                     temp_r0);
                 }
                 temp_r3 = &fp->ft_data->x14[i];
                 temp_r3->x14 = temp_r30 + temp_r3->x4;
@@ -1805,8 +1802,8 @@ void ftData_80085CD8(Fighter* fp, Fighter* arg1, int msid)
                         &sp14, temp_r4->x0, temp_r3->x8,
                         (intptr_t) temp_r4 - (intptr_t) temp_r3_3->x59C);
                     if (temp_ret == -1) {
-                        OSReport("lbArchiveRelocate error! %x\n", msid);
-                        __assert("ftdata.c", 0x9FA, "0");
+                        HSD_ASSERTREPORT(
+                            0x9FA, 0, "lbArchiveRelocate error! %x\n", msid);
                     }
                 } else {
                     temp_r4_2 = temp_r3->x14;
@@ -1819,8 +1816,8 @@ void ftData_80085CD8(Fighter* fp, Fighter* arg1, int msid)
                     temp_ret_2 =
                         HSD_ArchiveParse(&sp14, fp->x59C->x0, temp_r3->x8);
                     if (temp_ret_2 == -1) {
-                        OSReport("HSD_ArchiveParse error! %x\n", msid);
-                        __assert("ftdata.c", 0xA0F, "0");
+                        HSD_ASSERTREPORT(0xA0F, 0,
+                                         "HSD_ArchiveParse error! %x\n", msid);
                     }
                 }
                 fp->x590 = HSD_ArchiveGetPublicAddress(&sp14, temp_r3->x0);
@@ -1858,8 +1855,8 @@ FigaTree* ftData_80085E50(Fighter* arg0, int msid)
                         &sp10, temp_r4->x0, temp_r3->x8,
                         (intptr_t) temp_r4 - (intptr_t) temp_r3_3->x59C);
                     if (temp_ret == -1) {
-                        OSReport("lbArchiveRelocate error! %x\n", msid);
-                        __assert("ftdata.c", 0xA30, "0");
+                        HSD_ASSERTREPORT(
+                            0xA30, 0, "lbArchiveRelocate error! %x\n", msid);
                     }
                 } else {
                     temp_r4_2 = temp_r3->x14;
@@ -1872,8 +1869,8 @@ FigaTree* ftData_80085E50(Fighter* arg0, int msid)
                     temp_ret_2 =
                         HSD_ArchiveParse(&sp10, arg0->x5A0->x0, temp_r3->x8);
                     if (temp_ret_2 == -1) {
-                        OSReport("HSD_ArchiveParse error! %x\n", msid);
-                        __assert("ftdata.c", 0xA45, "0");
+                        HSD_ASSERTREPORT(0xA45, 0,
+                                         "HSD_ArchiveParse error! %x\n", msid);
                     }
                 }
                 arg0->x598 = HSD_ArchiveGetPublicAddress(&sp10, temp_r3->x0);

--- a/src/melee/ft/ftdemo.c
+++ b/src/melee/ft/ftdemo.c
@@ -158,8 +158,7 @@ char* ftDemo_GetMotionFileString(int cb_idx, int cb_arg)
     if (ftData_803C24EC[cb_idx] != NULL) {
         return ftData_803C24EC[cb_idx](cb_arg);
     } else {
-        OSReport("no demo vi anim! %d\n", cb_arg);
-        __assert("ftdemo.c", 296, "0");
+        HSD_ASSERTREPORT(296, 0, "no demo vi anim! %d\n", cb_arg);
     }
 }
 

--- a/src/melee/ft/ftdevice.c
+++ b/src/melee/ft/ftdevice.c
@@ -60,8 +60,7 @@ void ftCo_800C06E8(Ground_GObj* gobj, int arg1, void* func)
             return;
         }
     }
-    OSReport("fighter chk device wind func num over!\n");
-    __assert("ftdevice.c", 0x49, "0");
+    HSD_ASSERTREPORT(0x49, 0, "fighter chk device wind func num over!\n");
 }
 
 void ftCo_800C0764(Ground_GObj* arg0, u32 arg1, void* arg2)
@@ -81,8 +80,7 @@ void ftCo_800C0764(Ground_GObj* arg0, u32 arg1, void* arg2)
         }
         ptr++;
     }
-    OSReport("fighter chk device catch func num over!\n");
-    __assert("ftdevice.c", 0x6FU, "0");
+    HSD_ASSERTREPORT(0x6FU, 0, "fighter chk device catch func num over!\n");
 }
 
 /// @todo pretty sure arg2 is a ftDevice callback, but unsure if its
@@ -104,6 +102,5 @@ void ftCo_800C07F8(Ground_GObj* arg0, u32 arg1, void* arg2)
         }
         ptr++;
     }
-    OSReport("fighter chk device coll func num over!\n");
-    __assert("ftdevice.c", 0x95, "0");
+    HSD_ASSERTREPORT(0x95, 0, "fighter chk device coll func num over!\n");
 }

--- a/src/melee/ft/ftdynamics.c
+++ b/src/melee/ft/ftdynamics.c
@@ -97,8 +97,7 @@ void ftCo_8009CF84(Fighter* fp)
     ftData* data = fp->ft_data;
     fp->dynamics_num = data->x2C->dynamicsNum;
     if (fp->dynamics_num >= Ft_Dynamics_NumMax) {
-        OSReport("fighter dynamics num over!\n");
-        __assert(__FILE__, 109, "0");
+        HSD_ASSERTREPORT(109, 0, "fighter dynamics num over!\n");
     }
     {
         ssize_t i;
@@ -119,10 +118,8 @@ void ftCo_8009D074(Fighter* fp)
 {
     KirbyHatStruct* hat = ft_80459B88.hats[FTKIND_KOOPA];
     fp->dynamics_num = hat->hat_dynamics[2]->dynamicsNum;
-    if (fp->dynamics_num >= Ft_Dynamics_NumMax) {
-        OSReport("fighter dynamics num over!\n");
-        __assert(__FILE__, 135, "fp->dynamics_num < Ft_Dynamics_NumMax");
-    }
+    HSD_ASSERTREPORT(135, fp->dynamics_num < Ft_Dynamics_NumMax,
+                     "fighter dynamics num over!\n");
     {
         ssize_t i;
         for (i = 0; i < fp->dynamics_num; i++) {
@@ -154,10 +151,8 @@ void ftCo_8009D18C(Fighter* fp)
 {
     KirbyHatStruct* hat = ft_80459B88.hats[FTKIND_ZELDA];
     fp->dynamics_num = hat->hat_dynamics[2]->dynamicsNum;
-    if (fp->dynamics_num >= Ft_Dynamics_NumMax) {
-        OSReport("fighter dynamics num over!\n");
-        __assert(__FILE__, 167, "fp->dynamics_num < Ft_Dynamics_NumMax");
-    }
+    HSD_ASSERTREPORT(167, fp->dynamics_num < Ft_Dynamics_NumMax,
+                     "fighter dynamics num over!\n");
     {
         ssize_t i;
         for (i = 0; i < fp->dynamics_num; i++) {
@@ -189,10 +184,8 @@ void ftCo_8009D2A4(Fighter* fp)
 {
     KirbyHatStruct* hat = ft_80459B88.hats[FTKIND_NANA];
     fp->dynamics_num = hat->hat_dynamics[2]->dynamicsNum;
-    if (fp->dynamics_num >= Ft_Dynamics_NumMax) {
-        OSReport("fighter dynamics num over!\n");
-        __assert(__FILE__, 199, "fp->dynamics_num < Ft_Dynamics_NumMax");
-    }
+    HSD_ASSERTREPORT(199, fp->dynamics_num < Ft_Dynamics_NumMax,
+                     "fighter dynamics num over!\n");
     {
         ssize_t i;
         for (i = 0; i < fp->dynamics_num; i++) {
@@ -224,10 +217,8 @@ void ftCo_8009D3BC(Fighter* fp)
 {
     KirbyHatStruct* hat = ft_80459B88.hats[FTKIND_FALCO];
     fp->dynamics_num = hat->hat_dynamics[2]->dynamicsNum;
-    if (fp->dynamics_num >= Ft_Dynamics_NumMax) {
-        OSReport("fighter dynamics num over!\n");
-        __assert(__FILE__, 232, "fp->dynamics_num < Ft_Dynamics_NumMax");
-    }
+    HSD_ASSERTREPORT(232, fp->dynamics_num < Ft_Dynamics_NumMax,
+                     "fighter dynamics num over!\n");
     {
         ssize_t i;
         for (i = 0; i < fp->dynamics_num; i++) {
@@ -259,10 +250,8 @@ void ftCo_8009D4D4(Fighter* fp)
 {
     KirbyHatStruct* hat = ft_80459B88.hats[FTKIND_KIRBY];
     fp->dynamics_num = hat->hat_dynamics[1]->dynamicsNum;
-    if (fp->dynamics_num >= Ft_Dynamics_NumMax) {
-        OSReport("fighter dynamics num over!\n");
-        __assert(__FILE__, 265, "fp->dynamics_num < Ft_Dynamics_NumMax");
-    }
+    HSD_ASSERTREPORT(265, fp->dynamics_num < Ft_Dynamics_NumMax,
+                     "fighter dynamics num over!\n");
     {
         ssize_t i;
         for (i = 0; i < fp->dynamics_num; i++) {
@@ -294,10 +283,8 @@ void ftCo_8009D5EC(Fighter* fp)
 {
     KirbyHatStruct* hat = ft_80459B88.hats[FTKIND_MARS];
     fp->dynamics_num = hat->hat_dynamics[0]->dynamicsNum;
-    if (fp->dynamics_num >= Ft_Dynamics_NumMax) {
-        OSReport("fighter dynamics num over!\n");
-        __assert(__FILE__, 298, "fp->dynamics_num < Ft_Dynamics_NumMax");
-    }
+    HSD_ASSERTREPORT(298, fp->dynamics_num < Ft_Dynamics_NumMax,
+                     "fighter dynamics num over!\n");
     {
         ssize_t i;
         for (i = 0; i < fp->dynamics_num; i++) {
@@ -329,10 +316,8 @@ void ftCo_8009D704(Fighter* fp)
 {
     KirbyHatStruct* hat = ft_80459B88.hats[FTKIND_LINK];
     fp->dynamics_num = hat->hat_dynamics[2]->dynamicsNum;
-    if (fp->dynamics_num >= Ft_Dynamics_NumMax) {
-        OSReport("fighter dynamics num over!\n");
-        __assert(__FILE__, 331, "fp->dynamics_num < Ft_Dynamics_NumMax");
-    }
+    HSD_ASSERTREPORT(331, fp->dynamics_num < Ft_Dynamics_NumMax,
+                     "fighter dynamics num over!\n");
     {
         ssize_t i;
         for (i = 0; i < fp->dynamics_num; i++) {
@@ -365,10 +350,8 @@ void ftCo_8009D81C(Fighter* fp)
     KirbyHatStruct* hat = ft_80459B88.hats[FTKIND_YOSHI];
     PAD_STACK(2 * 4);
     fp->dynamics_num = hat->hat_dynamics[3]->dynamicsNum;
-    if (fp->dynamics_num >= Ft_Dynamics_NumMax) {
-        OSReport("fighter dynamics num over!\n");
-        __assert(__FILE__, 364, "fp->dynamics_num < Ft_Dynamics_NumMax");
-    }
+    HSD_ASSERTREPORT(364, fp->dynamics_num < Ft_Dynamics_NumMax,
+                     "fighter dynamics num over!\n");
     {
         ssize_t i;
         for (i = 0; i < fp->dynamics_num; i++) {
@@ -390,10 +373,8 @@ void ftCo_8009D920(Fighter* fp)
 {
     KirbyHatStruct* hat = ft_80459B88.hats[FTKIND_LUIGI];
     fp->dynamics_num = hat->hat_dynamics[1]->dynamicsNum;
-    if (fp->dynamics_num >= Ft_Dynamics_NumMax) {
-        OSReport("fighter dynamics num over!\n");
-        __assert(__FILE__, 388, "fp->dynamics_num < Ft_Dynamics_NumMax");
-    }
+    HSD_ASSERTREPORT(388, fp->dynamics_num < Ft_Dynamics_NumMax,
+                     "fighter dynamics num over!\n");
     {
         ssize_t i;
         for (i = 0; i < fp->dynamics_num; i++) {
@@ -427,10 +408,8 @@ void ftCo_8009DA38(Fighter* fp)
 {
     KirbyHatStruct* hat = ft_80459B88.hats[FTKIND_GANON];
     fp->dynamics_num = hat->hat_dynamics[1]->dynamicsNum;
-    if (fp->dynamics_num >= Ft_Dynamics_NumMax) {
-        OSReport("fighter dynamics num over!\n");
-        __assert(__FILE__, 421, "fp->dynamics_num < Ft_Dynamics_NumMax");
-    }
+    HSD_ASSERTREPORT(421, fp->dynamics_num < Ft_Dynamics_NumMax,
+                     "fighter dynamics num over!\n");
     {
         ssize_t i;
         for (i = 0; i < fp->dynamics_num; i++) {
@@ -484,10 +463,8 @@ void ftCo_8009DC54(Fighter* fp)
         return;
     }
     fp->dynamics_num = 3;
-    if (fp->dynamics_num >= Ft_Dynamics_NumMax) {
-        OSReport("fighter dynamics num over!\n");
-        __assert(__FILE__, 490, "fp->dynamics_num < Ft_Dynamics_NumMax");
-    }
+    HSD_ASSERTREPORT(490, fp->dynamics_num < Ft_Dynamics_NumMax,
+                     "fighter dynamics num over!\n");
     {
         ssize_t i;
         for (i = 0; i < 2; i++) {
@@ -521,10 +498,8 @@ void ftCo_8009DB50(Fighter* fp)
     KirbyHatStruct* hat = ft_80459B88.hats[FTKIND_PURIN];
     PAD_STACK(2 * 4);
     fp->dynamics_num = hat->hat_dynamics[4]->dynamicsNum;
-    if (fp->dynamics_num >= Ft_Dynamics_NumMax) {
-        OSReport("fighter dynamics num over!\n");
-        __assert(__FILE__, 455, "fp->dynamics_num < Ft_Dynamics_NumMax");
-    }
+    HSD_ASSERTREPORT(455, fp->dynamics_num < Ft_Dynamics_NumMax,
+                     "fighter dynamics num over!\n");
     {
         ssize_t i;
         for (i = 0; i < fp->dynamics_num; i++) {

--- a/src/melee/ft/ftlib.c
+++ b/src/melee/ft/ftlib.c
@@ -1044,9 +1044,7 @@ float ftLib_8008777C(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
 
-    if (fp->ground_or_air != GA_Ground) {
-        __assert("ftlib.c", 1517, "fp->ground_or_air == GA_Ground");
-    }
+    HSD_ASSERT(1517, fp->ground_or_air == GA_Ground);
 
     {
         CollData* cd = Fighter_GetCollData(fp);

--- a/src/melee/ft/ftmetal.c
+++ b/src/melee/ft/ftmetal.c
@@ -221,8 +221,8 @@ void ft_800C85B8(Fighter_GObj* gobj)
                         break;
                     }
                     if (var_r26 >= 0x20) {
-                        OSReport("fighter parts model dobj num over!\n");
-                        __assert("ftmetal.c", 0xF8, "0");
+                        HSD_ASSERTREPORT(
+                            0xF8, 0, "fighter parts model dobj num over!\n");
                     }
                     temp_r28->x203C.data[var_r26] = var_r24_2;
                     {
@@ -236,8 +236,7 @@ void ft_800C85B8(Fighter_GObj* gobj)
                     i++;
                 }
                 if (i >= 0x80) {
-                    OSReport("fighter dobj num over!\n");
-                    __assert("ftmetal.c", 0x106, "0");
+                    HSD_ASSERTREPORT(0x106, 0, "fighter dobj num over!\n");
                 }
                 temp_r28->parts[i].xD = var_r26 - 1;
                 temp_r28->parts[i].flags2_b6 = true;

--- a/src/melee/ft/ftswing.c
+++ b/src/melee/ft/ftswing.c
@@ -42,8 +42,7 @@ int fn_800CCEC4(int x)
     case 23:
         return 5;
     default:
-        OSReport("ellegal swing item!!!\n");
-        __assert("ftswing.c", 82, "0");
+        HSD_ASSERTREPORT(82, 0, "ellegal swing item!!!\n");
     }
 }
 

--- a/src/melee/gm/gmmain.c
+++ b/src/melee/gm/gmmain.c
@@ -110,9 +110,8 @@ static void gmMain_8015FDA4(void)
             db_804D6B20 = false;
         }
     } else {
-        if (g_debugLevel != DbLKind_NoDebugRom) {
-            __assert(__FILE__, 0xD2, "DbLevel == DbLKind_NoDebugRom");
-        }
+        HSD_ASSERTMSG(0xD2, g_debugLevel == DbLKind_NoDebugRom,
+                      "DbLevel == DbLKind_NoDebugRom");
         g_debugLevel = 0;
     }
 }

--- a/src/melee/gm/gmregcommon.c
+++ b/src/melee/gm/gmregcommon.c
@@ -70,9 +70,9 @@ void gmRegSetupEnemyColorTable(s8 ckind, u8 color, s8* ckinds, u8* colors)
             }
         }
         if (colors[i] == 0xFF) {
-            OSReport(
+            HSD_ASSERTREPORT(
+                0xDA, 0,
                 "Error : not find color in gmRegSetupEnemyColorTable()\n");
-            __assert(__FILE__, 0xDA, "0");
         }
     }
 }

--- a/src/melee/gr/grinishie1.c
+++ b/src/melee/gr/grinishie1.c
@@ -503,7 +503,7 @@ void grInishie1_801FB0AC(HSD_GObj* gobj, u32 index)
         gp->gv.inishie1.xD8 = grI1_804D69F8->unk10;
     } else {
         if (gp->gv.inishie1.blocks[index].hatena_gobj != NULL) {
-            __assert("grinishie1.c", 0x29D, "0");
+            HSD_ASSERT(0x29D, 0);
         }
     }
 }
@@ -683,9 +683,8 @@ void grInishie1_801FBAA0(HSD_GObj* gobj, s32 index)
         return;
     }
 
-    if (slot->hatena_gobj != NULL) {
-        __assert("grinishie1.c", 0x39E, "!mapgp->u.map.block[ix].hatena_gobj");
-    }
+    HSD_ASSERTMSG(0x39E, !slot->hatena_gobj,
+                  "!mapgp->u.map.block[ix].hatena_gobj");
 
     slot->hatena_gobj = hatena;
 

--- a/src/melee/gr/grkongo.c
+++ b/src/melee/gr/grkongo.c
@@ -1271,7 +1271,7 @@ f32 grKongo_801D8314(void)
                                     if (temp_r3_8 < 0) {
                                         var_f31 = -3.1415927f;
                                     } else {
-                                        __assert("grkongo.c", 1753, "0");
+                                        HSD_ASSERT(1753, 0);
                                     }
                                 }
                             }

--- a/src/melee/gr/gronett.c
+++ b/src/melee/gr/gronett.c
@@ -177,9 +177,7 @@ void grOnett_801E3930(Ground_GObj* gobj)
     mpJointSetCb1(0, gp, grOnett_801E54B4);
     mpJointSetCb1(1, gp, grOnett_801E54B4);
     gp->gv.onett.subject = Camera_80029020();
-    if (gp->gv.onett.subject == NULL) {
-        __assert("gronett.c", 331, "gp->u.map.subject");
-    }
+    HSD_ASSERTMSG(331, gp->gv.onett.subject, "gp->u.map.subject");
     gp->gv.onett.subject->x40.x = -40.0f;
     gp->gv.onett.subject->x40.y = 40.0f;
     gp->gv.onett.subject->x48.x = 20.0f;

--- a/src/melee/gr/ground.c
+++ b/src/melee/gr/ground.c
@@ -1182,12 +1182,8 @@ LightList** Ground_801C20E0(UnkArchiveStruct* archive, LightList** lights)
     s32 b6, b7, b5;
     s32 matched;
 
-    if (lights == NULL) {
-        __assert(__FILE__, 0x773, lightset);
-    }
-    if (*lights == NULL) {
-        __assert(__FILE__, 0x774, plightset);
-    }
+    HSD_ASSERTMSG(0x773, lights, lightset);
+    HSD_ASSERTMSG(0x774, *lights, plightset);
 
     walker = lights;
     matched = 0;
@@ -1303,9 +1299,7 @@ void Ground_801C2374(HSD_LObj* lobj)
 HSD_Spline* Ground_801C247C(s32 arg0, s32 arg1)
 {
     UnkArchiveStruct* archive = grDatFiles_801C6330(arg0);
-    if (archive == NULL) {
-        __assert(__FILE__, 0x7E1, Ground_804D44F8);
-    }
+    HSD_ASSERTMSG(0x7E1, archive, Ground_804D44F8);
     if (archive->unk4 != NULL && arg1 < archive->unk4->unk14) {
         return archive->unk4->unk10[arg1];
     } else {
@@ -2004,9 +1998,7 @@ void Ground_801C36F4(int map_id, HSD_JObj* root, UNK_T joint)
     u32 unused[4];
 
     archive = grDatFiles_801C6330(map_id);
-    if (archive == NULL) {
-        __assert(__FILE__, 2936, "archive");
-    }
+    HSD_ASSERT(2936, archive);
     if (root == NULL || joint == NULL) {
         OSReport("%s:%d:Error (root=%08x joint=%08x)\n", __FILE__, __FILE__,
                  root, joint);

--- a/src/melee/gr/grpstadium.c
+++ b/src/melee/gr/grpstadium.c
@@ -969,7 +969,7 @@ void grStadium_801D2528(Ground_GObj* gobj, int arg1, int arg2)
         case 4:
         case 5:
         case 6:
-            __assert("grpstadium.c", 0x536, "0");
+            HSD_ASSERT(0x536, 0);
             break;
         }
     }

--- a/src/melee/gr/grpushon.c
+++ b/src/melee/gr/grpushon.c
@@ -471,7 +471,7 @@ int grPushOn_80219230(int arg0)
         }
         i++;
     }
-    __assert("grpushon.c", 0x35DU, "0");
+    HSD_ASSERT(0x35DU, 0);
 }
 
 void grPushOn_80218888(Ground_GObj* arg0)
@@ -528,7 +528,7 @@ void grPushOn_80218888(Ground_GObj* arg0)
                 }
                 sp60[i] = dx;
             } else {
-                __assert("grpushon.c", 0x1C5, "0");
+                HSD_ASSERT(0x1C5, 0);
             }
             if (sp60[i] < 10.0f) {
                 sp60[i] = 10.0f;

--- a/src/melee/gr/grzakogenerator.c
+++ b/src/melee/gr/grzakogenerator.c
@@ -128,9 +128,7 @@ grZakoGenerator_Data* grZakoGenerator_801CA67C(void)
     int i;
     PAD_STACK(8);
 
-    if (data == NULL) {
-        __assert("grzakogenerator.c", 0x52, "pointp");
-    }
+    HSD_ASSERTMSG(0x52, data, "pointp");
 
     for (i = 0; i < 80; i++) {
         data->entries[i].x0 = i + 0x20;

--- a/src/melee/gr/stage.c
+++ b/src/melee/gr/stage.c
@@ -323,7 +323,7 @@ s32 Stage_80225074(s32 arg0)
     } else if (arg0 == 1) {
         r31 = 0x44;
     } else {
-        __assert(__FILE__, 526, "0");
+        HSD_ASSERT(526, 0);
     }
 
     tmp = Ground_801C28AC(unk_struct_804D49E8.list_idx, r31, &spC);

--- a/src/melee/if/textlib.c
+++ b/src/melee/if/textlib.c
@@ -90,8 +90,7 @@ DevText* DevText_Create(char id, int x, int y, int w, int h, char* buf)
     }
     if (text == NULL) {
         // HSD_ASSERT
-        OSReport("TW : Screen alloc Fail\n");
-        __assert("textlib.c", 309, "0");
+        HSD_ASSERTREPORT(309, 0, "TW : Screen alloc Fail\n");
     }
     if (text != NULL) {
         text->x = x;

--- a/src/melee/it/itanimlist.c
+++ b/src/melee/it/itanimlist.c
@@ -99,8 +99,7 @@ void it_802790C0(Item_GObj* item_gobj, CommandInfo* cmd)
     bone_idx = cmd->u->it_create_hitbox_0.bone;
     if (bone_idx != 0) {
         if (item->xBBC_dynamicBoneTable == NULL) {
-            OSReport("item can\'t set attack!\n");
-            __assert("itanimlist.c", 0x8B, "0");
+            HSD_ASSERTREPORT(0x8B, 0, "item can\'t set attack!\n");
         }
         hit->jobj = item->xBBC_dynamicBoneTable->bones[bone_idx];
     } else {

--- a/src/melee/it/itcoll.c
+++ b/src/melee/it/itcoll.c
@@ -1032,8 +1032,7 @@ void it_8027163C(Item_GObj* item_gobj)
     it_dynams = (ItCollDynamics*) article->x14_dynamics;
     if (it_hurtbox != NULL) {
         if (it_hurtbox->count > 2) {
-            OSReport("item hit num over!\n");
-            __assert("itcoll.c", 0x3F4, "0");
+            HSD_ASSERTREPORT(0x3F4, 0, "item hit num over!\n");
         }
         cnt = 0U;
         item->xAC8_hurtboxNum = it_hurtbox->count;
@@ -1044,8 +1043,7 @@ void it_8027163C(Item_GObj* item_gobj)
             item->xACC_itemHurtbox[index].state = HurtCapsule_Enabled;
             if (hurt_dyn_desc->bone_id != 0) {
                 if (item->xBBC_dynamicBoneTable == NULL) {
-                    OSReport("item can't init hit!\n");
-                    __assert("itcoll.c", 0x402, "0");
+                    HSD_ASSERTREPORT(0x402, 0, "item can't init hit!\n");
                 }
                 hurt->bone =
                     item->xBBC_dynamicBoneTable->bones[hurt_dyn_desc->bone_id];
@@ -1063,8 +1061,7 @@ void it_8027163C(Item_GObj* item_gobj)
     }
     if (it_dynams != NULL) {
         if ((s32) it_dynams->count > 2) {
-            OSReport("item dynamics hit num over!\n");
-            __assert("itcoll.c", 0x415, "0");
+            HSD_ASSERTREPORT(0x415, 0, "item dynamics hit num over!\n");
         }
         cnt = 0U;
         item->xB68 = it_dynams->count;

--- a/src/melee/it/item.c
+++ b/src/melee/it/item.c
@@ -557,8 +557,8 @@ void Item_80267978(HSD_GObj* gobj)
         item_data->xC4_article_data = it_804A0F60[idx];
         item_data->xB8_itemLogicTable = &it_803F4D20[idx];
         if (item_data->xC4_article_data == NULL) {
-            OSReport("not found zako model data! check ground dat file!\n");
-            __assert("item.c", 686, "0");
+            HSD_ASSERTREPORT(
+                686, 0, "not found zako model data! check ground dat file!\n");
         }
     }
     item_data->xBC_itemStateContainer = item_data->xB8_itemLogicTable->states;
@@ -1994,8 +1994,7 @@ void Item_8026A8EC(Item_GObj* gobj)
     Item* ip = (Item*) HSD_GObjGetUserData(gobj);
 
     if (!it_80272D1C(gobj) || ip == NULL) {
-        OSReport("===== Not Found Item_Struct!! =====\n");
-        __assert("item.c", 2405, "0");
+        HSD_ASSERTREPORT(2405, 0, "===== Not Found Item_Struct!! =====\n");
     }
 
     it_802725D4(gobj);

--- a/src/melee/it/items/itzgshell.c
+++ b/src/melee/it/items/itzgshell.c
@@ -700,8 +700,8 @@ void it_802DF230(Item_GObj* gobj)
     } else {
         f32 factor;
         if (angle > 2147483600.0f || angle < -2147483600.0f) {
-            OSReport("*** ZGShell Restoration Rot Y Irregul!\n");
-            __assert("itzgshell.c", 0x3A1, "0");
+            HSD_ASSERTREPORT(0x3A1, 0,
+                             "*** ZGShell Restoration Rot Y Irregul!\n");
         }
         angle = (f32) ((s32) angle % 360);
         HSD_JObjSetRotationY(jobj, deg_to_rad * angle);

--- a/src/melee/it/itmaplib.c
+++ b/src/melee/it/itmaplib.c
@@ -111,8 +111,7 @@ void it_80275BC8(Item_GObj* item_gobj, HSD_GObj* arg_gobj)
             it_8026BB88(arg_gobj, &sp14);
             break;
         default:
-            OSReport("couldn't get Owner_GObj_Kind!!");
-            __assert("itmaplib.c", 0x7FU, "0");
+            HSD_ASSERTREPORT(0x7FU, 0, "couldn't get Owner_GObj_Kind!!");
             break;
         }
     } else {

--- a/src/melee/lb/lbcardgame.c
+++ b/src/melee/lb/lbcardgame.c
@@ -105,9 +105,7 @@ u32 lb_8001C87C(void)
 
 int lb_8001C8BC(void)
 {
-    if (!lb_80433318.enable) {
-        __assert("lbcardgame.c", 0x140, "_p(enable)");
-    }
+    HSD_ASSERTMSG(0x140, lb_80433318.enable, "_p(enable)");
 
     return lb_8001BC18(0, "SuperSmashBros0110290334", (void**) &lb_803BAB74,
                        &lb_803BAB60, lb_8001C658(), lb_8001C820(),
@@ -232,9 +230,7 @@ void lb_8001CDB4(void)
 
 void lb_8001CE00(void)
 {
-    if (!lb_80433318.enable) {
-        __assert("lbcardgame.c", 0x2A3, "_p(enable)");
-    }
+    HSD_ASSERTMSG(0x2A3, lb_80433318.enable, "_p(enable)");
     *gm_GetPowerTime() += gmMainLib_8015FC74();
     lb_80433318.xC = true;
 }

--- a/src/melee/lb/lbcardnew.c
+++ b/src/melee/lb/lbcardnew.c
@@ -51,9 +51,7 @@ struct CardTask* lb_80019C38(void)
             break;
         }
     }
-    if (i == 0xB) {
-        __assert("lbcardnew.c", 0x154, "i != LbCardNewTaskArray_Max");
-    }
+    HSD_ASSERTMSG(0x154, i != 0xB, "i != LbCardNewTaskArray_Max");
     return result;
 }
 
@@ -250,9 +248,7 @@ int lb_8001A184(void)
         if (lb_80432A68.unk_10 != NULL) {
             *(s32*) lb_80432A68.unk_10 = 0;
         }
-        if (lb_80432A68.work_area == NULL) {
-            __assert("lbcardnew.c", 0x23F, "_p(work_area)");
-        }
+        HSD_ASSERTMSG(0x23F, lb_80432A68.work_area, "_p(work_area)");
         enabled = OSDisableInterrupts();
         did_disable = 1;
         mount_result = CARDMountAsync(lb_80432A68.chan, lb_80432A68.work_area,
@@ -371,9 +367,7 @@ int lb_8001A594(char* filename, void* file_entries)
                 open_result = CARDOpen(lb_80432A68.chan, filename,
                                        &lb_80432A68.file_info);
                 CARDClose(&lb_80432A68.file_info);
-                if (lb_80432A68.lib_area == NULL) {
-                    __assert("lbcardnew.c", 0x2C8, "_p(lib_area)");
-                }
+                HSD_ASSERTMSG(0x2C8, lb_80432A68.lib_area, "_p(lib_area)");
                 hsd_803B24E4(&lb_80432A68.unk_A8, lb_80432A68.chan, 0x2000,
                              lb_80432A68.lib_area);
                 if (open_result == 0) {

--- a/src/melee/lb/lbdvd.c
+++ b/src/melee/lb/lbdvd.c
@@ -142,16 +142,13 @@ void* lbDvd_80017740(int type, int entry_num, int transient_heap, int heap,
         }
     }
 
-    if (free_index == -1) {
-        __assert("lbdvd.c", 0x1C1, "free_index != -1");
-    }
+    HSD_ASSERT(0x1C1, free_index != -1);
     entry = &preloadCache.entries[free_index];
     entry->state = 1;
     entry->type = type;
     entry->entry_num = entry_num;
     if (lbHeap_80015BB8(heap)) {
-        OSReport("%d, %d\n", heap, entry_num);
-        __assert("lbdvd.c", 0x1CB, "0");
+        HSD_ASSERTREPORT(0x1CB, 0, "%d, %d\n", heap, entry_num);
     }
     entry->heap = heap;
     entry->size = size;
@@ -331,7 +328,7 @@ void lbDvd_80017E64(int key, int index, void* value, bool cancelflag)
 {
     PreloadEntry* preloadEntry = &preloadCache.entries[index];
     if (cancelflag != 0) {
-        __assert(__FILE__, 827, "0");
+        HSD_ASSERT(827, 0);
     } else {
         preloadEntry->state = 3;
     }
@@ -389,7 +386,7 @@ void* lbDvd_GetPreloadedArchive(ssize_t entry_num)
             break;
 
         default:
-            __assert(__FILE__, 864, "0");
+            HSD_ASSERT(864, 0);
             break;
         }
 
@@ -447,8 +444,7 @@ HSD_Archive* lbDvd_8001819C(const char* basename)
     char* filename = lbFile_80016204(basename);
     archive = lbDvd_GetPreloadedArchive(DVDConvertPathToEntrynum(filename));
     if (g_debugLevel != 0 && preloadCache.preloaded && archive == NULL) {
-        OSReport("[LbDvd] %s is not PRELOADed.\n", filename);
-        __assert(__FILE__, 948, "0");
+        HSD_ASSERTREPORT(948, 0, "[LbDvd] %s is not PRELOADed.\n", filename);
     }
     return archive;
 }

--- a/src/melee/lb/lbheap.c
+++ b/src/melee/lb/lbheap.c
@@ -229,9 +229,7 @@ void lbHeap_80015CA8(int arg0, void* arg1)
     int enabled = OSDisableInterrupts();
     struct Heap* p = &lbHeap_80431FA0.heap_array[arg0];
 
-    if (p->status != 0) {
-        __assert("lbheap.c", 0x143, "p->status == LbHeapStatus_Create");
-    }
+    HSD_ASSERTMSG(0x143, p->status == 0, "p->status == LbHeapStatus_Create");
     if (p->type == 0) {
         int cur_heap = HSD_GetHeap();
         HSD_SetHeap(p->id);

--- a/src/melee/lb/lbshadow.c
+++ b/src/melee/lb/lbshadow.c
@@ -110,9 +110,7 @@ void lbShadow_8000ED54(LbShadow* lbshadow, HSD_JObj* jobj)
 {
     HSD_Shadow* shadow;
 
-    if (lbshadow == NULL) {
-        __assert("lbshadow.c", 0x36, "lbshadow");
-    }
+    HSD_ASSERT(0x36, lbshadow);
     shadow = HSD_ShadowAlloc();
     if (shadow != NULL) {
         HSD_CObjSetProjectionType(shadow->camera, PROJ_ORTHO);
@@ -139,9 +137,7 @@ void lbShadow_8000ED54(LbShadow* lbshadow, HSD_JObj* jobj)
 
 void lbShadow_8000EE8C(LbShadow* lbshadow)
 {
-    if (lbshadow == NULL) {
-        __assert("lbshadow.c", 0x62U, "lbshadow");
-    }
+    HSD_ASSERT(0x62U, lbshadow);
     if (lbshadow->shadow != NULL) {
         HSD_ShadowRemove(lbshadow->shadow);
     }

--- a/src/melee/mn/mndeflicker.c
+++ b/src/melee/mn/mndeflicker.c
@@ -141,7 +141,7 @@ void mnDeflicker_8024A4BC(HSD_GObj* arg0)
     HSD_GObjProc* proc;
     HSD_JObj* jobj;
     u8 temp_r29;
-    Menu* menu;
+    Menu* user_data;
     PAD_STACK(4);
 
     gobj = GObj_Create(HSD_GOBJ_CLASS_ITEM, 7U, 0x80);
@@ -155,17 +155,14 @@ void mnDeflicker_8024A4BC(HSD_GObj* arg0)
                        mnDeflicker_804A08B8.shapeanim_joint);
     HSD_JObjReqAnimAll(jobj, 0.0F);
     HSD_JObjAnimAll(jobj);
-    menu = HSD_MemAlloc(8);
-    if (menu == NULL) {
-        OSReport("Can't get user_data.\n");
-        __assert("mndeflicker.c", 344, "user_data");
-    }
-    menu->cursor = gmMainLib_8015F4E8();
-    menu->text = NULL;
-    GObj_InitUserData(gobj, 0, HSD_Free, menu);
+    user_data = HSD_MemAlloc(8);
+    HSD_ASSERTREPORT(344, user_data, "Can't get user_data.\n");
+    user_data->cursor = gmMainLib_8015F4E8();
+    user_data->text = NULL;
+    GObj_InitUserData(gobj, 0, HSD_Free, user_data);
     proc = HSD_GObj_SetupProc(gobj, mnDeflicker_8024A3E8, 0U);
     proc->flags_3 = HSD_GObj_804D783C;
-    temp_r29 = menu->cursor;
+    temp_r29 = user_data->cursor;
     lb_80011E24(GET_JOBJ(gobj), &sp1C, 5, -1);
     HSD_JObjReqAnimAll(sp1C, (f32) temp_r29);
     mn_8022F3D8(sp1C, 0xFF, 0x20);

--- a/src/melee/mn/mnhyaku.c
+++ b/src/melee/mn/mnhyaku.c
@@ -164,6 +164,8 @@ inline static Menu* allocMenu(u8 arg0, HSD_GObj* gobj)
     Menu* user_data;
 
     user_data = HSD_MemAlloc(8);
+    /// @todo Convert to @c HSD_ASSERTREPORT once a byte-matching form is
+    /// found.
     if (user_data == NULL) {
         OSReport("Can't get user_data.\n");
         __assert(__FILE__, 360, "user_data");

--- a/src/melee/mn/mnlanguage.c
+++ b/src/melee/mn/mnlanguage.c
@@ -173,10 +173,7 @@ void mnLanguage_8024C3C4(HSD_GObj* arg0_unused)
     HSD_JObjReqAnimAll(jobj, 0.0F);
     HSD_JObjAnimAll(jobj);
     user_data = HSD_MemAlloc(8);
-    if (user_data == NULL) {
-        OSReport("Can't get user_data.\n");
-        __assert("mnlanguage.c", 0x163, "user_data");
-    }
+    HSD_ASSERTREPORT(0x163, user_data, "Can't get user_data.\n");
     lang = lbLang_GetSavedLanguage();
     user_data->x0 = lang;
     user_data->x1 = lang;

--- a/src/melee/mn/mnmain.c
+++ b/src/melee/mn/mnmain.c
@@ -888,7 +888,7 @@ HSD_GObj* mn_80229DC0(void)
     HSD_JObj* sp8;
     HSD_GObj* temp_r31;
     HSD_JObj* temp_r3;
-    MainMenuPanelData* data;
+    MainMenuPanelData* user_data;
     u8 tmp;
 
     temp_r31 = GObj_Create(5, 6, 0x80);
@@ -911,16 +911,13 @@ HSD_GObj* mn_80229DC0(void)
                            mn_803EAE8C[mn_804A04F0.cur_menu][2].start_frame);
     }
     HSD_JObjAnimAll(sp8);
-    data = HSD_MemAlloc(4);
-    if (data == NULL) {
-        OSReport("Can't get user_data.\n");
-        __assert("mnmain.c", 0x427, "user_data");
-    }
-    GObj_InitUserData(temp_r31, 0, mn_8022EB04, data);
+    user_data = HSD_MemAlloc(4);
+    HSD_ASSERTREPORT(0x427, user_data, "Can't get user_data.\n");
+    GObj_InitUserData(temp_r31, 0, mn_8022EB04, user_data);
     tmp = mn_804A04F0.cur_menu;
-    data->cur_menu = tmp;
-    data->prev_menu = tmp;
-    data->state = 0;
+    user_data->cur_menu = tmp;
+    user_data->prev_menu = tmp;
+    user_data->state = 0;
     return temp_r31;
 }
 
@@ -1407,7 +1404,7 @@ HSD_GObj* mn_8022B3A0(u8 state)
     u8 option_count;
     u8 cur_menu;
     MenuKind menu_kind;
-    MainMenuData* data;
+    MainMenuData* user_data;
     AnimLoopSettings* anim_loop;
     int i;
     HSD_JObj* jobj;
@@ -1438,36 +1435,33 @@ HSD_GObj* mn_8022B3A0(u8 state)
     HSD_JObjAddAnimAll(root_jobj, top->animjoint, top->matanim_joint,
                        top->shapeanim_joint);
     HSD_JObjReqAnimAll(root_jobj, 0.0F);
-    data = HSD_MemAlloc(sizeof(MainMenuData));
-    if (data == NULL) {
-        OSReport("Can't get user_data.\n");
-        __assert("mnmain.c", 0x65D, "user_data");
-    }
-    GObj_InitUserData(gobj, 0, mn_8022EB04, data);
-    data->menu_kind = mn_804A04F0.cur_menu;
-    data->hovered_selection = mn_804A04F0.hovered_selection;
-    data->state = state;
-    data->description = NULL;
+    user_data = HSD_MemAlloc(sizeof(MainMenuData));
+    HSD_ASSERTREPORT(0x65D, user_data, "Can't get user_data.\n");
+    GObj_InitUserData(gobj, 0, mn_8022EB04, user_data);
+    user_data->menu_kind = mn_804A04F0.cur_menu;
+    user_data->hovered_selection = mn_804A04F0.hovered_selection;
+    user_data->state = state;
+    user_data->description = NULL;
     for (idx = 0; idx < 0x2A; idx++) {
-        lb_80011E24(root_jobj, &data->tree[idx], idx, -1);
+        lb_80011E24(root_jobj, &user_data->tree[idx], idx, -1);
     }
-    if (data->state != MENU_STATE_IDLE) {
-        switch (data->state) {
+    if (user_data->state != MENU_STATE_IDLE) {
+        switch (user_data->state) {
         case MENU_STATE_EXIT_TO:
         case MENU_STATE_ENTER_TO:
-            HSD_JObjReqAnim(data->tree[3], mn_803EB39C.start_frame);
+            HSD_JObjReqAnim(user_data->tree[3], mn_803EB39C.start_frame);
             break;
         case MENU_STATE_EXIT_FROM:
-            HSD_JObjReqAnim(data->tree[3], mn_803EB3B4.start_frame);
+            HSD_JObjReqAnim(user_data->tree[3], mn_803EB3B4.start_frame);
             break;
         case MENU_STATE_ENTER_FROM:
         case MENU_STATE_5:
             break;
         }
-        HSD_JObjAnim(data->tree[3]);
+        HSD_JObjAnim(user_data->tree[3]);
     }
     for (i = 0; i < option_count; i++) {
-        sp48[i] = data->tree[mn_803EAE68[i]];
+        sp48[i] = user_data->tree[mn_803EAE68[i]];
     }
     for (i = 0; i < option_count; i++) {
         StaticModelDesc* top = &MenMainCursor_Top;
@@ -1515,22 +1509,23 @@ HSD_GObj* mn_8022B3A0(u8 state)
             HSD_JObjAddChild(sp48[var_r16_2], cursor_jobj);
         }
     }
-    temp_r16_2 = data->tree[14];
-    if (data->menu_kind == 0 && data->hovered_selection == 4 &&
+    temp_r16_2 = user_data->tree[14];
+    if (user_data->menu_kind == 0 && user_data->hovered_selection == 4 &&
         gmMainLib_8015EE90() == 0)
     {
         var_r4_3 = &mn_803EB438;
-    } else if ((data->menu_kind == 1) && (data->hovered_selection == 0) &&
+    } else if ((user_data->menu_kind == 1) &&
+               (user_data->hovered_selection == 0) &&
                (gmMainLib_8015EDD4() == 0))
     {
         var_r4_3 = &mn_803EB480;
     } else {
-        var_r4_3 = &anim_loop[data->hovered_selection];
+        var_r4_3 = &anim_loop[user_data->hovered_selection];
     }
     HSD_JObjReqAnimAll(temp_r16_2, var_r4_3->start_frame);
     HSD_JObjAnimAll(temp_r16_2);
 
-    mn_80229A7C(data, data->menu_kind, data->hovered_selection);
+    mn_80229A7C(user_data, user_data->menu_kind, user_data->hovered_selection);
     return gobj;
 }
 

--- a/src/melee/pl/player.c
+++ b/src/melee/pl/player.c
@@ -97,8 +97,7 @@ static inline bool hasExtraFighterId(ftMapping* data)
 static inline void Player_CheckSlot(int slot)
 {
     if (slot < 0 || !(slot < PL_SLOT_MAX)) {
-        OSReport("cant get player struct! %d\n", slot);
-        __assert(__FILE__, 102, "0");
+        HSD_ASSERTREPORT(102, 0, "cant get player struct! %d\n", slot);
     }
 }
 

--- a/src/melee/pl/plbonuslib.c
+++ b/src/melee/pl/plbonuslib.c
@@ -1396,6 +1396,8 @@ void pl_8004049C(int player, ItemKind arg1)
     }
     if (var_r0 == 0) {
         OSReport("zako ko player illegal ! :%d\n", player);
+        /// @todo Convert to @c HSD_ASSERT once a byte-matching form is
+        /// found.
         __assert("plbonuslib.c", 1559,
                  "0 <= player && player < Gm_Player_NumMax");
     }

--- a/src/sysdolphin/baselib/axdriver.c
+++ b/src/sysdolphin/baselib/axdriver.c
@@ -464,9 +464,7 @@ static void fn_8038CEA4(s32 vID)
     HSD_SM* v;
     int idx = vID & 0x3F;
 
-    if (vID <= 0) {
-        __assert("axdriver.c", 0x26D, "vID > 0");
-    }
+    HSD_ASSERT(0x26D, vID > 0);
 
     v = AXDriver_804C5920[idx];
     if (v == NULL || v->vID != vID) {

--- a/src/sysdolphin/baselib/devcom.c
+++ b/src/sysdolphin/baselib/devcom.c
@@ -278,12 +278,8 @@ static void HSD_DevComDVDCallback(s32 result, DVDFileInfo* unused)
     }
     type = dvdDC->type;
     if (type == 0x22) {
-        if (dvdDC->size > DEVCOM_BUF_SIZE) {
-            __assert("devcom.c", 0x18C, "dvdDC->size <= DEVCOM_BUF_SIZE");
-        }
-        if (dvdDC->callback == NULL) {
-            __assert("devcom.c", 0x18D, "dvdDC->callback");
-        }
+        HSD_ASSERT(0x18C, dvdDC->size <= DEVCOM_BUF_SIZE);
+        HSD_ASSERT(0x18D, dvdDC->callback);
         if (HSD_DevCom_804D7804 == 0) {
             dvdDC->callback(dvdDC->dcReq, (s32) dvdDC->args,
                             HSD_DevCom_804C6330_bufs[HSD_DevCom_804D77F6],

--- a/src/sysdolphin/baselib/id.c
+++ b/src/sysdolphin/baselib/id.c
@@ -33,6 +33,7 @@ inline IDEntry* IDEntryAlloc(void)
     IDEntry* entry;
 
     entry = HSD_ObjAlloc(&hsd_iddata);
+    /// @todo Convert to @c HSD_ASSERT once a byte-matching form is found.
     if (entry == NULL) {
         __assert("id.c", 67, "entry");
     }

--- a/src/sysdolphin/baselib/jobj.c
+++ b/src/sysdolphin/baselib/jobj.c
@@ -836,14 +836,10 @@ void HSD_JObjAddChild(HSD_JObj* jobj, HSD_JObj* child)
     if (jobj == NULL || child == NULL) {
         return;
     }
-    if (child->parent != NULL) {
-        OSReport("child should be a orphan.\n");
-        __assert(__FILE__, 1350, "child->parent == NULL");
-    }
-    if (child->next != NULL) {
-        OSReport("child should not have siblings");
-        __assert(__FILE__, 1351, "child->next == NULL");
-    }
+    HSD_ASSERTREPORT(1350, child->parent == NULL,
+                     "child should be a orphan.\n");
+    HSD_ASSERTREPORT(1351, child->next == NULL,
+                     "child should not have siblings");
     if (jobj->child == NULL) {
         jobj->child = child;
     } else {

--- a/src/sysdolphin/baselib/lobj.c
+++ b/src/sysdolphin/baselib/lobj.c
@@ -337,7 +337,7 @@ void HSD_LObjSetupSpecularInit(Mtx pmtx)
             break;
 
         default:
-            __assert(__FILE__, 617, "0");
+            HSD_ASSERT(617, 0);
         }
         PSVECNormalize(&half, &half);
         GXInitLightDir(&lobj->spec_lightobj, half.x, half.y, half.z);
@@ -362,7 +362,7 @@ static void setup_diffuse_lightobj(HSD_LObj* lobj)
     case LOBJ_INFINITE:
         break;
     default:
-        __assert(__FILE__, 642, "0");
+        HSD_ASSERT(642, 0);
     }
 
     if (lobj->flags & LOBJ_ALPHA) {
@@ -396,7 +396,7 @@ static void setup_spec_lightobj(HSD_LObj* lobj, Mtx mtx, s32 spec_id)
             VECNormalize(&lobj->lvec, &lobj->lvec);
             break;
         default:
-            __assert(__FILE__, 680, "0");
+            HSD_ASSERT(680, 0);
         }
         lobj->flags |= 0x100;
         lightmask_specular |= spec_id;

--- a/src/sysdolphin/baselib/mobj.c
+++ b/src/sysdolphin/baselib/mobj.c
@@ -454,10 +454,7 @@ void HSD_MObjSetToonTextureImage(HSD_ImageDesc* imagedesc)
     if (tobj_toon == NULL) {
         tobj_toon_desc.imagedesc = imagedesc;
         tobj_toon = HSD_TObjLoadDesc(&tobj_toon_desc);
-        if (tobj_toon == NULL) {
-            OSReport("cannot allocate tobj for toon.");
-            __assert(__FILE__, 0x2F8, "tobj_toon");
-        }
+        HSD_ASSERTREPORT(0x2F8, tobj_toon, "cannot allocate tobj for toon.");
     }
     tobj_toon->imagedesc = imagedesc;
 }

--- a/src/sysdolphin/baselib/mtx.c
+++ b/src/sysdolphin/baselib/mtx.c
@@ -462,9 +462,7 @@ void* HSD_VecAlloc(void)
 {
     void* vec = HSD_ObjAlloc(&HSD_Mtx_804C2310);
 
-    if (vec == NULL) {
-        __assert("mtx.c", 0x335, "vec");
-    }
+    HSD_ASSERT(0x335, vec);
 
     return vec;
 }
@@ -481,9 +479,7 @@ void* HSD_MtxAlloc(void)
     void* mtx;
 
     mtx = HSD_ObjAlloc(&HSD_Mtx_804C233C);
-    if (mtx == NULL) {
-        __assert("mtx.c", 0x354, "mtx");
-    }
+    HSD_ASSERT(0x354, mtx);
     return mtx;
 }
 

--- a/src/sysdolphin/baselib/robj.c
+++ b/src/sysdolphin/baselib/robj.c
@@ -735,9 +735,7 @@ static void expEvaluate(HSD_Exp* exp, u32 type, void* obj,
     temp_f31 = 57.29578F;
     for (rvalue = exp->rvalue; rvalue != NULL; rvalue = rvalue->next) {
         jobj = rvalue->jobj;
-        if (jobj == NULL) {
-            __assert(__FILE__, 0x467, "jobj");
-        }
+        HSD_ASSERT(0x467, jobj);
         HSD_JObjSetupMatrix(rvalue->jobj);
         for (cur_bit = 1; cur_bit && cur_bit <= rvalue->flags; cur_bit <<= 1) {
             switch (rvalue->flags & cur_bit) {

--- a/src/sysdolphin/baselib/synth.c
+++ b/src/sysdolphin/baselib/synth.c
@@ -17,12 +17,9 @@
 
 void* HSD_AudioMalloc(size_t size)
 {
-    void* ptr = OSAllocFromHeap(HSD_Synth_804D6018, size);
-    if (ptr == NULL) {
-        OSReport("audio heap overflow.\n");
-        __assert("synth.c", 0x29U, "p");
-    }
-    return ptr;
+    void* p = OSAllocFromHeap(HSD_Synth_804D6018, size);
+    HSD_ASSERTREPORT(0x29U, p, "audio heap overflow.\n");
+    return p;
 }
 
 void HSD_AudioFree(void* ptr)
@@ -145,7 +142,7 @@ static void HSD_SynthSFXHeaderLoadCallback(int result, int length, void* addr,
 {
     AXVPB** unused;
     s32 header_size;
-    void* buf;
+    void* p;
     size_t alloc_size;
 
     if (HSD_Synth_804D7738 == 0) {
@@ -160,13 +157,10 @@ static void HSD_SynthSFXHeaderLoadCallback(int result, int length, void* addr,
 
         alloc_size = hsd_SynthSFXLoadBuf[2] * 8 + 0x18;
         header_size = hsd_SynthSFXLoadBuf[0];
-        buf = OSAllocFromHeap(HSD_Synth_804D6018,
-                              OSRoundUp32B(alloc_size + header_size));
-        if (buf == NULL) {
-            OSReport("audio heap overflow.\n");
-            __assert("synth.c", 0x29U, "p");
-        }
-        HSD_Synth_804D7730 = buf;
+        p = OSAllocFromHeap(HSD_Synth_804D6018,
+                            OSRoundUp32B(alloc_size + header_size));
+        HSD_ASSERTREPORT(0x29U, p, "audio heap overflow.\n");
+        HSD_Synth_804D7730 = p;
         HSD_Synth_804D6028[1] = HSD_DevComRequest(
             HSD_Synth_804C2A60[0].entrynum, 0x20, (u32) HSD_Synth_804D7730,
             OSRoundUp32B(header_size - 0x10), 0x21, 1, NULL, NULL);
@@ -1359,9 +1353,7 @@ void HSD_SynthPStreamHeaderCallback(int arg0, int arg1, void* arg2,
         node->voice_count = entry[3];
         if (node->voice_count == 2) {
             node->voice[1] = AXAcquireVoice(0x1D, dropcallback, 0);
-            if (node->voice[1] == NULL) {
-                __assert("synth.c", 0x5CF, "entry->voice[1]");
-            }
+            HSD_ASSERTMSG(0x5CF, node->voice[1], "entry->voice[1]");
         }
         node->x14 = 0.00003125f * (f32) entry[2];
         for (i = 0; i < node->voice_count; i++) {

--- a/src/sysdolphin/baselib/tobj.c
+++ b/src/sysdolphin/baselib/tobj.c
@@ -377,6 +377,7 @@ static void MakeTextureMtx(HSD_TObj* tobj)
         no_assert = true;
     }
 
+    /// @todo Convert to @c HSD_ASSERT once a byte-matching form is found.
     if (!no_assert) {
         __assert(__FILE__, 589, "tobj->repeat_s && tobj->repeat_t");
     }

--- a/src/sysdolphin/baselib/util.c
+++ b/src/sysdolphin/baselib/util.c
@@ -53,7 +53,7 @@ s32 HSD_Index2PosNrmMtx(u32 arg0)
     case 9:
         return 27;
     default:
-        __assert("util.c", 132, "0");
+        HSD_ASSERT(132, 0);
         return 0;
     }
 }


### PR DESCRIPTION
Split from #2671.
> Convert direct __assert calls whose file argument is __FILE__ or the file's own basename to HSD_ASSERT / HSD_ASSERTMSG / HSD_ASSERTREPORT: 102 of 107 sites across ~50 files. Where the assert string preserves an original variable name, the local is renamed back to it (synth.c ptr/ buf -> p, mnmain.c and mndeflicker.c data/menu -> user_data) so the macro's stringification reproduces the original string. Sites passing a different filename string cannot use the macros and are untouched.
> 
> 5 sites did not produce byte-identical objects under the macro form (ftchangeparam.c float-compare polarity; mnhyaku.c and id.c inside inline functions) or need structural changes (tobj.c, plbonuslib.c); these keep the expanded form and are annotated with @todo.
> 
> All 1046 compiled objects verified byte-identical before and after; main.dol sha1 unchanged.