### PR TITLE
Melee decomp: Interface and trophy UI matches

### DIFF
--- a/src/melee/if/ifcoget.c
+++ b/src/melee/if/ifcoget.c
@@ -58,15 +58,15 @@ struct un_804A1F58_x8_t {
     HSD_GObj* x0;
     HSD_Text* x4;
     unsigned int x8;
+    unsigned int xC;
+    unsigned char x10;
 };
 
-// TODO: sizeof(un_804A1F58) should be 0x80, see un_802FF498
-// change 0x80 to sizeof(un_804A1F58) when done
 /* 4A1F58 */ static struct un_804A1F58_t {
     unsigned int x0;
-    unsigned char x4;
-    struct un_804A1F58_x8_t x8;
-} un_804A1F58[7];
+    char pad_x4[4];
+    struct un_804A1F58_x8_t x8[6];
+} un_804A1F58;
 
 /// .sbss
 /* 4D6DA0 */ static void* un_804D6DA0;
@@ -169,9 +169,10 @@ void fn_802FF218(HSD_GObj* arg0)
 {
     int x;
     int y;
+    struct un_804A1F58_x8_t* thing;
     PAD_STACK(24);
     for (x = 0; x < 6; x++) {
-        if (un_804A1F58[x].x8.x0 == arg0) {
+        if (un_804A1F58.x8[x].x0 == arg0) {
             y = x;
             goto _done;
         }
@@ -179,9 +180,9 @@ void fn_802FF218(HSD_GObj* arg0)
     y = -1;
 _done:
     if (y >= 0) {
-        if (un_804A1F58[y].x0 == 1) {
-            HSD_SisLib_803A70A0(un_804A1F58[y].x8.x4, un_804A1F58[y].x8.x8,
-                                "");
+        thing = &un_804A1F58.x8[y];
+        if (thing->x10 == 1) {
+            HSD_SisLib_803A70A0(thing->x4, thing->x8, "");
         } else {
             int s;
             gm_8016B774();
@@ -189,10 +190,9 @@ _done:
             if (s > 9999) {
                 s = 9999;
             }
-            if (un_804A1F58[y].x0 != s) {
-                HSD_SisLib_803A70A0(un_804A1F58[y].x8.x4, un_804A1F58[y].x8.x8,
-                                    "%d", s);
-                un_804A1F58[y].x0 = s;
+            if (thing->xC != s) {
+                HSD_SisLib_803A70A0(thing->x4, thing->x8, "%d", s);
+                thing->xC = s;
             }
         }
     }
@@ -206,9 +206,9 @@ void un_802FF364(int slot)
     Vec3* ifAll;
     struct un_804A1F58_x8_t* thing;
     HSD_GObj* gobj;
-    struct un_804A1F58_t* base = un_804A1F58;
+    struct un_804A1F58_t* base = &un_804A1F58;
     PAD_STACK(0x10);
-    thing = &base[slot].x8;
+    thing = &base->x8[slot];
     ifAll = ifAll_802F3424(slot);
     gobj = thing->x0;
     if ((thing && thing) && thing) {
@@ -239,9 +239,8 @@ void un_802FF364(int slot)
 void un_802FF498(void)
 {
     PAD_STACK(8);
-    memzero(un_804A1F58,
-            0x80); // TODO: change to sizeof(un_802FF498) when size fixed
-    un_804A1F58->x0 =
+    memzero(&un_804A1F58, sizeof(un_804A1F58));
+    un_804A1F58.x0 =
         HSD_SisLib_803A611C(2, ifAll_802F3404(), 14, 15, 0, 11, 0, 19);
 }
 
@@ -250,39 +249,37 @@ void un_802FF4FC(void)
     int i;
     PAD_STACK(8);
     for (i = 0; i < 6; i++) {
-        if (un_804A1F58[i].x8.x0) {
-            HSD_GObjPLink_80390228(un_804A1F58[i].x8.x0);
+        if (un_804A1F58.x8[i].x0) {
+            HSD_GObjPLink_80390228(un_804A1F58.x8[i].x0);
         }
-        if (un_804A1F58[i].x8.x4) {
-            HSD_SisLib_803A5CC4(un_804A1F58[i].x8.x4);
+        if (un_804A1F58.x8[i].x4) {
+            HSD_SisLib_803A5CC4(un_804A1F58.x8[i].x4);
         }
     }
 }
 
-// Same issue as un_802FF620
 void un_802FF570(void)
 {
     int i;
     struct un_804A1F58_x8_t* thing;
     HSD_Text* text;
     for (i = 0; i < 6; i++) {
-        un_804A1F58[i + 1].x4 = 1;
-        text = (thing = &un_804A1F58[i].x8)->x4;
+        thing = &un_804A1F58.x8[i];
+        thing->x10 = 1;
+        text = thing->x4;
         if (text) {
             text->hidden = 1;
         }
     }
 }
 
-// Same issue as un_802FF570
 void un_802FF620(void)
 {
     int i;
-    struct un_804A1F58_t* base = un_804A1F58;
-
+    struct un_804A1F58_t* base = &un_804A1F58;
     for (i = 0; i < 6; i++) {
-        struct un_804A1F58_x8_t* thing = (0, &base[i].x8);
-        base[i + 1].x4 = 0;
+        struct un_804A1F58_x8_t* thing = (0, &base->x8[i]);
+        thing->x10 = 0;
 
         if (thing->x4) {
             un_802FF364(i);

--- a/src/melee/if/ifstock.c
+++ b/src/melee/if/ifstock.c
@@ -732,6 +732,9 @@ void ifStock_802FA5BC(int arg)
 void fn_802FA6C4(HSD_GObj* arg)
 {
     int i;
+    char* p;
+    int j;
+    int k;
     char* q;
     char* w;
     if (gm_8016B184() && gm_8016A1F8()) {
@@ -739,16 +742,18 @@ void fn_802FA6C4(HSD_GObj* arg)
             ifStock_804A1774.x0 = 1;
             q = gm_80169520();
             w = gm_80169530();
-            for (i = 0; i != 130; i++) {
-                ifStock_804A1774.x10C[i + 1] = NULL;
-                ifStock_804A1774.x1[i] = q[i];
-                ifStock_804A1774.x83[i] = w[i];
+            for (k = 0; k != 130; k++) {
+                ifStock_804A1774.x10C[k + 1] = NULL;
+                ifStock_804A1774.x1[k] = *q++;
+                ifStock_804A1774.x83[k] = *w++;
             }
-            for (i = 0; i < 130; i++) {
+            i = 0;
+            p = &ifStock_804A1774.x0 + i;
+            for (; i < 130; i++, p++) {
                 if (ifStock_804A1774.x10C[1 + i]) {
                     HSD_GObjPLink_80390228(ifStock_804A1774.x10C[1 + i]);
                 }
-                if (ifStock_804A1774.x1[i] == -2) {
+                if (p[1] == -2) {
                     return;
                 }
                 ifStock_804A1774.x10C[1 + i] = ifStock_802F9F48(i);
@@ -756,10 +761,10 @@ void fn_802FA6C4(HSD_GObj* arg)
         }
     } else {
         if (ifStock_804A1774.x0 == 1) {
-            for (i = 129; i >= 0; i--) {
-                if (ifStock_804A1774.x10C[1 + i]) {
-                    HSD_GObjPLink_80390228(ifStock_804A1774.x10C[1 + i]);
-                    ifStock_804A1774.x10C[1 + i] = NULL;
+            for (j = 129; j >= 0; j--) {
+                if (ifStock_804A1774.x10C[1 + j]) {
+                    HSD_GObjPLink_80390228(ifStock_804A1774.x10C[1 + j]);
+                    ifStock_804A1774.x10C[1 + j] = NULL;
                 }
             }
         }

--- a/src/melee/if/textlib.c
+++ b/src/melee/if/textlib.c
@@ -32,8 +32,15 @@
 #include <MSL/string.h>
 
 /// ?
-/* 4D6E18 */ extern DevText* devtext_drawlist;
-/* 4D6E38 */ extern DevText* devtext_poolhead;
+/* 4D6E18 */ extern DevText* un_804D6E18;
+/* 4D6E38 */ extern DevText* un_804D6E38;
+/* 4DDC88 */ extern GXColor un_804DDC88;
+/* 4DDC8C */ extern GXColor un_804DDC8C;
+/* 4DDC90 */ extern GXColor un_804DDC90;
+/* 4DDC94 */ extern GXColor un_804DDC94;
+/* 4DDC98 */ extern GXColor un_804DDC98;
+/* 4DDC9C */ extern f32 un_804DDC9C;
+/* 4DDCA0 */ extern f32 un_804DDCA0;
 unsigned short un_804A26B8[1000];
 unsigned short un_804A284C[1000];
 short* un_804D6EB4;
@@ -57,15 +64,15 @@ GXColor red = { 0xFF, 0x80, 0x80, 0xFF };
 GXColor green = { 0x80, 0xFF, 0x80, 0xFF };
 GXColor blue = { 0x80, 0x80, 0xFF, 0xFF };
 
-GXColor color_08 = { 0x40, 0x50, 0x80, 0x80 };
-GXColor color_0C = { 0xE2, 0xE2, 0xE2, 0xFF };
-GXColor color_10 = { 0xFF, 0x80, 0x20, 0xFF };
-GXColor color_14 = { 0xA0, 0xA0, 0xFF, 0xFF };
+GXColor un_804D5A08 = { 0x40, 0x50, 0x80, 0x80 };
+GXColor un_804D5A0C = { 0xE2, 0xE2, 0xE2, 0xFF };
+GXColor un_804D5A10 = { 0xFF, 0x80, 0x20, 0xFF };
+GXColor un_804D5A14 = { 0xA0, 0xA0, 0xFF, 0xFF };
 
 static inline DevText* find_by_id(char id)
 {
     DevText* text;
-    for (text = devtext_drawlist; text != NULL; text = text->next) {
+    for (text = un_804D6E18; text != NULL; text = text->next) {
         if (text->id == id) {
             return text;
         }
@@ -76,15 +83,16 @@ static inline DevText* find_by_id(char id)
 DevText* DevText_Create(char id, int x, int y, int w, int h, char* buf)
 {
     DevText* text;
-    GXColor bg = { 0x60, 0xD0, 0xB0, 0x70 };
-    PAD_STACK(0x60 - 0x48);
+    UNUSED u32 pad;
+    GXColor bg = un_804DDC88;
+    PAD_STACK(0x14);
 
     if ((text = find_by_id(id))) {
         return NULL;
     }
-    text = devtext_poolhead;
+    text = un_804D6E38;
     if (text != NULL) {
-        devtext_poolhead = text->next;
+        un_804D6E38 = text->next;
     } else {
         text = NULL;
     }
@@ -99,13 +107,13 @@ DevText* DevText_Create(char id, int x, int y, int w, int h, char* buf)
         text->h = h;
         text->cursor_x = 0;
         text->cursor_y = 0;
-        text->scale_x = 10.0;
-        text->scale_y = 16.0;
+        text->scale_x = un_804DDC9C;
+        text->scale_y = un_804DDCA0;
         text->bg_color = bg;
-        text->text_colors[0] = white;
-        text->text_colors[1] = red;
-        text->text_colors[2] = green;
-        text->text_colors[3] = blue;
+        text->text_colors[0] = un_804DDC8C;
+        text->text_colors[1] = un_804DDC90;
+        text->text_colors[2] = un_804DDC94;
+        text->text_colors[3] = un_804DDC98;
         text->id = (int) id;
         text->line_width = 10;
         text->flags = DEVTEXT_FLAG_SHOWCURSOR;
@@ -143,11 +151,24 @@ inline int DevText_Clamp(int val, int max)
     }
 }
 
+#pragma push
+#pragma dont_inline on
 void DevText_SetCursorXY(DevText* text, int x, int y)
 {
-    text->cursor_x = DevText_Clamp(x, text->w);
-    text->cursor_y = DevText_Clamp(y, text->h);
+    if (text->w <= x) {
+        x = text->w - 1;
+    } else if (x < 0) {
+        x = 0;
+    }
+    text->cursor_x = x;
+    if (text->h <= y) {
+        y = text->h - 1;
+    } else if (y < 0) {
+        y = 0;
+    }
+    text->cursor_y = y;
 }
+#pragma pop
 
 void DevText_SetCursorX(DevText* text, int x)
 {
@@ -263,15 +284,23 @@ inline void DevText_AdvanceLine(DevText* text)
     }
 }
 
+typedef struct DevTextGlyph {
+    u8 chr;
+    u8 color : 2;
+    u8 unk : 6;
+} DevTextGlyph;
+
 void DevText_Print(DevText* text, char* str)
 {
-    PAD_STACK(8);
-    if (str) {
-        while (*str) {
-            if (*str != '\n') {
-                int index = (text->cursor_x + text->cursor_y * text->w) * 2;
-                text->buf[index] = *str;
-                text->buf[index + 1] = text->current_color << 6;
+    char* cur;
+    if (str != NULL) {
+        cur = str;
+        while (*cur) {
+            if (*cur != '\n') {
+                int index = text->cursor_x + text->cursor_y * text->w;
+                ((DevTextGlyph*) text->buf)[index].chr = *cur;
+                ((DevTextGlyph*) text->buf)[index].color =
+                    text->current_color;
                 if (text->cursor_x < text->w - 1) {
                     text->cursor_x++;
                 } else if ((text->flags & DEVTEXT_FLAG_NOWRAP) == 0) {
@@ -280,7 +309,7 @@ void DevText_Print(DevText* text, char* str)
             } else {
                 DevText_AdvanceLine(text);
             }
-            str++;
+            cur++;
         }
     }
 }
@@ -397,6 +426,7 @@ void un_80302FFC(struct un_80304138_objalloc_t* arg0)
     struct un_80304138_objalloc_t_x8* thing;
     int cursor_x = 1;
     int cursor_y;
+    GXColor color;
     for (thing = x8; thing->x0 != 9; thing++) {
         if (thing->x0 != 0 && thing->x0 != 1) {
             int len = DevText_StrLen(thing->x8);
@@ -407,20 +437,24 @@ void un_80302FFC(struct un_80304138_objalloc_t* arg0)
     }
     if (arg0->x1 & 0x10) {
         DevText_StoreColorIndex(arg0->x4, 0);
-        DevText_SetTextColor(arg0->x4, adjust(color_0C));
+        color = adjust(un_804D5A0C);
+        DevText_SetTextColor(arg0->x4, color);
         DevText_StoreColorIndex(arg0->x4, 1);
-        DevText_SetTextColor(arg0->x4, adjust(color_10));
+        color = adjust(un_804D5A10);
+        DevText_SetTextColor(arg0->x4, color);
         DevText_StoreColorIndex(arg0->x4, 2);
-        DevText_SetTextColor(arg0->x4, adjust(color_14));
-        DevText_SetBGColor(arg0->x4, adjust(color_08));
+        color = adjust(un_804D5A14);
+        DevText_SetTextColor(arg0->x4, color);
+        color = adjust(un_804D5A08);
+        DevText_SetBGColor(arg0->x4, color);
     } else {
         DevText_StoreColorIndex(arg0->x4, 0);
-        DevText_SetTextColor(arg0->x4, color_0C);
+        DevText_SetTextColor(arg0->x4, un_804D5A0C);
         DevText_StoreColorIndex(arg0->x4, 1);
-        DevText_SetTextColor(arg0->x4, color_10);
+        DevText_SetTextColor(arg0->x4, un_804D5A10);
         DevText_StoreColorIndex(arg0->x4, 2);
-        DevText_SetTextColor(arg0->x4, color_14);
-        DevText_SetBGColor(arg0->x4, color_08);
+        DevText_SetTextColor(arg0->x4, un_804D5A14);
+        DevText_SetBGColor(arg0->x4, un_804D5A08);
     }
     for (cursor_y = 0; cursor_y < arg0->x4->h; cursor_y++) {
         if (x8->x0 == 0) {
@@ -667,34 +701,36 @@ void un_80303AC4(struct un_80304138_objalloc_t* arg0)
             un_804D6E44->xC(6);
         }
     } else if (buttons & (0x10000000 | HSD_PAD_Y)) { // up
-        int i;
-        int w;
-        for (i = arg0->x0; i >= 0; i--) {
+        u8 j = arg0->x0;
+        int i = j;
+        (void) j;
+        for (i--; i >= 0; i--) {
             if (arg0->x8[i].x0 != NULL) {
-                w = i;
+                (void) i;
                 goto up_found;
             }
         }
-        w = -1;
+        i = -1;
     up_found:
-        if (w != -1) {
-            arg0->x0 = w;
+        if (i != -1) {
+            arg0->x0 = i;
             arg0->x1 = arg0->x1 | 1;
             lbAudioAx_80024030(2);
         }
     } else if (buttons & (0x20000000 | HSD_PAD_X)) { // down
-        int i;
-        int w;
-        for (i = arg0->x0; i < arg0->x4->h; i++) {
+        u8 j = arg0->x0;
+        int i = j;
+        (void) j;
+        for (i++; i < arg0->x4->h; i++) {
             if (arg0->x8[i].x0 != NULL) {
-                w = i;
+                (void) i;
                 goto down_found;
             }
         }
-        w = -1;
+        i = -1;
     down_found:
-        if (w != -1) {
-            arg0->x0 = w;
+        if (i != -1) {
+            arg0->x0 = i;
             arg0->x1 = arg0->x1 | 1;
             lbAudioAx_80024030(2);
         }
@@ -877,9 +913,13 @@ void un_80304210(struct un_80304138_objalloc_t* arg0, void* arg1, int arg2,
     struct un_80304138_objalloc_t* obj = HSD_ObjAlloc(&un_804A2688);
     if (obj != NULL) {
         DevText* text = arg0->x4;
-        un_80303FD4(arg0->x10, obj, arg1, arg2,
-                    text->x + arg3 + text->scale_x * text->w,
-                    text->y + arg4 + text->scale_y * arg0->x0);
+        f32 x = text->scale_x * (f32) text->w;
+        {
+            s32 x_pos = (s32) ((f32) arg3 + x);
+            s32 y_pos = (s32) (text->scale_y * (f32) arg0->x0 + (f32) arg4);
+            un_80303FD4(arg0->x10, obj, arg1, arg2, text->x + x_pos,
+                        text->y + y_pos);
+        }
         arg0->x1 = arg0->x1 | 0x10;
         arg0->prev = obj;
         obj->next = arg0;

--- a/src/melee/ty/tyfigupon.c
+++ b/src/melee/ty/tyfigupon.c
@@ -218,7 +218,8 @@ void tyFigupon_80314BE4(HSD_GObj* gobj, int unused)
 void tyFigupon_80314C5C(HSD_GObj* gobj)
 {
     Toy* tp1 = GET_TOY(gobj);
-    HSD_JObj* jobj = GET_JOBJ(gobj);
+    HSD_JObj* tmp_jobj = GET_JOBJ(gobj);
+    HSD_JObj* jobj = tmp_jobj;
     struct un_804D6EF4_t* temp_r29 = un_804D6EF4;
     PAD_STACK(40);
     if (tp1 != NULL) {
@@ -456,15 +457,17 @@ void fn_803155C8(void)
         ef4->x58 -= 1;
         if (ef4->x58 == 0) {
             if ((s8) data->x29 != 0) {
+                s32 bet_count;
                 new_var = un_80314B54();
-                sc = ef4->x5D;
+                bet_count = ef4->x5D;
                 fval = (f32) (ef4->x54 + new_var);
                 lbAudioAx_80023694();
-                if (sc != 0) {
-                    sc -= 1;
+                if (bet_count != 0) {
+                    bet_count -= 1;
                 }
                 pct = 100.0f *
-                      (((f32) ef4->x54 / fval) + ((f32) (sc * 5) / 100.0f));
+                      (((f32) ef4->x54 / fval) +
+                       ((f32) (bet_count * 5) / 100.0f));
                 if (pct >= 100.0f) {
                     pct = 99.9f;
                 }


### PR DESCRIPTION
## Summary

- Exact-match decompilation for IF text/HUD helpers and TY Figupon.
- Adds 7 newly exact function(s) across 4 file(s).
- Verified alone against the current upstream baseline with zero regressions.

## PR Shape

- Scope: IF text/HUD helpers and TY Figupon
- Change type: implementation-only match work
- Review risk: Low; UI-facing implementation files with no shared declaration churn.
- Header/naming churn: none
- Regression signal: clean in isolated slice verification and clean in the full ship set

## Reviewer Notes

- This file-level slice also improves 4 still-unmatched function(s); no fuzzy or metric regressions were introduced.
- Files:
  - `src/melee/if/ifcoget.c`
  - `src/melee/if/ifstock.c`
  - `src/melee/if/textlib.c`
  - `src/melee/ty/tyfigupon.c`

## Verification

- Applied this slice alone to baseline `3a7df8e49f` and ran `MVK_CONFIG_LOG_LEVEL=0 WINEDEBUG=-all ninja -C /tmp/melee-baseline-3a7df8e49fcbdbbb3e3be32b47f47954581bc8b8 -j8 changes_all`.
- Slice regression report: 7 new match(es), 0 broken matches, 0 fuzzy regressions, 0 metric regressions.
- Full ship-set regression report: 96 new match(es), 0 broken matches, 0 fuzzy regressions, 0 metric regressions.
- `git diff --check` passed for the slice and full ship set.
- review_lint on the full ship set: 0 error(s), 112 warning(s).
