### PR TITLE
Melee decomp: SysDolphin baselib matches

### DIFF
--- a/src/sysdolphin/baselib/axdriver.c
+++ b/src/sysdolphin/baselib/axdriver.c
@@ -72,8 +72,12 @@ static void unk_inline(HSD_SM* v, HSD_SM** head)
 static bool tmp(HSD_SM* v)
 {
     int idx;
-    HSD_ASSERT(0x92, (v->flags&SMSTATE_MASK) == SMSTATE_ACTIVE ||
-                     (v->flags&SMSTATE_MASK) == SMSTATE_SLEEP);
+    u32 state;
+
+    state = v->flags & SMSTATE_MASK;
+    HSD_ASSERTMSG(0x92, state == SMSTATE_ACTIVE || state == SMSTATE_SLEEP,
+                  "(v->flags&SMSTATE_MASK) == SMSTATE_ACTIVE || "
+                  "(v->flags&SMSTATE_MASK) == SMSTATE_SLEEP");
 
     idx = v->vID;
     if (v->vID != -1) {
@@ -334,7 +338,8 @@ void AXDriver_8038C6C0(HSD_SM* v)
             break;
         case 7:
             v->flags |= 4;
-            v->x1A = CLAMP(0, v->x1A + (s8) (u8) *v->cmd_stream, 0xFF);
+            cmd_val = v->x1A + (s8) (u8) *v->cmd_stream;
+            v->x1A = CLAMP(0, cmd_val, 0xFF);
             break;
         case 8:
             v->flags |= 8;
@@ -342,7 +347,8 @@ void AXDriver_8038C6C0(HSD_SM* v)
             break;
         case 9:
             v->flags |= 8;
-            v->x1C = CLAMP(0, v->x1C + (s8) (u8) *v->cmd_stream, 0xFF);
+            cmd_val = v->x1C + (s8) (u8) *v->cmd_stream;
+            v->x1C = CLAMP(0, cmd_val, 0xFF);
             break;
         case 10:
             v->flags |= 0x10;
@@ -350,7 +356,8 @@ void AXDriver_8038C6C0(HSD_SM* v)
             break;
         case 11:
             v->flags |= 0x10;
-            v->x1E = CLAMP(0, v->x1E + (s8) (u8) *v->cmd_stream, 0xFF);
+            cmd_val = v->x1E + (s8) (u8) *v->cmd_stream;
+            v->x1E = CLAMP(0, cmd_val, 0xFF);
             break;
         case 12:
             v->flags |= 0x20;
@@ -358,8 +365,8 @@ void AXDriver_8038C6C0(HSD_SM* v)
             break;
         case 13:
             v->flags |= 0x20;
-            v->x20 =
-                CLAMP(-0x2A30, v->x20 + (s16) (u16) *v->cmd_stream, 0x960);
+            cmd_val = v->x20 + (s16) (u16) *v->cmd_stream;
+            v->x20 = CLAMP(-0x2A30, cmd_val, 0x960);
             break;
         case 16:
             if (!(AXDriver_804D603C & 1)) {
@@ -380,8 +387,8 @@ void AXDriver_8038C6C0(HSD_SM* v)
         case 17:
             if (!(AXDriver_804D603C & 1)) {
                 v->flags |= 0x80;
-                v->x24[0] =
-                    CLAMP(0, v->x24[0] + (s8) (u8) *v->cmd_stream, 0xFF);
+                cmd_val = v->x24[0] + (s8) (u8) *v->cmd_stream;
+                v->x24[0] = CLAMP(0, cmd_val, 0xFF);
             }
             break;
         case 18:
@@ -393,8 +400,8 @@ void AXDriver_8038C6C0(HSD_SM* v)
         case 19:
             if (!(AXDriver_804D603C >> 1 & 1)) {
                 v->flags |= 0x80;
-                v->x24[1] =
-                    CLAMP(0, v->x24[1] + (s8) (u8) *v->cmd_stream, 0xFF);
+                cmd_val = v->x24[1] + (s8) (u8) *v->cmd_stream;
+                v->x24[1] = CLAMP(0, cmd_val, 0xFF);
             }
             break;
         case 15:
@@ -773,8 +780,6 @@ static void fn_8038DA5C(s32 result, DVDFileInfo* fileInfo)
     }
 }
 
-/// @todo Currently 97.58% match - register allocation in section 1 and 2
-/// parsing blocks (r0/r3 swap for count/ptr, r4/r5 swap for base pointer)
 void AXDriver_8038DA70(const char* path, void (*callback)(void))
 {
     DVDFileInfo fileInfo;
@@ -782,6 +787,7 @@ void AXDriver_8038DA70(const char* path, void (*callback)(void))
     s32 alignedSize;
     void* ptr;
     s32 offset;
+    s32 count;
     s32 j;
     s32 i;
 
@@ -810,12 +816,13 @@ void AXDriver_8038DA70(const char* path, void (*callback)(void))
     DVDClose(&fileInfo);
 
     AXDriver_804D77A0 = ((s32*) AXDriver_804D7798)[0];
-    if (AXDriver_804D77A0 != 0) {
+    count = AXDriver_804D77A0;
+    if (count != 0) {
         ptr = (void*) ((u8*) AXDriver_804D7798 + 4);
     } else {
         ptr = NULL;
     }
-    offset = AXDriver_804D77A0 * 4 + 4;
+    offset = count * 4 + 4;
     AXDriver_804D77A4 = ptr;
 
     AXDriver_804D77A8 = *(s32*) ((u8*) AXDriver_804D7798 + offset);
@@ -827,8 +834,8 @@ void AXDriver_8038DA70(const char* path, void (*callback)(void))
     }
     AXDriver_804D77AC = ptr;
 
-    j = 0;
     i = 0;
+    j = i;
     while (i < AXDriver_804D77A8) {
         i++;
         *(u32*) ((u8*) AXDriver_804D77AC + j) += (u32) AXDriver_804D7798 & ~3u;
@@ -836,30 +843,27 @@ void AXDriver_8038DA70(const char* path, void (*callback)(void))
     }
 
     offset += AXDriver_804D77A8 * 4;
-    AXDriver_804D77B0 = *(s32*) ((u8*) AXDriver_804D7798 + offset);
+    ptr = AXDriver_804D7798;
+    AXDriver_804D77B0 = *(s32*) ((u8*) ptr + offset);
     offset += 4;
-    if (AXDriver_804D77B0 != 0) {
-        ptr = (u8*) AXDriver_804D7798 + offset;
-    } else {
-        ptr = NULL;
-    }
-    offset += AXDriver_804D77B0 * 4;
-    AXDriver_804D77B4 = ptr;
+    count = AXDriver_804D77B0;
+    AXDriver_804D77B4 = count != 0 ? (u32*) ((u8*) ptr + offset) : NULL;
+    offset += count * 4;
 
-    AXDriver_804D77B8 = *(s32*) ((u8*) AXDriver_804D7798 + offset);
+    AXDriver_804D77B8 = *(s32*) ((u8*) ptr + offset);
     offset += 4;
     if (AXDriver_804D77B8 != 0) {
-        ptr = (u8*) AXDriver_804D7798 + offset;
+        ptr = (u8*) ptr + offset;
     } else {
         ptr = NULL;
     }
+    j = 0;
     AXDriver_804D77BC = ptr;
-    i = 0;
-    j = i;
-    while (i < AXDriver_804D77B8) {
-        i++;
-        *(u32*) ((u8*) AXDriver_804D77BC + j) += (u32) AXDriver_804D7798 & ~3u;
-        j += 4;
+    i = j;
+    while (j < AXDriver_804D77B8) {
+        j++;
+        *(u32*) ((u8*) AXDriver_804D77BC + i) += (u32) AXDriver_804D7798 & ~3u;
+        i += 4;
     }
 
     offset += AXDriver_804D77B8 * 4;
@@ -870,13 +874,13 @@ void AXDriver_8038DA70(const char* path, void (*callback)(void))
     } else {
         ptr = NULL;
     }
+    j = 0;
     AXDriver_804D77C4 = ptr;
-    i = 0;
-    j = i;
-    while (i < AXDriver_804D77C0) {
-        i++;
-        *(u32*) ((u8*) AXDriver_804D77C4 + j) += (u32) AXDriver_804D7798 & ~3u;
-        j += 4;
+    i = j;
+    while (j < AXDriver_804D77C0) {
+        j++;
+        *(u32*) ((u8*) AXDriver_804D77C4 + i) += (u32) AXDriver_804D7798 & ~3u;
+        i += 4;
     }
 }
 
@@ -996,25 +1000,14 @@ int AXDriverSetupAux(int channel, AXDriverAuxType type, void* param)
     return result;
 }
 
-static const RevHiDims revhi_dims = {
-    { 0x6FD, 0x7CF, 0x91D, 0x1B1, 0x95, 0x2F, 0x49, 0x43 },
-};
+extern const RevHiDims AXDriver_803B95F8;
+extern const s32 AXDriver_803B9618[];
 
-static const s32 revstd_dims[] = {
-    0x6FD,
-    0x7CF,
-    0x1B1,
-    0x95,
-};
-
-/// @todo Currently 53.61% match - needs struct copy and computation order
-/// fixes
 s32 HSD_AudioGetAuxHeapSize(AXDriverAuxType type, void* param)
 {
     s32 result;
-    s32 d[8];
-    s32 predelay;
-    s32 s0, s1, s2, s3, s4, s5;
+    int i;
+    int k;
 
     result = 0;
 
@@ -1029,40 +1022,34 @@ s32 HSD_AudioGetAuxHeapSize(AXDriverAuxType type, void* param)
     case AXDRIVER_AUX_REVERB_HI: {
         RevHiDims tmp;
 
-        tmp = revhi_dims;
-        predelay =
-            (s32) (32000.0F * ((struct AXFX_REVERBHI*) param)->preDelay);
+        tmp = AXDriver_803B95F8;
 
-        s0 = (tmp.v[0] + 2) * 4;
-        s1 = (tmp.v[1] + 2) * 4;
-        s2 = (tmp.v[2] + 2) * 4;
-        s3 = (tmp.v[3] + 2) * 4;
-        s4 = (tmp.v[4] + 2) * 4;
-        s5 = (tmp.v[5] + 2) * 4;
-
-        result +=
-            s0 + s3 + s1 + s4 + s2 + s5 + (tmp.v[5] + 2) * 4 + predelay * 4;
-        result +=
-            s0 + s3 + s1 + s4 + s2 + s5 + (tmp.v[6] + 2) * 4 + predelay * 4;
-        result +=
-            s0 + s3 + s1 + s4 + s2 + s5 + (tmp.v[7] + 2) * 4 + predelay * 4;
+        for (k = 0; k < 3; k++) {
+            for (i = 0; i < 3; i++) {
+                result += (tmp.v[i] + 2) * 4;
+            }
+            for (i = 0; i < 3; i++) {
+                result += (tmp.v[i + 3] + 2) * 4;
+            }
+            result += (tmp.v[k + 5] + 2) * 4;
+            result += ((s32) (32000.0F *
+                              ((struct AXFX_REVERBHI*) param)->preDelay)) * 4;
+        }
         break;
     }
 
-    case AXDRIVER_AUX_REVERB_STD: {
-        s0 = (revstd_dims[0] + 2) * 4;
-        s1 = (revstd_dims[1] + 2) * 4;
-        s2 = (revstd_dims[2] + 2) * 4;
-        s3 = (revstd_dims[3] + 2) * 4;
-
-        predelay =
-            (s32) (32000.0F * ((struct AXFX_REVERBSTD*) param)->preDelay);
-
-        result = s0 + s2 + s1 + s3 + predelay * 4;
-        result += s0 + s2 + s1 + s3 + predelay * 4;
-        result += s0 + s2 + s1 + s3 + predelay * 4;
+    case AXDRIVER_AUX_REVERB_STD:
+        for (k = 0; k < 3; k++) {
+            for (i = 0; i < 2; i++) {
+                result += (AXDriver_803B9618[i] + 2) * 4;
+            }
+            for (i = 0; i < 2; i++) {
+                result += (AXDriver_803B9618[i + 2] + 2) * 4;
+            }
+            result += ((s32) (32000.0F *
+                              ((struct AXFX_REVERBSTD*) param)->preDelay)) * 4;
+        }
         break;
-    }
 
     case AXDRIVER_AUX_CHORUS:
         result = 0x1680;
@@ -1082,6 +1069,17 @@ s32 HSD_AudioGetAuxHeapSize(AXDriverAuxType type, void* param)
 
     return result;
 }
+
+const RevHiDims AXDriver_803B95F8 = {
+    { 0x6FD, 0x7CF, 0x91D, 0x1B1, 0x95, 0x2F, 0x49, 0x43 },
+};
+
+const s32 AXDriver_803B9618[] = {
+    0x6FD,
+    0x7CF,
+    0x1B1,
+    0x95,
+};
 
 bool AXDriver_8038E30C(s32 channel, s32 type, void* param, u8* heap,
                        u32 heap_size)

--- a/src/sysdolphin/baselib/cobj.c
+++ b/src/sysdolphin/baselib/cobj.c
@@ -677,14 +677,24 @@ static int roll2upvec(HSD_CObj* cobj, Vec3* up, float roll)
     return 0;
 }
 
+static inline f32 cobj_get_roll(HSD_CObj* cobj)
+{
+    return cobj->u.roll;
+}
+
+static inline f32 cobj_get_up_x(Vec3* up)
+{
+    return up->x;
+}
+
 int HSD_CObjGetUpVector(HSD_CObj* cobj, Vec3* up)
 {
-    if (cobj && up) {
+    if (cobj != NULL && up != NULL) {
         if ((cobj->flags & 1) != 0) {
             *up = cobj->u.up;
             return 0;
         }
-        if (roll2upvec(cobj, up, cobj->u.roll) == 0) {
+        if (roll2upvec(cobj, up, cobj_get_roll(cobj)) == 0) {
             return 0;
         }
     }
@@ -709,7 +719,7 @@ void HSD_CObjSetUpVector(HSD_CObj* cobj, Vec3* up)
             up = &v;
         }
 
-        if (cobj->u.up.x != up->x || cobj->u.up.y != up->y ||
+        if (cobj->u.up.x != cobj_get_up_x(up) || cobj->u.up.y != up->y ||
             cobj->u.up.z != up->z)
         {
             HSD_CObjSetMtxDirty(cobj);
@@ -774,15 +784,43 @@ MtxPtr HSD_CObjGetInvViewingMtxPtrDirect(HSD_CObj* cobj)
 
 MtxPtr HSD_CObjGetViewingMtxPtr(HSD_CObj* cobj)
 {
-    HSD_CObjSetupViewingMtx(cobj);
+    extern int HSD_CObjGetUpVector(HSD_CObj* cobj, Vec3* up);
+    Vec3 interest;
+    Vec3 up_vec;
+    Vec3 eyepos;
     PAD_STACK(24);
+
+    if (!(cobj->flags & 2) && HSD_CObjMtxIsDirty(cobj)) {
+        HSD_CObjGetEyePosition(cobj, &eyepos);
+        HSD_CObjGetUpVector(cobj, &up_vec);
+        HSD_CObjGetInterest(cobj, &interest);
+        C_MTXLookAt(cobj->view_mtx, &eyepos, &up_vec, &interest);
+        HSD_WObjClearFlags(cobj->eyepos, 2);
+        HSD_WObjClearFlags(cobj->interest, 2);
+        HSD_CObjClearFlags(cobj, 0x40000000);
+        HSD_CObjSetFlags(cobj, 0x80000000);
+    }
     return HSD_CObjGetViewingMtxPtrDirect(cobj);
 }
 
 MtxPtr HSD_CObjGetInvViewingMtxPtr(HSD_CObj* cobj)
 {
-    HSD_CObjSetupViewingMtx(cobj);
+    extern int HSD_CObjGetUpVector(HSD_CObj* cobj, Vec3* up);
+    Vec3 interest;
+    Vec3 up_vec;
+    Vec3 eyepos;
     PAD_STACK(24);
+
+    if (!(cobj->flags & 2) && HSD_CObjMtxIsDirty(cobj)) {
+        HSD_CObjGetEyePosition(cobj, &eyepos);
+        HSD_CObjGetUpVector(cobj, &up_vec);
+        HSD_CObjGetInterest(cobj, &interest);
+        C_MTXLookAt(cobj->view_mtx, &eyepos, &up_vec, &interest);
+        HSD_WObjClearFlags(cobj->eyepos, 2);
+        HSD_WObjClearFlags(cobj->interest, 2);
+        HSD_CObjClearFlags(cobj, 0x40000000);
+        HSD_CObjSetFlags(cobj, 0x80000000);
+    }
     return HSD_CObjGetInvViewingMtxPtrDirect(cobj);
 }
 

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -75,6 +75,11 @@ typedef struct _DispItem {
 
 typedef DispItem* (*DispCallback)(void*);
 
+typedef union {
+    f32 f;
+    u8 bytes[4];
+} ParticleFloatBytes;
+
 typedef struct {
     /* 0x00 */ void* next;
     /* 0x04 */ s32 type;
@@ -1116,7 +1121,7 @@ void fn_80392E2C(s32 event_type)
 }
 
 ParticleLogEntry hsd_804CEB40[0x100];
-s32 hsd_804CF740[42];
+extern s32 hsd_804CF740[42];
 
 extern s32 hsd_804D78A8;
 extern s32 hsd_804D78AC;
@@ -1249,31 +1254,32 @@ void hsd_80392E80(void)
     }
 }
 
-// @TODO: Currently 99.75% match - BSS relocation encoding difference
 bool hsd_803931A4(s32 exi_channel)
 {
     s32 channel;
+    s32* channel_flags;
     PAD_STACK(16);
 
-    hsd_804CF740[0] = 0;
-    hsd_804CF740[1] = 0;
-    hsd_804CF740[2] = 0;
-    hsd_804CF740[3] = 0;
-    hsd_804CF740[4] = 0;
-    hsd_804CF740[5] = 0;
-    hsd_804CF740[6] = 0;
-    hsd_804CF740[7] = 0;
-    hsd_804CF740[8] = 0;
-    hsd_804CF740[9] = 0;
-    hsd_804CF740[10] = 0;
-    hsd_804CF740[11] = 0;
-    hsd_804CF740[12] = 0;
-    hsd_804CF740[13] = 0;
-    hsd_804CF740[14] = 0;
-    hsd_804CF740[15] = 0;
-    hsd_804CF740[0] = 1;
-    hsd_804CF740[8] = 1;
-    hsd_804CF740[15] = 1;
+    channel_flags = (s32*) hsd_804CF740;
+    channel_flags[0] = 0;
+    channel_flags[1] = 0;
+    channel_flags[2] = 0;
+    channel_flags[3] = 0;
+    channel_flags[4] = 0;
+    channel_flags[5] = 0;
+    channel_flags[6] = 0;
+    channel_flags[7] = 0;
+    channel_flags[8] = 0;
+    channel_flags[9] = 0;
+    channel_flags[10] = 0;
+    channel_flags[11] = 0;
+    channel_flags[12] = 0;
+    channel_flags[13] = 0;
+    channel_flags[14] = 0;
+    channel_flags[15] = 0;
+    channel_flags[0] = 1;
+    channel_flags[8] = 1;
+    channel_flags[15] = 1;
 
     channel = exi_channel;
 
@@ -1303,6 +1309,8 @@ bool hsd_803931A4(s32 exi_channel)
     OSReport("EXI initialized (EXI_%d)\n", channel);
     return 1;
 }
+
+s32 hsd_804CF740[42];
 
 void fn_803932D0(s32 type, u32 flags, s32 value)
 {
@@ -1695,6 +1703,8 @@ s32 hsd_80393D2C(s32 enable)
 }
 #pragma pop
 
+#pragma push
+#pragma pool_data off
 void hsd_80393DA0(u8* buf, size_t size)
 {
     PAD_STACK(4);
@@ -1707,6 +1717,7 @@ void hsd_80393DA0(u8* buf, size_t size)
     hsd_804CF7E8.x0_b1 = true;
     HSD_SetReportCallback(fn_80393C14);
 }
+#pragma pop
 
 #pragma push
 #pragma dont_inline on
@@ -1835,6 +1846,7 @@ void hsd_80393EF4(int col_delta, int row_delta)
 #pragma pop
 
 #pragma push
+#pragma pool_data off
 #pragma dont_inline on
 u8 hsd_80394068(void)
 {
@@ -2659,21 +2671,22 @@ extern u8 lbl_8040AB20[];
 extern u8 lbl_8040B8AC[];
 extern u8 lbl_8040B904[];
 
-// @TODO: Currently 99.78% match - minor addressing difference
 void hsd_80395644(void)
 {
+    struct ParticleScreenState* sp =
+        (struct ParticleScreenState*) &hsd_804CF810;
     void* saved;
-    void** p = &hsd_804CF810.x50;
+    void** p = &sp->x50;
     s32 val_x20;
     s32 val_x1C;
 
     PAD_STACK(16);
     saved = *p;
     *p = lbl_8040AB20;
-    val_x20 = hsd_804CF810.x20;
-    val_x1C = hsd_804CF810.x1C;
-    hsd_804CF810.x4 = (val_x20 - 21) * 11 + 20;
-    hsd_804CF810.x8 = (hsd_804CF810.x40 - 40) - (val_x1C + 1) * 14;
+    val_x20 = sp->x20;
+    val_x1C = sp->x1C;
+    sp->x4 = (val_x20 - 21) * 11 + 20;
+    sp->x8 = (sp->x40 - 40) - (val_x1C + 1) * 14;
     if (hsd_804D78C8 >= 1) {
         hsd_80394434(lbl_8040B8AC);
     }
@@ -2969,8 +2982,7 @@ static inline void ps_remove_node(struct ParticleScreenState* sp, void* node)
     sp->x0_b5 = 1;
 }
 
-// @TODO: Currently 80.89% match - .bss.0 relocation issue affects register
-// allocation
+// @TODO: Currently 99.38% match - remaining register allocation differences
 s32 hsd_80395D88(void* data)
 {
     char* msg = (char*) lbl_8040AB00;
@@ -3006,21 +3018,21 @@ s32 hsd_80395D88(void* data)
             ps_remove_node(sp, data);
             return 0;
         case 6: {
+            s32 i;
             OSContext* ctx;
             OSContext** ctx_ptr;
+            u32* ctx_words;
             s32 saved;
-            s32 i;
 
-            ctx_ptr = &sp->xD4;
-            if (*ctx_ptr != NULL) {
+            if (*(ctx_ptr = &sp->xD4) != NULL) {
                 saved = hsd_80393D2C(1);
-                ctx = *ctx_ptr;
+                ctx_words = (u32*) *ctx_ptr;
                 OSReport(msg + 0x728);
                 i = 0;
                 do {
-                    OSReport(msg + 0x760, i, ((u32*) ctx)[i], ((u32*) ctx)[i],
-                             i + 0x10, ((u32*) ctx)[i + 0x10],
-                             ((u32*) ctx)[i + 0x10]);
+                    OSReport(msg + 0x760, i, ctx_words[i], ctx_words[i],
+                             i + 0x10, ctx_words[i + 0x10],
+                             ctx_words[i + 0x10]);
                     i++;
                 } while (i < 0x10);
                 hsd_80394950(*ctx_ptr);
@@ -3048,13 +3060,15 @@ s32 hsd_80395D88(void* data)
             hsd_80394E8C(lbl_8040BEC4);
             return 1;
         case 8: {
-            ExcptNode* cur = sp->xD0;
+            void** head_ptr;
+            ExcptNode* cur;
+            cur = *(head_ptr = &sp->xD0);
             while (cur != NULL) {
                 ExcptNode* next = cur->next;
                 cur->next = NULL;
                 cur = next;
             }
-            sp->xD0 = NULL;
+            *head_ptr = NULL;
             sp->x0_b5 = 1;
             return 1;
         }
@@ -3352,6 +3366,7 @@ void hsd_80396884(void)
 s32 hsd_80396A20(void* data)
 {
     struct ParticleScreenState* sp = &hsd_804CF810;
+    ExcptNode* node = data;
     u32 val = lbl_8040BC3C.x10;
     s32 shift = 24 - (lbl_8040BC3C.x14 * 4);
     u32 bit = 1;
@@ -3387,17 +3402,17 @@ s32 hsd_80396A20(void* data)
             lbl_8040BC3C.x10 = val & ~mask;
             return 1;
         case 0x200:
-            ps_remove_node(sp, data);
+            ps_remove_node(sp, node);
             return 1;
         case 0x1000: {
             extern u8 lbl_8040BD74[];
-            data = (ExcptNode*) lbl_8040BD74;
-            if (data != NULL) {
-                fn_80394DF4(data);
-                ((ExcptNode*) data)->next = sp->xD0;
-                sp->xD0 = data;
-                if (((ExcptNode*) data)->callback != NULL) {
-                    ((ExcptNode*) data)->callback(data);
+            node = (ExcptNode*) lbl_8040BD74;
+            if (node != NULL) {
+                fn_80394DF4(node);
+                node->next = sp->xD0;
+                sp->xD0 = node;
+                if (node->callback != NULL) {
+                    node->callback(node);
                 }
                 sp->x0_b5 = 1;
             }
@@ -4988,61 +5003,72 @@ void hsd_80398F8C(HSD_Particle* pp, f32 angle)
     f32 vx = pp->vel.x;
     f32 vz = pp->vel.z;
     f32 vy = pp->vel.y;
-    f32 azimuth;
     f32 sin_a, cos_a;
     f32 sin_e, cos_e;
-    f32 mag_sq;
     f32 rand_angle;
+    f32 cos_rand, sin_rand;
     f32 sin_angle, cos_angle;
-    f32 sin_rand, cos_rand;
+    f32 abs_z;
     f32 temp;
-    PAD_STACK(24);
+    f32 abs_temp;
+    volatile f32 sqrt_tmp;
+    PAD_STACK(16);
 
-    temp = vz;
-    *(s32*) &temp &= 0x7FFFFFFF;
-    if (temp < 1.1754944e-38F) {
-        if (vy >= 0.0F) {
-            azimuth = 1.5707964F;
+    {
+        f32 azimuth;
+
+        abs_z = vz;
+        *(s32*) &abs_z &= 0x7FFFFFFF;
+        if (abs_z < 1.1754944e-38F) {
+            if (vy >= 0.0F) {
+                azimuth = 1.5707964F;
+            } else {
+                azimuth = -1.5707964F;
+            }
         } else {
-            azimuth = -1.5707964F;
+            azimuth = atan2f(vy, vz);
         }
-    } else {
-        azimuth = atan2f(vy, vz);
+
+        sin_a = sinf(azimuth);
+        cos_a = cosf(azimuth);
     }
 
-    sin_a = sinf(azimuth);
-    cos_a = cosf(azimuth);
+    {
+        f32 azimuth;
 
-    temp = vy * sin_a + vz * cos_a;
-    *(s32*) &temp &= 0x7FFFFFFF;
-    if (temp < 1.1754944e-38F) {
-        if (vx >= 0.0F) {
-            azimuth = 1.5707964F;
+        temp = vy * sin_a + vz * cos_a;
+        abs_temp = temp;
+        *(s32*) &abs_temp &= 0x7FFFFFFF;
+        if (abs_temp < 1.1754944e-38F) {
+            if (vx >= 0.0F) {
+                azimuth = 1.5707964F;
+            } else {
+                azimuth = -1.5707964F;
+            }
         } else {
-            azimuth = -1.5707964F;
+            azimuth = atan2f(vx, temp);
         }
-    } else {
-        azimuth = atan2f(vx, vy * sin_a + vz * cos_a);
+
+        sin_e = sinf(azimuth);
+        cos_e = cosf(azimuth);
     }
 
-    sin_e = sinf(azimuth);
-    cos_e = cosf(azimuth);
-
-    mag_sq = vz * vz + (vx * vx + vy * vy);
-    if (mag_sq > 0.0F) {
-        f64 x = __frsqrte((f64) mag_sq);
-        x = 0.5 * x * -(((f64) mag_sq * (x * x)) - 3.0);
-        x = 0.5 * x * -(((f64) mag_sq * (x * x)) - 3.0);
-        x = 0.5 * x * -(((f64) mag_sq * (x * x)) - 3.0);
-        mag_sq = (f32) ((f64) mag_sq * x);
+    vx = (vx * vx + vy * vy) + vz * vz;
+    if (vx > 0.0F) {
+        f64 x = __frsqrte((f64) vx);
+        x = 0.5 * x * -(((f64) vx * (x * x)) - 3.0);
+        x = 0.5 * x * -(((f64) vx * (x * x)) - 3.0);
+        x = 0.5 * x * -(((f64) vx * (x * x)) - 3.0);
+        sqrt_tmp = (f32) ((f64) vx * x);
+        vx = sqrt_tmp;
     }
 
     rand_angle = (f32) (3.141592653589793 * HSD_Randf() * 2.0);
 
-    sin_angle = mag_sq * sinf(angle);
+    sin_angle = vx * sinf(angle);
     cos_rand = sin_angle * cosf(rand_angle);
     sin_rand = sin_angle * sinf(rand_angle);
-    cos_angle = mag_sq * cosf(angle);
+    cos_angle = vx * cosf(angle);
 
     pp->vel.x = cos_rand * cos_e + cos_angle * sin_e;
     pp->vel.y = cos_e * (cos_angle * sin_a) +
@@ -5100,6 +5126,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
     PAD_STACK(464);
 
 #define fval (*(f32*) &hsd_804D78D0)
+#define fbytes (*(ParticleFloatBytes*) &hsd_804D78D0).bytes
 
     /* Early exit: bit 11 of kind set */
     if (pp->kind & 0x800) {
@@ -5720,21 +5747,26 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
 
             case 0xA8:
                 /* Position random offset */
-                ((u8*) &fval)[0] = *pc++;
-                ((u8*) &fval)[1] = *pc++;
-                ((u8*) &fval)[2] = *pc++;
-                ((u8*) &fval)[3] = *pc++;
-                pp->pos.x += 2.0F * fval * HSD_Randf() - fval;
-                ((u8*) &fval)[0] = *pc++;
-                ((u8*) &fval)[1] = *pc++;
-                ((u8*) &fval)[2] = *pc++;
-                ((u8*) &fval)[3] = *pc++;
-                pp->pos.y += 2.0F * fval * HSD_Randf() - fval;
-                ((u8*) &fval)[0] = *pc++;
-                ((u8*) &fval)[1] = *pc++;
-                ((u8*) &fval)[2] = *pc++;
-                ((u8*) &fval)[3] = *pc++;
-                pp->pos.z += 2.0F * fval * HSD_Randf() - fval;
+                {
+                    u8* pc2;
+                    fbytes[0] = *pc++;
+                    fbytes[1] = *pc++;
+                    fbytes[2] = *pc++;
+                    fbytes[3] = *pc++;
+                    pp->pos.x += 2.0F * fval * HSD_Randf() - fval;
+                    pc2 = pc + 4;
+                    fbytes[0] = pc[0];
+                    fbytes[1] = pc[1];
+                    fbytes[2] = pc[2];
+                    fbytes[3] = pc[3];
+                    pp->pos.y += 2.0F * fval * HSD_Randf() - fval;
+                    pc = pc2 + 4;
+                    fbytes[0] = pc2[0];
+                    fbytes[1] = pc2[1];
+                    fbytes[2] = pc2[2];
+                    fbytes[3] = pc2[3];
+                    pp->pos.z += 2.0F * fval * HSD_Randf() - fval;
+                }
                 break;
 
             case 0xA9:
@@ -7320,6 +7352,7 @@ do_life:
     }
 
     return pp->next;
+#undef fbytes
 #undef fval
 }
 

--- a/src/sysdolphin/baselib/texpdag.c
+++ b/src/sysdolphin/baselib/texpdag.c
@@ -1323,8 +1323,9 @@ int HSD_TExpSimplify(HSD_TExp* texp_)
     return res;
 }
 
-int HSD_TExpSimplify2(HSD_TExp* texp)
+int HSD_TExpSimplify2(HSD_TExp* texp_)
 {
+    HSD_TExp* texp = (HSD_TExp*) texp_;
     HSD_TExp* src_exp;
     u8 src_sel;
     int i;


### PR DESCRIPTION
## Summary

- Exact-match decompilation for SysDolphin audio, camera object, particle, and TExp implementation files.
- Adds 12 newly exact function(s) across 4 file(s).
- Verified alone against the current upstream baseline with zero regressions.

## PR Shape

- Scope: SysDolphin audio, camera object, particle, and TExp implementation files
- Change type: implementation-only match work
- Review risk: Medium; support-library code, but implementation-only in this slice.
- Header/naming churn: none
- Regression signal: clean in isolated slice verification and clean in the full ship set

## Reviewer Notes

- This file-level slice also improves 6 still-unmatched function(s); no fuzzy or metric regressions were introduced.
- The risky `hsd_3AA7.h`/`hsd_3AA7.c` support pair is intentionally not included in this PR; it was not needed for these exact matches.
- Files:
  - `src/sysdolphin/baselib/axdriver.c`
  - `src/sysdolphin/baselib/cobj.c`
  - `src/sysdolphin/baselib/particle.c`
  - `src/sysdolphin/baselib/texpdag.c`

## Verification

- Applied this slice alone to baseline `3a7df8e49f` and ran `MVK_CONFIG_LOG_LEVEL=0 WINEDEBUG=-all ninja -C /tmp/melee-baseline-3a7df8e49fcbdbbb3e3be32b47f47954581bc8b8 -j8 changes_all`.
- Slice regression report: 12 new match(es), 0 broken matches, 0 fuzzy regressions, 0 metric regressions.
- Full ship-set regression report: 96 new match(es), 0 broken matches, 0 fuzzy regressions, 0 metric regressions.
- `git diff --check` passed for the slice and full ship set.
- review_lint on the full ship set: 0 error(s), 112 warning(s).
