### PR TITLE
Melee decomp: Item collision and projectile matches

### DIFF
--- a/src/melee/it/itcoll.c
+++ b/src/melee/it/itcoll.c
@@ -48,10 +48,14 @@
 static inline bool itColl_chkECBOverlap(f32 pos_x, f32 pos_y, itECB* ecb_a,
                                         itECB* ecb_b, Vec3* target)
 {
-    f32 top = pos_y + (ecb_a->top + ecb_b->top);
-    f32 bottom = pos_y + (ecb_a->bottom + ecb_b->bottom);
-    f32 right = pos_x + (ecb_a->right + ecb_b->right);
-    f32 left = pos_x + (ecb_a->left + ecb_b->left);
+    f32 top;
+    f32 left;
+    f32 right;
+    f32 bottom;
+    top = pos_y + (ecb_a->top + ecb_b->top);
+    bottom = pos_y + (ecb_a->bottom + ecb_b->bottom);
+    right = pos_x + (ecb_a->right + ecb_b->right);
+    left = pos_x + (ecb_a->left + ecb_b->left);
     if (top >= target->y && bottom <= target->y && right <= target->x &&
         left >= target->x)
     {
@@ -534,7 +538,7 @@ static inline bool it_802706D0_sub(Item_GObj* arg_item_gobj, Item* item,
                         item->xDCE_flag.b6 = 1;
                         item->toucher = arg_item_gobj;
                     } else {
-                        item->xDCE_flag.b6 = 1;
+                        arg_item->xDCE_flag.b6 = 1;
                         arg_item->toucher = item->entity;
                     }
                     chk2 = true;
@@ -618,14 +622,15 @@ static inline void it_802706D0_sub3(Item* item, Item* arg_item,
 
 void it_802706D0(Item_GObj* arg_item_gobj)
 {
-    HSD_GObj* item_gobj;
-    Item* arg_item;
-    Item* item;
     u32 hit_index;
-    s32 count;
-    bool chk;
+    u32 hurt_index;
+    Item* arg_item;
+    HSD_GObj* item_gobj;
     HitCapsule* hit;
-    PAD_STACK(8);
+    bool chk;
+    s32 count;
+    Item* item;
+    PAD_STACK(12);
 
     chk = false;
     arg_item = GET_ITEM(arg_item_gobj);
@@ -635,6 +640,7 @@ void it_802706D0(Item_GObj* arg_item_gobj)
         item = item_gobj->user_data;
         if (arg_item_gobj == item_gobj) {
             chk = true;
+            continue;
         } else if (((arg_item->owner == NULL) && (item->owner == NULL) &&
                     !item->xDCD_flag.b7 && !arg_item->xDCE_flag.b2) ||
                    (ftLib_80086960(item->owner) &&
@@ -648,7 +654,24 @@ void it_802706D0(Item_GObj* arg_item_gobj)
             continue;
         }
         if (chk && !arg_item->xDD0_flag.b1) {
-            count = it_802706D0_sub2(item, arg_item);
+            count = 0;
+            for (hit_index = 0; hit_index < 4; hit_index++) {
+                HitCapsule* arg_hit =
+                    &arg_item->x5D4_hitboxes[hit_index].hit;
+                HitCapsule* tmp_hit = arg_hit;
+                if ((arg_hit->state != HitCapsule_Disabled) &&
+                    (arg_hit->element != HitElement_Catch) &&
+                    ((arg_hit->x40_b2 && (item->ground_or_air == GA_Air)) ||
+                     (arg_hit->x40_b3 &&
+                      (item->ground_or_air == GA_Ground))) &&
+                    !lbColl_8000ACFC(item, tmp_hit))
+                {
+                    it_804D6D1C[hit_index] = 1;
+                    count++;
+                } else {
+                    it_804D6D1C[hit_index] = 0;
+                }
+            }
         }
         for (hit_index = 0; hit_index < 4; hit_index++) {
             hit = &item->x5D4_hitboxes[hit_index].hit;
@@ -659,10 +682,46 @@ void it_802706D0(Item_GObj* arg_item_gobj)
             {
                 continue;
             }
-            if (!chk || arg_item->xDD0_flag.b1 || (count == 0) ||
-                it_802706D0_sub(arg_item_gobj, item, arg_item, hit) ||
-                (arg_item->xAC8_hurtboxNum == 0))
-            {
+            if (chk && !arg_item->xDD0_flag.b1 && (count != 0)) {
+                u32 i;
+                bool chk2 = false;
+                for (i = 0; i < 4U; i++) {
+                    if (it_804D6D1C[i] != 0) {
+                        HitCapsule* arg_hit = &arg_item->x5D4_hitboxes[i].hit;
+                        HitCapsule* tmp_hit = arg_hit;
+                        if ((hit->element == HitElement_Inert) ||
+                            (arg_hit->element == HitElement_Inert))
+                        {
+                            if ((hit->element != arg_hit->element) &&
+                                lbColl_80007AFC(hit, tmp_hit, item->scl,
+                                                arg_item->scl))
+                            {
+                                if (hit->element == HitElement_Inert) {
+                                    item->xDCE_flag.b6 = 1;
+                                    item->toucher = arg_item_gobj;
+                                } else {
+                                    arg_item->xDCE_flag.b6 = 1;
+                                    arg_item->toucher = item->entity;
+                                }
+                                chk2 = true;
+                                break;
+                            }
+                        } else if ((hit->x40_b0 == 1) &&
+                                   (arg_hit->x40_b0 == 1) &&
+                                   lbColl_80007AFC(hit, tmp_hit, item->scl,
+                                                   arg_item->scl))
+                        {
+                            it_8026FE68(item, hit, arg_item, tmp_hit);
+                            chk2 = true;
+                            break;
+                        }
+                    }
+                }
+                if (chk2) {
+                    continue;
+                }
+            }
+            if (arg_item->xAC8_hurtboxNum == 0) {
                 continue;
             }
             if (hit->element == HitElement_Inert) {
@@ -676,14 +735,16 @@ void it_802706D0(Item_GObj* arg_item_gobj)
                     }
                 }
             } else if (arg_item->xD0C != 2) {
-                u32 i;
-                for (i = 0; i < arg_item->xAC8_hurtboxNum; i++) {
-                    if (lbColl_8000805C(hit, &arg_item->xACC_itemHurtbox[i],
-                                        NULL, 0, item->scl, arg_item->scl,
-                                        0.0f))
+                for (hurt_index = 0; hurt_index < arg_item->xAC8_hurtboxNum;
+                     hurt_index++)
+                {
+                    if (lbColl_8000805C(
+                            hit, &arg_item->xACC_itemHurtbox[hurt_index],
+                            NULL, 0, item->scl, arg_item->scl, 0.0f))
                     {
-                        it_802706D0_sub3(item, arg_item, hit,
-                                         &arg_item->xACC_itemHurtbox[i]);
+                        it_802706D0_sub3(
+                            item, arg_item, hit,
+                            &arg_item->xACC_itemHurtbox[hurt_index]);
                         break;
                     }
                 }
@@ -725,23 +786,21 @@ f32 it_80270CD8(Item* ip, HitCapsule* hit)
 
 void it_80270E30(Item_GObj* arg_item_gobj)
 {
-    u8 _padA[4];
-    Vec3 sp2C;
-    u8 _padB[4];
     f32 sp18;
-    DamageLogEntry* var_r29;
+    Vec3 hurt_pos;
+    DamageLogEntry* damage_log;
     HSD_GObj* item_owner_gobj;
-    f32 temp_f0;
-    f32 temp_f7;
+    f32 knockback_cap;
+    UNUSED f32 unused_float0;
     f32 dir;
-    f32 var_f1;
-    f32 var_f27;
-    f32 var_f28;
-    f32 var_f2;
-    f32 var_f3;
-    f32 var_f4;
-    s32 temp_r0_2;
-    s32 temp_r0_3;
+    UNUSED f32 unused_float1;
+    f32 knockback;
+    f32 max_knockback;
+    UNUSED f32 unused_float2;
+    UNUSED f32 unused_float3;
+    UNUSED f32 unused_float4;
+    UNUSED s32 unused_int0;
+    UNUSED s32 unused_int1;
     s32 element;
     u32 index;
     Item* item;
@@ -757,42 +816,44 @@ void it_80270E30(Item_GObj* arg_item_gobj)
 
     if (it_804D6D18 != 0U) {
         arg_item = arg_item_gobj->user_data;
-        var_f28 = -1.0f;
+        max_knockback = -1.0f;
+        damage_log = it_804A0E70;
         index = 0;
-        var_r29 = &it_804A0E70[index];
         while (index < it_804D6D18) {
-            hit = var_r29->x8;
+            hit = damage_log->x8;
             attr = arg_item->xCC_item_attr;
             if (hit->x28 != 0) {
-                var_f2 =
-                    attr->x1C_damage_mul *
-                    ((it_804D6D28->x80_float[10] * it_804D6D28->x80_float[8]) +
-                     (it_804D6D28->x80_float[9] *
-                      (it_804D6D28->x80_float[10] * hit->x28)));
-                var_f3 = it_804D6D28->x80_float[11];
-                var_f4 = hit->x24;
-                var_f4 = 0.01f * var_f4;
-                var_f1 = (var_f3 * var_f2) + it_804D6D28->x80_float[0xC];
-                var_f27 = (var_f4 * var_f1) + hit->x2C;
+                knockback =
+                    (0.01f * hit->x24 *
+                     ((it_804D6D28->x80_float[11] *
+                       (attr->x1C_damage_mul *
+                        ((it_804D6D28->x80_float[10] *
+                          it_804D6D28->x80_float[8]) +
+                         (it_804D6D28->x80_float[9] *
+                          (it_804D6D28->x80_float[10] * hit->x28))))) +
+                      it_804D6D28->x80_float[12])) +
+                    hit->x2C;
             } else {
-                temp_f7 = arg_item->xC9C + (f32) arg_item->xCA0;
-                var_f3 = it_804D6D28->x80_float[8];
-                var_f4 = attr->x1C_damage_mul;
-                var_f2 =
-                    var_f4 * ((var_f3 * temp_f7) + (it_804D6D28->x80_float[9] *
-                                                    (hit->damage * temp_f7)));
-                var_f1 = (it_804D6D28->x80_float[11] * var_f2) +
-                         it_804D6D28->x80_float[12];
-                var_f27 = (0.01f * hit->x24 * var_f1) + hit->x2C;
+                knockback =
+                    ((0.01f * hit->x24) *
+                     ((it_804D6D28->x80_float[11] *
+                       (attr->x1C_damage_mul *
+                        ((it_804D6D28->x80_float[8] *
+                          (arg_item->xC9C + (f32) arg_item->xCA0)) +
+                         (it_804D6D28->x80_float[9] *
+                          (hit->damage *
+                           (arg_item->xC9C + (f32) arg_item->xCA0)))))) +
+                      it_804D6D28->x80_float[12])) +
+                    hit->x2C;
             }
-            temp_f0 = it_804D6D28->x80_float[7];
-            if (var_f27 >= temp_f0) {
-                var_f27 = temp_f0;
+            knockback_cap = it_804D6D28->x80_float[7];
+            if (knockback >= knockback_cap) {
+                knockback = knockback_cap;
             }
             if (!arg_item->xDCF_flag.b1) {
                 if ((arg_item->hold_kind == 4) || (arg_item->hold_kind == 6)) {
                     sp18 = hit->damage;
-                    hit2 = var_r29->x8;
+                    hit2 = damage_log->x8;
                     arg_item2 = arg_item_gobj->user_data;
                     hurt_coll_pos = &hit2->hurt_coll_pos;
                     element = it_803F1384[hit2->element];
@@ -801,9 +862,11 @@ void it_80270E30(Item_GObj* arg_item_gobj)
                         efSync_Spawn(0x3E8, arg_item_gobj, hurt_coll_pos,
                                      &sp18);
                         break;
-                    case 0x479:
+                    case 0x3E9:
+                    case 0x3EA:
+                    case 0x3EC:
                     case 0x416:
-                    case 0x3EB:
+                    case 0x479:
                         efSync_Spawn(it_803F1384[hit2->element], arg_item_gobj,
                                      hurt_coll_pos, arg_item2);
                         break;
@@ -813,17 +876,16 @@ void it_80270E30(Item_GObj* arg_item_gobj)
                         break;
                     }
                 } else {
-                    Vec3* sp2C_ref = &sp2C;
-                    *sp2C_ref = hit->hurt_coll_pos;
-                    efSync_Spawn(0x3E8, arg_item_gobj, sp2C_ref,
-                                 &var_r29->x8->damage);
+                    hurt_pos = hit->hurt_coll_pos;
+                    efSync_Spawn(0x3E8, arg_item_gobj, &hurt_pos,
+                                 &damage_log->x8->damage);
                 }
             }
-            if (var_f27 > var_f28) {
-                var_f28 = var_f27;
+            if (knockback > max_knockback) {
+                max_knockback = knockback;
                 index2 = index;
             }
-            var_r29++;
+            damage_log++;
             index++;
         }
         temp_r29 = &it_804A0E70[index2];
@@ -872,7 +934,7 @@ void it_80270E30(Item_GObj* arg_item_gobj)
             break;
         }
         arg_item->xCAC_angle = temp_r29->x8->kb_angle;
-        arg_item->xCC8_knockback = var_f28;
+        arg_item->xCC8_knockback = max_knockback;
         arg_item->xCC4 = temp_r29->x8->element;
         arg_item->xDCF_flag.b6 = temp_r29->x8->x43_b0;
     }
@@ -1156,8 +1218,8 @@ void it_80271A58(Item_GObj* item_gobj)
 void it_80271B60(Item_GObj* item_gobj)
 {
     f32 x_pos;
-    Item_FtTrack* var_r29;
-    Item_FtTrack* var_r30;
+    itECB* ecb;
+    UNUSED Item_FtTrack* unused_ft_track;
     f32 x_float;
     Vec3 sp24;
     f32 y_pos;
@@ -1172,15 +1234,13 @@ void it_80271B60(Item_GObj* item_gobj)
     item = GET_ITEM(item_gobj);
     if (Item_804A0CCC.x154.b0 != 1) {
         HSD_JObjGetTranslation(item_jobj, &sp24);
-        var_r30 = &Item_804A0CCC;
-        var_r29 = &Item_804A0CCC;
         cnt = 0U;
 
         while (cnt < Item_804A0CCC.x150_count) {
-            y_pos = var_r29->xC0_pos_arr[cnt].y;
-            x_pos = var_r29->xC0_pos_arr[cnt].x;
-            if (itColl_chkECBOverlap(x_pos, y_pos, &item->xBEC,
-                                     &var_r30->x0_ecb_arr[cnt], &sp24))
+            ecb = &Item_804A0CCC.x0_ecb_arr[cnt];
+            y_pos = Item_804A0CCC.xC0_pos_arr[cnt].y;
+            x_pos = Item_804A0CCC.xC0_pos_arr[cnt].x;
+            if (itColl_chkECBOverlap(x_pos, y_pos, &item->xBEC, ecb, &sp24))
             {
                 if (ABS(sp24.x - x_pos) < 0.001f) {
                     if (HSD_Randi(2) != 0) {
@@ -1211,8 +1271,6 @@ void it_80271D2C(Item_GObj* arg_item_gobj)
     Vec3 sp34;
     Vec3 sp28;
     HSD_GObj* item_gobj;
-    f32 x_float;
-    f32 x_float_mag;
     f32 dir;
     HSD_JObj* item_jobj;
     Item* item;
@@ -1236,13 +1294,7 @@ void it_80271D2C(Item_GObj* arg_item_gobj)
             if (itColl_chkECBOverlap(sp28.x, sp28.y, &arg_item->xBEC,
                                      &item->xBEC, &sp34))
             {
-                x_float = sp34.x - sp28.x;
-                if (x_float < 0.0f) {
-                    x_float_mag = -x_float;
-                } else {
-                    x_float_mag = x_float;
-                }
-                if (x_float_mag < 0.001f) {
+                if (ABS(sp34.x - sp28.x) < 0.001f) {
                     if (!item->xDC8_word.flags.x1B) {
                         if (item->x70_nudge.x < 0.0f) {
                             dir = 1.0f;
@@ -1254,7 +1306,7 @@ void it_80271D2C(Item_GObj* arg_item_gobj)
                     } else {
                         dir = -1.0f;
                     }
-                } else if (x_float < 0.0f) {
+                } else if (sp34.x - sp28.x < 0.0f) {
                     dir = -1.0f;
                 } else {
                     dir = 1.0f;

--- a/src/melee/it/items/itarwinglaser.c
+++ b/src/melee/it/items/itarwinglaser.c
@@ -136,6 +136,7 @@ Item_GObj* it_802E72E0(Item_GObj* parent, HSD_JObj* bone, s32 type, f32 scale,
     SpawnItem spawn;
     Vec3 sp24;
     Item_GObj* new_gobj;
+    f32 z;
 
     lb_8000B1CC(bone, NULL, &sp24);
     switch (type) {
@@ -145,7 +146,6 @@ Item_GObj* it_802E72E0(Item_GObj* parent, HSD_JObj* bone, s32 type, f32 scale,
         break;
     case 4:
     case 5: {
-        f32 z;
         if (type == 4) {
             z = sp24.z;
             if (z < 0.0f) {
@@ -162,8 +162,7 @@ Item_GObj* it_802E72E0(Item_GObj* parent, HSD_JObj* bone, s32 type, f32 scale,
         break;
     }
     }
-    spawn.pos = sp24;
-    spawn.prev_pos = spawn.pos;
+    spawn.prev_pos = spawn.pos = sp24;
     spawn.kind = 0xEA;
     spawn.facing_dir = scale;
     spawn.x3C_damage = 0;
@@ -213,7 +212,6 @@ Item_GObj* it_802E72E0(Item_GObj* parent, HSD_JObj* bone, s32 type, f32 scale,
             break;
         case 4:
         case 5: {
-            f32 z;
             ip->xDD4_itemVar.arwinglaser.xE40 = NULL;
             ip->xDD4_itemVar.arwinglaser.xE44 = NULL;
             ip->xDD4_itemVar.arwinglaser.xE00 = 0.0f;
@@ -224,13 +222,11 @@ Item_GObj* it_802E72E0(Item_GObj* parent, HSD_JObj* bone, s32 type, f32 scale,
                     z = -z;
                 }
             } else {
-                f32 z_abs;
                 z = ip->pos.z;
-                z_abs = z;
                 if (z < 0.0f) {
-                    z_abs = -z;
+                    z = -z;
                 }
-                z = -z_abs;
+                z = -z;
             }
             ip->xDD4_itemVar.arwinglaser.xE08 = z;
             it_802E7A4C(new_gobj);

--- a/src/melee/it/items/itkyasarin.c
+++ b/src/melee/it/items/itkyasarin.c
@@ -484,17 +484,27 @@ bool itKyasarin_UnkMotion10_Coll(Item_GObj* gobj)
     return it_8027C79C(gobj);
 }
 
-static inline void itKyasarin_FlipAndFall(Item_GObj* gobj, HSD_JObj* jobj,
-                                          Item* ip)
+static inline void itKyasarin_SetFallCollPos(Item* ip, CollData* coll,
+                                             Vec3* pos)
 {
-    CollData* coll = &ip->x378_itemColl;
-    Vec3 pos;
+    coll->cur_pos = ip->pos;
+    *pos = ip->pos;
+}
+
+static inline CollData* itKyasarin_GetCollData(Item* ip)
+{
+    return &ip->x378_itemColl;
+}
+
+static inline void itKyasarin_FlipAndFall(Item_GObj* gobj, HSD_JObj* jobj,
+                                          Item* ip, Vec3* pos)
+{
+    CollData* coll = itKyasarin_GetCollData(ip);
 
     HSD_JObjSetRotationXWithMtxDirty(jobj, M_PI);
     it_802762BC(ip);
-    coll->cur_pos = ip->pos;
-    pos = ip->pos;
-    it_80276100(gobj, &pos);
+    itKyasarin_SetFallCollPos(ip, coll, pos);
+    it_80276100(gobj, pos);
     it_802756D0(gobj);
 }
 
@@ -511,7 +521,7 @@ bool it_802EDDC0(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
     itKyasarinAttributes* attr = ip->xC4_article_data->x4_specialAttributes;
-    PAD_STACK(32);
+    PAD_STACK(4);
 
     ip->xDD4_itemVar.kyasarin.x38 += ip->xCA0;
     if (ip->xDD4_itemVar.kyasarin.x38 < attr->x40) {
@@ -528,11 +538,17 @@ bool it_802EDDC0(Item_GObj* gobj)
         }
         ip->xDCC_flag.b3 = 1;
         if (HSD_Randf() < it_804D6D40->x8) {
-            itKyasarin_FlipAndFall(gobj, GET_JOBJ(gobj), GET_ITEM(gobj));
+            Vec3 pos;
+
+            ip = GET_ITEM(gobj);
+            itKyasarin_FlipAndFall(gobj, GET_JOBJ(gobj), ip, &pos);
             it_8027BA54(gobj, &ip->x40_vel);
             Item_80268E5C(gobj, 9, ITEM_ANIM_UPDATE);
         } else {
-            itKyasarin_FlipAndFall(gobj, GET_JOBJ(gobj), GET_ITEM(gobj));
+            Vec3 pos;
+
+            ip = GET_ITEM(gobj);
+            itKyasarin_FlipAndFall(gobj, GET_JOBJ(gobj), ip, &pos);
             it_8027B964(gobj, 0);
             ip->xDD4_itemVar.kyasarin.x18 = 0;
             Item_80268E5C(gobj, 0xA, ITEM_ANIM_UPDATE);

--- a/src/melee/it/items/itsamusgrapple.c
+++ b/src/melee/it/items/itsamusgrapple.c
@@ -137,7 +137,12 @@ void it_802B7160(Fighter_GObj* gobj, itSamusGrapple_HitboxData* data)
     Fighter* fp;
     u32 hit_group;
     HitCapsule* hitbox;
-    struct spawn_hitbox_4* hitbox_data4;
+    u32 damage_arg;
+    struct samus_grapple_hitbox_flags {
+        u8 : 6;
+        u8 hit_grounded : 1;
+    };
+    struct samus_grapple_hitbox_flags* hitbox_flags;
     PAD_STACK(8);
 
     fp = GET_FIGHTER(gobj);
@@ -161,7 +166,9 @@ void it_802B7160(Fighter_GObj* gobj, itSamusGrapple_HitboxData* data)
             hitbox->jobj = fp->parts[bone].joint;
         }
     }
-    ftColl_8007ABD0(hitbox, *damage & 0x3FF, gobj);
+    damage_arg = *damage;
+    damage_arg &= 0x3FF;
+    ftColl_8007ABD0(hitbox, damage_arg, gobj);
     hitbox->scale = data->create_hitbox.create_hitbox_1.size * 0.003906f;
     hitbox->b_offset.x =
         data->create_hitbox.create_hitbox_1.z_offset * 0.003906f;
@@ -170,20 +177,26 @@ void it_802B7160(Fighter_GObj* gobj, itSamusGrapple_HitboxData* data)
     hitbox->b_offset.z =
         data->create_hitbox.create_hitbox_2.x_offset * 0.003906f;
     ftColl_8007AC9C(hitbox, data->create_hitbox.create_hitbox_3.angle, gobj);
-    hitbox_data4 = &data->create_hitbox.create_hitbox_4;
+    hitbox_flags = (struct samus_grapple_hitbox_flags*)
+        &data->create_hitbox.create_hitbox_4 + 3;
     hitbox->x24 = data->create_hitbox.create_hitbox_3.knockback_growth;
     hitbox->x28 = data->create_hitbox.create_hitbox_3.weight_set_knockback;
     hitbox->x43_b0 = data->create_hitbox.create_hitbox_3.item_hit_interaction;
     hitbox->x43_b1 = data->create_hitbox.create_hitbox_3.ignore_fighter_scale;
     hitbox->x40_b0 = data->create_hitbox.create_hitbox_3.clank;
     hitbox->x40_b1 = data->create_hitbox.create_hitbox_3.rebound;
-    hitbox->x2C = hitbox_data4->base_knockback;
-    hitbox->element = hitbox_data4->element;
-    hitbox->x34 = hitbox_data4->shield_damage;
-    hitbox->sfx_severity = hitbox_data4->hit_sfx_severity;
-    hitbox->sfx_kind = hitbox_data4->hit_sfx_kind;
-    hitbox->x40_b2 = hitbox_data4->hit_aerial;
-    hitbox->x40_b3 = hitbox_data4->hit_grounded;
+    hitbox->x2C =
+        ((struct spawn_hitbox_4*) (hitbox_flags - 3))->base_knockback;
+    hitbox->element = ((struct spawn_hitbox_4*) (hitbox_flags - 3))->element;
+    hitbox->x34 =
+        ((struct spawn_hitbox_4*) (hitbox_flags - 3))->shield_damage;
+    hitbox->sfx_severity =
+        ((struct spawn_hitbox_4*) (hitbox_flags - 3))->hit_sfx_severity;
+    hitbox->sfx_kind =
+        ((struct spawn_hitbox_4*) (hitbox_flags - 3))->hit_sfx_kind;
+    hitbox->x40_b2 =
+        ((struct spawn_hitbox_4*) (hitbox_flags - 3))->hit_aerial;
+    hitbox->x40_b3 = hitbox_flags->hit_grounded;
     hitbox->x42_b5 = 1;
     hitbox->x42_b7 = 1;
     hitbox->x41_b4 = 0;
@@ -515,14 +528,28 @@ static inline Item* fn_802B7E34_inline(Item_GObj* gobj, Item* ip, Mtx m)
     return GET_ITEM(gobj);
 }
 
-static inline void link_all(Item_GObj* gobj, Item* ip)
+static inline void fn_802B7E34_anim_inline(Item_GObj* gobj, Item* ip, Mtx m)
 {
-    ItemLink* link;
-    HSD_JObjAnimAll(GET_JOBJ(gobj));
-    link = ip->xDD4_itemVar.samusgrapple.x4;
-    while (link != NULL) {
-        HSD_JObjAnimAll(link->gobj->hsd_obj);
-        link = link->prev;
+    {
+        HSD_JObj* jobj;
+        ItemLink* link = ip->xDD4_itemVar.samusgrapple.x0;
+        jobj = link->gobj->hsd_obj;
+        HSD_JObjSetupMatrix(link->jobj);
+        PSMTXIdentity(m);
+        PSMTXConcat(link->jobj->mtx, m, m);
+        HSD_JObjCopyMtx(jobj, m);
+        jobj->flags |= 0x03800000;
+        HSD_JObjSetMtxDirty(jobj);
+    }
+    {
+        Item* ip = GET_ITEM(gobj);
+        ItemLink* link;
+        HSD_JObjAnimAll(GET_JOBJ(gobj));
+        link = ip->xDD4_itemVar.samusgrapple.x4;
+        while (link != NULL) {
+            HSD_JObjAnimAll(link->gobj->hsd_obj);
+            link = link->prev;
+        }
     }
 }
 
@@ -534,8 +561,7 @@ void fn_802B7E34(Item_GObj* gobj)
     PAD_STACK(20);
 
     samus_grapple_state_sync(fp);
-    ip = fn_802B7E34_inline(gobj, ip, m);
-    link_all(gobj, ip);
+    fn_802B7E34_anim_inline(gobj, ip, m);
     if (samus_grapple_fighter_compare(fp->motion_id)) {
         return;
     }
@@ -1008,17 +1034,14 @@ void it_802B91C4(ItemLink* link, Vec3* pos, itSamusGrappleAttributes* attrs,
     }
 }
 
-static inline void it_802B9328_attach(ItemLink* link, Mtx m)
+static inline void it_802B9328_attach(ItemLink* link, Vec3* pos, Mtx m)
 {
-    Vec3 pos;
-    PAD_STACK(0xE4);
-
     PSMTXIdentity(m);
     HSD_JObjSetupMatrix(link->jobj);
-    pos.x = link->jobj->mtx[0][3];
-    pos.y = link->jobj->mtx[1][3];
-    pos.z = link->jobj->mtx[2][3];
-    link->pos = pos;
+    pos->x = link->jobj->mtx[0][3];
+    pos->y = link->jobj->mtx[1][3];
+    pos->z = link->jobj->mtx[2][3];
+    link->pos = *pos;
     link->coll_data.cur_pos = link->pos;
     link->coll_data.last_pos = link->coll_data.cur_pos;
     link->x2C_b0 = 1;
@@ -1042,29 +1065,42 @@ static inline f32 it_802B9328_grav(f32 vely)
 s32 it_802B9328(ItemLink* link, Vec3* pos, itSamusGrappleAttributes* attrs,
                 Fighter* fp)
 {
-    u8 _padA[80];
+    u8 _padA[0x10];
     ItemLink* cur;
     ItemLink* next;
     Item* grapple_ip = fp->fv.ss.x223C->user_data;
     ftSs_DatAttrs* da = fp->ft_data->ext_attr;
     Vec3 dir;
     Vec3 d2;
+    u8 _padB[4];
+    Vec3 attach_pos_1;
+    u8 _padC[8];
+    Vec3 attach_pos_2;
+    u8 _padD[8];
+    Vec3 attach_pos_3;
+    u8 _padE[4];
     itSamusGrapple_HitboxData hitbox_data;
-    Mtx m1, m2, m3;
+    u8 _padF[4];
+    Mtx m1;
+    u8 _padG[4];
+    Mtx m2;
+    u8 _padH[4];
+    Mtx m3;
+    u8 _padI[0x1C];
     s32 result;
     f32 d;
 
     if (fp->motion_id == 0xD4) {
         if (fp->mv.ss.unk7.x0 == da->xA0) {
-            it_802B9328_attach(link, m1);
+            it_802B9328_attach(link, &attach_pos_1, m1);
         }
     } else if (fp->motion_id == 0xD6) {
         if (fp->mv.ss.unk7.x0 == da->xB0) {
-            it_802B9328_attach(link, m2);
+            it_802B9328_attach(link, &attach_pos_2, m2);
         }
     } else if (fp->motion_id == 0x165) {
         if (fp->mv.ss.unk7.x0 == da->xC0) {
-            it_802B9328_attach(link, m3);
+            it_802B9328_attach(link, &attach_pos_3, m3);
         }
     }
 


### PR DESCRIPTION
## Summary

- Exact-match decompilation for Item collision plus Samus grapple, Arwing laser, and Kyasarin item files.
- Adds 9 newly exact function(s) across 4 file(s).
- Verified alone against the current upstream baseline with zero regressions.

## PR Shape

- Scope: Item collision plus Samus grapple, Arwing laser, and Kyasarin item files
- Change type: implementation-only match work
- Review risk: Low; item subsystem-local implementation files.
- Header/naming churn: none
- Regression signal: clean in isolated slice verification and clean in the full ship set

## Reviewer Notes

- This file-level slice also improves 1 still-unmatched function(s); no fuzzy or metric regressions were introduced.
- Files:
  - `src/melee/it/itcoll.c`
  - `src/melee/it/items/itsamusgrapple.c`
  - `src/melee/it/items/itarwinglaser.c`
  - `src/melee/it/items/itkyasarin.c`

## Verification

- Applied this slice alone to baseline `3a7df8e49f` and ran `MVK_CONFIG_LOG_LEVEL=0 WINEDEBUG=-all ninja -C /tmp/melee-baseline-3a7df8e49fcbdbbb3e3be32b47f47954581bc8b8 -j8 changes_all`.
- Slice regression report: 9 new match(es), 0 broken matches, 0 fuzzy regressions, 0 metric regressions.
- Full ship-set regression report: 96 new match(es), 0 broken matches, 0 fuzzy regressions, 0 metric regressions.
- `git diff --check` passed for the slice and full ship set.
- review_lint on the full ship set: 0 error(s), 112 warning(s).
