### PR TITLE
Melee decomp: Menu screen matches

### DIFF
--- a/src/melee/mn/mncharsel.c
+++ b/src/melee/mn/mncharsel.c
@@ -202,8 +202,8 @@ void mnCharSel_8025C020(int arg0)
     u8 sp74[4];
     HSD_JObj* sp70;
 
-    int i = mnCharSel_803F0DFC.doors[0].sel_icon;
-    int temp_r31 = icons[i].ft_hudindex;
+    u8 i = mnCharSel_803F0DFC.doors[0].sel_icon;
+    u8 hud_index = icons[i].ft_hudindex;
     if (arg0 != 0) {
         if (mnCharSel_804D6CDC != 0U) {
             HSD_SisLib_803A70A0(mnCharSel_804D6CDC, 0, NULL);
@@ -214,51 +214,54 @@ void mnCharSel_8025C020(int arg0)
     }
     switch (mnCharSel_804D6CB0->match_type) {
     case REG_CLASSIC:
-        sp7C = inline3(0x42, *gmMainLib_8015D194(temp_r31));
+        sp7C = inline3(0x42, *gmMainLib_8015D194(hud_index));
         if (arg0 != 0) {
             HSD_JObjSetFlags(sp7C, JOBJ_HIDDEN);
         } else {
             HSD_SisLib_803A70A0(mnCharSel_804D6CDC, 0, "%08d",
-                                gm_80162BD8(temp_r31));
-            if (gmMainLib_8015D0D8(temp_r31) != 0) {
+                                gm_80162BD8(hud_index));
+            if (gmMainLib_8015D0D8(hud_index) != 0) {
                 HSD_JObjClearFlags(sp7C, JOBJ_HIDDEN);
             }
         }
-        HSD_SisLib_803A70A0(mnCharSel_804D6CE4, 0, "%09d", gm_80162C48());
+        HSD_SisLib_803A70A0(mnCharSel_804D6CE4, 0, "%09d",
+                            gm_80162C48());
         if (gm_80162D1C() != 0) {
             sp7C = inline3(0x43, gm_80162D6C());
             HSD_JObjClearFlags(sp7C, JOBJ_HIDDEN);
         }
         break;
     case REG_ADVENTURE:
-        sp7C = inline3(0x42, *gmMainLib_8015D2BC(temp_r31));
+        sp7C = inline3(0x42, *gmMainLib_8015D2BC(hud_index));
         if (arg0 != 0) {
             HSD_JObjSetFlags(sp7C, JOBJ_HIDDEN);
         } else {
             HSD_SisLib_803A70A0(mnCharSel_804D6CDC, 0, "%08d",
-                                gm_80162DD4(temp_r31));
-            if (gmMainLib_8015D200(temp_r31) != 0) {
+                                gm_80162DD4(hud_index));
+            if (gmMainLib_8015D200(hud_index) != 0) {
                 HSD_JObjClearFlags(sp7C, JOBJ_HIDDEN);
             }
         }
-        HSD_SisLib_803A70A0(mnCharSel_804D6CE4, 0, "%09d", gm_80162E44());
+        HSD_SisLib_803A70A0(mnCharSel_804D6CE4, 0, "%09d",
+                            gm_80162E44());
         if (gm_80162F18() != 0) {
             sp7C = inline3(0x43, gm_80162F68());
             HSD_JObjClearFlags(sp7C, JOBJ_HIDDEN);
         }
         break;
     case REG_ALLSTAR:
-        sp7C = inline3(0x42, *gmMainLib_8015D3E4(temp_r31));
+        sp7C = inline3(0x42, *gmMainLib_8015D3E4(hud_index));
         if (arg0 != 0) {
             HSD_JObjSetFlags(sp7C, JOBJ_HIDDEN);
         } else {
             HSD_SisLib_803A70A0(mnCharSel_804D6CDC, 0, "%08d",
-                                gm_80162FD0(temp_r31));
-            if (gmMainLib_8015D328(temp_r31) != 0) {
+                                gm_80162FD0(hud_index));
+            if (gmMainLib_8015D328(hud_index) != 0) {
                 HSD_JObjClearFlags(sp7C, JOBJ_HIDDEN);
             }
         }
-        HSD_SisLib_803A70A0(mnCharSel_804D6CE4, 0, "%09d", gm_80163040());
+        HSD_SisLib_803A70A0(mnCharSel_804D6CE4, 0, "%09d",
+                            gm_80163040());
         if (gm_80163114() != 0) {
             sp7C = inline3(0x43, gm_80163164());
             HSD_JObjClearFlags(sp7C, JOBJ_HIDDEN);
@@ -266,16 +269,17 @@ void mnCharSel_8025C020(int arg0)
         break;
     case STADIUM_TARGET:
         if (arg0 == 0) {
-            int temp_r29 = gm_8016332C(temp_r31);
-            if (temp_r29 != -1U) {
+            int target_count = gm_8016332C(hud_index);
+            if (target_count != -1U) {
                 if (lbLang_IsSavedLanguageJP() != 0) {
                     HSD_SisLib_803A70A0(mnCharSel_804D6CDC, 0, "%d 個",
-                                        temp_r29);
+                                        target_count);
                 } else {
-                    HSD_SisLib_803A70A0(mnCharSel_804D6CDC, 0, "%d", temp_r29);
+                    HSD_SisLib_803A70A0(mnCharSel_804D6CDC, 0, "%d",
+                                        target_count);
                 }
             } else {
-                gm_80163374(temp_r31, &sp7B, &sp7A, &sp79, &sp78);
+                gm_80163374(hud_index, &sp7B, &sp7A, &sp79, &sp78);
                 drawTimeText(mnCharSel_804D6CDC, mnCharSel_804D6CE0, sp7B,
                              sp7A, sp79, sp78);
             }
@@ -296,12 +300,12 @@ void mnCharSel_8025C020(int arg0)
             if (lbLang_IsSavedLanguageJP()) {
                 HSD_SisLib_803A70A0(
                     mnCharSel_804D6CDC, 0, "%.1f",
-                    (f32) (int) (10.0f * (gm_801631CC(temp_r31) / 100.0f)) /
+                    (f32) (int) (10.0f * (gm_801631CC(hud_index) / 100.0f)) /
                         10.0f);
             } else {
                 HSD_SisLib_803A70A0(
                     mnCharSel_804D6CDC, 0, "%.1f",
-                    (f32) (int) (10.0f * (gm_801631CC(temp_r31) / 30.4788f)) /
+                    (f32) (int) (10.0f * (gm_801631CC(hud_index) / 30.4788f)) /
                         10.0f);
             }
         }
@@ -318,15 +322,15 @@ void mnCharSel_8025C020(int arg0)
     case 23:
         if (arg0 == 0) {
             HSD_SisLib_803A70A0(mnCharSel_804D6CDC, 0, "%d",
-                                gm_80163274(temp_r31));
+                                gm_80163274(hud_index));
         }
         break;
     case STADIUM_MULTIMAN_10:
         if (arg0 == 0) {
-            if (gm_8016365C(temp_r31) != 0) {
-                show_kos(mnCharSel_804D6CDC, gm_80163690(temp_r31));
+            if (gm_8016365C(hud_index) != 0) {
+                show_kos(mnCharSel_804D6CDC, gm_80163690(hud_index));
             } else {
-                gm_801636D8(temp_r31, &sp7B, &sp7A, &sp79, &sp78);
+                gm_801636D8(hud_index, &sp7B, &sp7A, &sp79, &sp78);
                 drawTimeText(mnCharSel_804D6CDC, mnCharSel_804D6CE0, sp7B,
                              sp7A, sp79, sp78);
             }
@@ -344,10 +348,10 @@ void mnCharSel_8025C020(int arg0)
         break;
     case STADIUM_MULTIMAN_100:
         if (arg0 == 0) {
-            if (gm_801639C0(temp_r31) != 0) {
-                show_kos(mnCharSel_804D6CDC, gm_801639F4(temp_r31));
+            if (gm_801639C0(hud_index) != 0) {
+                show_kos(mnCharSel_804D6CDC, gm_801639F4(hud_index));
             } else {
-                gm_80163A3C(temp_r31, &sp7B, &sp7A, &sp79, &sp78);
+                gm_80163A3C(hud_index, &sp7B, &sp7A, &sp79, &sp78);
                 drawTimeText(mnCharSel_804D6CDC, mnCharSel_804D6CE0, sp7B,
                              sp7A, sp79, sp78);
             }
@@ -367,10 +371,10 @@ void mnCharSel_8025C020(int arg0)
         if (arg0 == 0) {
             if (lbLang_IsSavedLanguageJP()) {
                 HSD_SisLib_803A70A0(mnCharSel_804D6CDC, 0, "%d 人抜き",
-                                    gm_Get3MinMultimanHighscore(temp_r31));
+                                    gm_Get3MinMultimanHighscore(hud_index));
             } else {
                 HSD_SisLib_803A70A0(mnCharSel_804D6CDC, 0, "%d ＫＯｓ",
-                                    gm_Get3MinMultimanHighscore(temp_r31));
+                                    gm_Get3MinMultimanHighscore(hud_index));
             }
         }
         if (lbLang_IsSavedLanguageJP()) {
@@ -385,10 +389,10 @@ void mnCharSel_8025C020(int arg0)
         if (!arg0) {
             if (lbLang_IsSavedLanguageJP()) {
                 HSD_SisLib_803A70A0(mnCharSel_804D6CDC, 0, "%d 人抜き",
-                                    gm_Get15MinMultimanHighscore(temp_r31));
+                                    gm_Get15MinMultimanHighscore(hud_index));
             } else {
                 HSD_SisLib_803A70A0(mnCharSel_804D6CDC, 0, "%d ＫＯｓ",
-                                    gm_Get15MinMultimanHighscore(temp_r31));
+                                    gm_Get15MinMultimanHighscore(hud_index));
             }
         }
         if (lbLang_IsSavedLanguageJP()) {
@@ -401,13 +405,13 @@ void mnCharSel_8025C020(int arg0)
         break;
     case STADIUM_ENDLESS_MELEE:
         if (!arg0) {
-            show_kos(mnCharSel_804D6CDC, gm_GetEndlessHighscore(temp_r31));
+            show_kos(mnCharSel_804D6CDC, gm_GetEndlessHighscore(hud_index));
         }
         show_kos(mnCharSel_804D6CE4, gm_GetEndlessTotalHighscore());
         break;
     case STADIUM_CRUEL_MELEE:
         if (!arg0) {
-            show_kos(mnCharSel_804D6CDC, gm_GetCruelHighscore(temp_r31));
+            show_kos(mnCharSel_804D6CDC, gm_GetCruelHighscore(hud_index));
         }
         show_kos(mnCharSel_804D6CE4, gm_GetCruelTotalHighscore());
         break;
@@ -1831,12 +1835,12 @@ void mnCharSel_CursorThink(HSD_GObj* gobj)
         cursor->x8 = 0;
 
         if ((u8) mnCharSel_804D6CF5 == 1) {
-            HSD_PadStatus* pad = &HSD_PadCopyStatus[(u8) mnCharSel_804D6CF0];
-            stick_y = (f32) (s8) (u8) pad->stickY;
-            trigger = pad->trigger;
-            buttons = pad->button;
-            stick_x = (f32) (s8) (u8) pad->stickX;
+            u8 port = mnCharSel_804D6CF0;
+            stick_y = (f32) (s8) (u8) HSD_PadCopyStatus[port].stickY;
+            stick_x = (f32) (s8) (u8) HSD_PadCopyStatus[port].stickX;
             mag_sq = (stick_x * stick_x) + (stick_y * stick_y);
+            trigger = HSD_PadCopyStatus[port].trigger;
+            buttons = HSD_PadCopyStatus[port].button;
             if (mag_sq < 200.0f) {
                 dy = 0.0f;
                 dx = 0.0f;
@@ -1862,12 +1866,11 @@ void mnCharSel_CursorThink(HSD_GObj* gobj)
             }
         } else {
             u8 port = cursor->x4;
-            HSD_PadStatus* pad = &HSD_PadCopyStatus[port];
-            stick_y = (f32) (s8) (u8) pad->stickY;
-            trigger = pad->trigger;
-            buttons = pad->button;
-            stick_x = (f32) (s8) (u8) pad->stickX;
+            stick_y = (f32) (s8) (u8) HSD_PadCopyStatus[port].stickY;
+            stick_x = (f32) (s8) (u8) HSD_PadCopyStatus[port].stickX;
             mag_sq = (stick_x * stick_x) + (stick_y * stick_y);
+            trigger = HSD_PadCopyStatus[port].trigger;
+            buttons = HSD_PadCopyStatus[port].button;
             if (mag_sq < 200.0f) {
                 dy = 0.0f;
                 dx = 0.0f;
@@ -1962,12 +1965,11 @@ void mnCharSel_CursorThink(HSD_GObj* gobj)
             if ((u8) tag->state != 0) {
                 if ((u8) mnCharSel_804D6CF5 == 1) {
                     lb_80011E24(mnCharSel_804D6CC0, &sp98,
-                                mnCharSel_803F0DFC.name_list_joint, -1,
-                                0.0002f);
+                                mnCharSel_803F0DFC.name_list_joint, -1);
                 } else {
                     lb_80011E24(mnCharSel_804D6CC0, &sp98,
                                 mnCharSel_803F0DFC.tags[cursor->x4].list_joint,
-                                -1, 0.0002f);
+                                -1);
                 }
                 lb_8000B1CC(sp98, NULL, &sp88);
 
@@ -2693,7 +2695,8 @@ void mnCharSel_CursorThink(HSD_GObj* gobj)
                                                   mnCharSel_804A0BC0[di])
                                                 ->x5 != 1)
                                     {
-                                        if ((u8) tp->data->state == 0) {
+                                        CSSTagData* tag_data = tp->data;
+                                        if ((u8) tag_data->state == 0) {
                                             f32 cx4 = cursor->xC;
                                             if (cx4 > dp->togglebtn_left &&
                                                 cx4 < dp->togglebtn_right)
@@ -2735,7 +2738,7 @@ void mnCharSel_CursorThink(HSD_GObj* gobj)
                                                             ->data.data
                                                             .players[di]
                                                             .xA = 0x78;
-                                                        tp->data->use_tag = 0;
+                                                        tag_data->use_tag = 0;
                                                         if ((u8) dp->selected_since_load ==
                                                                 0 &&
                                                             (s32) cursor->x4 !=
@@ -2813,8 +2816,8 @@ void mnCharSel_CursorThink(HSD_GObj* gobj)
                                                         f32 sdy =
                                                             cursor->xC -
                                                             (-2.9f + sp88.x);
-                                                        if ((sdy * sdy +
-                                                             sdx * sdx) < 5.0f)
+                                                        if ((sdx * sdx +
+                                                             sdy * sdy) < 5.0f)
                                                         {
                                                             cursor->x5 = 1;
                                                             cursor->x6 =
@@ -2858,11 +2861,13 @@ void mnCharSel_CursorThink(HSD_GObj* gobj)
                                                                 sp98, NULL,
                                                                 (Point3d*) &sp88);
                                                             {
-                                                                f32 hdx =
+                                                                f32 hdx_val =
                                                                     cursor
                                                                         ->x10 -
                                                                     (1.7f +
                                                                      sp88.y);
+                                                                f32 hdx =
+                                                                    hdx_val;
                                                                 f32 hdy =
                                                                     cursor
                                                                         ->xC -
@@ -3193,15 +3198,15 @@ block_392:
 void fn_80262648(HSD_GObj* gobj)
 {
     HSD_JObj* sp24;
-    HSD_JObj* sp18;
     u32 pad1;
     u32 pad2;
+    HSD_JObj* jobj4;
     HSD_JObj* sp14;
     HSD_JObj* sp10;
     struct CSSCharModel* model = gobj->user_data;
     HSD_JObj* jobj = GET_JOBJ(gobj);
-    u8 prev_port = model->x6;
     CSSData* css = mnCharSel_804D6CB0;
+    u8 prev_port = model->x6;
     int n_doors;
 
     if ((u8) css->match_type == 0x17) {
@@ -3252,11 +3257,11 @@ void fn_80262648(HSD_GObj* gobj)
             if (port < 4U) {
                 if ((u8) mnCharSel_804D6CF5 == 1) {
                     f32 f24 = (f32) ((s8) (u8) mnCharSel_804D6CF0 * 4);
-                    lb_80011E24(jobj, &sp18, 4, -1);
-                    HSD_ForeachAnim(sp18, JOBJ_TYPE, TOBJ_MASK,
+                    lb_80011E24(jobj, &jobj4, 4, -1);
+                    HSD_ForeachAnim(jobj4, JOBJ_TYPE, TOBJ_MASK,
                                     HSD_AObjReqAnim, AOBJ_ARG_AF, f24);
-                    HSD_JObjAnimAll(sp18);
-                    HSD_ForeachAnim(sp18, JOBJ_TYPE, TOBJ_MASK,
+                    HSD_JObjAnimAll(jobj4);
+                    HSD_ForeachAnim(jobj4, JOBJ_TYPE, TOBJ_MASK,
                                     HSD_AObjStopAnim, AOBJ_ARG_AOV, 0, 0);
                 } else {
                     f32 f24 = (f32) (model->x4 * 4);
@@ -3287,9 +3292,9 @@ void fn_80262648(HSD_GObj* gobj)
         if (status == 0) {
             s32 iter;
             for (iter = 0; iter < 0x14; iter++) {
-                s32 j;
                 struct CSSCharModel** bdp = mnCharSel_804A0BD0;
                 CSSDoor* dp = mnCharSel_803F0DFC.doors;
+                s32 j;
 
                 for (j = 0; j < (s32) n_doors; j++) {
                     if (j != (s32) model->x4 && (u8) (*bdp)->x5 == 0 &&
@@ -3415,9 +3420,12 @@ void fn_80262648(HSD_GObj* gobj)
     }
 
     {
-        f32 dy = model->x14 - model->xC;
-        f32 tx = model->x8;
-        f32 dx = model->x10 - tx;
+        f32 dx;
+        f32 tx;
+        f32 dy;
+
+        dy = model->x14 - model->xC;
+        dx = model->x10 - (tx = model->x8);
 
         if ((dx * dx + dy * dy) < 4.0f) {
             model->x10 = tx;
@@ -4072,14 +4080,14 @@ s32 mnCharSel_802640A0(void)
     HSD_JObj* spA4;
     HSD_JObj* sp9C;
     HSD_JObj* sp70;
-    HSD_JObj* sp64;
+    s32 row_b;
     HSD_GObj* gobj;
     HSD_JObj* jobj;
     HSD_Text* text;
     s32 ctx;
     s32 num_players;
     s32 row_a;
-    s32 row_b;
+    HSD_JObj* jobj43;
     s32 i;
     u8 match_type = mnCharSel_804D6CB0->match_type;
 
@@ -4142,8 +4150,8 @@ s32 mnCharSel_802640A0(void)
     }
 
     gobj = GObj_Create(2, 3, 0x80);
-    MenMain_cam = MODELS->cam;
     mnCharSel_804D6CB8 = gobj;
+    MenMain_cam = MODELS->cam;
     HSD_GObjObject_80390A70(gobj, HSD_GObj_804D784B,
                             HSD_CObjLoadDesc(MODELS->cam));
     GObj_SetupGXLinkMax(gobj, HSD_GObj_803910D8, 0);
@@ -4433,7 +4441,11 @@ s32 mnCharSel_802640A0(void)
             lb_80011E24(mnCharSel_804D6CC0, &sp108,
                         mnCharSel_803F0DFC.name_list_joint, -1);
         } else {
-            lb_80011E24(mnCharSel_804D6CC0, &sp9C, tag->name_jointl, -1);
+            {
+                HSD_JObj** jobj_ptr = &sp9C;
+                lb_80011E24(mnCharSel_804D6CC0, jobj_ptr, tag->name_jointl,
+                            -1);
+            }
             HSD_ForeachAnim(sp9C, JOBJ_TYPE, JOBJ_MASK, HSD_AObjReqAnim,
                             AOBJ_ARG_AF, 2.0);
             HSD_JObjAnimAll(sp9C);
@@ -4643,13 +4655,13 @@ s32 mnCharSel_802640A0(void)
             text->font_size.y = 0.055f;
             text->default_alignment = 2;
             HSD_SisLib_803A6B98(text, 0.0f, 0.0f, NULL);
-            lb_80011E24(mnCharSel_804D6CC0, &sp64, 0x43, -1);
-            HSD_ForeachAnim(sp64, JOBJ_TYPE, TOBJ_MASK, HSD_AObjReqAnim,
+            lb_80011E24(mnCharSel_804D6CC0, &jobj43, 0x43, -1);
+            HSD_ForeachAnim(jobj43, JOBJ_TYPE, TOBJ_MASK, HSD_AObjReqAnim,
                             AOBJ_ARG_AF, 0.0);
-            HSD_JObjAnimAll(sp64);
-            HSD_ForeachAnim(sp64, JOBJ_TYPE, TOBJ_MASK, HSD_AObjStopAnim,
+            HSD_JObjAnimAll(jobj43);
+            HSD_ForeachAnim(jobj43, JOBJ_TYPE, TOBJ_MASK, HSD_AObjStopAnim,
                             AOBJ_ARG_AOV, 0, 0);
-            sp108 = sp64;
+            sp108 = jobj43;
             HSD_JObjSetFlags(sp108, JOBJ_HIDDEN);
             break;
         case STADIUM_TARGET:
@@ -5162,11 +5174,7 @@ void mnCharSel_80266D70_OnLeave(void* unused)
                 data->data.data.players[mnCharSel_804D6CF1].c_kind);
         }
     } else {
-        if (mnCharSel_804D6CB0->match_type == VS_CAMERA) {
-            num_slots = 3;
-        } else {
-            num_slots = 4;
-        }
+        num_slots = mnCharSel_804D6CB0->match_type == VS_CAMERA ? 3 : 4;
         for (i = 0; i < num_slots; i++) {
             data = mnCharSel_804D6CB0;
             type = data->data.data.players[i].slot_type;

--- a/src/melee/mn/mncount.c
+++ b/src/melee/mn/mncount.c
@@ -651,10 +651,11 @@ void fn_802514B8(HSD_GObj* gobj)
     HSD_GObjPLink_80390228(gobj);
 }
 
-void fn_802514D8(HSD_GObj* gobj)
+static inline void fn_802514D8_inline(MnCountData* userdata,
+                                       HSD_GObj* gobj)
 {
-    MnCountData* userdata = GET_MNCOUNT(gobj);
     HSD_GObjProc* proc;
+    HSD_JObj* jobj;
     PAD_STACK(16);
     if (mn_804A04F0.cur_menu != MENU_KIND_RECORDS_MISC) {
         HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
@@ -666,15 +667,17 @@ void fn_802514D8(HSD_GObj* gobj)
             MnCountData* userdata2 = GET_MNCOUNT(gobj);
             MnCountData* userdata3 = userdata2;
             int i;
+            HSD_Text* label_null = NULL;
+            HSD_Text* value_null = NULL;
 
             for (i = 0; i < MNCOUNT_VISIBLE_ROWS; i++) {
                 if (userdata2->labels[i] != NULL) {
                     HSD_SisLib_803A5CC4(userdata3->labels[i]);
-                    userdata2->labels[i] = NULL;
+                    userdata2->labels[i] = label_null;
                 }
                 if (userdata2->values[i] != NULL) {
                     HSD_SisLib_803A5CC4(userdata3->values[i]);
-                    userdata2->values[i] = NULL;
+                    userdata2->values[i] = value_null;
                 }
             }
 
@@ -683,8 +686,8 @@ void fn_802514D8(HSD_GObj* gobj)
     } else {
         // mnCount_UpdateArrowIndicators
 
-        HSD_JObj* jobj = gobj->hsd_obj;
         HSD_JObj* child;
+        jobj = gobj->hsd_obj;
 
         // up arrow
         lb_80011E24(jobj, &child, 2, -1);
@@ -706,13 +709,20 @@ void fn_802514D8(HSD_GObj* gobj)
     }
 }
 
-void fn_80251640(HSD_GObj* gobj)
+void fn_802514D8(HSD_GObj* gobj)
 {
     MnCountData* userdata = GET_MNCOUNT(gobj);
+    PAD_STACK(4);
+    fn_802514D8_inline(userdata, gobj);
+}
+
+void fn_80251640(HSD_GObj* gobj)
+{
     HSD_GObjProc* proc;
     int i;
     HSD_JObj* jobj;
     StaticModelDesc* md;
+    MnCountData* userdata = GET_MNCOUNT(gobj);
     PAD_STACK(24);
 
     if (mn_804A04F0.cur_menu != MENU_KIND_RECORDS_MISC) {

--- a/src/melee/mn/mndiagram.c
+++ b/src/melee/mn/mndiagram.c
@@ -1849,13 +1849,6 @@ void mnDiagram_80241310(s32 arg0, s32 arg1, s32 arg2)
     HSD_JObj* jobj;
     mnDiagram_PopupData* user_data;
 
-    /// @todo Constant-pool anchors: these dead literals emit no code but
-    ///       reserve .sdata2 slots for mnDiagram_804DBF94 (-1.0f) and
-    ///       mnDiagram_804DBF98 (the s32-to-f32 bias) so the section layout
-    ///       matches the target object.
-    (void) -1.0F;
-    (void) 4503601774854144.0;
-
     tbl = (mnDiagram_AnimTable*) &mnDiagram_803EE728;
     joint_data = mnDiagram_804A07E4;
     data = GET_DIAGRAM(mnDiagram_804D6C10);

--- a/src/melee/mn/mndiagram.c
+++ b/src/melee/mn/mndiagram.c
@@ -1695,6 +1695,7 @@ void mnDiagram_80240D94(void* arg0, s32 arg1, s32 arg2, s32 arg3)
     mnDiagram_PopupData* data = ((HSD_GObj*) arg0)->user_data;
     mnDiagram_AnimTable* tbl = (mnDiagram_AnimTable*) &mnDiagram_803EE728;
     Point3d pos;
+    float new_var;
     char buf[8];
     u32 kos;
     u32 sd_count;
@@ -1709,7 +1710,7 @@ void mnDiagram_80240D94(void* arg0, s32 arg1, s32 arg2, s32 arg3)
         f32 y = pos.y;
         f32 z = pos.z;
         text->pos_x = pos.x;
-        text->pos_y = -y;
+        text->pos_y = (new_var = -y);
         text->pos_z = z;
     }
     text->default_alignment = 0;
@@ -1722,35 +1723,44 @@ void mnDiagram_80240D94(void* arg0, s32 arg1, s32 arg2, s32 arg3)
     }
 
     if ((arg3 != 0) && (arg1 != arg2)) {
-        text = HSD_SisLib_803A6754(0, 1);
-        data->text[2] = text;
-        lb_8000B1CC(data->jobjs[10], &tbl->points[2], &pos);
-        text->font_size.x = 0.035f;
-        text->font_size.y = 0.05f;
         {
-            f32 y = pos.y;
-            f32 z = pos.z;
-            text->pos_x = pos.x;
-            text->pos_y = -y;
-            text->pos_z = z;
-        }
-        text->default_alignment = 1;
-        HSD_SisLib_803A6B98(text, 0.0f, 0.0f, GetNameText((u8) arg2));
+            HSD_Text* label_text;
 
-        text = HSD_SisLib_803A6754(0, 1);
-        data->text[4] = text;
-        lb_8000B1CC(data->jobjs[2], &tbl->points[2], &pos);
-        text->font_size.x = 0.035f;
-        text->font_size.y = 0.05f;
-        {
-            f32 y = pos.y;
-            f32 z = pos.z;
-            text->pos_x = pos.x;
-            text->pos_y = -y;
-            text->pos_z = z;
+            label_text = HSD_SisLib_803A6754(0, 1);
+            data->text[2] = label_text;
+            lb_8000B1CC(data->jobjs[10], &tbl->points[2], &pos);
+            label_text->font_size.x = 0.035f;
+            label_text->font_size.y = 0.05f;
+            {
+                f32 y = pos.y;
+                f32 z = pos.z;
+                label_text->pos_x = pos.x;
+                label_text->pos_y = (new_var = -y);
+                label_text->pos_z = z;
+            }
+            label_text->default_alignment = 1;
+            HSD_SisLib_803A6B98(label_text, 0.0f, 0.0f,
+                                GetNameText(arg2 & 0xFF));
         }
-        text->default_alignment = 1;
-        HSD_SisLib_803A6B98(text, 0.0f, 0.0f, GetNameText((u8) arg2));
+
+        {
+            HSD_Text* label_text;
+
+            label_text = HSD_SisLib_803A6754(0, 1);
+            data->text[4] = label_text;
+            lb_8000B1CC(data->jobjs[2], &tbl->points[2], &pos);
+            label_text->font_size.x = 0.035f;
+            label_text->font_size.y = 0.05f;
+            {
+                f32 y = pos.y;
+                f32 z = pos.z;
+                label_text->pos_x = pos.x;
+                label_text->pos_y = (new_var = -y);
+                label_text->pos_z = z;
+            }
+            label_text->default_alignment = 1;
+            HSD_SisLib_803A6B98(label_text, 0.0f, 0.0f, GetNameText((u8) arg2));
+        }
     }
 
     if ((arg3 == 0) || (arg1 != arg2)) {
@@ -1764,7 +1774,7 @@ void mnDiagram_80240D94(void* arg0, s32 arg1, s32 arg2, s32 arg3)
             f32 y = pos.y;
             f32 z = pos.z;
             text->pos_x = pos.x;
-            text->pos_y = -y;
+            text->pos_y = (new_var = -y);
             text->pos_z = z;
         }
 
@@ -1789,7 +1799,7 @@ void mnDiagram_80240D94(void* arg0, s32 arg1, s32 arg2, s32 arg3)
             f32 y = pos.y;
             f32 z = pos.z;
             text->pos_x = pos.x;
-            text->pos_y = -y;
+            text->pos_y = (new_var = -y);
             text->pos_z = z;
         }
         if (arg3 != 0) {
@@ -1803,7 +1813,10 @@ void mnDiagram_80240D94(void* arg0, s32 arg1, s32 arg2, s32 arg3)
     } else {
         text = HSD_SisLib_803A6754(0, 1);
         data->text[3] = text;
-        lb_8000B1CC(data->jobjs[3], &tbl->points[1], &pos);
+        {
+            Point3d* point = &tbl->points[1];
+            lb_8000B1CC(data->jobjs[3], point, &pos);
+        }
         text->font_size.x = 0.0521f;
         text->font_size.y = 0.0521f;
         text->default_alignment = 1;
@@ -1811,15 +1824,16 @@ void mnDiagram_80240D94(void* arg0, s32 arg1, s32 arg2, s32 arg3)
             f32 y = pos.y;
             f32 z = pos.z;
             text->pos_x = pos.x;
-            text->pos_y = -y;
+            text->pos_y = (new_var = -y);
             text->pos_z = z;
         }
         if (arg3 != 0) {
-            kos = GetPersistentNameData((u8) arg2)->vs_kos[(u8) arg1];
-            mnDiagram_FormatPopupNumber(buf, kos);
+            u32 count = GetPersistentNameData((u8) arg2)->vs_kos[(u8) arg1];
+            mnDiagram_FormatPopupNumber(buf, count);
         } else {
-            kos = GetPersistentFighterData((u8) arg2)->fighter_kos[(u8) arg1];
-            mnDiagram_FormatPopupNumber(buf, kos);
+            u32 count =
+                GetPersistentFighterData((u8) arg2)->fighter_kos[(u8) arg1];
+            mnDiagram_FormatPopupNumber(buf, count);
         }
         HSD_SisLib_803A6B98(text, 0.0f, 0.0f, buf);
     }
@@ -1834,6 +1848,13 @@ void mnDiagram_80241310(s32 arg0, s32 arg1, s32 arg2)
     HSD_GObj* gobj;
     HSD_JObj* jobj;
     mnDiagram_PopupData* user_data;
+
+    /// @todo Constant-pool anchors: these dead literals emit no code but
+    ///       reserve .sdata2 slots for mnDiagram_804DBF94 (-1.0f) and
+    ///       mnDiagram_804DBF98 (the s32-to-f32 bias) so the section layout
+    ///       matches the target object.
+    (void) -1.0F;
+    (void) 4503601774854144.0;
 
     tbl = (mnDiagram_AnimTable*) &mnDiagram_803EE728;
     joint_data = mnDiagram_804A07E4;
@@ -1977,7 +1998,7 @@ void mnDiagram_802417D0(HSD_GObj* gobj)
     s32 i;
     u8* ptr;
     s32 count;
-    u8 result;
+    s32 result;
     HSD_JObj* jobj2;
     PAD_STACK(8);
 
@@ -2239,7 +2260,21 @@ void mnDiagram_OnFrame(HSD_GObj* gobj)
             } else {
                 count = mnDiagram_CountUnlockedFighters();
             }
-            mnDiagram_UpdateScrollArrowVisibility(gobj, count);
+            data2 = gobj->user_data;
+            if (count <= 7) {
+                HSD_JObjSetFlagsAll(((HSD_JObj**) data2)[7], JOBJ_HIDDEN);
+                HSD_JObjSetFlagsAll(((HSD_JObj**) data2)[8], JOBJ_HIDDEN);
+            } else {
+                HSD_JObjClearFlagsAll(((HSD_JObj**) data2)[7], JOBJ_HIDDEN);
+                HSD_JObjClearFlagsAll(((HSD_JObj**) data2)[8], JOBJ_HIDDEN);
+            }
+            if (count <= 10) {
+                HSD_JObjSetFlagsAll(((HSD_JObj**) data2)[6], JOBJ_HIDDEN);
+                HSD_JObjSetFlagsAll(((HSD_JObj**) data2)[5], JOBJ_HIDDEN);
+            } else {
+                HSD_JObjClearFlagsAll(((HSD_JObj**) data2)[6], JOBJ_HIDDEN);
+                HSD_JObjClearFlagsAll(((HSD_JObj**) data2)[5], JOBJ_HIDDEN);
+            }
         } else {
             HSD_JObjSetFlagsAll(jobj, JOBJ_HIDDEN);
         }
@@ -2251,6 +2286,7 @@ void mnDiagram_80241E78(void* arg0, u8 arg1, u8 arg2, int arg3)
 {
     HSD_JObj* jobj;
     HSD_JObj* jobj2;
+    Diagram* user_data;
     Diagram* data;
     void** joint_data;
     s32 digit_count;
@@ -2261,12 +2297,13 @@ void mnDiagram_80241E78(void* arg0, u8 arg1, u8 arg2, int arg3)
     f32 y_offset;
     f32 base;
     f32 row_offset;
-    f32 col_offset;
     f32 row_offset_adj;
+    f32 col_offset;
     u8 col = arg1;
     u8 row = arg2;
 
-    data = ((HSD_GObj*) arg0)->user_data;
+    user_data = ((HSD_GObj*) arg0)->user_data;
+    data = user_data;
 
     jobj = data->jobjs[11];
     base = HSD_JObjGetTranslationX(jobj);
@@ -2281,12 +2318,13 @@ void mnDiagram_80241E78(void* arg0, u8 arg1, u8 arg2, int arg3)
     jobj = data->jobjs[9];
     base = HSD_JObjGetTranslationY(jobj);
     jobj2 = data->jobjs[10];
-    y_offset = HSD_JObjGetTranslationY(jobj2) - base;
+    y_offset = HSD_JObjGetTranslationY(jobj2);
+    y_offset -= base;
 
     digit_count = mn_GetDigitCount(arg3);
     col_offset = y_spacing * (f32) col;
     row_offset = y_offset * (f32) row;
-    row_offset_adj = row_offset - 1.0f;
+    row_offset_adj = row_offset - 0.4f;
 
     joint_data = mnDiagram_804A07F4;
     for (i = 0; i < digit_count; i++) {
@@ -2296,10 +2334,11 @@ void mnDiagram_80241E78(void* arg0, u8 arg1, u8 arg2, int arg3)
         HSD_JObjReqAnimAll(jobj, (f32) digit);
         HSD_JObjAnimAll(jobj);
         if (col < 7) {
-            HSD_JObjSetTranslateX(jobj, (x_spacing * (f32) i) + col_offset);
+            HSD_JObjSetTranslateX(
+                jobj, (x_spacing * (f32) i) + col_offset);
         } else {
-            HSD_JObjSetTranslateX(jobj,
-                                  (x_spacing * (f32) i) + col_offset + 1.0f);
+            HSD_JObjSetTranslateX(
+                jobj, (x_spacing * (f32) i) + col_offset + 0.4f);
         }
         if (row < 10) {
             HSD_JObjSetTranslateY(jobj, row_offset);
@@ -2540,8 +2579,8 @@ void mnDiagram_802427B4(void* arg0, s32 arg1, s32 arg2)
     {
         HSD_JObj* j = data->jobjs[7];
         pos.z = HSD_JObjGetTranslationZ(j);
-        pos.y = -HSD_JObjGetTranslationY(j) - 0.5f;
-        pos.x = HSD_JObjGetTranslationX(j) - 1.3f;
+        pos.y = -0.5f - HSD_JObjGetTranslationY(j);
+        pos.x = -1.3f + HSD_JObjGetTranslationX(j);
         text->pos_x = pos.x;
         text->pos_y = pos.y;
         text->pos_z = pos.z;
@@ -2568,8 +2607,8 @@ void mnDiagram_802427B4(void* arg0, s32 arg1, s32 arg2)
     {
         HSD_JObj* j = data->jobjs[9];
         pos.z = HSD_JObjGetTranslationZ(j);
-        pos.y = -HSD_JObjGetTranslationY(j) - 0.5f;
-        pos.x = HSD_JObjGetTranslationX(j) - 1.3f;
+        pos.y = -0.5f - HSD_JObjGetTranslationY(j);
+        pos.x = -1.3f + HSD_JObjGetTranslationX(j);
         row_text->pos_x = pos.x;
         row_text->pos_y = pos.y;
         row_text->pos_z = pos.z;
@@ -2621,6 +2660,7 @@ void mnDiagram_80242C0C(void* arg0, int arg1, int arg2)
     void** joint_data = assets->FaceB;
     HSD_JObj* jobj;
     HSD_JObj* sp_jobj;
+    HSD_JObj** jobjs;
     int i;
     int k;
     s32 idx;
@@ -2641,7 +2681,8 @@ void mnDiagram_80242C0C(void* arg0, int arg1, int arg2)
         if (count > i) {
             idx = arg2;
             remaining = i;
-            p = &assets->sorted_fighters[arg2];
+            p = assets->sorted_fighters;
+            p += arg2;
             while (remaining >= 0) {
                 if (remaining == 0) {
                     fighter_id = assets->sorted_fighters[idx];
@@ -2688,7 +2729,8 @@ void mnDiagram_80242C0C(void* arg0, int arg1, int arg2)
         if (count > i) {
             idx = arg1;
             remaining = i;
-            p = &assets->sorted_fighters[arg1];
+            p = assets->sorted_fighters;
+            p += arg1;
             while (remaining >= 0) {
                 if (remaining == 0) {
                     fighter_id = assets->sorted_fighters[idx];
@@ -2720,21 +2762,26 @@ void mnDiagram_80242C0C(void* arg0, int arg1, int arg2)
             y_spacing = HSD_JObjGetTranslationY(data->jobjs[10]) -
                         HSD_JObjGetTranslationY(data->jobjs[9]);
             HSD_JObjSetTranslateY(jobj, y_spacing * i);
-            HSD_JObjAddChild(data->jobjs[9], jobj);
+            jobjs = data->jobjs;
+            HSD_JObjAddChild(jobjs[9], jobj);
         }
     }
 }
 
+static inline Diagram* mnDiagram_GetCurrentDiagramData(void)
+{
+    return mnDiagram_804D6C10->user_data;
+}
+
 void mnDiagram_CursorProc(HSD_GObj* gobj)
 {
-    Diagram* data;
     HSD_JObj* sp_jobj;
+    u16* selection;
     int col;
     int row;
     f32 x_spacing;
     f32 y_spacing;
-    f64 row_center = (f64) 4.5F;
-    f64 y_offset = (f64) 0.1F;
+    Diagram* data;
     PAD_STACK(8);
 
     if ((mn_804A04F0.cur_menu != 0x1E) || (mn_804A04F0.x10 != 0)) {
@@ -2742,23 +2789,24 @@ void mnDiagram_CursorProc(HSD_GObj* gobj)
         return;
     }
 
-    data = mnDiagram_804D6C10->user_data;
+    data = mnDiagram_GetCurrentDiagramData();
     lb_80011E24((HSD_JObj*) gobj->hsd_obj, &sp_jobj, 3, -1);
 
-    col = mn_804A04F0.hovered_selection >> 8;
+    selection = (u16*) &mn_804A04F0;
+    col = *++selection >> 8;
     x_spacing = HSD_JObjGetTranslationX(data->jobjs[8]) -
                 HSD_JObjGetTranslationX(data->jobjs[7]);
     HSD_JObjSetTranslateX(sp_jobj, x_spacing * (col - 3));
 
     lb_80011E24((HSD_JObj*) gobj->hsd_obj, &sp_jobj, 4, -1);
-    row = (u8) mn_804A04F0.hovered_selection;
+    row = *selection & 0xFF;
     y_spacing = HSD_JObjGetTranslationY(data->jobjs[10]) -
                 HSD_JObjGetTranslationY(data->jobjs[9]);
-    HSD_JObjSetTranslateY(sp_jobj, y_spacing * (row - row_center) - y_offset);
+    HSD_JObjSetTranslateY(sp_jobj, y_spacing * (row - 4.5) - 0.1F);
 
     lb_80011E24((HSD_JObj*) gobj->hsd_obj, &sp_jobj, 2, -1);
     HSD_JObjSetTranslateX(sp_jobj, x_spacing * (col - 3));
-    HSD_JObjSetTranslateY(sp_jobj, y_spacing * (row - row_center) - y_offset);
+    HSD_JObjSetTranslateY(sp_jobj, y_spacing * (row - 4.5) - 0.1F);
 }
 
 void mnDiagram_802433AC(void)

--- a/src/melee/mn/mnmain.c
+++ b/src/melee/mn/mnmain.c
@@ -1000,6 +1000,7 @@ void mn_8022A440(HSD_GObj* gp, HSD_JObj* root, MainMenuSelection selection)
     lb_8001204C(root, sp24, mn_803EAE7C, 7);
     r29 = sp24[1];
     flow = &mn_804A04F0;
+    !flow; // Permuter slop
     HSD_JObjReqAnimAll(r29, 0.0F);
     HSD_JObjAnimAll(r29);
     HSD_JObjReqAnim(r29,
@@ -1447,13 +1448,13 @@ HSD_GObj* mn_8022B3A0(u8 state)
     }
     if (user_data->state != MENU_STATE_IDLE) {
         switch (user_data->state) {
-        case MENU_STATE_EXIT_TO:
         case MENU_STATE_ENTER_TO:
             HSD_JObjReqAnim(user_data->tree[3], mn_803EB39C.start_frame);
             break;
-        case MENU_STATE_EXIT_FROM:
+        case MENU_STATE_EXIT_TO:
             HSD_JObjReqAnim(user_data->tree[3], mn_803EB3B4.start_frame);
             break;
+        case MENU_STATE_EXIT_FROM:
         case MENU_STATE_ENTER_FROM:
         case MENU_STATE_5:
             break;
@@ -1474,8 +1475,8 @@ HSD_GObj* mn_8022B3A0(u8 state)
             HSD_JObjAddAnimAll(cursor_jobj, top->animjoint, top->matanim_joint,
                                top->shapeanim_joint);
             lb_8001204C(cursor_jobj, sp2C, mn_803EAE7C, 7);
-            tmp = &mn_803EB378[hovered_selection == i];
-            HSD_JObjReqAnim(sp2C[0], mn_803EB360[0].start_frame);
+            HSD_JObjReqAnim(sp2C[0],
+                            mn_803EB360[hovered_selection == i].start_frame);
             HSD_JObjAnim(sp2C[0]);
             jobj = sp2C[1];
             HSD_JObjReqAnimAll(jobj, hovered_selection == i);
@@ -1492,9 +1493,11 @@ HSD_GObj* mn_8022B3A0(u8 state)
             mn_8022F3D8(jobj, 0x13, TOBJ_MASK);
             HSD_JObjAnim(jobj);
             if (i == hovered_selection) {
-                HSD_JObjReqAnimAll(sp2C[2], tmp->start_frame);
+                HSD_JObjReqAnimAll(
+                    sp2C[2], mn_803EB378[hovered_selection == i].start_frame);
             } else {
-                HSD_JObjReqAnimAll(sp2C[2], tmp->end_frame);
+                HSD_JObjReqAnimAll(
+                    sp2C[2], mn_803EB378[hovered_selection == i].end_frame);
             }
             HSD_JObjAnimAll(sp2C[2]);
             if (i == hovered_selection) {

--- a/src/melee/mn/mnname.c
+++ b/src/melee/mn/mnname.c
@@ -196,7 +196,6 @@ bool IsNameUnique(char* name)
     }
     return false;
 }
-
 void DeleteName(u8 arg0)
 {
     u8 _2[8];
@@ -441,34 +440,50 @@ u8 mnName_80237D94(s32 arg0, u8 arg1)
 
 void mnName_ConfirmNameDeleteInput(HSD_GObj* arg0)
 {
-    HSD_GObj* gobj2 = (HSD_GObj*) mnName_804D6BF8->user_data;
-    u32 buttons = mn_80229624(4U);
-    mn_804A04F0.buttons = buttons;
-    PAD_STACK(0x20);
+    s32 col;
+    s32 nameIdx;
+    s32 nameIdxInt;
+    s32 colCount;
+    s32 idx;
+    u32 buttons;
+    u8 sel;
+    MenuFlow* flow;
+    HSD_GObj* gobj2;
+
+    gobj2 = (HSD_GObj*) mnName_804D6BF8->user_data;
+    buttons = mn_80229624(4U);
+    flow = &mn_804A04F0;
+    flow->buttons = buttons;
+    PAD_STACK(0x18);
     if (buttons & 0x10) {
-        if ((u8) mn_804A04F0.confirmed_selection == 0) {
+        if ((u8) flow->confirmed_selection == 0) {
             lbAudioAx_80024030(0);
             mn_804D6BC8.cooldown = 5;
-            mn_804A04F0.x10 = 0;
+            flow->x10 = 0;
             return;
         }
         {
-            u8 sel = (u8) mn_804A04F0.hovered_selection;
-            s32 col = ((HSD_GObj*) mnName_804D6BF8->user_data)->gx_link +
-                      ((mn_804A04F0.hovered_selection & 0xFF) / 6);
-            s32 colCount = mnName_GetColumnCount();
-            u8 nameIdx;
+            sel = (u8) flow->hovered_selection;
+            {
+                s32 tmp =
+                    ((HSD_GObj*) mnName_804D6BF8->user_data)->gx_link +
+                    ((flow->hovered_selection & 0xFF) / 6);
+                col = tmp;
+            }
+            colCount = mnName_GetColumnCount();
             if (colCount > 4 && col >= colCount) {
                 col -= colCount;
             }
-            nameIdx = mnName_NameDisplayOrder[col * 6 + (sel % 6)];
+            idx = (sel % 6) + (col * 6);
+            nameIdx = mnName_NameDisplayOrder[idx];
             lbAudioAx_80024030(1);
             {
                 u8 term = mnName_StringTerminator;
+                nameIdxInt = (u8) nameIdx;
                 mn_804D6BC8.cooldown = 5;
-                GetPersistentNameData((s32) nameIdx)->namedata[0] = term;
+                GetPersistentNameData(nameIdxInt)->namedata[0] = term;
             }
-            GetPersistentNameData((s32) nameIdx)->x1A1 = 1;
+            GetPersistentNameData(nameIdxInt)->x1A1 = 1;
             InitializePersistentNameData((s32) nameIdx);
             if ((s32) gobj2->gx_link > (s32) (mnName_GetColumnCount() - 1)) {
                 gobj2->gx_link = 0;
@@ -487,7 +502,7 @@ void mnName_ConfirmNameDeleteInput(HSD_GObj* arg0)
     if (buttons & 0x20) {
         lbAudioAx_80024030(0);
         mn_804D6BC8.cooldown = 5;
-        mn_804A04F0.x10 = 0;
+        flow->x10 = 0;
         return;
     }
     if ((buttons & 8) || (buttons & 4)) {
@@ -869,16 +884,24 @@ void mnName_80238AE0(HSD_GObj* gobj, u8 index, u8 arg2)
 static inline AnimLoopSettings*
 mnName_FindAnimLoop(AnimLoopSettings** tableBase, f32 frame)
 {
-    AnimLoopSettings* table[6];
-    char* msg;
     s32 i;
+    AnimLoopSettings* table[6];
+    AnimLoopSettings* temp0;
+    AnimLoopSettings* temp1;
+    char* msg;
 
-    table[0] = tableBase[0];
-    table[1] = tableBase[1];
-    table[2] = tableBase[2];
-    table[3] = tableBase[3];
-    table[4] = tableBase[4];
-    table[5] = tableBase[5];
+    temp0 = tableBase[0];
+    temp1 = tableBase[1];
+    table[0] = temp0;
+    table[1] = temp1;
+    temp0 = tableBase[2];
+    temp1 = tableBase[3];
+    table[2] = temp0;
+    table[3] = temp1;
+    temp0 = tableBase[4];
+    temp1 = tableBase[5];
+    table[4] = temp0;
+    table[5] = temp1;
 
     for (i = 0; i < 6; i++) {
         if (table[i]->start_frame <= frame && frame <= table[i]->end_frame) {
@@ -890,15 +913,20 @@ mnName_FindAnimLoop(AnimLoopSettings** tableBase, f32 frame)
     HSD_ASSERTREPORT(0x3DC, NULL, msg);
 }
 
+inline f32 mnName_80238C34_inline(HSD_JObj* jobj)
+{
+    return mn_8022F298(jobj);
+}
+
 void mnName_80238C34(HSD_GObj* arg0, u8 arg1, u8 arg2)
 {
-    AnimLoopSettings** tableBase = mnName_803B8510;
     AnimLoopSettings* base = mnName_803ED538;
+    AnimLoopSettings** tableBase = mnName_803B8510;
     MnName_GObj* data = (MnName_GObj*) arg0->user_data;
     AnimLoopSettings* found;
 
     if (arg1 != 0) {
-        u8 prev = *((u8*) data + 1);
+        u8 prev = (u8) data->gobj.classifier;
         if (prev != 0x1A || (u16) mn_804A04F0.hovered_selection >= 0x18U) {
             mnName_80238AE0((HSD_GObj*) data, prev, 0);
         }
@@ -907,19 +935,19 @@ void mnName_80238C34(HSD_GObj* arg0, u8 arg1, u8 arg2)
     }
 
     {
-        HSD_JObj* jobj = *(HSD_JObj**) ((u8*) data + 0x24);
+        HSD_JObj* jobj = mnName_802388D4_noinline((HSD_GObj*) data, 0x18U);
         found = mnName_FindAnimLoop(tableBase, mn_8022F298(jobj));
         mn_8022ED6C(jobj, found);
     }
 
     {
-        HSD_JObj* jobj = *(HSD_JObj**) ((u8*) data + 0x18);
+        HSD_JObj* jobj = mnName_802388D4_noinline((HSD_GObj*) data, 0x19U);
         found = mnName_FindAnimLoop(tableBase, mn_8022F298(jobj));
         mn_8022ED6C(jobj, found);
     }
 
     {
-        HSD_JObj* jobj = *(HSD_JObj**) ((u8*) data + 0x1C);
+        HSD_JObj* jobj = mnName_802388D4_noinline((HSD_GObj*) data, 0x1AU);
         found = mnName_FindAnimLoop(tableBase, mn_8022F298(jobj));
         mn_8022ED6C(jobj, found);
     }
@@ -928,7 +956,7 @@ void mnName_80238C34(HSD_GObj* arg0, u8 arg1, u8 arg2)
         HSD_JObj* jobj = (HSD_JObj*) data->gobj.prev_gx;
         f32 result;
 
-        found = mnName_FindAnimLoop(tableBase, mn_8022F298(jobj));
+        found = mnName_FindAnimLoop(tableBase, mnName_80238C34_inline(jobj));
         result = mn_8022ED6C(jobj, found);
 
         found = mnName_FindAnimLoop(tableBase, result);
@@ -1363,15 +1391,16 @@ void mnName_8023A290(void)
     HSD_GObj* gobj;
     HSD_JObj* jobj;
     u8 sel;
+    MnNameArchive* archive = &mnName_804A06D0;
 
     gobj = GObj_Create(6U, 7U, 0x80U);
-    jobj = HSD_JObjLoadJoint(mnName_804A06D0.joint);
+    jobj = HSD_JObjLoadJoint(archive->joint);
     HSD_GObjObject_80390A70(gobj, HSD_GObj_804D7849, jobj);
     GObj_SetupGXLink(gobj, HSD_GObj_JObjCallback, 6U, 0x80U);
     HSD_GObj_SetupProc(gobj, fn_8023A0BC, 0U);
-    HSD_JObjAddAnimAll(jobj, mnName_804A06D0.anim_joint,
-                       mnName_804A06D0.matanim_joint,
-                       mnName_804A06D0.shapeanim_joint);
+    HSD_JObjAddAnimAll(jobj, archive->anim_joint,
+                       archive->matanim_joint,
+                       archive->shapeanim_joint);
     HSD_JObjReqAnimAll(jobj, mnName_803ED600[0]);
     HSD_JObjAnimAll(jobj);
     lb_80011E24(jobj, &sp28, 0xA, -1);
@@ -1406,23 +1435,22 @@ void mnName_8023A290(void)
 
 HSD_GObj* mnName_8023A59C(u8 arg0)
 {
-    HSD_JObj* root_jobj;
-    char* base = (char*) &mnName_803ED538;
-    HSD_GObj* gobj;
-    MnName_GObj* user_data;
-    HSD_JObj* jobj5;
-    MnNameArchive* archive = &mnName_804A06E0;
-    s32 i;
-    HSD_JObj* jobj7;
-    HSD_JObj* jobj4;
-    HSD_JObj* scrollbar_container;
-    HSD_JObj* slider;
     s32 count;
+    HSD_JObj* jobj5;
+    HSD_JObj* root_jobj;
     s32 extra;
-    f32 rows;
     f32 pos;
+    f32 rows;
+    HSD_JObj* jobj7;
+    MnNameArchive* archive = &mnName_804A06E0;
+    HSD_JObj* slider;
+    HSD_JObj* scrollbar_container;
+    HSD_JObj* jobj4;
     HSD_Text* txt;
-    PAD_STACK(16);
+    MnName_GObj* user_data;
+    HSD_GObj* gobj;
+    s32 i;
+    PAD_STACK(24);
 
     gobj = GObj_Create(6U, 7U, 0x80U);
     mnName_804D6BF8 = gobj;

--- a/src/melee/mn/mnsoundtest.c
+++ b/src/melee/mn/mnsoundtest.c
@@ -754,23 +754,28 @@ void fn_8024BAF0(HSD_GObj* arg0)
 
 void mnSoundTest_8024BCA0(int arg0)
 {
-    HSD_JObj* sp24;
+    HSD_JObj* jobj;
+    UNUSED u8 pad[0xC];
     HSD_GObj* gobj;
     HSD_GObjProc* proc;
-    HSD_JObj* jobj;
+    HSD_JObj* category_jobj;
+    SoundTestModelDesc* model_desc;
     soundtest_user_data* user_data;
+    soundtest_user_data* text_user_data;
+    u32 pad2;
     HSD_Text* text;
-    u8 temp_r29_2;
-    u8 temp_r29_3;
+    u8 selection;
 
+    PAD_STACK(0x14);
+    model_desc = &mnSoundTest_804A08C8;
     gobj = GObj_Create(6U, 7U, 0x80U);
     mnSoundTest_804D6C40 = gobj;
-    jobj = HSD_JObjLoadJoint(mnSoundTest_804A08C8.joint);
+    jobj = HSD_JObjLoadJoint(model_desc->joint);
     HSD_GObjObject_80390A70(gobj, HSD_GObj_804D7849, jobj);
     GObj_SetupGXLink(gobj, HSD_GObj_JObjCallback, 4U, 0x80U);
-    HSD_JObjAddAnimAll(jobj, mnSoundTest_804A08C8.animjoint,
-                       mnSoundTest_804A08C8.matanim_joint,
-                       mnSoundTest_804A08C8.shapeanim_joint);
+    HSD_JObjAddAnimAll(jobj, model_desc->animjoint,
+                       model_desc->matanim_joint,
+                       model_desc->shapeanim_joint);
     HSD_JObjReqAnimAll(jobj, 0.0f);
     HSD_JObjAnimAll(jobj);
     proc = HSD_GObj_SetupProc(gobj, (void (*)(HSD_GObj*)) fn_8024BAF0, 0U);
@@ -792,24 +797,24 @@ void mnSoundTest_8024BCA0(int arg0)
     user_data->unk18 = NULL;
     user_data->unk1C = NULL;
     GObj_InitUserData(gobj, 0U, HSD_Free, user_data);
-    text = user_data->unk10;
-    if (text != NULL) {
-        HSD_SisLib_803A5CC4(text);
+    text_user_data = mnSoundTest_804D6C40->user_data;
+    if (text_user_data->unk10 != NULL) {
+        HSD_SisLib_803A5CC4(text_user_data->unk10);
     }
     text =
         HSD_SisLib_803A5ACC(0, 1, -9.5f, 9.1f, 17.0f, 364.68332f, 38.38772f);
-    user_data->unk10 = text;
+    text_user_data->unk10 = text;
     text->font_size.x = 0.0521f;
     text->font_size.y = 0.0521f;
     HSD_SisLib_803A6368(text, 0xBE);
-    temp_r29_2 = user_data->unk0;
-    mnSoundTest_8024ABF8(gobj, temp_r29_2 == 0);
-    mnSoundTest_8024AD58(gobj, temp_r29_2);
-    temp_r29_3 = data_3[user_data->unk3];
-    lb_80011E24(GET_JOBJ(gobj), &sp24, 0x15, -1);
-    HSD_JObjReqAnimAll(sp24, data_4[temp_r29_3]);
-    mn_8022F3D8(sp24, 0xFFU, 0xA0);
-    HSD_JObjAnimAll(sp24);
+    selection = user_data->unk0;
+    mnSoundTest_8024ABF8(gobj, selection == 0);
+    mnSoundTest_8024AD58(gobj, selection);
+    selection = data_3[user_data->unk3];
+    lb_80011E24(GET_JOBJ(gobj), &category_jobj, 0x15, -1);
+    HSD_JObjReqAnimAll(category_jobj, data_4[selection]);
+    mn_8022F3D8(category_jobj, 0xFFU, 0xA0);
+    HSD_JObjAnimAll(category_jobj);
 }
 
 HSD_GObjProc* mnSoundTest_8024BEE0(s32 arg0)


### PR DESCRIPTION
## Summary

- Exact-match decompilation for MN menu screen translation units.
- Adds 7 newly exact function(s) across 6 file(s).
- Verified alone against the current upstream baseline with zero regressions.

## PR Shape

- Scope: MN menu screen translation units
- Change type: implementation-only match work
- Review risk: Medium; one menu subsystem with several local files.
- Header/naming churn: none
- Regression signal: clean in isolated slice verification and clean in the full ship set

## Reviewer Notes

- This file-level slice also improves 13 still-unmatched function(s); no fuzzy or metric regressions were introduced.
- Files:
  - `src/melee/mn/mnmain.c`
  - `src/melee/mn/mnname.c`
  - `src/melee/mn/mndiagram.c`
  - `src/melee/mn/mnsoundtest.c`
  - `src/melee/mn/mncount.c`
  - `src/melee/mn/mncharsel.c`

## Verification

- Applied this slice alone to baseline `3a7df8e49f` and ran `MVK_CONFIG_LOG_LEVEL=0 WINEDEBUG=-all ninja -C /tmp/melee-baseline-3a7df8e49fcbdbbb3e3be32b47f47954581bc8b8 -j8 changes_all`.
- Slice regression report: 7 new match(es), 0 broken matches, 0 fuzzy regressions, 0 metric regressions.
- Full ship-set regression report: 96 new match(es), 0 broken matches, 0 fuzzy regressions, 0 metric regressions.
- `git diff --check` passed for the slice and full ship set.
- review_lint on the full ship set: 0 error(s), 112 warning(s).
