### PR TITLE
Melee decomp: Stage-specific GR matches

### DIFF
--- a/src/melee/gr/grbigblue.c
+++ b/src/melee/gr/grbigblue.c
@@ -1407,7 +1407,7 @@ void grBigBlue_801E8D64(Ground_GObj* gobj)
 
     HSD_JObjGetTranslation2(jobj, &pos);
     {
-        f32 inv = grBb_804DB2F0 / Ground_801C0498();
+        f32 inv = 1.0F / Ground_801C0498();
         pos.x *= inv;
         pos.y *= inv;
         pos.z *= inv;
@@ -1760,15 +1760,15 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
     switch ((s8) gp->gv.bigblue.x0) {
     case 0:
         if (*(s32*) ((u8*) GET_GROUND(Ground_801C2BA4(32)) + 0xD0) != 0) {
-            gp->gv.arwing.xC8 = 0;
-            gp->gv.arwing.xD0 = 0;
-            gp->gv.arwing.xCC = 0;
+            gp->gv.bigblue.platform.xC8_timer = 0;
+            gp->gv.bigblue.platform.xD0_timer = 0;
+            gp->gv.bigblue.platform.xCC_timer = 0;
             gp->gv.bigblue.x0 = 1;
         }
         break;
 
     case 1: {
-        s32 timer = gp->gv.arwing.xC8;
+        s32 timer = gp->gv.bigblue.platform.xC8_timer;
         if (timer <= 0) {
             f32 right_y;
             f32 left_y;
@@ -1783,17 +1783,17 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
             right_y = grBigBlue_801EC58C(&pos, NULL, 500.0f);
             left_y = grBigBlue_801EC58C(&half_bot, NULL, 500.0f);
 
-            *(f32*) &gp->gv.arwing.xD4 = grBb_804D69C8->xF4;
+            gp->gv.bigblue.platform.height_offset = grBb_804D69C8->xF4;
             range = ABS(grBb_804D69C8->xF8 - grBb_804D69C8->xF4);
             if ((s32) range != 0) {
                 r = HSD_Randi((s32) range);
             } else {
                 r = 0;
             }
-            *(f32*) &gp->gv.arwing.xD4 = *(f32*) &gp->gv.arwing.xD4 + (f32) r;
+            gp->gv.bigblue.platform.height_offset += (f32) r;
 
-            pos.y = right_y + *(f32*) &gp->gv.arwing.xD4;
-            half_bot.y = left_y + *(f32*) &gp->gv.arwing.xD4;
+            pos.y = right_y + gp->gv.bigblue.platform.height_offset;
+            half_bot.y = left_y + gp->gv.bigblue.platform.height_offset;
 
             if (grBb_804DB310 != right_y || grBb_804DB310 != left_y) {
                 s32 collision;
@@ -1857,17 +1857,17 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
 
                     HSD_JObjSetTranslate(jobj, &pos);
 
-                    gp->gv.arwing.xDC = pos.y;
-                    gp->gv.arwing.xEC = 0.0f;
-                    gp->gv.arwing.xE0.z = 0.0f;
-                    gp->gv.arwing.xE0.y = 0.0f;
+                    gp->gv.bigblue.platform.target_y = pos.y;
+                    gp->gv.bigblue.platform.xEC = 0.0f;
+                    gp->gv.bigblue.platform.velocity.z = 0.0f;
+                    gp->gv.bigblue.platform.velocity.y = 0.0f;
 
                     HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
                     gp->gv.bigblue.x0 = 2;
                 }
             }
         } else {
-            gp->gv.arwing.xC8 = timer - 1;
+            gp->gv.bigblue.platform.xC8_timer = timer - 1;
         }
         break;
     }
@@ -1896,19 +1896,21 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
         if (ace_result == 0 || (ace_result == 1 && pos.y < y_check)) {
             if (bounds_y <= surface_y) {
                 if (surface_y == grBb_804DB310) {
-                    gp->gv.arwing.xDC = half_top.y;
+                    gp->gv.bigblue.platform.target_y = half_top.y;
                 } else {
-                    gp->gv.arwing.xDC = surface_y + *(f32*) &gp->gv.arwing.xD4;
+                    gp->gv.bigblue.platform.target_y =
+                        surface_y + gp->gv.bigblue.platform.height_offset;
                 }
             } else {
-                gp->gv.arwing.xDC = bounds_y + *(f32*) &gp->gv.arwing.xD4;
+                gp->gv.bigblue.platform.target_y =
+                    bounds_y + gp->gv.bigblue.platform.height_offset;
             }
         } else if (ace_result == 1) {
-            gp->gv.arwing.xDC = pos.y + (pos.y - y_check);
+            gp->gv.bigblue.platform.target_y = pos.y + (pos.y - y_check);
         }
 
         {
-            f32 target_y = gp->gv.arwing.xDC;
+            f32 target_y = gp->gv.bigblue.platform.target_y;
             f32 diff = pos.y - target_y;
             if (diff < 0.0f) {
                 diff = -diff;
@@ -1934,7 +1936,7 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
         HSD_JObjSetTranslateY(jobj, pos.y);
 
         {
-            s32 timer = gp->gv.arwing.xCC;
+            s32 timer = gp->gv.bigblue.platform.xCC_timer;
             if (timer <= 0) {
                 s32 timer_range = grBb_804D69C8->x110 - grBb_804D69C8->x10C;
                 s32 r;
@@ -1950,8 +1952,8 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
                 } else {
                     r = 0;
                 }
-                gp->gv.arwing.xCC = r;
-                gp->gv.arwing.xCC += grBb_804D69C8->x10C;
+                gp->gv.bigblue.platform.xCC_timer = r;
+                gp->gv.bigblue.platform.xCC_timer += grBb_804D69C8->x10C;
 
                 speed_range =
                     (grBb_804D69C8->x100 - grBb_804D69C8->xFC) / 0.1f;
@@ -1964,14 +1966,15 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
                 if (speed == 0.0f) {
                     speed = grBb_804D69C8->xFC;
                 }
-                gp->gv.arwing.xE0.y = speed * (f32) (s8) gp->gv.bigblue.x1;
+                gp->gv.bigblue.platform.velocity.y =
+                    speed * (f32) (s8) gp->gv.bigblue.x1;
             } else {
-                gp->gv.arwing.xCC = timer - 1;
+                gp->gv.bigblue.platform.xCC_timer = timer - 1;
             }
         }
 
         {
-            s32 timer = gp->gv.arwing.xD0;
+            s32 timer = gp->gv.bigblue.platform.xD0_timer;
             if (timer <= 0) {
                 s32 timer_range = grBb_804D69C8->x110 - grBb_804D69C8->x10C;
                 s32 r;
@@ -1987,8 +1990,8 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
                 } else {
                     r = 0;
                 }
-                gp->gv.arwing.xD0 = r;
-                gp->gv.arwing.xD0 += grBb_804D69C8->x10C;
+                gp->gv.bigblue.platform.xD0_timer = r;
+                gp->gv.bigblue.platform.xD0_timer += grBb_804D69C8->x10C;
 
                 speed_range =
                     (grBb_804D69C8->x108 - grBb_804D69C8->x104) / 0.1f;
@@ -2004,14 +2007,14 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
                 if (HSD_Randi(2) != 0) {
                     speed *= -1.0f;
                 }
-                gp->gv.arwing.xE0.z = speed;
+                gp->gv.bigblue.platform.velocity.z = speed;
             } else {
-                gp->gv.arwing.xD0 = timer - 1;
+                gp->gv.bigblue.platform.xD0_timer = timer - 1;
             }
         }
 
-        HSD_JObjAddTranslationX(jobj, gp->gv.arwing.xE0.y);
-        HSD_JObjAddTranslationY(jobj, gp->gv.arwing.xE0.z);
+        HSD_JObjAddTranslationX(jobj, gp->gv.bigblue.platform.velocity.y);
+        HSD_JObjAddTranslationY(jobj, gp->gv.bigblue.platform.velocity.z);
 
         if (((s8) gp->gv.bigblue.x1 == -1 &&
              HSD_JObjGetTranslationX(jobj) <
@@ -2021,9 +2024,9 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
                  Stage_GetBlastZoneRightOffset() - 50.0f))
         {
             HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
-            gp->gv.arwing.xEC = 0.0f;
-            gp->gv.arwing.xE0.z = 0.0f;
-            gp->gv.arwing.xE0.y = 0.0f;
+            gp->gv.bigblue.platform.xEC = 0.0f;
+            gp->gv.bigblue.platform.velocity.z = 0.0f;
+            gp->gv.bigblue.platform.velocity.y = 0.0f;
             GET_GROUND(Ground_801C2BA4(32))->gv.bigblue.xD0 = 0;
             gp->gv.bigblue.x0 = 0;
         }
@@ -2094,7 +2097,6 @@ s32 grBigBlue_801EACE8(HSD_JObj* exclude, Vec3* point, f32* out_y,
     f32 left_bound, right_bound, top_bound, bottom_bound;
     f32 left_x, right_x;
     f32 dist;
-    f32 zero;
     f32* p_left;
     f32* p_right;
     s32 i;
@@ -2107,8 +2109,7 @@ s32 grBigBlue_801EACE8(HSD_JObj* exclude, Vec3* point, f32* out_y,
     bottom_bound = point->y - half_range_y;
 
     best_in_range = F32_MAX;
-    best_above = grBb_804DB310;
-    zero = grBb_804DB2F4;
+    best_above = -F32_MAX;
 
     gp = gobj->user_data;
     p_left = &hw_left.x;
@@ -2140,7 +2141,7 @@ s32 grBigBlue_801EACE8(HSD_JObj* exclude, Vec3* point, f32* out_y,
         {
             if (pos.y > bottom_bound && pos.y < top_bound) {
                 dist = point->y - pos.y;
-                if (dist < zero) {
+                if (dist < 0.0F) {
                     dist = -dist;
                 }
                 if (dist < best_in_range) {
@@ -2168,7 +2169,7 @@ s32 grBigBlue_801EACE8(HSD_JObj* exclude, Vec3* point, f32* out_y,
         {
             if (route_pos.y > bottom_bound && route_pos.y < top_bound) {
                 dist = point->y - route_pos.y;
-                if (dist < grBb_804DB2F4) {
+                if (dist < 0.0F) {
                     dist = -dist;
                 }
                 if (dist < best_in_range) {
@@ -2184,7 +2185,7 @@ s32 grBigBlue_801EACE8(HSD_JObj* exclude, Vec3* point, f32* out_y,
         *out_y = best_in_range;
         return 1;
     }
-    if (grBb_804DB310 != best_above) {
+    if (-F32_MAX != best_above) {
         *out_y = best_above;
         return 2;
     }

--- a/src/melee/gr/grbigblue.c
+++ b/src/melee/gr/grbigblue.c
@@ -622,6 +622,8 @@ void grBigBlue_801E6C60(Ground_GObj* gobj)
                     if (right_y != -F32_MAX || left_y != -F32_MAX)
                     {
                         f32 height_range;
+                        s32 height_range_i;
+                        s32 height_range_arg;
                         s32 height_rand;
 
                         gp->gv.bigblue.data[i].x8 = grBb_804D69C8->x90;
@@ -629,8 +631,10 @@ void grBigBlue_801E6C60(Ground_GObj* gobj)
                         if (height_range < 0.0f) {
                             height_range = -height_range;
                         }
-                        if ((s32) height_range != 0) {
-                            height_rand = HSD_Randi((s32) height_range);
+                        height_range_i = (s32) height_range;
+                        height_range_arg = (s32) height_range;
+                        if (height_range_i != 0) {
+                            height_rand = HSD_Randi(height_range_arg);
                         } else {
                             height_rand = 0;
                         }
@@ -681,16 +685,14 @@ void grBigBlue_801E6C60(Ground_GObj* gobj)
                             speeds = grBb_803B8114;
                             found = grBigBlue_801E8794(
                                 jobj, &pos, 0,
-                                2.0f * (((f32*) &speeds)[(s8) idx] *
-                                        Ground_801C0498()),
+                                2.0f * (speeds.x * Ground_801C0498()),
                                 25.0f);
                             if (found == 0) {
                                 Vec3 speeds2;
                                 speeds2 = grBb_803B8114;
                                 found = grBigBlue_801EAB50(
                                     &pos, 0,
-                                    2.0f * (((f32*) &speeds2)[(s8) idx] *
-                                            Ground_801C0498()),
+                                    2.0f * (speeds2.x * Ground_801C0498()),
                                     25.0f);
                             }
                             if (found == 0) {
@@ -1368,6 +1370,7 @@ void grBigBlue_801E8D64(Ground_GObj* gobj)
     HSD_JObj* jobj = gobj->hsd_obj;
     Vec3 pos;
     Vec3 scale;
+    UNUSED f32 unused;
     Vec3 translate;
     f32 y_pos;
     PAD_STACK(0xC);
@@ -1404,7 +1407,7 @@ void grBigBlue_801E8D64(Ground_GObj* gobj)
 
     HSD_JObjGetTranslation2(jobj, &pos);
     {
-        f32 inv = 1.0F / Ground_801C0498();
+        f32 inv = grBb_804DB2F0 / Ground_801C0498();
         pos.x *= inv;
         pos.y *= inv;
         pos.z *= inv;
@@ -1725,9 +1728,9 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
     Vec3 half_top;
     Vec3 half_bot;
     Vec3 normal;
+    f32 y_check;
     Vec3 euler;
     Vec3 pos2;
-    f32 y_check;
     PAD_STACK(0x1c);
 
     HSD_JObjGetTranslation2(jobj, &pos);
@@ -1742,13 +1745,13 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
     euler.x = 0.0f;
     euler.z = atan2f(-normal.x, normal.y);
 
-    half_top.x = 68.0f * Ground_801C0498() * 0.5f;
+    half_top.x = (68.0f * Ground_801C0498()) * 0.5f;
     half_top.z = 0.0f;
     half_top.y = 0.0f;
     lbVector_ApplyEulerRotation(&half_top, &euler);
     lbVector_Add(&half_top, &pos);
 
-    half_bot.x = -(68.0f * Ground_801C0498() * 0.5f);
+    half_bot.x = -((68.0f * Ground_801C0498()) * 0.5f);
     half_bot.z = 0.0f;
     half_bot.y = 0.0f;
     lbVector_ApplyEulerRotation(&half_bot, &euler);
@@ -1757,15 +1760,15 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
     switch ((s8) gp->gv.bigblue.x0) {
     case 0:
         if (*(s32*) ((u8*) GET_GROUND(Ground_801C2BA4(32)) + 0xD0) != 0) {
-            *(s32*) ((u8*) gp + 0xC8) = 0;
-            *(s32*) ((u8*) gp + 0xD0) = 0;
-            *(s32*) ((u8*) gp + 0xCC) = 0;
+            gp->gv.arwing.xC8 = 0;
+            gp->gv.arwing.xD0 = 0;
+            gp->gv.arwing.xCC = 0;
             gp->gv.bigblue.x0 = 1;
         }
         break;
 
     case 1: {
-        s32 timer = *(s32*) ((u8*) gp + 0xC8);
+        s32 timer = gp->gv.arwing.xC8;
         if (timer <= 0) {
             f32 right_y;
             f32 left_y;
@@ -1780,29 +1783,26 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
             right_y = grBigBlue_801EC58C(&pos, NULL, 500.0f);
             left_y = grBigBlue_801EC58C(&half_bot, NULL, 500.0f);
 
-            *(f32*) ((u8*) gp + 0xD4) = grBb_804D69C8->xF4;
-            range = grBb_804D69C8->xF8 - grBb_804D69C8->xF4;
-            if (range < 0.0f) {
-                range = -range;
-            }
+            *(f32*) &gp->gv.arwing.xD4 = grBb_804D69C8->xF4;
+            range = ABS(grBb_804D69C8->xF8 - grBb_804D69C8->xF4);
             if ((s32) range != 0) {
                 r = HSD_Randi((s32) range);
             } else {
                 r = 0;
             }
-            *(f32*) ((u8*) gp + 0xD4) = *(f32*) ((u8*) gp + 0xD4) + (f32) r;
+            *(f32*) &gp->gv.arwing.xD4 = *(f32*) &gp->gv.arwing.xD4 + (f32) r;
 
-            pos.y = right_y + *(f32*) ((u8*) gp + 0xD4);
-            half_bot.y = left_y + *(f32*) ((u8*) gp + 0xD4);
+            pos.y = right_y + *(f32*) &gp->gv.arwing.xD4;
+            half_bot.y = left_y + *(f32*) &gp->gv.arwing.xD4;
 
-            if (right_y != grBb_804DB310 || left_y != grBb_804DB310) {
+            if (grBb_804DB310 != right_y || grBb_804DB310 != left_y) {
                 s32 collision;
                 f32 platform_h;
                 f32 bounds_y;
 
-                if (left_y == grBb_804DB310) {
-                    gp->gv.bigblue.x1 = (u8) (s8) -1;
-                } else if (right_y == grBb_804DB310) {
+                if (grBb_804DB310 == left_y) {
+                    gp->gv.bigblue.x1 = -1;
+                } else if (grBb_804DB310 == right_y) {
                     gp->gv.bigblue.x1 = 1;
                 } else {
                     f32 diff = right_y - left_y;
@@ -1810,28 +1810,26 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
                         diff = -diff;
                     }
                     if (diff < 80.0f) {
-                        s8 dir;
+                        s32 dir;
                         if (HSD_Randi(2) != 0) {
                             dir = 1;
                         } else {
                             dir = -1;
                         }
-                        gp->gv.bigblue.x1 = (u8) dir;
+                        gp->gv.bigblue.x1 = (u8) (s8) dir;
                     } else {
-                        s8 dir;
+                        s32 dir;
                         if (right_y < left_y) {
                             dir = -1;
                         } else {
                             dir = 1;
                         }
-                        gp->gv.bigblue.x1 = (u8) dir;
+                        gp->gv.bigblue.x1 = (u8) (s8) dir;
                     }
                 }
 
                 if ((s8) gp->gv.bigblue.x1 == 1) {
-                    pos.x = half_bot.x;
-                    pos.y = half_bot.y;
-                    pos.z = half_bot.z;
+                    pos = half_bot;
                 }
 
                 platform_h = 52.0f * Ground_801C0498();
@@ -1859,17 +1857,17 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
 
                     HSD_JObjSetTranslate(jobj, &pos);
 
-                    *(f32*) ((u8*) gp + 0xDC) = pos.y;
-                    *(f32*) ((u8*) gp + 0xEC) = 0.0f;
-                    *(f32*) ((u8*) gp + 0xE8) = 0.0f;
-                    *(f32*) ((u8*) gp + 0xE4) = 0.0f;
+                    gp->gv.arwing.xDC = pos.y;
+                    gp->gv.arwing.xEC = 0.0f;
+                    gp->gv.arwing.xE0.z = 0.0f;
+                    gp->gv.arwing.xE0.y = 0.0f;
 
                     HSD_JObjClearFlagsAll(jobj, JOBJ_HIDDEN);
                     gp->gv.bigblue.x0 = 2;
                 }
             }
         } else {
-            *(s32*) ((u8*) gp + 0xC8) = timer - 1;
+            gp->gv.arwing.xC8 = timer - 1;
         }
         break;
     }
@@ -1898,19 +1896,19 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
         if (ace_result == 0 || (ace_result == 1 && pos.y < y_check)) {
             if (bounds_y <= surface_y) {
                 if (surface_y == grBb_804DB310) {
-                    *(f32*) ((u8*) gp + 0xDC) = half_top.y;
+                    gp->gv.arwing.xDC = half_top.y;
                 } else {
-                    *(f32*) ((u8*) gp + 0xDC) = surface_y + *(f32*) ((u8*) gp + 0xD4);
+                    gp->gv.arwing.xDC = surface_y + *(f32*) &gp->gv.arwing.xD4;
                 }
             } else {
-                *(f32*) ((u8*) gp + 0xDC) = bounds_y + *(f32*) ((u8*) gp + 0xD4);
+                gp->gv.arwing.xDC = bounds_y + *(f32*) &gp->gv.arwing.xD4;
             }
         } else if (ace_result == 1) {
-            *(f32*) ((u8*) gp + 0xDC) = pos.y + (pos.y - y_check);
+            gp->gv.arwing.xDC = pos.y + (pos.y - y_check);
         }
 
         {
-            f32 target_y = *(f32*) ((u8*) gp + 0xDC);
+            f32 target_y = gp->gv.arwing.xDC;
             f32 diff = pos.y - target_y;
             if (diff < 0.0f) {
                 diff = -diff;
@@ -1936,7 +1934,7 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
         HSD_JObjSetTranslateY(jobj, pos.y);
 
         {
-            s32 timer = *(s32*) ((u8*) gp + 0xCC);
+            s32 timer = gp->gv.arwing.xCC;
             if (timer <= 0) {
                 s32 timer_range = grBb_804D69C8->x110 - grBb_804D69C8->x10C;
                 s32 r;
@@ -1952,8 +1950,8 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
                 } else {
                     r = 0;
                 }
-                *(s32*) ((u8*) gp + 0xCC) = r;
-                *(s32*) ((u8*) gp + 0xCC) += grBb_804D69C8->x10C;
+                gp->gv.arwing.xCC = r;
+                gp->gv.arwing.xCC += grBb_804D69C8->x10C;
 
                 speed_range =
                     (grBb_804D69C8->x100 - grBb_804D69C8->xFC) / 0.1f;
@@ -1966,14 +1964,14 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
                 if (speed == 0.0f) {
                     speed = grBb_804D69C8->xFC;
                 }
-                *(f32*) ((u8*) gp + 0xE4) = speed * (f32) (s8) gp->gv.bigblue.x1;
+                gp->gv.arwing.xE0.y = speed * (f32) (s8) gp->gv.bigblue.x1;
             } else {
-                *(s32*) ((u8*) gp + 0xCC) = timer - 1;
+                gp->gv.arwing.xCC = timer - 1;
             }
         }
 
         {
-            s32 timer = *(s32*) ((u8*) gp + 0xD0);
+            s32 timer = gp->gv.arwing.xD0;
             if (timer <= 0) {
                 s32 timer_range = grBb_804D69C8->x110 - grBb_804D69C8->x10C;
                 s32 r;
@@ -1989,8 +1987,8 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
                 } else {
                     r = 0;
                 }
-                *(s32*) ((u8*) gp + 0xD0) = r;
-                *(s32*) ((u8*) gp + 0xD0) += grBb_804D69C8->x10C;
+                gp->gv.arwing.xD0 = r;
+                gp->gv.arwing.xD0 += grBb_804D69C8->x10C;
 
                 speed_range =
                     (grBb_804D69C8->x108 - grBb_804D69C8->x104) / 0.1f;
@@ -2006,14 +2004,14 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
                 if (HSD_Randi(2) != 0) {
                     speed *= -1.0f;
                 }
-                *(f32*) ((u8*) gp + 0xE8) = speed;
+                gp->gv.arwing.xE0.z = speed;
             } else {
-                *(s32*) ((u8*) gp + 0xD0) = timer - 1;
+                gp->gv.arwing.xD0 = timer - 1;
             }
         }
 
-        HSD_JObjAddTranslationX(jobj, *(f32*) ((u8*) gp + 0xE4));
-        HSD_JObjAddTranslationY(jobj, *(f32*) ((u8*) gp + 0xE8));
+        HSD_JObjAddTranslationX(jobj, gp->gv.arwing.xE0.y);
+        HSD_JObjAddTranslationY(jobj, gp->gv.arwing.xE0.z);
 
         if (((s8) gp->gv.bigblue.x1 == -1 &&
              HSD_JObjGetTranslationX(jobj) <
@@ -2023,9 +2021,9 @@ void grBigBlue_801EA05C(Ground_GObj* gobj)
                  Stage_GetBlastZoneRightOffset() - 50.0f))
         {
             HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
-            *(f32*) ((u8*) gp + 0xEC) = 0.0f;
-            *(f32*) ((u8*) gp + 0xE8) = 0.0f;
-            *(f32*) ((u8*) gp + 0xE4) = 0.0f;
+            gp->gv.arwing.xEC = 0.0f;
+            gp->gv.arwing.xE0.z = 0.0f;
+            gp->gv.arwing.xE0.y = 0.0f;
             GET_GROUND(Ground_801C2BA4(32))->gv.bigblue.xD0 = 0;
             gp->gv.bigblue.x0 = 0;
         }
@@ -2083,17 +2081,20 @@ bool grBigBlue_801EAB50(Vec3* pos, s32 flag, f32 rangeX, f32 rangeY)
 s32 grBigBlue_801EACE8(HSD_JObj* exclude, Vec3* point, f32* out_y,
                        f32 half_range_x, f32 half_range_y)
 {
-    u8 _padA[32];
     HSD_GObj* gobj;
     Ground* gp;
     HSD_JObj* jobj;
+    u8 _padC[8];
     Vec3 pos;
+    u8 _padA[12];
     Vec3 hw_left, hw_right;
+    u8 _padB[16];
     Vec3 route_pos;
     f32 best_in_range, best_above;
     f32 left_bound, right_bound, top_bound, bottom_bound;
     f32 left_x, right_x;
     f32 dist;
+    f32 zero;
     f32* p_left;
     f32* p_right;
     s32 i;
@@ -2106,7 +2107,8 @@ s32 grBigBlue_801EACE8(HSD_JObj* exclude, Vec3* point, f32* out_y,
     bottom_bound = point->y - half_range_y;
 
     best_in_range = F32_MAX;
-    best_above = -F32_MAX;
+    best_above = grBb_804DB310;
+    zero = grBb_804DB2F4;
 
     gp = gobj->user_data;
     p_left = &hw_left.x;
@@ -2138,7 +2140,7 @@ s32 grBigBlue_801EACE8(HSD_JObj* exclude, Vec3* point, f32* out_y,
         {
             if (pos.y > bottom_bound && pos.y < top_bound) {
                 dist = point->y - pos.y;
-                if (dist < 0.0F) {
+                if (dist < zero) {
                     dist = -dist;
                 }
                 if (dist < best_in_range) {
@@ -2166,7 +2168,7 @@ s32 grBigBlue_801EACE8(HSD_JObj* exclude, Vec3* point, f32* out_y,
         {
             if (route_pos.y > bottom_bound && route_pos.y < top_bound) {
                 dist = point->y - route_pos.y;
-                if (dist < 0.0F) {
+                if (dist < grBb_804DB2F4) {
                     dist = -dist;
                 }
                 if (dist < best_in_range) {
@@ -2182,7 +2184,7 @@ s32 grBigBlue_801EACE8(HSD_JObj* exclude, Vec3* point, f32* out_y,
         *out_y = best_in_range;
         return 1;
     }
-    if (-F32_MAX != best_above) {
+    if (grBb_804DB310 != best_above) {
         *out_y = best_above;
         return 2;
     }
@@ -4761,13 +4763,15 @@ bool grBigBlue_801EEF00(Ground_GObj* gobj, s32 index)
 }
 #pragma pop
 
-/// @todo Currently 98.03% match - float register allocation off by 1
+/// @todo Currently 99.88% match - instructions match but relocations differ
 void grBigBlue_801EF424(Ground_GObj* gobj)
 {
-    Ground* gp = gobj->user_data;
-    u8* car_i;
     u8* car_j;
-    int i, j, k;
+    u8* car_i;
+    int i;
+    Ground* gp = gobj->user_data;
+    int init_i;
+    int j, k;
     int changed;
     f32 zero;
     f32 diff;
@@ -4775,8 +4779,8 @@ void grBigBlue_801EF424(Ground_GObj* gobj)
 
     grBigBlue_801ECB50(gobj);
 
-    for (i = 0; i < 4; i++) {
-        grBigBlue_801ED694(gobj, i);
+    for (init_i = 0; init_i < 4; init_i++) {
+        grBigBlue_801ED694(gobj, init_i);
     }
 
     zero = 0.0F;
@@ -4820,7 +4824,7 @@ void grBigBlue_801EF424(Ground_GObj* gobj)
 
                     diff -= adjustment;
                     changed = 1;
-                    diff = (f32) (diff * 0.5);
+                    diff *= 0.5;
 
                     *(f32*) (car_i + 0xDC) -= diff;
                     *(f32*) (car_i + 0xE0) -= diff;

--- a/src/melee/gr/grfourside.c
+++ b/src/melee/gr/grfourside.c
@@ -440,13 +440,10 @@ bool grFourside_801F388C(Ground_GObj* arg)
     return false;
 }
 
-void grFourside_801F3894(Ground_GObj* arg0)
+static inline void grFourside_801F3894_inline(Ground_GObj* gobj, Ground* gp,
+                                              HSD_JObj* jobj, u8 state,
+                                              u8 prev_building)
 {
-    Ground* gp = arg0->user_data;
-    u8 state = gp->gv.foursideUfo.x0;
-    u8 prev_building = gp->gv.foursideUfo.x1;
-    HSD_JObj* jobj = arg0->hsd_obj;
-    PAD_STACK(8);
     switch (state) {
     case 0: {
         s32 timer = gp->gv.foursideUfo.x4;
@@ -466,7 +463,7 @@ void grFourside_801F3894(Ground_GObj* arg0)
                 } while (prev_building == building);
                 if (building == 2 || grFourside_801F3F10() == 0) {
                     gp->gv.foursideUfo.x1 = building;
-                    grAnime_801C8138(arg0, gp->map_id,
+                    grAnime_801C8138(gobj, gp->map_id,
                                      gp->gv.foursideUfo.x1 * 4);
                     mpLib_80055E9C(4);
                     mpLib_80057424(4);
@@ -486,7 +483,7 @@ void grFourside_801F3894(Ground_GObj* arg0)
         break;
     }
     case 1: {
-        if (grAnime_801C83D0(arg0, 0, 7) != 0) {
+        if (grAnime_801C83D0(gobj, 0, 7) != 0) {
             s32 rand_add = grFs_804D69D8->ufo_stay_time_add;
             s32 var_r6;
             if (rand_add != 0) {
@@ -495,12 +492,12 @@ void grFourside_801F3894(Ground_GObj* arg0)
                 var_r6 = 0;
             }
             gp->gv.foursideUfo.x4 = grFs_804D69D8->ufo_stay_time + var_r6;
-            grAnime_801C8138(arg0, gp->map_id, (prev_building * 4) + 1);
+            grAnime_801C8138(gobj, gp->map_id, (prev_building * 4) + 1);
             Camera_800290D4(gp->gv.foursideUfo.xC);
             gp->gv.foursideUfo.xC = 0;
             gp->gv.foursideUfo.x0 = 2;
         }
-        grFourside_801F3B70(arg0);
+        grFourside_801F3B70(gobj);
         if (gp->gv.foursideUfo.x3 == 1) {
             u8 building = gp->gv.foursideUfo.x1;
             if (building == 0) {
@@ -517,8 +514,8 @@ void grFourside_801F3894(Ground_GObj* arg0)
     case 2: {
         s32 timer = gp->gv.foursideUfo.x4;
         if (timer <= 0) {
-            if (grAnime_801C84A4(arg0, 0, 7) != 0) {
-                grAnime_801C8138(arg0, gp->map_id, (prev_building * 4) + 2);
+            if (grAnime_801C84A4(gobj, 0, 7) != 0) {
+                grAnime_801C8138(gobj, gp->map_id, (prev_building * 4) + 2);
                 gp->gv.foursideUfo.x0 = 4;
             }
         } else {
@@ -539,8 +536,19 @@ void grFourside_801F3894(Ground_GObj* arg0)
         break;
     }
     }
-    Ground_801C2FE0(arg0);
+    Ground_801C2FE0(gobj);
     gp->gv.foursideUfo.x8 = 0;
+}
+
+void grFourside_801F3894(Ground_GObj* gobj)
+{
+    Ground* gp = gobj->user_data;
+    u8 state = gp->gv.foursideUfo.x0;
+    u8 prev_building = gp->gv.foursideUfo.x1;
+    HSD_JObj* jobj = gobj->hsd_obj;
+    PAD_STACK(8);
+
+    grFourside_801F3894_inline(gobj, gp, jobj, state, prev_building);
 }
 
 void grFourside_801F3B6C(Ground_GObj* arg) {}

--- a/src/melee/gr/groldyoshi.c
+++ b/src/melee/gr/groldyoshi.c
@@ -370,35 +370,37 @@ bool grOldYoshi_8020F080(Ground_GObj* arg)
 {
     return false;
 }
-const int grOy_803B83F0[5] = { 1, 2, 3, 4, 5 };
-/// #grOldYoshi_8020F088
+typedef struct grOy_803B83F0_t {
+    int x[5];
+} grOy_803B83F0_t;
+
+typedef struct grOy_803B83F0_Data {
+    grOy_803B83F0_t ids;
+    int pad;
+} grOy_803B83F0_Data;
+
+const grOy_803B83F0_Data grOy_803B83F0 = { { { 1, 2, 3, 4, 5 } }, 0 };
+
 void grOldYoshi_8020F088(Ground_GObj* arg)
 {
-    HSD_JObj* jobj = arg->hsd_obj;
     Ground* gp = arg->user_data;
-    s16 sVar5;
     float dVar9;
     float dVar10;
-    int local34[5];
-    PAD_STACK(8);
     if (gp->gv.oldyoshiguest.xC6 == -1) {
+        s16 sVar5;
         sVar5 = gp->gv.oldyoshiguest.xC4;
         gp->gv.oldyoshiguest.xC4 = sVar5 - 1;
         if (sVar5 < 0) {
-            local34[0] = grOy_803B83F0[0];
-            local34[1] = grOy_803B83F0[1];
-            local34[2] = grOy_803B83F0[2];
-            local34[3] = grOy_803B83F0[3];
-            local34[4] = grOy_803B83F0[4];
-            gp->gv.oldyoshiguest.xC6 = local34[HSD_Randi(5)];
+            grOy_803B83F0_t local34 = grOy_803B83F0.ids;
+            PAD_STACK(8);
+            gp->gv.oldyoshiguest.xC6 = local34.x[HSD_Randi(5)];
         }
         grAnime_801C8138(arg, gp->map_id, 0);
         dVar10 = HSD_Randf();
-        jobj = arg->hsd_obj;
         dVar9 = grOy_804D6A88->x18 * (dVar10 * 2.0f - 1.0f);
-        HSD_JObjSetTranslateY(jobj, dVar9);
+        HSD_JObjSetTranslateY(arg->hsd_obj, dVar9);
     } else {
-        jobj = Ground_801C3FA4(arg, gp->gv.oldyoshiguest.xC6);
+        HSD_JObj* jobj = Ground_801C3FA4(arg, gp->gv.oldyoshiguest.xC6);
         if (jobj == NULL) {
             return;
         }

--- a/src/melee/gr/grrcruise.c
+++ b/src/melee/gr/grrcruise.c
@@ -85,6 +85,7 @@ struct StageData grRc_803E4ECC = {
 extern Vec3 grRc_803B8288;
 extern s16 grRc_803E4FF0[];
 extern s16 grRc_804D4790[4];
+const f32 grRc_804DB644;
 
 static struct {
     f32 x0;
@@ -306,6 +307,12 @@ void grRCruise_801FF79C(Ground_GObj* arg) {}
 
 void grRCruise_801FF7A0(Ground_GObj* arg) {}
 
+char grRc_803E4F44[] = "dynamicsdata_shipflag\0\0\0"
+                         "gp->u.scroll.int_jobj\0\0\0"
+                         "gp->u.scroll.cam_jobj\0\0\0"
+                         "gp->u.scroll.ctr_jobj\0\0\0"
+                         "translate\0\0";
+
 void grRCruise_801FF7A4(Ground_GObj* gobj)
 {
     Ground_GObj* stage_gobj = gobj;
@@ -320,7 +327,7 @@ void grRCruise_801FF7A4(Ground_GObj* gobj)
     grAnime_801C752C(jobj, 1, 30628, HSD_AObjSetFlags, 3, 0x20000000);
     archive = grDatFiles_801C6324();
     if (archive != NULL && (data = HSD_ArchiveGetPublicAddress(
-                                archive->unk0, "dynamicsdata_shipflag"),
+                                archive->unk0, grRc_803E4F44),
                             data != NULL))
     {
         grLib_801C9B20(Ground_801C3FA4(stage_gobj, 23), data,
@@ -363,7 +370,39 @@ void grRCruise_801FF920(Ground_GObj* arg) {}
 
 void grRCruise_801FF924(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
+    // RCruise uses an anim_gobj/int_jobj split not represented by ScrollVars.
+    struct grRCruise_ScrollVarsForInit {
+        struct {
+            u8 b0 : 1;
+            u8 b1 : 1;
+            u8 b2 : 1;
+            u8 b3 : 1;
+            u8 b4 : 1;
+            u8 b5 : 1;
+            u8 b6 : 1;
+            u8 b7 : 1;
+        } x00;
+        u8 pad_01[3];
+        Vec3 x04;
+        Vec3 x10;
+        Vec3 x1C;
+        HSD_GObj* anim_gobj;
+        HSD_JObj* int_jobj;
+        HSD_JObj* cam_jobj;
+        HSD_JObj* ctr_jobj;
+        HSD_JObj* x34[3];
+        HSD_JObj* x40;
+    };
+    struct grRCruise_ScrollGround {
+        u8 pad_00[0x14];
+        s32 map_id;
+        u8 pad_18[0xAC];
+        struct {
+            struct grRCruise_ScrollVarsForInit scroll;
+        } u;
+    };
+    struct grRCruise_ScrollGround* gp =
+        (struct grRCruise_ScrollGround*) GET_GROUND(gobj);
     HSD_JObj* jobj = GET_JOBJ(gobj);
     PAD_STACK(0x8);
 
@@ -371,22 +410,22 @@ void grRCruise_801FF924(Ground_GObj* gobj)
     gp->u.scroll.x34[1] = Ground_801C3FA4(gobj, 5);
     gp->u.scroll.x34[2] = Ground_801C3FA4(gobj, 6);
     gp->u.scroll.x40 = Ground_801C3FA4(gobj, 7);
-    gp->u.scroll.scroll_jobj = Ground_801C3FA4(gobj, 3);
-    HSD_ASSERT(0x2B0, gp->u.scroll.scroll_jobj);
+    gp->u.scroll.int_jobj = Ground_801C3FA4(gobj, 3);
+    HSD_ASSERTMSG(0x2B0, gp->u.scroll.int_jobj, grRc_803E4F44 + 0x18);
     gp->u.scroll.cam_jobj = Ground_801C3FA4(gobj, 2);
-    HSD_ASSERT(0x2B2, gp->u.scroll.cam_jobj);
+    HSD_ASSERTMSG(0x2B2, gp->u.scroll.cam_jobj, grRc_803E4F44 + 0x30);
 
     gp->u.scroll.ctr_jobj = Ground_801C3FA4(gobj, 1);
-    HSD_ASSERT(0x2B4, gp->u.scroll.ctr_jobj);
+    HSD_ASSERTMSG(0x2B4, gp->u.scroll.ctr_jobj, grRc_803E4F44 + 0x48);
 
     HSD_JObjGetTranslation(gp->u.scroll.ctr_jobj, &gp->u.scroll.x04);
-    gp->u.scroll.x10.z = 0.0f;
-    gp->u.scroll.x10.y = 0.0f;
-    gp->u.scroll.x10.x = 0.0f;
-    gp->u.scroll.x1C.z = 0.0f;
-    gp->u.scroll.x1C.y = 0.0f;
-    gp->u.scroll.x1C.x = 0.0f;
-    gp->u.scroll.x00 &= ~0x80;
+    gp->u.scroll.x10.z = grRc_804DB644;
+    gp->u.scroll.x10.y = grRc_804DB644;
+    gp->u.scroll.x10.x = grRc_804DB644;
+    gp->u.scroll.x1C.z = grRc_804DB644;
+    gp->u.scroll.x1C.y = grRc_804DB644;
+    gp->u.scroll.x1C.x = grRc_804DB644;
+    gp->u.scroll.x00.b0 = 0;
     grAnime_801C8138(gobj, gp->map_id, 0);
     grAnime_801C752C(jobj, 1, 30628, HSD_AObjSetFlags, 3, 0x20000000);
     gobj->render_cb = (GObj_RenderFunc) fn_80201BE0;
@@ -400,33 +439,38 @@ bool grRCruise_801FFAD4(Ground_GObj* arg)
 void grRCruise_801FFADC(Ground_GObj* arg0)
 {
     Vec3 sp64;
+    UNUSED Vec3 pad58;
     Vec3 cam_offset;
+    UNUSED f32 pad48;
     Vec3 cam_offset2;
     Vec3 diff;
     Vec3 sp24;
     Vec3 sp18;
     Ground* gp;
     HSD_GObj* gobj;
-    HSD_JObj* temp_r30;
-    HSD_JObj* temp_r31;
+    HSD_JObj* cam_jobj;
+    HSD_JObj* ctr_jobj;
     HSD_JObj* temp_r29_2;
     f32 temp_f31;
     f32 temp_f4;
 
     HSD_JObj* jobj;
-    Ground* temp_r4;
-    PAD_STACK(0x18);
+    Ground* anim_gp;
+    PAD_STACK(0x8);
 
     gp = arg0->user_data;
     if (!(((u8) gp->u.scroll.x00 >> 7U) & 1)) {
         Stage_UnkSetVec3TCam_Offset(&cam_offset);
         HSD_ASSERT(0x2E0U, gp->u.scroll.anim_gobj);
-        temp_r4 = gp->u.scroll.anim_gobj->user_data;
-        temp_r30 = temp_r4->u.scroll.cam_jobj;
-        temp_r31 = temp_r4->u.scroll.ctr_jobj;
+        {
+            HSD_GObj* anim_gobj = gp->u.scroll.anim_gobj;
+            anim_gp = anim_gobj->user_data;
+        }
+        cam_jobj = anim_gp->u.scroll.cam_jobj;
+        ctr_jobj = anim_gp->u.scroll.ctr_jobj;
         Stage_UnkSetVec3TCam_Offset(&cam_offset2);
-        lb_8000B1CC(temp_r31, NULL, &sp18);
-        lb_8000B1CC(temp_r30, NULL, &sp24);
+        lb_8000B1CC(ctr_jobj, NULL, &sp18);
+        lb_8000B1CC(cam_jobj, NULL, &sp24);
         lbVector_Diff(&sp24, &sp18, &diff);
         temp_f4 = sp18.z / diff.z;
         sp64.x = -((diff.x * temp_f4) - sp18.x);
@@ -509,76 +553,96 @@ bool grRCruise_8020014C(Ground_GObj* arg)
 
 void grRCruise_80200154(Ground_GObj* gobj)
 {
+    struct grRCruise_SubEntryFlags {
+        u8 b0 : 1;
+        u8 b1 : 1;
+        u8 b2 : 1;
+        u8 b3 : 1;
+        u8 b4 : 1;
+        u8 b5 : 1;
+        u8 b6 : 1;
+        u8 b7 : 1;
+    };
     Ground* gp = gobj->user_data;
+    Ground* gp2 = gp;
     s32 i;
 
     for (i = 0; i < 3; i++) {
-        struct grRCruise_SubEntry* entry = &gp->gv.rcruise.x3C[i];
-
-        switch (entry->x00) {
+        switch (gp->gv.rcruise.x3C[i].x00) {
         case 0:
-            mpJointListAdd(entry->x02);
-            grRCruise_80201B60(entry->x0C->child, 1);
-            entry->x08 = 0;
-            entry->x00 = 1;
+            mpJointListAdd(gp2->gv.rcruise.x3C[i].x02);
+            grRCruise_80201B60(gp2->gv.rcruise.x3C[i].x0C->child, 1);
+            gp->gv.rcruise.x3C[i].x04 = 0;
+            gp->gv.rcruise.x3C[i].x00 = 1;
             break;
         case 2:
-            if (entry->x04 == 0) {
-                entry->x08 = 0;
-                grAnime_801C7A94(gobj, grRc_804D4790[i], 1, 0.0f);
-                entry->x00 = 3;
+            if (gp->gv.rcruise.x3C[i].x08 == 0) {
+                gp->gv.rcruise.x3C[i].x04 = 0;
+                grAnime_801C7A94(gobj, grRc_804D4790[i], 1, grRc_804DB644);
+                gp->gv.rcruise.x3C[i].x00 = 3;
             } else if (grAnime_801C83D0(gobj, grRc_804D4790[i], 7) != 0) {
-                entry->x08 = 0;
-                entry->x00 = 5;
+                gp->gv.rcruise.x3C[i].x04 = 0;
+                gp->gv.rcruise.x3C[i].x00 = 5;
             }
             break;
         case 3:
-            if (entry->x08 >= grRc_804D6A10->x0C) {
-                entry->x08 = 0;
-                entry->pad_01 &= ~0x80;
-                entry->x00 = 4;
+            if (gp->gv.rcruise.x3C[i].x04 >= grRc_804D6A10->x0C) {
+                gp->gv.rcruise.x3C[i].x04 = 0;
+                ((struct grRCruise_SubEntryFlags*) &gp->gv.rcruise.x3C[i]
+                     .pad_01)
+                    ->b0 = 0;
+                gp->gv.rcruise.x3C[i].x00 = 4;
             }
-            entry->x08++;
+            gp->gv.rcruise.x3C[i].x04++;
             break;
         case 4:
-            if (entry->x08 % grRc_804D6A10->x14 == 0) {
-                entry->pad_01 ^= 0x80;
-                if ((entry->pad_01 & 0x80) != 0) {
-                    grRCruise_80201B60(entry->x0C->child, 0);
+            if (gp->gv.rcruise.x3C[i].x04 % grRc_804D6A10->x14 == 0) {
+                ((struct grRCruise_SubEntryFlags*) &gp->gv.rcruise.x3C[i]
+                     .pad_01)
+                    ->b0 =
+                    ((struct grRCruise_SubEntryFlags*) &gp->gv.rcruise.x3C[i]
+                         .pad_01)
+                        ->b0 ^
+                    1;
+                if (((struct grRCruise_SubEntryFlags*) &gp->gv.rcruise.x3C[i]
+                         .pad_01)
+                        ->b0)
+                {
+                    grRCruise_80201B60(gp2->gv.rcruise.x3C[i].x0C->child, 0);
                 } else {
-                    grRCruise_80201B60(entry->x0C->child, 1);
+                    grRCruise_80201B60(gp2->gv.rcruise.x3C[i].x0C->child, 1);
                 }
             }
-            if (entry->x08 >= grRc_804D6A10->x10) {
-                mpLib_80057BC0(entry->x02);
-                grRCruise_80201B60(entry->x0C->child, 0);
-                grAnime_801C7BA0(gobj, grRc_804D4790[i], 1, 0.0f);
-                grAnime_801C7A94(gobj, grRc_804D4790[i], 1, 0.0f);
-                mpLib_80055E9C(entry->x02);
-                mpLib_80057424(entry->x02);
-                entry->x00 = 0;
+            if (gp->gv.rcruise.x3C[i].x04 >= grRc_804D6A10->x10) {
+                mpLib_80057BC0(gp2->gv.rcruise.x3C[i].x02);
+                grRCruise_80201B60(gp2->gv.rcruise.x3C[i].x0C->child, 0);
+                grAnime_801C7BA0(gobj, grRc_804D4790[i], 1, grRc_804DB644);
+                grAnime_801C7A94(gobj, grRc_804D4790[i], 1, grRc_804DB644);
+                mpLib_80055E9C(gp2->gv.rcruise.x3C[i].x02);
+                mpLib_80057424(gp2->gv.rcruise.x3C[i].x02);
+                gp->gv.rcruise.x3C[i].x00 = 0;
             }
-            entry->x08++;
+            gp->gv.rcruise.x3C[i].x04++;
             break;
         case 5:
-            if (entry->x08 % grRc_804D6A10->x1C == 0) {
-                grRCruise_80201B60(entry->x0C->child, 0);
+            if (gp->gv.rcruise.x3C[i].x04 % grRc_804D6A10->x1C == 0) {
+                grRCruise_80201B60(gp2->gv.rcruise.x3C[i].x0C->child, 0);
             } else {
-                grRCruise_80201B60(entry->x0C->child, 1);
+                grRCruise_80201B60(gp2->gv.rcruise.x3C[i].x0C->child, 1);
             }
-            if (entry->x08 >= grRc_804D6A10->x18) {
-                mpLib_80057BC0(entry->x02);
-                grRCruise_80201B60(entry->x0C->child, 0);
-                grAnime_801C7BA0(gobj, grRc_804D4790[i], 1, 0.0f);
-                grAnime_801C7A94(gobj, grRc_804D4790[i], 1, 0.0f);
-                mpLib_80055E9C(entry->x02);
-                mpLib_80057424(entry->x02);
-                entry->x00 = 0;
+            if (gp->gv.rcruise.x3C[i].x04 >= grRc_804D6A10->x18) {
+                mpLib_80057BC0(gp2->gv.rcruise.x3C[i].x02);
+                grRCruise_80201B60(gp2->gv.rcruise.x3C[i].x0C->child, 0);
+                grAnime_801C7BA0(gobj, grRc_804D4790[i], 1, grRc_804DB644);
+                grAnime_801C7A94(gobj, grRc_804D4790[i], 1, grRc_804DB644);
+                mpLib_80055E9C(gp2->gv.rcruise.x3C[i].x02);
+                mpLib_80057424(gp2->gv.rcruise.x3C[i].x02);
+                gp->gv.rcruise.x3C[i].x00 = 0;
             }
-            entry->x08++;
+            gp->gv.rcruise.x3C[i].x04++;
             break;
         }
-        entry->x04 = 0;
+        gp->gv.rcruise.x3C[i].x08 = 0;
     }
     Ground_801C2FE0(gobj);
 }
@@ -628,6 +692,7 @@ void grRCruise_80200540(Ground_GObj* gobj)
 void grRCruise_80200578(Ground* gp_arg, s32 joint_id, CollData* cd, s32 arg3,
                         mpLib_GroundEnum arg4, f32 arg5)
 {
+    UNUSED u8 pad[8];
     Point3d pos;
     HSD_GObj* gobj = (HSD_GObj*) gp_arg;
     Ground* gp = HSD_GObjGetUserData(gobj);
@@ -635,30 +700,30 @@ void grRCruise_80200578(Ground* gp_arg, s32 joint_id, CollData* cd, s32 arg3,
     f32 dx;
     f32 dy;
     f32 dist;
-    PAD_STACK(16);
+    PAD_STACK(8);
 
-    if (cd->x34_flags.b1234 == 1 || cd->x34_flags.b1234 == 2 ||
-        cd->x34_flags.b1234 == 3)
+    if ((s32) cd->x34_flags.b1234 != 1 &&
+        (s32) cd->x34_flags.b1234 != 2 &&
+        (s32) cd->x34_flags.b1234 != 3)
     {
-        if ((f32) arg3 > 1000.0f) {
-            arg3 = 1000;
-        }
-        lb_8000B1CC(jobj, NULL, &pos);
-        dx = pos.x - cd->cur_pos.x;
-        dy = pos.y - cd->cur_pos.y;
-        dist = dx * dx + dy * dy;
-        if (dist > 0.0f) {
-            dist = sqrtf(dist);
-        }
-        if (dist > 4.0f) {
-            if (pos.x < cd->cur_pos.x) {
-                gp->gv.rcruise.x24 += dist * ((f32) arg3 / 1000.0f);
-            } else {
-                gp->gv.rcruise.x28 += dist * ((f32) arg3 / 1000.0f);
-            }
-        }
-        gp->gv.rcruise.x34++;
+        return;
     }
+
+    if ((f32) arg3 > 1000.0f) {
+        arg3 = 1000;
+    }
+    lb_8000B1CC(jobj, NULL, &pos);
+    dx = pos.x - cd->cur_pos.x;
+    dy = pos.y - cd->cur_pos.y;
+    dist = sqrtf(dy * dy + dx * dx);
+    if (dist > 4.0f) {
+        if (pos.x < cd->cur_pos.x) {
+            gp->gv.rcruise.x24 += dist * ((f32) arg3 / 1000.0f);
+        } else {
+            gp->gv.rcruise.x28 += dist * ((f32) arg3 / 1000.0f);
+        }
+    }
+    gp->gv.rcruise.x34++;
 }
 
 void grRCruise_8020071C(Ground_GObj* gobj)
@@ -731,28 +796,61 @@ void grRCruise_8020071C(Ground_GObj* gobj)
     gp->gv.rcruise.x24 = 0.0f;
 }
 
+s16 grRc_803E4FF0[] = {
+    0x20, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30,
+    0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0,
+    0x06, 0x04, 0,    0,    0x08, 0x05, 0,    0,
+    0x10, 0x0A, 0,    0,    0x0B, 0x06, 0,    0,
+    0x0C, 0x07, 0,    0,    0x0D, 0x08, 0,    0,
+    0x0E, 0x09, 0,    0,    0x0F, 0x08, 0,    0,
+    0x13, 0x0C, 0,    1,    0x14, 0x0D, 0,    1,
+    0x15, 0x0E, 0,    1,    0x1E, 0x0F, 0,    1,
+    0x16, 0x10, 0,    1,    0x17, 0x11, 0,    1,
+    0x18, 0x12, 0,    1,    0x19, 0x13, 0,    1,
+    0x1A, 0x14, 0,    1,    0x1B, 0x15, 0,    1,
+    0x1C, 0x16, 0,    1,    0x1D, 0x17, 0,    1,
+};
+
 void grRCruise_80200B48(Ground_GObj* gobj)
 {
-    Ground* gp = gobj->user_data;
+    Ground* gp;
+    HSD_JObj* jobj;
+    struct grRCruise_Entry* entry;
     s32 i;
 
+    gp = gobj->user_data;
     for (i = 0; i < 17; i++) {
-        struct grRCruise_Entry* entry = &gp->gv.rcruise.entries[i];
+        entry = &gp->gv.rcruise.entries[i];
         entry->x02 = Ground_801C32D4(gp->map_id, grRc_803E4FF0[i]);
         entry->x14 = Ground_801C3FA4(gobj, grRc_803E4FF0[i]);
         entry->x08 = 0;
         entry->x04 = 0;
-        entry->x0C = HSD_JObjGetTranslationY(entry->x14);
+        entry->x0C = HSD_JObjGetTranslationY(jobj = entry->x14);
         entry->x00 = 0;
     }
 }
 
+inline Ground* grRCruise_80200C04_inline(Ground_GObj* gobj)
+{
+    return gobj->user_data;
+}
+
 void grRCruise_80200C04(Ground_GObj* gobj)
 {
-    Ground* gp = gobj->user_data;
+    struct grRCruise_EntryFlags {
+        u8 b0 : 1;
+        u8 b1 : 1;
+        u8 b2 : 1;
+        u8 b3 : 1;
+        u8 b4 : 1;
+        u8 b5 : 1;
+        u8 b6 : 1;
+        u8 b7 : 1;
+    };
+    Ground* gp;
     s32 i;
-    PAD_STACK(8);
 
+    gp = grRCruise_80200C04_inline(gobj);
     for (i = 0; i < 17; i++) {
         struct grRCruise_Entry* entry = &gp->gv.rcruise.entries[i];
 
@@ -769,8 +867,9 @@ void grRCruise_80200C04(Ground_GObj* gobj)
             break;
         case 2:
             if ((entry->x04 % grRc_804D6A10->x28) == 0) {
-                s32 randi = HSD_Randi((
-                    s32) (100.0f * (grRc_804D6A10->x30 - grRc_804D6A10->x2C)));
+                f32 range =
+                    100.0f * (grRc_804D6A10->x30 - grRc_804D6A10->x2C);
+                s32 randi = (s32) range != 0 ? HSD_Randi((s32) range) : 0;
                 HSD_JObjSetTranslateY(entry->x14,
                                       entry->x0C + (grRc_804D6A10->x2C +
                                                     ((f32) randi / 100.0f)));
@@ -783,11 +882,15 @@ void grRCruise_80200C04(Ground_GObj* gobj)
             break;
         case 3:
             entry->x10 -= grRc_804D6A10->x34;
-            if (entry->x10 < -grRc_804D6A10->x38) {
+            if ((entry->x10 < 0.0f ? -entry->x10 : entry->x10) >
+                grRc_804D6A10->x38)
+            {
                 entry->x10 = -grRc_804D6A10->x38;
             }
             HSD_JObjAddTranslationY(entry->x14, entry->x10);
-            if (entry->x14->translate.y <= Stage_GetCamBoundsBottomOffset()) {
+            if (HSD_JObjGetTranslationY(entry->x14) <=
+                Stage_GetCamBoundsBottomOffset())
+            {
                 entry->x10 = 0.0f;
                 grRCruise_80201B60(entry->x14, 0);
                 mpLib_80057BC0(entry->x02);
@@ -803,15 +906,16 @@ void grRCruise_80200C04(Ground_GObj* gobj)
                 grRCruise_80201B60(entry->x14, 1);
                 mpJointListAdd(entry->x02);
                 entry->x04 = 0;
-                entry->pad_01 &= ~0x80;
+                ((struct grRCruise_EntryFlags*) &entry->pad_01)->b0 = 0;
                 entry->x00 = 5;
             }
             entry->x04++;
             break;
         case 5:
             if ((entry->x04 % grRc_804D6A10->x44) == 0) {
-                entry->pad_01 ^= 0x80;
-                if ((entry->pad_01 & 0x80) != 0) {
+                ((struct grRCruise_EntryFlags*) &entry->pad_01)->b0 =
+                    ((struct grRCruise_EntryFlags*) &entry->pad_01)->b0 ^ 1;
+                if (((struct grRCruise_EntryFlags*) &entry->pad_01)->b0) {
                     grRCruise_80201B60(entry->x14, 0);
                 } else {
                     grRCruise_80201B60(entry->x14, 1);
@@ -971,24 +1075,29 @@ void grRCruise_80201288(HSD_JObj* jobj, void (*callback)(HSD_DObj*, u32),
 
 void grRCruise_80201410(Ground_GObj* gobj)
 {
+    struct grRCruise_VanishDescTable {
+        u8 pad[0x26C];
+        struct grRCruise_VanishDesc desc[20];
+    };
     Ground* gp = gobj->user_data;
-    struct grRCruise_VanishDesc* desc;
+    struct grRCruise_VanishDescTable* desc_table;
     u32 i;
 
     gp->u.map.vanish = HSD_MemAlloc(0xA0);
     HSD_ASSERT(0x5AD, gp->u.map.vanish);
 
-    desc = &grRc_803E5014;
+    desc_table = (struct grRCruise_VanishDescTable*) grRc_803E4DA8;
     for (i = 0; i < 20; i++) {
-        gp->u.map.vanish[i].jobj = Ground_801C3FA4(gobj, desc[i].x00);
+        gp->u.map.vanish[i].jobj =
+            Ground_801C3FA4(gobj, desc_table->desc[i].x00);
         HSD_ASSERT(0x5B3, gp->u.map.vanish[i].jobj);
-        if (desc[i].x04 != 0) {
-            HSD_GObj* gobj5;
+        if (desc_table->desc[i].x04 != 0) {
             HSD_GObj* gobj1;
-            s16 joint;
+            HSD_GObj* gobj5;
+            s32 joint;
 
             gp->u.map.vanish[i].x00 = 2;
-            joint = desc[i].x00;
+            joint = desc_table->desc[i].x00;
             gobj5 = Ground_801C2BA4(5);
             if (gobj5 != NULL) {
                 gobj1 = Ground_801C2BA4(1);
@@ -1003,11 +1112,12 @@ void grRCruise_80201410(Ground_GObj* gobj)
                     }
                 }
             }
-            mpJointListAdd(desc[i].x02);
+            mpJointListAdd(desc_table->desc[i].x02);
         } else {
             gp->u.map.vanish[i].x00 = 0;
-            grAnime_801C7FF8(gobj, desc[i].x00, 2, 1, 0.0f, 1.0f);
-            mpLib_80057BC0(desc[i].x02);
+            grAnime_801C7FF8(gobj, desc_table->desc[i].x00, 2, 1, 0.0f,
+                             1.0f);
+            mpLib_80057BC0(desc_table->desc[i].x02);
         }
     }
 }

--- a/src/melee/gr/grrcruise.c
+++ b/src/melee/gr/grrcruise.c
@@ -85,7 +85,6 @@ struct StageData grRc_803E4ECC = {
 extern Vec3 grRc_803B8288;
 extern s16 grRc_803E4FF0[];
 extern s16 grRc_804D4790[4];
-const f32 grRc_804DB644;
 
 static struct {
     f32 x0;
@@ -307,12 +306,6 @@ void grRCruise_801FF79C(Ground_GObj* arg) {}
 
 void grRCruise_801FF7A0(Ground_GObj* arg) {}
 
-char grRc_803E4F44[] = "dynamicsdata_shipflag\0\0\0"
-                         "gp->u.scroll.int_jobj\0\0\0"
-                         "gp->u.scroll.cam_jobj\0\0\0"
-                         "gp->u.scroll.ctr_jobj\0\0\0"
-                         "translate\0\0";
-
 void grRCruise_801FF7A4(Ground_GObj* gobj)
 {
     Ground_GObj* stage_gobj = gobj;
@@ -327,7 +320,7 @@ void grRCruise_801FF7A4(Ground_GObj* gobj)
     grAnime_801C752C(jobj, 1, 30628, HSD_AObjSetFlags, 3, 0x20000000);
     archive = grDatFiles_801C6324();
     if (archive != NULL && (data = HSD_ArchiveGetPublicAddress(
-                                archive->unk0, grRc_803E4F44),
+                                archive->unk0, "dynamicsdata_shipflag"),
                             data != NULL))
     {
         grLib_801C9B20(Ground_801C3FA4(stage_gobj, 23), data,
@@ -370,39 +363,7 @@ void grRCruise_801FF920(Ground_GObj* arg) {}
 
 void grRCruise_801FF924(Ground_GObj* gobj)
 {
-    // RCruise uses an anim_gobj/int_jobj split not represented by ScrollVars.
-    struct grRCruise_ScrollVarsForInit {
-        struct {
-            u8 b0 : 1;
-            u8 b1 : 1;
-            u8 b2 : 1;
-            u8 b3 : 1;
-            u8 b4 : 1;
-            u8 b5 : 1;
-            u8 b6 : 1;
-            u8 b7 : 1;
-        } x00;
-        u8 pad_01[3];
-        Vec3 x04;
-        Vec3 x10;
-        Vec3 x1C;
-        HSD_GObj* anim_gobj;
-        HSD_JObj* int_jobj;
-        HSD_JObj* cam_jobj;
-        HSD_JObj* ctr_jobj;
-        HSD_JObj* x34[3];
-        HSD_JObj* x40;
-    };
-    struct grRCruise_ScrollGround {
-        u8 pad_00[0x14];
-        s32 map_id;
-        u8 pad_18[0xAC];
-        struct {
-            struct grRCruise_ScrollVarsForInit scroll;
-        } u;
-    };
-    struct grRCruise_ScrollGround* gp =
-        (struct grRCruise_ScrollGround*) GET_GROUND(gobj);
+    Ground* gp = GET_GROUND(gobj);
     HSD_JObj* jobj = GET_JOBJ(gobj);
     PAD_STACK(0x8);
 
@@ -410,22 +371,22 @@ void grRCruise_801FF924(Ground_GObj* gobj)
     gp->u.scroll.x34[1] = Ground_801C3FA4(gobj, 5);
     gp->u.scroll.x34[2] = Ground_801C3FA4(gobj, 6);
     gp->u.scroll.x40 = Ground_801C3FA4(gobj, 7);
-    gp->u.scroll.int_jobj = Ground_801C3FA4(gobj, 3);
-    HSD_ASSERTMSG(0x2B0, gp->u.scroll.int_jobj, grRc_803E4F44 + 0x18);
+    gp->u.scroll.scroll_jobj = Ground_801C3FA4(gobj, 3);
+    HSD_ASSERT(0x2B0, gp->u.scroll.scroll_jobj);
     gp->u.scroll.cam_jobj = Ground_801C3FA4(gobj, 2);
-    HSD_ASSERTMSG(0x2B2, gp->u.scroll.cam_jobj, grRc_803E4F44 + 0x30);
+    HSD_ASSERT(0x2B2, gp->u.scroll.cam_jobj);
 
     gp->u.scroll.ctr_jobj = Ground_801C3FA4(gobj, 1);
-    HSD_ASSERTMSG(0x2B4, gp->u.scroll.ctr_jobj, grRc_803E4F44 + 0x48);
+    HSD_ASSERT(0x2B4, gp->u.scroll.ctr_jobj);
 
     HSD_JObjGetTranslation(gp->u.scroll.ctr_jobj, &gp->u.scroll.x04);
-    gp->u.scroll.x10.z = grRc_804DB644;
-    gp->u.scroll.x10.y = grRc_804DB644;
-    gp->u.scroll.x10.x = grRc_804DB644;
-    gp->u.scroll.x1C.z = grRc_804DB644;
-    gp->u.scroll.x1C.y = grRc_804DB644;
-    gp->u.scroll.x1C.x = grRc_804DB644;
-    gp->u.scroll.x00.b0 = 0;
+    gp->u.scroll.x10.z = 0.0f;
+    gp->u.scroll.x10.y = 0.0f;
+    gp->u.scroll.x10.x = 0.0f;
+    gp->u.scroll.x1C.z = 0.0f;
+    gp->u.scroll.x1C.y = 0.0f;
+    gp->u.scroll.x1C.x = 0.0f;
+    gp->u.scroll.x00 &= ~0x80;
     grAnime_801C8138(gobj, gp->map_id, 0);
     grAnime_801C752C(jobj, 1, 30628, HSD_AObjSetFlags, 3, 0x20000000);
     gobj->render_cb = (GObj_RenderFunc) fn_80201BE0;
@@ -553,96 +514,76 @@ bool grRCruise_8020014C(Ground_GObj* arg)
 
 void grRCruise_80200154(Ground_GObj* gobj)
 {
-    struct grRCruise_SubEntryFlags {
-        u8 b0 : 1;
-        u8 b1 : 1;
-        u8 b2 : 1;
-        u8 b3 : 1;
-        u8 b4 : 1;
-        u8 b5 : 1;
-        u8 b6 : 1;
-        u8 b7 : 1;
-    };
     Ground* gp = gobj->user_data;
-    Ground* gp2 = gp;
     s32 i;
 
     for (i = 0; i < 3; i++) {
-        switch (gp->gv.rcruise.x3C[i].x00) {
+        struct grRCruise_SubEntry* entry = &gp->gv.rcruise.x3C[i];
+
+        switch (entry->x00) {
         case 0:
-            mpJointListAdd(gp2->gv.rcruise.x3C[i].x02);
-            grRCruise_80201B60(gp2->gv.rcruise.x3C[i].x0C->child, 1);
-            gp->gv.rcruise.x3C[i].x04 = 0;
-            gp->gv.rcruise.x3C[i].x00 = 1;
+            mpJointListAdd(entry->x02);
+            grRCruise_80201B60(entry->x0C->child, 1);
+            entry->x08 = 0;
+            entry->x00 = 1;
             break;
         case 2:
-            if (gp->gv.rcruise.x3C[i].x08 == 0) {
-                gp->gv.rcruise.x3C[i].x04 = 0;
-                grAnime_801C7A94(gobj, grRc_804D4790[i], 1, grRc_804DB644);
-                gp->gv.rcruise.x3C[i].x00 = 3;
+            if (entry->x04 == 0) {
+                entry->x08 = 0;
+                grAnime_801C7A94(gobj, grRc_804D4790[i], 1, 0.0f);
+                entry->x00 = 3;
             } else if (grAnime_801C83D0(gobj, grRc_804D4790[i], 7) != 0) {
-                gp->gv.rcruise.x3C[i].x04 = 0;
-                gp->gv.rcruise.x3C[i].x00 = 5;
+                entry->x08 = 0;
+                entry->x00 = 5;
             }
             break;
         case 3:
-            if (gp->gv.rcruise.x3C[i].x04 >= grRc_804D6A10->x0C) {
-                gp->gv.rcruise.x3C[i].x04 = 0;
-                ((struct grRCruise_SubEntryFlags*) &gp->gv.rcruise.x3C[i]
-                     .pad_01)
-                    ->b0 = 0;
-                gp->gv.rcruise.x3C[i].x00 = 4;
+            if (entry->x08 >= grRc_804D6A10->x0C) {
+                entry->x08 = 0;
+                entry->pad_01 &= ~0x80;
+                entry->x00 = 4;
             }
-            gp->gv.rcruise.x3C[i].x04++;
+            entry->x08++;
             break;
         case 4:
-            if (gp->gv.rcruise.x3C[i].x04 % grRc_804D6A10->x14 == 0) {
-                ((struct grRCruise_SubEntryFlags*) &gp->gv.rcruise.x3C[i]
-                     .pad_01)
-                    ->b0 =
-                    ((struct grRCruise_SubEntryFlags*) &gp->gv.rcruise.x3C[i]
-                         .pad_01)
-                        ->b0 ^
-                    1;
-                if (((struct grRCruise_SubEntryFlags*) &gp->gv.rcruise.x3C[i]
-                         .pad_01)
-                        ->b0)
-                {
-                    grRCruise_80201B60(gp2->gv.rcruise.x3C[i].x0C->child, 0);
+            if (entry->x08 % grRc_804D6A10->x14 == 0) {
+                entry->pad_01 ^= 0x80;
+                if ((entry->pad_01 & 0x80) != 0) {
+                    grRCruise_80201B60(entry->x0C->child, 0);
                 } else {
-                    grRCruise_80201B60(gp2->gv.rcruise.x3C[i].x0C->child, 1);
+                    grRCruise_80201B60(entry->x0C->child, 1);
                 }
             }
-            if (gp->gv.rcruise.x3C[i].x04 >= grRc_804D6A10->x10) {
-                mpLib_80057BC0(gp2->gv.rcruise.x3C[i].x02);
-                grRCruise_80201B60(gp2->gv.rcruise.x3C[i].x0C->child, 0);
-                grAnime_801C7BA0(gobj, grRc_804D4790[i], 1, grRc_804DB644);
-                grAnime_801C7A94(gobj, grRc_804D4790[i], 1, grRc_804DB644);
-                mpLib_80055E9C(gp2->gv.rcruise.x3C[i].x02);
-                mpLib_80057424(gp2->gv.rcruise.x3C[i].x02);
-                gp->gv.rcruise.x3C[i].x00 = 0;
+            if (entry->x08 >= grRc_804D6A10->x10) {
+                mpLib_80057BC0(entry->x02);
+                grRCruise_80201B60(entry->x0C->child, 0);
+                grAnime_801C7BA0(gobj, grRc_804D4790[i], 1, 0.0f);
+                grAnime_801C7A94(gobj, grRc_804D4790[i], 1, 0.0f);
+                mpLib_80055E9C(entry->x02);
+                mpLib_80057424(entry->x02);
+                entry->x00 = 0;
             }
-            gp->gv.rcruise.x3C[i].x04++;
+            entry->x08++;
             break;
         case 5:
-            if (gp->gv.rcruise.x3C[i].x04 % grRc_804D6A10->x1C == 0) {
-                grRCruise_80201B60(gp2->gv.rcruise.x3C[i].x0C->child, 0);
+            if (entry->x08 % grRc_804D6A10->x1C == 0) {
+                grRCruise_80201B60(entry->x0C->child, 0);
             } else {
-                grRCruise_80201B60(gp2->gv.rcruise.x3C[i].x0C->child, 1);
+                grRCruise_80201B60(entry->x0C->child, 1);
             }
-            if (gp->gv.rcruise.x3C[i].x04 >= grRc_804D6A10->x18) {
-                mpLib_80057BC0(gp2->gv.rcruise.x3C[i].x02);
-                grRCruise_80201B60(gp2->gv.rcruise.x3C[i].x0C->child, 0);
-                grAnime_801C7BA0(gobj, grRc_804D4790[i], 1, grRc_804DB644);
-                grAnime_801C7A94(gobj, grRc_804D4790[i], 1, grRc_804DB644);
-                mpLib_80055E9C(gp2->gv.rcruise.x3C[i].x02);
-                mpLib_80057424(gp2->gv.rcruise.x3C[i].x02);
-                gp->gv.rcruise.x3C[i].x00 = 0;
+            if (entry->x08 >= grRc_804D6A10->x18) {
+                mpLib_80057BC0(entry->x02);
+                grRCruise_80201B60(entry->x0C->child, 0);
+                grAnime_801C7BA0(gobj, grRc_804D4790[i], 1, 0.0f);
+                grAnime_801C7A94(gobj, grRc_804D4790[i], 1, 0.0f);
+                mpLib_80055E9C(entry->x02);
+                mpLib_80057424(entry->x02);
+                entry->x00 = 0;
             }
-            gp->gv.rcruise.x3C[i].x04++;
+            entry->x08++;
             break;
         }
-        gp->gv.rcruise.x3C[i].x08 = 0;
+        entry->x04 = 0;
     }
     Ground_801C2FE0(gobj);
 }

--- a/src/melee/gr/grshrineroute.c
+++ b/src/melee/gr/grshrineroute.c
@@ -375,6 +375,8 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
 {
     Vec3 sp88;
     Vec3 sp7C;
+    f32 unused1;
+    f32 unused2;
     Vec3 sp68;
     Vec3 sp5C;
     Vec3 sp50;
@@ -382,7 +384,7 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
     Ground* gp = gobj->user_data;
     HSD_GObj* player;
     s32 track_plat = 0;
-    PAD_STACK(64);
+    PAD_STACK(56);
 
     player = Ground_801C57A4();
     if (player != NULL) {
@@ -397,16 +399,18 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
     case 0: {
         f32 radius;
         s32 result;
+        s32 ix;
         track_plat = 0;
         radius = grSh_Route_804D6A58->x20 * Ground_801C0498();
         result = Ground_801C3DB4(grShrineRoute_80208F14,
                                  grSh_Route_804D6A58->x1C * Ground_801C0498(),
                                  radius);
         if (result != -1) {
-            s32 ix = result - 0xBD;
+            ix = result - 0xBD;
             if (!(gp->gv.shrineroute.xC6 & (1 << ix))) {
-                HSD_ASSERT(0x213, gp->gv.shrineroute.symbols[ix]);
-                gp->gv.shrineroute.xC8 = (u16) result;
+                *(volatile u16*) &gp->gv.shrineroute.xC8 = (u16) result;
+                HSD_ASSERTMSG(0x213, gp->gv.shrineroute.symbols[(u32) ix],
+                              "gp->u.map.symbol[ix]");
                 {
                     s32 mid =
                         ((Ground*) gp->gv.shrineroute.symbols[ix]->user_data)
@@ -499,7 +503,7 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
                         {
                             HSD_JObj* dst = Ground_801C2CF4(5);
                             HSD_JObj* src = Ground_801C2CF4(result - 0xA);
-                            if (dst != NULL) {
+                            if (dst != NULL && src != NULL) {
                                 HSD_JObjGetTranslation(src, &sp68);
                                 HSD_JObjSetTranslate(dst, &sp68);
                             }
@@ -527,7 +531,8 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
                     HSD_JObjSetFlagsAll(Ground_801C3FA4(gr2, 0), JOBJ_HIDDEN);
                 }
             }
-            grAnime_801C7A04((HSD_GObj*) gobj, 0, 7U, 0.0f);
+            grAnime_801C7A04((HSD_GObj*) gobj, 0, 7U,
+                               0.0f);
             grLib_801C9908(gobj->hsd_obj);
             if (gp->gv.shrineroute.xD4 != 0) {
                 grMaterial_801C9604((HSD_GObj*) gp->gv.shrineroute.xD4,
@@ -548,8 +553,8 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
             }
         }
         {
-            HSD_GObj* eff2 = (HSD_GObj*) gp->gv.shrineroute.xD4;
-            if (((eff2 != NULL) && (grLib_801C96E8(eff2) != 0)) ||
+            if (((gp->gv.shrineroute.xD4 != 0) &&
+                 (grLib_801C96E8((HSD_GObj*) gp->gv.shrineroute.xD4) != 0)) ||
                 (gp->gv.shrineroute.xD4 == 0))
             {
                 gp->gv.shrineroute.xC4 = 3;
@@ -593,18 +598,15 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
         break;
     }
     case 4: {
-        HSD_GObj* eff4;
         track_plat = 0;
-        eff4 = (HSD_GObj*) gp->gv.shrineroute.xD4;
-        if (((eff4 != NULL) && (grLib_801C96E8(eff4) != 0)) ||
+        if (((gp->gv.shrineroute.xD4 != 0) &&
+             (grLib_801C96E8((HSD_GObj*) gp->gv.shrineroute.xD4) != 0)) ||
             (gp->gv.shrineroute.xD4 == 0))
         {
-            HSD_GObj* temp4;
             gp->gv.shrineroute.xC4 = 5;
             grLib_801C9908(((HSD_GObj*) gp->gv.shrineroute.xD4)->hsd_obj);
-            temp4 = (HSD_GObj*) gp->gv.shrineroute.xD4;
-            if (temp4 != NULL) {
-                Ground_801C4A08(temp4);
+            if (gp->gv.shrineroute.xD4 != 0) {
+                Ground_801C4A08((HSD_GObj*) gp->gv.shrineroute.xD4);
                 gp->gv.shrineroute.xD4 = 0;
             }
             grMaterial_801C9604((HSD_GObj*) gobj, grSh_Route_804D6A58->xC, 0);
@@ -727,10 +729,10 @@ void grShrineRoute_80208F70(Ground_GObj* gobj)
 
     Stage_UnkSetVec3TCam_Offset(&sp44);
     {
+        HSD_JObj* jobj;
         s32 k;
         for (k = 0; k < 3; k++) {
-            HSD_JObj* jobj = gp->gv.shrineroute.platforms[k].jobj;
-            if (jobj != NULL) {
+            if ((jobj = gp->gv.shrineroute.platforms[k].jobj) != NULL) {
                 f32 tx = gp->gv.shrineroute.platforms[k].offset.x + sp44.x;
                 HSD_JObjSetTranslateX(jobj, tx);
                 jobj = gp->gv.shrineroute.platforms[k].jobj;
@@ -760,12 +762,14 @@ void grShrineRoute_80209AF0(Ground_GObj* gobj)
     grMaterial_801C94D8(jobj);
     gp->gv.shrineroute3.xC4 = Ground_801C3FA4(gobj, 10);
     grShrineRoute_8020A8A4(gobj);
-    gp->gv.shrineroute3.xCC = 0;
-    gp->gv.shrineroute3.xC8 = 0;
+    gp->gv.shrineroute3.xCC = 0.0f;
+    gp->gv.shrineroute3.xC8 = 0.0f;
     gp->gv.shrineroute3.xD0 = 0.00006981317F * HSD_Randf() + 0.000017453292F;
-    gp->gv.shrineroute3.xD0 *= (HSD_Randi(2) != 0) ? 1.0F : -1.0F;
+    gp->gv.shrineroute3.xD0 *=
+        (HSD_Randi(2) != 0) ? 1.0f : -1.0F;
     gp->gv.shrineroute3.xD4 = 0.00006981317F * HSD_Randf() + 0.000017453292F;
-    gp->gv.shrineroute3.xD4 *= (HSD_Randi(2) != 0) ? 1.0F : -1.0F;
+    gp->gv.shrineroute3.xD4 *=
+        (HSD_Randi(2) != 0) ? 1.0f : -1.0F;
 }
 
 bool grShrineRoute_80209BE4(Ground_GObj* arg)
@@ -1139,9 +1143,11 @@ void grShrineRoute_8020A8A4(Ground_GObj* gobj)
         HSD_JObjSetTranslateX(gp->gv.shrineroute3.xC4, 300.0f * cosf(angle));
         HSD_JObjSetTranslateY(gp->gv.shrineroute3.xC4, 300.0f * sinf(angle));
         gp->gv.shrineroute3.xD8 =
-            0.04363323f * ((2.0f * grShrineRoute_8020A8A4_rand()) - 1.0f);
+            0.04363323f *
+            ((2.0f * grShrineRoute_8020A8A4_rand()) - 1.0f);
         gp->gv.shrineroute3.xDC =
-            0.04363323f * ((2.0f * grShrineRoute_8020A8A4_rand()) - 1.0f);
+            0.04363323f *
+            ((2.0f * grShrineRoute_8020A8A4_rand()) - 1.0f);
     }
 }
 

--- a/src/melee/gr/grvenom.c
+++ b/src/melee/gr/grvenom.c
@@ -1323,9 +1323,9 @@ venom_80205AD4_spawn: {
     s32 idx = data[14];
     s32* data2 = base + idx;
     other = (Ground_GObj*) grVenom_80203EAC(data2[0xC9]);
-    *(s32*) &gp->gv.venom.xDC = (s32) other;
+    gp->gv.venom.linked_gobj = other;
     if (other != NULL) {
-        other = *(Ground_GObj**) &gp->gv.venom.xDC;
+        other = gp->gv.venom.linked_gobj;
         other_gp = other->user_data;
         if (other_gp != NULL) {
             other_gp->gv.venom.xC8 = gp->gv.venom.xC8;
@@ -1337,7 +1337,7 @@ venom_80205AD4_spawn: {
 venom_80205AD4_link:
     jobj2 = Ground_801C3FA4((HSD_GObj*) data[8], 5);
     lb_8000C2F8(Ground_801C3FA4(gobj, 0), jobj2);
-    *(s32*) &gp->gv.venom.xDC = zero;
+    gp->gv.venom.linked_gobj = NULL;
     goto venom_80205AD4_done;
 
 venom_80205AD4_default:
@@ -1355,7 +1355,7 @@ venom_80205AD4_done:
     attr = grVe_804D6A30;
     HSD_JObjSetScaleZ(jobj, scale * attr->x34);
 
-    ((struct grCorneria_GroundVars2*) &gp->gv.venom)->xC4.flags.b0 = false;
+    gp->gv.venom.xC4_flags.b0 = false;
     *(s32*) &gp->gv.venom.xD4 = zero;
     gp->gv.venom.xF0 = zero;
     gp->gv.venom.xF4 = zero;
@@ -1440,12 +1440,10 @@ void grVenom_80205F30(Ground_GObj* gobj)
     s32 retries;
     s32 type_idx;
     HSD_JObj* helper;
-    struct grCorneria_GroundVars2* arwing_vars;
 
     base = (s32*) &grVe_803E5348;
     gp = gobj->user_data;
     jobj = gobj->hsd_obj;
-    arwing_vars = (struct grCorneria_GroundVars2*) &gp->gv.venom;
     sp94 = grVe_803B82D0;
     sp88 = grVe_803B82DC;
     PAD_STACK(0x28);
@@ -1543,8 +1541,8 @@ void grVenom_80205F30(Ground_GObj* gobj)
                     lb_8000B1CC(Ground_801C3FA4((HSD_GObj*) gobj, anim_id),
                                 NULL, &sp94);
                 }
-                if (arwing_vars->xDC != NULL) {
-                    Ground* sub = arwing_vars->xDC->user_data;
+                if (gp->gv.venom.linked_gobj != NULL) {
+                    Ground* sub = gp->gv.venom.linked_gobj->user_data;
                     if (sub != NULL) {
                         sub->gv.venom.xE0 = sp94.x;
                         sub->gv.venom.xE4 = sp94.y;
@@ -1558,8 +1556,8 @@ void grVenom_80205F30(Ground_GObj* gobj)
                     s32 anim_id = base[idx0 + 0xD6];
                     helper = Ground_801C3FA4((HSD_GObj*) gobj, anim_id);
                     rot_z = HSD_JObjGetRotationZ(helper);
-                    if (arwing_vars->xDC != NULL) {
-                        Ground* sub = arwing_vars->xDC->user_data;
+                    if (gp->gv.venom.linked_gobj != NULL) {
+                        Ground* sub = gp->gv.venom.linked_gobj->user_data;
                         if (sub != NULL) {
                             sub->gv.venom.xDC = rot_z;
                         }
@@ -1719,10 +1717,9 @@ void grVenom_80206874(Ground_GObj* gobj)
     case 7: {
         HSD_GObj* other = grVenom_80203EAC(
             data[data[gp->gv.venom.xC8 + 14] + 0xC9]);
-        *(s32*) &gp->gv.venom.xDC = (s32) other;
+        gp->gv.venom.linked_gobj = other;
         if (other != NULL) {
-            Ground* other_gp =
-                GET_GROUND(*(Ground_GObj**) &gp->gv.venom.xDC);
+            Ground* other_gp = GET_GROUND(gp->gv.venom.linked_gobj);
             if (other_gp != NULL) {
                 other_gp->gv.venom.xC8 = gp->gv.venom.xC8;
             }
@@ -1736,7 +1733,7 @@ void grVenom_80206874(Ground_GObj* gobj)
         lb_8000C2F8(
             Ground_801C3FA4(gobj, 0),
             Ground_801C3FA4((HSD_GObj*) data[gp->gv.venom.xC8 + 8], 5));
-        *(s32*) &gp->gv.venom.xDC = 0;
+        gp->gv.venom.linked_gobj = NULL;
         break;
     default:
         *(s32*) &gp->gv.venom.xE0 = -1;
@@ -1748,7 +1745,7 @@ void grVenom_80206874(Ground_GObj* gobj)
     HSD_JObjSetScaleY(jobj, scale * grVe_804D6A30->x34);
     HSD_JObjSetScaleZ(jobj, scale * grVe_804D6A30->x34);
 
-    ((struct grCorneria_GroundVars2*) &gp->gv.venom)->xC4.flags.b0 = false;
+    gp->gv.venom.xC4_flags.b0 = false;
     *(s32*) &gp->gv.venom.xD4 = 0;
     gp->gv.venom.xF0 = 0;
     gp->gv.venom.xF4 = 0;

--- a/src/melee/gr/grvenom.c
+++ b/src/melee/gr/grvenom.c
@@ -69,102 +69,6 @@ extern s32 grVe_804D6A38;
 extern s32 grVe_804D6A3C;
 extern s32 grVe_804D6A40;
 
-/* literal */ SDATA char grVe_804D47B8[] = "/GrVe";
-/* literal */ SDATA char grVe_804D47C0[] = "jobj.h";
-/* literal */ SDATA char grVe_804D47C8[] = "jobj";
-
-#undef __FILE__
-#define __FILE__ (&grVe_804D47C0[0])
-static inline bool grVenom_JObjMtxIsDirty(HSD_JObj* jobj)
-{
-    bool result;
-    HSD_ASSERTMSG(0x234, jobj, &grVe_804D47C8[0]);
-    result = false;
-    if (!(jobj->flags & JOBJ_USER_DEF_MTX) && (jobj->flags & JOBJ_MTX_DIRTY)) {
-        result = true;
-    }
-    return result;
-}
-
-static inline void grVenom_JObjSetMtxDirty(HSD_JObj* jobj)
-{
-    if (jobj != NULL && !grVenom_JObjMtxIsDirty(jobj)) {
-        HSD_JObjSetMtxDirtySub(jobj);
-    }
-}
-
-static inline void grVenom_JObjSetRotationY(HSD_JObj* jobj, f32 y)
-{
-    HSD_ASSERTMSG(0x294, jobj, &grVe_804D47C8[0]);
-    HSD_ASSERT(0x295, !(jobj->flags & JOBJ_USE_QUATERNION));
-    jobj->rotate.y = y;
-    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
-        grVenom_JObjSetMtxDirty(jobj);
-    }
-}
-
-static inline void grVenom_JObjSetRotationZ(HSD_JObj* jobj, f32 z)
-{
-    HSD_ASSERTMSG(0x2A9, jobj, &grVe_804D47C8[0]);
-    HSD_ASSERT(0x2AA, !(jobj->flags & JOBJ_USE_QUATERNION));
-    jobj->rotate.z = z;
-    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
-        grVenom_JObjSetMtxDirty(jobj);
-    }
-}
-
-static inline f32 grVenom_JObjGetRotationZ(HSD_JObj* jobj)
-{
-    HSD_ASSERTMSG(0x2E9, jobj, &grVe_804D47C8[0]);
-    return jobj->rotate.z;
-}
-
-static inline void grVenom_JObjSetScaleX(HSD_JObj* jobj, f32 x)
-{
-    HSD_ASSERTMSG(0x308, jobj, &grVe_804D47C8[0]);
-    jobj->scale.x = x;
-    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
-        grVenom_JObjSetMtxDirty(jobj);
-    }
-}
-
-static inline void grVenom_JObjSetScaleY(HSD_JObj* jobj, f32 y)
-{
-    HSD_ASSERTMSG(0x317, jobj, &grVe_804D47C8[0]);
-    jobj->scale.y = y;
-    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
-        grVenom_JObjSetMtxDirty(jobj);
-    }
-}
-
-static inline void grVenom_JObjSetScaleZ(HSD_JObj* jobj, f32 z)
-{
-    HSD_ASSERTMSG(0x326, jobj, &grVe_804D47C8[0]);
-    jobj->scale.z = z;
-    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
-        grVenom_JObjSetMtxDirty(jobj);
-    }
-}
-
-static inline void grVenom_JObjSetTranslate(HSD_JObj* jobj, Vec3* translate)
-{
-    HSD_ASSERTMSG(0x394, jobj, &grVe_804D47C8[0]);
-    HSD_ASSERT(0x395, translate);
-    jobj->translate = *translate;
-    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
-        grVenom_JObjSetMtxDirty(jobj);
-    }
-}
-
-static inline void grVenom_JObjGetTranslation(HSD_JObj* jobj, Vec3* translate)
-{
-    HSD_ASSERTMSG(0x3D3, jobj, &grVe_804D47C8[0]);
-    HSD_ASSERT(0x3D4, translate);
-    *translate = jobj->translate;
-}
-#undef __FILE__
-#define __FILE__ "grvenom.c"
-
 typedef struct grVe_Lighting {
     char pad[0xE0];
     u8 xE0;
@@ -687,8 +591,8 @@ void grVenom_80204284(Ground_GObj* gobj)
     src_jobj = GET_JOBJ(gobj);
     dst_jobj = (HSD_JObj*) ((HSD_GObj*) gp->gv.venom.xC4)->hsd_obj;
 
-    grVenom_JObjGetTranslation(src_jobj, &pos);
-    grVenom_JObjSetTranslate(dst_jobj, &pos);
+    HSD_JObjGetTranslation(src_jobj, &pos);
+    HSD_JObjSetTranslate(dst_jobj, &pos);
 
     Ground_801C39C0();
     Ground_801C3BB4();
@@ -1043,46 +947,6 @@ void grVenom_80204DB0(Ground_GObj* gobj)
     un_802FF620();
 }
 
-#undef __FILE__
-#define __FILE__ (&grVe_804D47C0[0])
-static inline bool grVenom_80204DD4_JObjMtxIsDirty(HSD_JObj* jobj)
-{
-    bool result;
-    HSD_ASSERTMSG(0x234, jobj, &grVe_804D47C8[0]);
-    result = false;
-    if (!(jobj->flags & JOBJ_USER_DEF_MTX) && (jobj->flags & JOBJ_MTX_DIRTY)) {
-        result = true;
-    }
-    return result;
-}
-
-static inline void grVenom_80204DD4_JObjSetMtxDirty(HSD_JObj* jobj)
-{
-    if (jobj != NULL && !grVenom_80204DD4_JObjMtxIsDirty(jobj)) {
-        HSD_JObjSetMtxDirtySub(jobj);
-    }
-}
-
-static inline void grVenom_80204DD4_JObjSetScaleX(HSD_JObj* jobj, f32 x)
-{
-    HSD_ASSERTMSG(0x308, jobj, &grVe_804D47C8[0]);
-    jobj->scale.x = x;
-    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
-        grVenom_80204DD4_JObjSetMtxDirty(jobj);
-    }
-}
-
-static inline void grVenom_80204DD4_JObjSetScaleY(HSD_JObj* jobj, f32 y)
-{
-    HSD_ASSERTMSG(0x317, jobj, &grVe_804D47C8[0]);
-    jobj->scale.y = y;
-    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
-        grVenom_80204DD4_JObjSetMtxDirty(jobj);
-    }
-}
-#undef __FILE__
-#define __FILE__ "grvenom.c"
-
 /// grVenom_80204DD4
 /// Unit: main/melee/gr/grvenom
 
@@ -1093,8 +957,8 @@ void grVenom_80204DD4(Ground_GObj* gobj)
     PAD_STACK(8);
 
     Ground_801C2ED0(jobj, gp->map_id);
-    grVenom_80204DD4_JObjSetScaleX(jobj, 1.0F);
-    grVenom_80204DD4_JObjSetScaleY(jobj, 1.0F);
+    HSD_JObjSetScaleX(jobj, 1.0F);
+    HSD_JObjSetScaleY(jobj, 1.0F);
 }
 
 bool grVenom_80204EF4(Ground_GObj* arg)
@@ -1154,16 +1018,16 @@ check_scale_uniform:
     goto scale_uniform;
 
 scale_nonuniform:
-    grVenom_JObjSetScaleX(jobj, scale);
-    grVenom_JObjSetScaleY(jobj, scale);
-    grVenom_JObjSetScaleZ(jobj,
-                          scale * *(f32*) ((u8*) grVe_804D6A30 + 0x34));
+    HSD_JObjSetScaleX(jobj, scale);
+    HSD_JObjSetScaleY(jobj, scale);
+    HSD_JObjSetScaleZ(jobj,
+                      scale * *(f32*) ((u8*) grVe_804D6A30 + 0x34));
     goto done_scale;
 
 scale_uniform:
-    grVenom_JObjSetScaleX(jobj, scale);
-    grVenom_JObjSetScaleY(jobj, scale);
-    grVenom_JObjSetScaleZ(jobj, scale);
+    HSD_JObjSetScaleX(jobj, scale);
+    HSD_JObjSetScaleY(jobj, scale);
+    HSD_JObjSetScaleZ(jobj, scale);
 
 done_scale:
 
@@ -1277,7 +1141,7 @@ void grVenom_802053B0(Ground_GObj* gobj)
                 }
             }
         } else if (state < 12) {
-            grVenom_JObjSetRotationY(jobj, grVe_804DB740);
+            HSD_JObjSetRotationY(jobj, grVe_804DB740);
 
             gp2 = gobj->user_data;
             grVenom_802052E0(gobj, &sp1C);
@@ -1393,12 +1257,12 @@ void grVenom_80205758(Ground_GObj* gobj)
             HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         }
 
-        grVenom_JObjSetTranslate(jobj, (Vec3*) &gp->gv.venom.xE0);
+        HSD_JObjSetTranslate(jobj, (Vec3*) &gp->gv.venom.xE0);
 
         scale = Ground_801C0498();
-        grVenom_JObjSetScaleX(jobj, scale * grVe_804D6A30->x34);
-        grVenom_JObjSetScaleY(jobj, scale * grVe_804D6A30->x34);
-        grVenom_JObjSetScaleZ(jobj, scale * grVe_804D6A30->x34);
+        HSD_JObjSetScaleX(jobj, scale * grVe_804D6A30->x34);
+        HSD_JObjSetScaleY(jobj, scale * grVe_804D6A30->x34);
+        HSD_JObjSetScaleZ(jobj, scale * grVe_804D6A30->x34);
 
         Ground_801C2FE0(gobj);
     } else {
@@ -1483,13 +1347,13 @@ venom_80205AD4_default:
 venom_80205AD4_done:
 
     attr = grVe_804D6A30;
-    grVenom_JObjSetScaleX(jobj, scale * attr->x34);
+    HSD_JObjSetScaleX(jobj, scale * attr->x34);
 
     attr = grVe_804D6A30;
-    grVenom_JObjSetScaleY(jobj, scale * attr->x34);
+    HSD_JObjSetScaleY(jobj, scale * attr->x34);
 
     attr = grVe_804D6A30;
-    grVenom_JObjSetScaleZ(jobj, scale * attr->x34);
+    HSD_JObjSetScaleZ(jobj, scale * attr->x34);
 
     ((struct grCorneria_GroundVars2*) &gp->gv.venom)->xC4.flags.b0 = false;
     *(s32*) &gp->gv.venom.xD4 = zero;
@@ -1594,12 +1458,12 @@ void grVenom_80205F30(Ground_GObj* gobj)
     if ((u32) entry[8] != 0U) {
         if (entry[14] == 4) {
             tmp_jobj = Ground_801C3FA4((HSD_GObj*) gobj, 1);
-            grVenom_JObjSetRotationZ(tmp_jobj, 0.0F);
+            HSD_JObjSetRotationZ(tmp_jobj, 0.0F);
         }
 
         state = base[gp->gv.venom.xC8 + 11];
         if (state >= 1 && state < 8) {
-            grVenom_JObjSetRotationY(jobj, 0.0F);
+            HSD_JObjSetRotationY(jobj, 0.0F);
 
                 {
                     s32 anim_state = gp->gv.venom.xF4;
@@ -1643,7 +1507,7 @@ void grVenom_80205F30(Ground_GObj* gobj)
                             s32 idx0 = base[gp->gv.venom.xC8 + 14];
                             s32 anim_id = base[idx0 + 0xD6];
                             tmp_jobj = Ground_801C3FA4((HSD_GObj*) gobj, anim_id);
-                            grVenom_JObjSetRotationZ(tmp_jobj, 0.0F);
+                            HSD_JObjSetRotationZ(tmp_jobj, 0.0F);
                         }
                         gp->gv.venom.xF8 = gp->gv.venom.xF8 - 1;
                     }
@@ -1671,7 +1535,7 @@ void grVenom_80205F30(Ground_GObj* gobj)
                     sp94.x = sp94.y = sp94.z = 0.0F;
                 }
 
-                grVenom_JObjSetTranslate(jobj, &sp94);
+                HSD_JObjSetTranslate(jobj, &sp94);
 
                 {
                     s32 idx0 = base[gp->gv.venom.xC8 + 14];
@@ -1682,7 +1546,9 @@ void grVenom_80205F30(Ground_GObj* gobj)
                 if (arwing_vars->xDC != NULL) {
                     Ground* sub = arwing_vars->xDC->user_data;
                     if (sub != NULL) {
-                        sub->gv.arwing.xE0 = sp94;
+                        sub->gv.venom.xE0 = sp94.x;
+                        sub->gv.venom.xE4 = sp94.y;
+                        sub->gv.venom.xE8 = sp94.z;
                     }
                 }
 
@@ -1691,11 +1557,11 @@ void grVenom_80205F30(Ground_GObj* gobj)
                     s32 idx0 = base[gp->gv.venom.xC8 + 14];
                     s32 anim_id = base[idx0 + 0xD6];
                     helper = Ground_801C3FA4((HSD_GObj*) gobj, anim_id);
-                    rot_z = grVenom_JObjGetRotationZ(helper);
+                    rot_z = HSD_JObjGetRotationZ(helper);
                     if (arwing_vars->xDC != NULL) {
                         Ground* sub = arwing_vars->xDC->user_data;
                         if (sub != NULL) {
-                            sub->gv.arwing.xDC = rot_z;
+                            sub->gv.venom.xDC = rot_z;
                         }
                     }
                 }
@@ -1878,9 +1744,9 @@ void grVenom_80206874(Ground_GObj* gobj)
         break;
     }
 
-    grVenom_JObjSetScaleX(jobj, scale * grVe_804D6A30->x34);
-    grVenom_JObjSetScaleY(jobj, scale * grVe_804D6A30->x34);
-    grVenom_JObjSetScaleZ(jobj, scale * grVe_804D6A30->x34);
+    HSD_JObjSetScaleX(jobj, scale * grVe_804D6A30->x34);
+    HSD_JObjSetScaleY(jobj, scale * grVe_804D6A30->x34);
+    HSD_JObjSetScaleZ(jobj, scale * grVe_804D6A30->x34);
 
     ((struct grCorneria_GroundVars2*) &gp->gv.venom)->xC4.flags.b0 = false;
     *(s32*) &gp->gv.venom.xD4 = 0;

--- a/src/melee/gr/grvenom.c
+++ b/src/melee/gr/grvenom.c
@@ -34,6 +34,8 @@ typedef struct grVe_Data {
     char x58[0x1B8 - 0x58];
     char x1B8_file[0x1DC - 0x1B8]; // 0x1B8: "%s:%d..." string
     char x1DC_func[0x20];          // 0x1DC: function name or filename
+    char x1FC[0x2BC - 0x1FC];
+    char x2BC[0x30];
 } grVe_Data;
 
 extern grVe_Data grVe_803E5348;
@@ -54,6 +56,11 @@ typedef struct grVe_TimingData {
     f32 x8;
     f32 xC;
     f32 x10;
+    char x14[0x2C - 0x14];
+    f32 x2C;
+    char x30[0x34 - 0x30];
+    f32 x34;
+    s32 x38;
 } grVe_TimingData;
 
 extern u32 grVe_804D6A34;
@@ -61,6 +68,102 @@ extern grVe_TimingData* grVe_804D6A30;
 extern s32 grVe_804D6A38;
 extern s32 grVe_804D6A3C;
 extern s32 grVe_804D6A40;
+
+/* literal */ SDATA char grVe_804D47B8[] = "/GrVe";
+/* literal */ SDATA char grVe_804D47C0[] = "jobj.h";
+/* literal */ SDATA char grVe_804D47C8[] = "jobj";
+
+#undef __FILE__
+#define __FILE__ (&grVe_804D47C0[0])
+static inline bool grVenom_JObjMtxIsDirty(HSD_JObj* jobj)
+{
+    bool result;
+    HSD_ASSERTMSG(0x234, jobj, &grVe_804D47C8[0]);
+    result = false;
+    if (!(jobj->flags & JOBJ_USER_DEF_MTX) && (jobj->flags & JOBJ_MTX_DIRTY)) {
+        result = true;
+    }
+    return result;
+}
+
+static inline void grVenom_JObjSetMtxDirty(HSD_JObj* jobj)
+{
+    if (jobj != NULL && !grVenom_JObjMtxIsDirty(jobj)) {
+        HSD_JObjSetMtxDirtySub(jobj);
+    }
+}
+
+static inline void grVenom_JObjSetRotationY(HSD_JObj* jobj, f32 y)
+{
+    HSD_ASSERTMSG(0x294, jobj, &grVe_804D47C8[0]);
+    HSD_ASSERT(0x295, !(jobj->flags & JOBJ_USE_QUATERNION));
+    jobj->rotate.y = y;
+    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
+        grVenom_JObjSetMtxDirty(jobj);
+    }
+}
+
+static inline void grVenom_JObjSetRotationZ(HSD_JObj* jobj, f32 z)
+{
+    HSD_ASSERTMSG(0x2A9, jobj, &grVe_804D47C8[0]);
+    HSD_ASSERT(0x2AA, !(jobj->flags & JOBJ_USE_QUATERNION));
+    jobj->rotate.z = z;
+    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
+        grVenom_JObjSetMtxDirty(jobj);
+    }
+}
+
+static inline f32 grVenom_JObjGetRotationZ(HSD_JObj* jobj)
+{
+    HSD_ASSERTMSG(0x2E9, jobj, &grVe_804D47C8[0]);
+    return jobj->rotate.z;
+}
+
+static inline void grVenom_JObjSetScaleX(HSD_JObj* jobj, f32 x)
+{
+    HSD_ASSERTMSG(0x308, jobj, &grVe_804D47C8[0]);
+    jobj->scale.x = x;
+    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
+        grVenom_JObjSetMtxDirty(jobj);
+    }
+}
+
+static inline void grVenom_JObjSetScaleY(HSD_JObj* jobj, f32 y)
+{
+    HSD_ASSERTMSG(0x317, jobj, &grVe_804D47C8[0]);
+    jobj->scale.y = y;
+    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
+        grVenom_JObjSetMtxDirty(jobj);
+    }
+}
+
+static inline void grVenom_JObjSetScaleZ(HSD_JObj* jobj, f32 z)
+{
+    HSD_ASSERTMSG(0x326, jobj, &grVe_804D47C8[0]);
+    jobj->scale.z = z;
+    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
+        grVenom_JObjSetMtxDirty(jobj);
+    }
+}
+
+static inline void grVenom_JObjSetTranslate(HSD_JObj* jobj, Vec3* translate)
+{
+    HSD_ASSERTMSG(0x394, jobj, &grVe_804D47C8[0]);
+    HSD_ASSERT(0x395, translate);
+    jobj->translate = *translate;
+    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
+        grVenom_JObjSetMtxDirty(jobj);
+    }
+}
+
+static inline void grVenom_JObjGetTranslation(HSD_JObj* jobj, Vec3* translate)
+{
+    HSD_ASSERTMSG(0x3D3, jobj, &grVe_804D47C8[0]);
+    HSD_ASSERT(0x3D4, translate);
+    *translate = jobj->translate;
+}
+#undef __FILE__
+#define __FILE__ "grvenom.c"
 
 typedef struct grVe_Lighting {
     char pad[0xE0];
@@ -584,8 +687,8 @@ void grVenom_80204284(Ground_GObj* gobj)
     src_jobj = GET_JOBJ(gobj);
     dst_jobj = (HSD_JObj*) ((HSD_GObj*) gp->gv.venom.xC4)->hsd_obj;
 
-    HSD_JObjGetTranslation(src_jobj, &pos);
-    HSD_JObjSetTranslate(dst_jobj, &pos);
+    grVenom_JObjGetTranslation(src_jobj, &pos);
+    grVenom_JObjSetTranslate(dst_jobj, &pos);
 
     Ground_801C39C0();
     Ground_801C3BB4();
@@ -689,17 +792,22 @@ extern f32 grVe_804DB7D4; // 9200
 void grVenom_8020454C(Ground_GObj* gobj)
 {
     Vec3 sp1C;
-    s32 i = 0;
-    Ground* gp = gobj->user_data;
-    Ground* gp_save = gp;
     s32 visible;
+    Ground* gp;
+    s32 i;
+    Ground* gp_save;
     HSD_GObj* lgobj;
     HSD_LObj* lobj;
+    HSD_LObj* next;
     f32 frame;
-    f32 prev;
-    f32 lo = grVe_804DB754;
-    f32 hi = grVe_804DB758;
-    PAD_STACK(8);
+    f32 hi;
+    f32 lo;
+    PAD_STACK(12);
+
+    i = 0;
+    gp_save = (gp = gobj->user_data);
+    lo = grVe_804DB754;
+    hi = grVe_804DB758;
 
     do {
         if (gp->gv.venom2.xC4 != NULL) {
@@ -724,25 +832,27 @@ void grVenom_8020454C(Ground_GObj* gobj)
     if (grAnime_801C84A4((HSD_GObj*) gobj, 0, 7)) {
         lgobj = Ground_801C498C();
         if (lgobj != NULL) {
-            lobj = lgobj->hsd_obj;
-            while (lobj != NULL) {
-                if (lobj->aobj != NULL) {
-                    HSD_AObjReqAnim(lobj->aobj, grVe_804DB740);
-                }
-                if (lobj->position != NULL) {
-                    HSD_ForeachAnim(lobj->position, WOBJ_TYPE, ALL_TYPE_MASK,
-                                    HSD_AObjReqAnim, AOBJ_ARG_AF,
-                                    grVe_804DB760);
-                }
-                if (lobj->interest != NULL) {
-                    HSD_ForeachAnim(lobj->interest, WOBJ_TYPE, ALL_TYPE_MASK,
-                                    HSD_AObjReqAnim, AOBJ_ARG_AF,
-                                    grVe_804DB760);
-                }
-                if (lobj == NULL) {
-                    lobj = NULL;
-                } else {
-                    lobj = lobj->next;
+            if ((lobj = lgobj->hsd_obj) != NULL) {
+                while (lobj != NULL) {
+                    if (lobj->aobj != NULL) {
+                        HSD_AObjReqAnim(lobj->aobj, grVe_804DB740);
+                    }
+                    if (lobj->position != NULL) {
+                        HSD_ForeachAnim(lobj->position, WOBJ_TYPE, ALL_TYPE_MASK,
+                                        HSD_AObjReqAnim, AOBJ_ARG_AF,
+                                        grVe_804DB760);
+                    }
+                    if (lobj->interest != NULL) {
+                        HSD_ForeachAnim(lobj->interest, WOBJ_TYPE, ALL_TYPE_MASK,
+                                        HSD_AObjReqAnim, AOBJ_ARG_AF,
+                                        grVe_804DB760);
+                    }
+                    if (lobj == NULL) {
+                        next = NULL;
+                    } else {
+                        next = lobj->next;
+                    }
+                    lobj = next;
                 }
             }
         }
@@ -751,75 +861,74 @@ void grVenom_8020454C(Ground_GObj* gobj)
     {
         HSD_AObj* a = grAnime_801C8318((HSD_GObj*) gobj, 0, 7);
         if (a != NULL) {
-            prev = gp->gv.venom.xE4;
             frame = HSD_AObjGetCurrFrame(a);
-            if ((prev < grVe_804DB768 && grVe_804DB768 <= frame) ||
-                (prev < grVe_804DB76C && grVe_804DB76C <= frame) ||
-                (prev < grVe_804DB770 && grVe_804DB770 <= frame) ||
-                (prev < grVe_804DB774 && grVe_804DB774 <= frame))
+            if ((gp->gv.venom.xE4 < grVe_804DB768 && grVe_804DB768 <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB76C && grVe_804DB76C <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB770 && grVe_804DB770 <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB774 && grVe_804DB774 <= frame))
             {
                 Ground_801C53EC(0x6B6C5);
             }
-            if ((prev < grVe_804DB778 && grVe_804DB778 <= frame) ||
-                (prev < grVe_804DB77C && grVe_804DB77C <= frame) ||
-                (prev < grVe_804DB780 && grVe_804DB780 <= frame) ||
-                (prev < grVe_804DB784 && grVe_804DB784 <= frame))
+            if ((gp->gv.venom.xE4 < grVe_804DB778 && grVe_804DB778 <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB77C && grVe_804DB77C <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB780 && grVe_804DB780 <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB784 && grVe_804DB784 <= frame))
             {
                 Ground_801C53EC(0x6B6C6);
             }
-            if ((prev < grVe_804DB788 && grVe_804DB788 <= frame) ||
-                (prev < grVe_804DB78C && grVe_804DB78C <= frame) ||
-                (prev < grVe_804DB790 && grVe_804DB790 <= frame))
+            if ((gp->gv.venom.xE4 < grVe_804DB788 && grVe_804DB788 <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB78C && grVe_804DB78C <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB790 && grVe_804DB790 <= frame))
             {
                 gp->gv.venom2.xE0_state.b6 = 1;
             }
-            if ((prev < grVe_804DB788 && grVe_804DB788 <= frame) ||
-                (prev < grVe_804DB794 && grVe_804DB794 <= frame) ||
-                (prev < grVe_804DB798 && grVe_804DB798 <= frame) ||
-                (prev < grVe_804DB79C && grVe_804DB79C <= frame) ||
-                (prev < grVe_804DB7A0 && grVe_804DB7A0 <= frame) ||
-                (prev < grVe_804DB78C && grVe_804DB78C <= frame) ||
-                (prev < grVe_804DB7A4 && grVe_804DB7A4 <= frame) ||
-                (prev < grVe_804DB790 && grVe_804DB790 <= frame) ||
-                (prev < grVe_804DB7A8 && grVe_804DB7A8 <= frame) ||
-                (prev < grVe_804DB7AC && grVe_804DB7AC <= frame))
+            if ((gp->gv.venom.xE4 < grVe_804DB788 && grVe_804DB788 <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB794 && grVe_804DB794 <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB798 && grVe_804DB798 <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB79C && grVe_804DB79C <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB7A0 && grVe_804DB7A0 <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB78C && grVe_804DB78C <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB7A4 && grVe_804DB7A4 <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB790 && grVe_804DB790 <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB7A8 && grVe_804DB7A8 <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB7AC && grVe_804DB7AC <= frame))
             {
                 Ground_801C53EC(0x6B6C7);
             }
-            if ((prev < grVe_804DB7B0 && grVe_804DB7B0 <= frame) ||
-                (prev < grVe_804DB7B4 && grVe_804DB7B4 <= frame) ||
-                (prev > frame))
+            if ((gp->gv.venom.xE4 < grVe_804DB7B0 && grVe_804DB7B0 <= frame) ||
+                (gp->gv.venom.xE4 < grVe_804DB7B4 && grVe_804DB7B4 <= frame) ||
+                (gp->gv.venom.xE4 > frame))
             {
                 gp->gv.venom2.xE0_state.b6 = 0;
             }
-            if (prev < grVe_804DB7B8 && grVe_804DB7B8 <= frame) {
+            if (gp->gv.venom.xE4 < grVe_804DB7B8 && grVe_804DB7B8 <= frame) {
                 gp->gv.venom2.xE0_state.b0 = 1;
             }
-            if (prev < grVe_804DB7BC && grVe_804DB7BC <= frame) {
+            if (gp->gv.venom.xE4 < grVe_804DB7BC && grVe_804DB7BC <= frame) {
                 gp->gv.venom2.xE0_state.b1 = 1;
             }
-            if (prev < grVe_804DB7C0 && grVe_804DB7C0 <= frame) {
+            if (gp->gv.venom.xE4 < grVe_804DB7C0 && grVe_804DB7C0 <= frame) {
                 Ground_801C5440(gp, 0, 0x6B6C4);
                 gp->gv.venom2.xE0_state.b2 = 1;
                 mpJointListAdd(2);
             }
-            if (prev < grVe_804DB7C4 && grVe_804DB7C4 <= frame) {
+            if (gp->gv.venom.xE4 < grVe_804DB7C4 && grVe_804DB7C4 <= frame) {
                 Ground_801C5440(gp, 0, 0x6B6C3);
                 gp->gv.venom2.xE0_state.b0 = 0;
                 gp->gv.venom2.xE0_state.b1 = 0;
                 gp->gv.venom2.xE0_state.b2 = 0;
                 mpLib_80057BC0(2);
             }
-            if (prev < grVe_804DB7C8 && grVe_804DB7C8 <= frame) {
+            if (gp->gv.venom.xE4 < grVe_804DB7C8 && grVe_804DB7C8 <= frame) {
                 gp->gv.venom2.xE0_state.b3 = 1;
             }
-            if (prev < grVe_804DB7CC && grVe_804DB7CC <= frame) {
+            if (gp->gv.venom.xE4 < grVe_804DB7CC && grVe_804DB7CC <= frame) {
                 gp->gv.venom2.xE0_state.b4 = 1;
             }
-            if (prev < grVe_804DB7D0 && grVe_804DB7D0 <= frame) {
+            if (gp->gv.venom.xE4 < grVe_804DB7D0 && grVe_804DB7D0 <= frame) {
                 gp->gv.venom2.xE0_state.b5 = 1;
             }
-            if (prev < grVe_804DB7D4 && grVe_804DB7D4 <= frame) {
+            if (gp->gv.venom.xE4 < grVe_804DB7D4 && grVe_804DB7D4 <= frame) {
                 gp->gv.venom2.xE0_state.b3 = 0;
                 gp->gv.venom2.xE0_state.b4 = 0;
                 gp->gv.venom2.xE0_state.b5 = 0;
@@ -934,40 +1043,58 @@ void grVenom_80204DB0(Ground_GObj* gobj)
     un_802FF620();
 }
 
+#undef __FILE__
+#define __FILE__ (&grVe_804D47C0[0])
+static inline bool grVenom_80204DD4_JObjMtxIsDirty(HSD_JObj* jobj)
+{
+    bool result;
+    HSD_ASSERTMSG(0x234, jobj, &grVe_804D47C8[0]);
+    result = false;
+    if (!(jobj->flags & JOBJ_USER_DEF_MTX) && (jobj->flags & JOBJ_MTX_DIRTY)) {
+        result = true;
+    }
+    return result;
+}
+
+static inline void grVenom_80204DD4_JObjSetMtxDirty(HSD_JObj* jobj)
+{
+    if (jobj != NULL && !grVenom_80204DD4_JObjMtxIsDirty(jobj)) {
+        HSD_JObjSetMtxDirtySub(jobj);
+    }
+}
+
+static inline void grVenom_80204DD4_JObjSetScaleX(HSD_JObj* jobj, f32 x)
+{
+    HSD_ASSERTMSG(0x308, jobj, &grVe_804D47C8[0]);
+    jobj->scale.x = x;
+    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
+        grVenom_80204DD4_JObjSetMtxDirty(jobj);
+    }
+}
+
+static inline void grVenom_80204DD4_JObjSetScaleY(HSD_JObj* jobj, f32 y)
+{
+    HSD_ASSERTMSG(0x317, jobj, &grVe_804D47C8[0]);
+    jobj->scale.y = y;
+    if (!(jobj->flags & JOBJ_MTX_INDEP_SRT)) {
+        grVenom_80204DD4_JObjSetMtxDirty(jobj);
+    }
+}
+#undef __FILE__
+#define __FILE__ "grvenom.c"
+
 /// grVenom_80204DD4
 /// Unit: main/melee/gr/grvenom
-/// Manual expansion of HSD_JObjSetScaleX/Y without using inline functions
 
 void grVenom_80204DD4(Ground_GObj* gobj)
 {
-    int new_var;
-    int new_var3;
-    HSD_JObj* new_var2;
     Ground* gp = gobj->user_data;
     HSD_JObj* jobj = gobj->hsd_obj;
+    PAD_STACK(8);
 
     Ground_801C2ED0(jobj, gp->map_id);
-
-    // HSD_JObjSetScaleX(jobj, 1.0F) expanded:
-    ((jobj) ? ((void) 0) : __assert("jobj.h", 0x308, "jobj"));
-    jobj->scale.x = 1.0F;
-    new_var3 = !(jobj->flags & (1 << 25));
-    if (new_var3) {
-        if (jobj != 0L && !HSD_JObjMtxIsDirty(jobj)) {
-            HSD_JObjSetMtxDirtySub(jobj);
-        }
-    }
-
-    new_var = 1 << 25;
-    // HSD_JObjSetScaleY(jobj, 1.0F) expanded:
-    ((jobj) ? ((void) 0) : __assert("jobj.h", 0x317, "jobj"));
-    jobj->scale.y = 1.0F;
-    new_var2 = jobj;
-    if (!(new_var2->flags & new_var)) {
-        if (new_var2 != 0L && !HSD_JObjMtxIsDirty(new_var2)) {
-            HSD_JObjSetMtxDirtySub(new_var2);
-        }
-    }
+    grVenom_80204DD4_JObjSetScaleX(jobj, 1.0F);
+    grVenom_80204DD4_JObjSetScaleY(jobj, 1.0F);
 }
 
 bool grVenom_80204EF4(Ground_GObj* arg)
@@ -989,13 +1116,16 @@ void grVenom_80204F20(Ground_GObj* arg0)
     HSD_JObj* jobj = arg0->hsd_obj;
     u32 idx = grVe_804D6A34;
     HSD_GObj* other;
+    s32* entry;
     f32 scale;
     s32 state;
+    PAD_STACK(0x10);
 
     gp->gv.venom.xC8 = idx;
-    base[idx + 8] = (s32) arg0;
+    entry = base + idx;
+    entry[8] = (s32) arg0;
 
-    other = grVenom_80203EAC(base[base[idx + 14] + 170]);
+    other = grVenom_80203EAC(base[base[gp->gv.venom.xC8 + 14] + 170]);
     if (other != NULL) {
         Ground* other_gp = other->user_data;
         other_gp->x10_flags.b2 = 0;
@@ -1003,27 +1133,42 @@ void grVenom_80204F20(Ground_GObj* arg0)
         if (other_gp != NULL) {
             other_gp->gv.venom.xC8 = gp->gv.venom.xC8;
         } else {
-            OSReport((char*) ((u8*) base + 0x2BC), other_gp, 0);
+            OSReport((char*) ((u8*) base + 0x2BC));
         }
     }
 
     scale = Ground_801C0498();
-    state = base[idx + 11];
-    if (state < 8) {
-        if (state >= 1) {
-            HSD_JObjSetScaleX(jobj, scale);
-            HSD_JObjSetScaleY(jobj, scale);
-            HSD_JObjSetScaleZ(jobj,
-                              scale * *(f32*) ((u8*) grVe_804D6A30 + 0x34));
-        }
-    } else if (state < 12) {
-        HSD_JObjSetScaleX(jobj, scale);
-        HSD_JObjSetScaleY(jobj, scale);
-        HSD_JObjSetScaleZ(jobj, scale);
+    state = base[gp->gv.venom.xC8 + 11];
+    if (state >= 8) {
+        goto check_scale_uniform;
     }
+    if (state >= 1) {
+        goto scale_nonuniform;
+    }
+    goto done_scale;
 
-    gp->gv.venom.xD4 = 1;
-    gp->gv.venom.xD8 = 0;
+check_scale_uniform:
+    if (state >= 12) {
+        goto done_scale;
+    }
+    goto scale_uniform;
+
+scale_nonuniform:
+    grVenom_JObjSetScaleX(jobj, scale);
+    grVenom_JObjSetScaleY(jobj, scale);
+    grVenom_JObjSetScaleZ(jobj,
+                          scale * *(f32*) ((u8*) grVe_804D6A30 + 0x34));
+    goto done_scale;
+
+scale_uniform:
+    grVenom_JObjSetScaleX(jobj, scale);
+    grVenom_JObjSetScaleY(jobj, scale);
+    grVenom_JObjSetScaleZ(jobj, scale);
+
+done_scale:
+
+    *(s32*) &gp->gv.venom.xD4 = 1;
+    *(s32*) &gp->gv.venom.xD8 = 0;
 }
 
 bool grVenom_802052D8(Ground_GObj* arg)
@@ -1132,7 +1277,7 @@ void grVenom_802053B0(Ground_GObj* gobj)
                 }
             }
         } else if (state < 12) {
-            HSD_JObjSetRotationY(jobj, grVe_804DB740);
+            grVenom_JObjSetRotationY(jobj, grVe_804DB740);
 
             gp2 = gobj->user_data;
             grVenom_802052E0(gobj, &sp1C);
@@ -1220,22 +1365,23 @@ void grVenom_80205758(Ground_GObj* gobj)
     s32* entry = base + gp->gv.venom.xC8;
     f32 v;
     f32 scale;
+    PAD_STACK(8);
 
     if ((u32) entry[8] != 0U) {
         v = gp->gv.venom.xE8;
-        if (v < grVe_804DB740) {
+        if (v < 0.0F) {
             v = -v;
         }
         if (v < grVe_804DB7E8) {
-            gp->gv.venom.xE8 = grVe_804DB740;
-            while (gp->gv.venom.xDC < (f32) grVe_804DB7F8) {
-                gp->gv.venom.xDC = gp->gv.venom.xDC + grVe_804DB7F0;
+            gp->gv.venom.xE8 = 0.0F;
+            while (gp->gv.venom.xDC < grVe_804DB7F8) {
+                gp->gv.venom.xDC += grVe_804DB7F0;
             }
-            while (gp->gv.venom.xDC > (f32) grVe_804DB800) {
-                gp->gv.venom.xDC = gp->gv.venom.xDC - grVe_804DB7F0;
+            while (gp->gv.venom.xDC > grVe_804DB800) {
+                gp->gv.venom.xDC -= grVe_804DB7F0;
             }
             v = gp->gv.venom.xDC;
-            if (v < grVe_804DB740) {
+            if (v < 0.0F) {
                 v = -v;
             }
             if (v < grVe_804DB744) {
@@ -1247,12 +1393,12 @@ void grVenom_80205758(Ground_GObj* gobj)
             HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         }
 
-        HSD_JObjSetTranslate(jobj, (Vec3*) &gp->gv.venom.xE0);
+        grVenom_JObjSetTranslate(jobj, (Vec3*) &gp->gv.venom.xE0);
 
         scale = Ground_801C0498();
-        HSD_JObjSetScaleX(jobj, scale * *(f32*) ((u8*) grVe_804D6A30 + 0x34));
-        HSD_JObjSetScaleY(jobj, scale * *(f32*) ((u8*) grVe_804D6A30 + 0x34));
-        HSD_JObjSetScaleZ(jobj, scale * *(f32*) ((u8*) grVe_804D6A30 + 0x34));
+        grVenom_JObjSetScaleX(jobj, scale * grVe_804D6A30->x34);
+        grVenom_JObjSetScaleY(jobj, scale * grVe_804D6A30->x34);
+        grVenom_JObjSetScaleZ(jobj, scale * grVe_804D6A30->x34);
 
         Ground_801C2FE0(gobj);
     } else {
@@ -1277,7 +1423,7 @@ void grVenom_80205AD4(Ground_GObj* gobj)
     Ground_GObj* other;
     Ground* other_gp;
     HSD_JObj* jobj2;
-    void* attr;
+    grVe_TimingData* attr;
 
     zero = 0;
     gp = gobj->user_data;
@@ -1337,13 +1483,13 @@ venom_80205AD4_default:
 venom_80205AD4_done:
 
     attr = grVe_804D6A30;
-    HSD_JObjSetScaleX(jobj, scale * *(f32*) ((u8*) attr + 0x34));
+    grVenom_JObjSetScaleX(jobj, scale * attr->x34);
 
     attr = grVe_804D6A30;
-    HSD_JObjSetScaleY(jobj, scale * *(f32*) ((u8*) attr + 0x34));
+    grVenom_JObjSetScaleY(jobj, scale * attr->x34);
 
     attr = grVe_804D6A30;
-    HSD_JObjSetScaleZ(jobj, scale * *(f32*) ((u8*) attr + 0x34));
+    grVenom_JObjSetScaleZ(jobj, scale * attr->x34);
 
     ((struct grCorneria_GroundVars2*) &gp->gv.venom)->xC4.flags.b0 = false;
     *(s32*) &gp->gv.venom.xD4 = zero;
@@ -1351,7 +1497,7 @@ venom_80205AD4_done:
     gp->gv.venom.xF4 = zero;
 
     attr = grVe_804D6A30;
-    gp->gv.venom.xF8 = (s32) * (f32*) ((u8*) attr + 0x2C);
+    gp->gv.venom.xF8 = (s32) attr->x2C;
     gp->gv.venom.xFC = zero;
     gp->gv.venom.x100 = HSD_Randi(2);
 }
@@ -1410,14 +1556,17 @@ extern Vec3 grVe_803B82DC;
 
 void grVenom_80205F30(Ground_GObj* gobj)
 {
+    u8 padA0[8];
     Vec3 sp94;
     Vec3 sp88;
+    u8 pad70[0x18];
     Vec3 sp64;
+    u8 pad5C[8];
     Vec3 sp50;
     Ground* gp;
     HSD_JObj* jobj;
-    HSD_GObj* other;
     Ground* other_gp;
+    HSD_GObj* other;
     HSD_JObj* tmp_jobj;
     s32* base;
     s32* entry;
@@ -1427,13 +1576,15 @@ void grVenom_80205F30(Ground_GObj* gobj)
     s32 retries;
     s32 type_idx;
     HSD_JObj* helper;
+    struct grCorneria_GroundVars2* arwing_vars;
 
     base = (s32*) &grVe_803E5348;
     gp = gobj->user_data;
     jobj = gobj->hsd_obj;
+    arwing_vars = (struct grCorneria_GroundVars2*) &gp->gv.venom;
     sp94 = grVe_803B82D0;
     sp88 = grVe_803B82DC;
-    PAD_STACK(0x3C);
+    PAD_STACK(0x28);
 
     if (grVe_804D6A3C != 0) {
         return;
@@ -1443,16 +1594,12 @@ void grVenom_80205F30(Ground_GObj* gobj)
     if ((u32) entry[8] != 0U) {
         if (entry[14] == 4) {
             tmp_jobj = Ground_801C3FA4((HSD_GObj*) gobj, 1);
-            HSD_JObjSetRotationZ(tmp_jobj, 0.0F);
+            grVenom_JObjSetRotationZ(tmp_jobj, 0.0F);
         }
 
         state = base[gp->gv.venom.xC8 + 11];
-        if (state >= 8) {
-            if (state < 0xC) {
-                goto venom_80205F30_far_type;
-            }
-        } else if (state >= 1) {
-                HSD_JObjSetRotationY(jobj, 0.0F);
+        if (state >= 1 && state < 8) {
+            grVenom_JObjSetRotationY(jobj, 0.0F);
 
                 {
                     s32 anim_state = gp->gv.venom.xF4;
@@ -1474,27 +1621,29 @@ void grVenom_80205F30(Ground_GObj* gobj)
                             switch (base[GET_GROUND(gobj)->gv.venom.xC8 + 14]) {
                             case 0:
                                 break;
+                            case 1:
+                            case 2:
+                            case 3:
+                                fire_kind = 0;
+                                break;
                             case 4:
                                 fire_kind = 1;
-                                break;
-                            default:
-                                fire_kind = 0;
                                 break;
                             }
                             {
                                 s32 idx0 = base[gp->gv.venom.xC8 + 14];
-                                s32 anim_id = base[idx0 * 4 + 0xD6];
-                                grAnime_801C8098(
-                                    (HSD_GObj*) gobj, anim_id, 7,
-                                    *(s32*) ((u8*) base + gp->gv.venom.xF4 * 8 +
-                                             fire_kind * 4 + 0x2FC),
-                                    0.0F, 1.0F);
+                                s32 anim_arg =
+                                    base[gp->gv.venom.xF4 * 2 + fire_kind +
+                                         0xBF];
+                                s32 anim_id = base[idx0 + 0xD6];
+                                grAnime_801C8098((HSD_GObj*) gobj, anim_id, 7,
+                                                 anim_arg, 0.0F, 1.0F);
                             }
                         } else {
                             s32 idx0 = base[gp->gv.venom.xC8 + 14];
-                            s32 anim_id = base[idx0 * 4 + 0xD6];
+                            s32 anim_id = base[idx0 + 0xD6];
                             tmp_jobj = Ground_801C3FA4((HSD_GObj*) gobj, anim_id);
-                            HSD_JObjSetRotationZ(tmp_jobj, 0.0F);
+                            grVenom_JObjSetRotationZ(tmp_jobj, 0.0F);
                         }
                         gp->gv.venom.xF8 = gp->gv.venom.xF8 - 1;
                     }
@@ -1502,69 +1651,55 @@ void grVenom_80205F30(Ground_GObj* gobj)
                 venom_80205F30_check_anim:
                     if (grAnime_801C83D0((HSD_GObj*) gobj, 0, 7) != 0) {
                         gp->gv.venom.xF4 = 0;
-                        gp->gv.venom.xF8 =
-                            (s32) * (f32*) ((u8*) grVe_804D6A30 + 0x2C);
+                        gp->gv.venom.xF8 = (s32) grVe_804D6A30->x2C;
                     }
                 venom_80205F30_anim_done:;
                 }
 
-                other = (HSD_GObj*) base[gp->gv.venom.xC8 + 8];
-                if (other != NULL) {
-                    Ground* other_gp_local = other->user_data;
+                if ((other = (HSD_GObj*) base[gp->gv.venom.xC8 + 8]) != NULL) {
+                    other_gp = other->user_data;
                     Ground_801C2BA4(5);
                     lb_8000B1CC(Ground_801C3FA4(other, 5), NULL, &sp64);
                     {
-                        f32* tab =
-                            (f32*) ((u8*) base +
-                                    base[other_gp_local->gv.venom.xC8 + 11] *
-                                        12);
-                        sp94.x = sp64.x + tab[0x86]; /* +0x218 / 4 */
-                        sp94.y = sp64.y + tab[0x87];
-                        sp94.z = sp64.z + tab[0x88];
+                        VenomSpawnData* spawn_data = (VenomSpawnData*) (
+                            base + base[other_gp->gv.venom.xC8 + 11] * 3);
+                        sp94.x = sp64.x + spawn_data->x;
+                        sp94.y = sp64.y + spawn_data->y;
+                        sp94.z = sp64.z + spawn_data->z;
                     }
                 } else {
-                    sp94.x = 0.0F;
-                    sp94.y = 0.0F;
-                    sp94.z = 0.0F;
+                    sp94.x = sp94.y = sp94.z = 0.0F;
                 }
 
-                HSD_JObjSetTranslate(jobj, &sp94);
+                grVenom_JObjSetTranslate(jobj, &sp94);
 
                 {
                     s32 idx0 = base[gp->gv.venom.xC8 + 14];
-                    s32 anim_id = base[idx0 * 4 + 0xD6];
+                    s32 anim_id = base[idx0 + 0xD6];
                     lb_8000B1CC(Ground_801C3FA4((HSD_GObj*) gobj, anim_id),
                                 NULL, &sp94);
                 }
-                if (*(u32*) &gp->gv.venom.xDC != 0U) {
-                    void* sub =
-                        *(void**) ((u8*) (*(u32*) &gp->gv.venom.xDC) + 0x2C);
+                if (arwing_vars->xDC != NULL) {
+                    Ground* sub = arwing_vars->xDC->user_data;
                     if (sub != NULL) {
-                        *(f32*) ((u8*) sub + 0xE0) = sp94.x;
-                        *(f32*) ((u8*) sub + 0xE4) = sp94.y;
-                        *(f32*) ((u8*) sub + 0xE8) = sp94.z;
+                        sub->gv.arwing.xE0 = sp94;
                     }
                 }
 
                 {
+                    f32 rot_z;
                     s32 idx0 = base[gp->gv.venom.xC8 + 14];
-                    s32 anim_id = base[idx0 * 4 + 0xD6];
+                    s32 anim_id = base[idx0 + 0xD6];
                     helper = Ground_801C3FA4((HSD_GObj*) gobj, anim_id);
-                    if (helper == NULL) {
-                        __assert("jobj.h", 0x2E9, "jobj");
-                    }
-                    if (*(u32*) &gp->gv.venom.xDC != 0U) {
-                        void* sub = *(
-                            void**) ((u8*) (*(u32*) &gp->gv.venom.xDC) + 0x2C);
+                    rot_z = grVenom_JObjGetRotationZ(helper);
+                    if (arwing_vars->xDC != NULL) {
+                        Ground* sub = arwing_vars->xDC->user_data;
                         if (sub != NULL) {
-                            *(f32*) ((u8*) sub + 0xDC) = helper->rotate.z;
+                            sub->gv.arwing.xDC = rot_z;
                         }
                     }
                 }
-            }
-        goto venom_80205F30_type_done;
-    venom_80205F30_far_type:
-        {
+        } else if (state >= 8 && state < 0xC) {
             if (!(gp->gv.venom.xF0 & 7) && HSD_Randi(8) == 0) {
                 gp->gv.venom.xFC = 0;
                 type_idx = base[gp->gv.venom.xC8 + 11];
@@ -1594,26 +1729,27 @@ void grVenom_80205F30(Ground_GObj* gobj)
                 gp->gv.venom.xFC = 0;
             }
 
-            other = (HSD_GObj*) base[gp->gv.venom.xC8 + 8];
-            if (other != NULL) {
-                Ground* other_gp_local = other->user_data;
-                Ground_801C2BA4(5);
-                lb_8000B1CC(Ground_801C3FA4(other, 5), NULL, &sp50);
-                {
-                    f32* tab =
-                        (f32*) ((u8*) base +
-                                base[other_gp_local->gv.venom.xC8 + 11] * 12);
-                    sp94.x = sp50.x + tab[0x86];
-                    sp94.y = sp50.y + tab[0x87];
-                    sp94.z = sp50.z + tab[0x88];
+            {
+                HSD_GObj* far_other;
+                Ground* far_other_gp;
+
+                if ((far_other = (HSD_GObj*) base[gp->gv.venom.xC8 + 8]) != NULL) {
+                    far_other_gp = far_other->user_data;
+                    Ground_801C2BA4(5);
+                    lb_8000B1CC(Ground_801C3FA4(far_other, 5), NULL, &sp50);
+                    {
+                        VenomSpawnData* spawn_data = (VenomSpawnData*) (
+                            base + base[far_other_gp->gv.venom.xC8 + 11] * 3);
+                        sp94.x = sp50.x + spawn_data->x;
+                        sp94.y = sp50.y + spawn_data->y;
+                        sp94.z = sp50.z + spawn_data->z;
+                    }
+                } else {
+                    sp94.x = sp94.y = sp94.z = 0.0F;
                 }
-            } else {
-                sp94.x = 0.0F;
-                sp94.y = 0.0F;
-                sp94.z = 0.0F;
             }
 
-            if (sp94.z < -100.0F && sp94.z > -2000.0F && gp->gv.venom.xFC != 0)
+            if (-100.0F > sp94.z && sp94.z > -2000.0F && gp->gv.venom.xFC != 0)
             {
                 gp->gv.venom.xFC = 0;
                 slot = HSD_Randi(4);
@@ -1633,42 +1769,38 @@ void grVenom_80205F30(Ground_GObj* gobj)
                     sp88.y += 5.0F;
                     lbAudioAx_800237A8(0x6B6C9, 0x7F, 0x40);
                     fire_kind = -1;
-                    {
-                        Ground* gp_re = gobj->user_data;
-                        s32 v = base[gp_re->gv.venom.xC8 + 14];
-                        if (v == 4) {
-                            fire_kind = 1;
-                        } else if (v >= 4) {
-                        } else if (v == 0) {
-                        } else if (v >= 0) {
-                            fire_kind = 0;
-                        }
+                    switch (base[GET_GROUND(gobj)->gv.venom.xC8 + 14]) {
+                    case 0:
+                        break;
+                    case 1:
+                    case 2:
+                    case 3:
+                        fire_kind = 0;
+                        break;
+                    case 4:
+                        fire_kind = 1;
+                        break;
                     }
                     if (fire_kind == 1) {
                         it_802E7654(gobj, Ground_801C3FA4((HSD_GObj*) gobj, 7),
-                                    &sp88, 3, 0,
-                                    *(f32*) ((u8*) grVe_804D6A30 + 0x34));
+                                    &sp88, 3, 0, grVe_804D6A30->x34);
                     } else {
                         if (gp->gv.venom.x100 != 0) {
                             it_802E7654(gobj,
                                         Ground_801C3FA4((HSD_GObj*) gobj, 5),
-                                        &sp88, 1, 0,
-                                        *(f32*) ((u8*) grVe_804D6A30 + 0x34));
+                                        &sp88, 1, 0, grVe_804D6A30->x34);
                         } else {
                             it_802E7654(gobj,
                                         Ground_801C3FA4((HSD_GObj*) gobj, 6),
-                                        &sp88, 1, 0,
-                                        *(f32*) ((u8*) grVe_804D6A30 + 0x34));
+                                        &sp88, 1, 0, grVe_804D6A30->x34);
                         }
                         gp->gv.venom.x100 = (gp->gv.venom.x100 + 1) & 1;
                     }
-                    grMaterial_801C9604((HSD_GObj*) gobj,
-                                        *(s32*) ((u8*) grVe_804D6A30 + 0x38),
+                    grMaterial_801C9604((HSD_GObj*) gobj, grVe_804D6A30->x38,
                                         0);
                 }
             }
         }
-    venom_80205F30_type_done:
 
         gp->gv.venom.xF0 = gp->gv.venom.xF0 + 1;
     } else {
@@ -1696,86 +1828,67 @@ void grVenom_80206870(Ground_GObj* arg) {}
 /// @todo Currently 99.60% match - needs register allocation fixes
 void grVenom_80206874(Ground_GObj* gobj)
 {
-    u32 zero = 0;
-    s32* base = (s32*) &grVe_803E5348;
+    s32* data = (s32*) &grVe_803E5348;
     Ground* gp = gobj->user_data;
     HSD_JObj* jobj = gobj->hsd_obj;
-    f32 scale = Ground_801C0498();
-    s32* data;
-    s32 type;
-    Ground_GObj* other;
-    Ground* other_gp;
-    HSD_JObj* jobj2;
-    void* attr;
+    f32 scale;
 
+    scale = Ground_801C0498();
     gp->gv.venom.xC8 = grVe_804D6A34;
-    *(s32*) &gp->gv.venom.xEC = zero;
-    *(s32*) &gp->gv.venom.xE8 = zero;
-    *(s32*) &gp->gv.venom.xE4 = zero;
-    *(s32*) &gp->gv.venom.xE0 = zero;
+    *(s32*) &gp->gv.venom.xEC = 0;
+    *(s32*) &gp->gv.venom.xE8 = 0;
+    *(s32*) &gp->gv.venom.xE4 = 0;
+    *(s32*) &gp->gv.venom.xE0 = 0;
 
     grAnime_801C7FF8(gobj, 0, 7, 1, 0.0F, 1.0F);
     grAnime_801C8098(gobj, 2, 7, 3, 0.0F, 1.0F);
 
-    data = base + gp->gv.venom.xC8;
-    type = data[11];
-
-    if (type < 8) {
-        if (type >= 1) {
-            goto venom_80206874_spawn;
+    switch (data[gp->gv.venom.xC8 + 11]) {
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+    case 5:
+    case 6:
+    case 7: {
+        HSD_GObj* other = grVenom_80203EAC(
+            data[data[gp->gv.venom.xC8 + 14] + 0xC9]);
+        *(s32*) &gp->gv.venom.xDC = (s32) other;
+        if (other != NULL) {
+            Ground* other_gp =
+                GET_GROUND(*(Ground_GObj**) &gp->gv.venom.xDC);
+            if (other_gp != NULL) {
+                other_gp->gv.venom.xC8 = gp->gv.venom.xC8;
+            }
         }
-        goto venom_80206874_default;
+        break;
     }
-    if (type >= 0xC) {
-        goto venom_80206874_default;
+    case 8:
+    case 9:
+    case 10:
+    case 11:
+        lb_8000C2F8(
+            Ground_801C3FA4(gobj, 0),
+            Ground_801C3FA4((HSD_GObj*) data[gp->gv.venom.xC8 + 8], 5));
+        *(s32*) &gp->gv.venom.xDC = 0;
+        break;
+    default:
+        *(s32*) &gp->gv.venom.xE0 = -1;
+        *(s32*) &gp->gv.venom.xE4 = -1;
+        break;
     }
-    goto venom_80206874_link;
 
-venom_80206874_spawn: {
-    s32 idx = data[14];
-    s32* data2 = base + idx;
-
-    other = (Ground_GObj*) grVenom_80203EAC(data2[0xC9]);
-    *(s32*) &gp->gv.venom.xDC = (s32) other;
-    if (other != NULL) {
-        other = *(Ground_GObj**) &gp->gv.venom.xDC;
-        other_gp = other->user_data;
-        if (other_gp != NULL) {
-            other_gp->gv.venom.xC8 = gp->gv.venom.xC8;
-        }
-    }
-    goto venom_80206874_done;
-}
-
-venom_80206874_link:
-    jobj2 = Ground_801C3FA4((HSD_GObj*) data[8], 5);
-    lb_8000C2F8(Ground_801C3FA4(gobj, 0), jobj2);
-    *(s32*) &gp->gv.venom.xDC = zero;
-    goto venom_80206874_done;
-
-venom_80206874_default:
-    *(s32*) &gp->gv.venom.xE0 = -1;
-    *(s32*) &gp->gv.venom.xE4 = -1;
-
-venom_80206874_done:
-
-    attr = grVe_804D6A30;
-    HSD_JObjSetScaleX(jobj, scale * *(f32*) ((u8*) attr + 0x34));
-
-    attr = grVe_804D6A30;
-    HSD_JObjSetScaleY(jobj, scale * *(f32*) ((u8*) attr + 0x34));
-
-    attr = grVe_804D6A30;
-    HSD_JObjSetScaleZ(jobj, scale * *(f32*) ((u8*) attr + 0x34));
+    grVenom_JObjSetScaleX(jobj, scale * grVe_804D6A30->x34);
+    grVenom_JObjSetScaleY(jobj, scale * grVe_804D6A30->x34);
+    grVenom_JObjSetScaleZ(jobj, scale * grVe_804D6A30->x34);
 
     ((struct grCorneria_GroundVars2*) &gp->gv.venom)->xC4.flags.b0 = false;
-    *(s32*) &gp->gv.venom.xD4 = zero;
-    gp->gv.venom.xF0 = zero;
-    gp->gv.venom.xF4 = zero;
+    *(s32*) &gp->gv.venom.xD4 = 0;
+    gp->gv.venom.xF0 = 0;
+    gp->gv.venom.xF4 = 0;
 
-    attr = grVe_804D6A30;
-    gp->gv.venom.xF8 = (s32) * (f32*) ((u8*) attr + 0x2C);
-    gp->gv.venom.xFC = zero;
+    gp->gv.venom.xF8 = (s32) grVe_804D6A30->x2C;
+    gp->gv.venom.xFC = 0;
 }
 
 /// #grVenom_80206874

--- a/src/melee/gr/types.h
+++ b/src/melee/gr/types.h
@@ -467,13 +467,21 @@ struct grSmashTaunt_GroundVars {
 };
 
 struct grVenom_GroundVars {
-    /* +00 gp+C4 */ u32 xC4;
+    /* +00 gp+C4 */ union {
+        u32 xC4;
+        struct {
+            u8 b0 : 1;
+        } xC4_flags;
+    };
     /* +04 gp+C8 */ u32 xC8;
     /* +08 gp+CC */ u32 xCC;
     /* +0C gp+D0 */ u32 xD0;
     /* +10 gp+D4 */ f32 xD4;
     /* +14 gp+D8 */ f32 xD8;
-    /* +18 gp+DC */ f32 xDC;
+    /* +18 gp+DC */ union {
+        f32 xDC;
+        Ground_GObj* linked_gobj;
+    };
     /* +1C gp+E0 */ f32 xE0;
     /* +20 gp+E4 */ f32 xE4;
     /* +24 gp+E8 */ f32 xE8;

--- a/src/melee/gr/types.h
+++ b/src/melee/gr/types.h
@@ -1224,6 +1224,18 @@ struct grBigBlue_GroundData {
 };
 STATIC_ASSERT(sizeof(struct grBigBlue_GroundData) == 0x54);
 
+struct grBigBlue_PlatformVars {
+    /* gp+C4 */ u32 xC4;
+    /* gp+C8 */ s32 xC8_timer;
+    /* gp+CC */ s32 xCC_timer;
+    /* gp+D0 */ s32 xD0_timer;
+    /* gp+D4 */ f32 height_offset;
+    /* gp+D8 */ f32 xD8;
+    /* gp+DC */ f32 target_y;
+    /* gp+E0 */ Vec3 velocity;
+    /* gp+EC */ f32 xEC;
+};
+
 /// Used by multiple Big Blue Ground subtypes (track, road, car gobjs).
 /// Different gobjs interpret the same offsets differently.
 ///
@@ -1236,24 +1248,29 @@ STATIC_ASSERT(sizeof(struct grBigBlue_GroundData) == 0x54);
 ///   angular_vel(+48).
 struct grBigBlue_GroundVars {
     union {
-        /*  +0 gp+C4 */ u32 x0_w;
         struct {
-            /*  +0 gp+C5 */ u8 x0;
-            /*  +0 gp+C6 */ u8 x1;
-            /*  +0 gp+C7 */ u8 x2;
-            /*  +0 gp+C8 */ u8 x3;
+            union {
+                /*  +0 gp+C4 */ u32 x0_w;
+                struct {
+                    /*  +0 gp+C5 */ u8 x0;
+                    /*  +0 gp+C6 */ u8 x1;
+                    /*  +0 gp+C7 */ u8 x2;
+                    /*  +0 gp+C8 */ u8 x3;
+                };
+                struct {
+                    u8 x0_b1 : 1;
+                    u8 pad[3];
+                };
+            };
+            /*  +4 gp+C8 */ void* xC8;
+            /*  +8 gp+CC */ void* xCC;
+            /*  +C gp+D0 */ f32 xD0;
+            /* +10 gp+D4 */ HSD_JObj* xD4[3];
+            /* pad */ char pad_3[4];
+            /* +20 gp+E4 */ struct grBigBlue_GroundData data[3];
         };
-        struct {
-            u8 x0_b1 : 1;
-            u8 pad[3];
-        };
+        struct grBigBlue_PlatformVars platform;
     };
-    /*  +4 gp+C8 */ void* xC8;
-    /*  +8 gp+CC */ void* xCC;
-    /*  +C gp+D0 */ f32 xD0;
-    /* +10 gp+D4 */ HSD_JObj* xD4[3];
-    /* pad */ char pad_3[4];
-    /* +20 gp+E4 */ struct grBigBlue_GroundData data[3];
 };
 
 struct grBigBlueRoute_GroundVars {


### PR DESCRIPTION
## Summary

- Exact-match decompilation for Big Blue, Fourside, Rainbow Cruise, Shrine Route, Old Yoshi, and Venom.
- Adds 10 newly exact function(s) across 6 file(s).
- Verified alone against the current upstream baseline with zero regressions.

## PR Shape

- Scope: Big Blue, Fourside, Rainbow Cruise, Shrine Route, Old Yoshi, and Venom
- Change type: implementation-only match work
- Review risk: Medium; several stage-local files, including Venom data exactness.
- Header/naming churn: none
- Regression signal: clean in isolated slice verification and clean in the full ship set

## Reviewer Notes

- This file-level slice also improves 11 still-unmatched function(s); no fuzzy or metric regressions were introduced.
- Files:
  - `src/melee/gr/grbigblue.c`
  - `src/melee/gr/grfourside.c`
  - `src/melee/gr/grrcruise.c`
  - `src/melee/gr/grshrineroute.c`
  - `src/melee/gr/groldyoshi.c`
  - `src/melee/gr/grvenom.c`

## Verification

- Applied this slice alone to baseline `3a7df8e49f` and ran `MVK_CONFIG_LOG_LEVEL=0 WINEDEBUG=-all ninja -C /tmp/melee-baseline-3a7df8e49fcbdbbb3e3be32b47f47954581bc8b8 -j8 changes_all`.
- Slice regression report: 10 new match(es), 0 broken matches, 0 fuzzy regressions, 0 metric regressions.
- Full ship-set regression report: 96 new match(es), 0 broken matches, 0 fuzzy regressions, 0 metric regressions.
- `git diff --check` passed for the slice and full ship set.
- review_lint on the full ship set: 0 error(s), 112 warning(s).
