### PR TITLE
Improve mnDiagram follow-up matches

### DIFF
--- a/src/melee/mn/mndiagram.c
+++ b/src/melee/mn/mndiagram.c
@@ -332,6 +332,22 @@ static inline int mnDiagram_SumFighterKOs(u8 field_index)
     return total;
 }
 
+static inline int mnDiagram_SumFighterKOsClamped(u8 field_index)
+{
+    int total = 0;
+    int i;
+    for (i = 0; i < 25; i++) {
+        if (mn_IsFighterUnlocked(i) != 0) {
+            total +=
+                GetPersistentFighterData(field_index)->fighter_kos[(u8) i];
+        }
+    }
+    if (total > 999999) {
+        total = 999999;
+    }
+    return total;
+}
+
 /// @brief Gets total falls (deaths) of a fighter against all other fighters.
 /// @details Iterates through all unlocked fighters and sums how many times
 ///          each fighter KO'd the target fighter. This is the column sum
@@ -355,6 +371,20 @@ int mnDiagram_GetFighterTotalFalls(u8 field_index)
 {
     PAD_STACK(16);
     return mnDiagram_SumFighterFalls(field_index);
+}
+
+/// @brief Counts the number of unlocked fighters (inline-expanded form).
+/// @return Number of unlocked fighters.
+static inline int mnDiagram_CountUnlockedFightersInline(void)
+{
+    int count = 0;
+    int i;
+    for (i = 0; i < 0x19; i++) {
+        if (mn_IsFighterUnlocked(i)) {
+            count++;
+        }
+    }
+    return count;
 }
 
 /// @brief Formats a number with optional decimal places.
@@ -756,28 +786,31 @@ static inline int mnDiagram_SumNameKOs(u8 field_index)
 void mnDiagram_8023FC28(void)
 {
     u32 totals[0x78];
+    int max_idx;
+    u8* dst_iter;
+    int i;
     mnDiagram_Assets* assets = (mnDiagram_Assets*) &mnDiagram_804A0750;
     u8* dst = assets->sorted_names;
-    u8* dst_iter;
     u32* tp;
-    int i;
+    int n;
     int j;
     PAD_STACK(12);
 
     dst_iter = dst;
     tp = totals;
-    for (i = 0; i < 0x78; i++, dst_iter++, tp++) {
-        *dst_iter = (u8) i;
-        *tp = mnDiagram_SumNameKOs(i & 0xFF);
+    for (n = 0; n < 0x78; n++, dst_iter++, tp++) {
+        *dst_iter = (u8) n;
+        *tp = mnDiagram_SumNameKOs(n & 0xFF);
     }
 
     for (i = 0; i < 0x78; i++) {
-        int max_idx = i;
+        max_idx = i;
         for (j = i + 1; j < 0x78; j++) {
             if ((GetNameText(mnDiagram_804A076C.sorted_names[j]) != NULL) &&
                 ((totals[mnDiagram_804A076C.sorted_names[max_idx]] <
                   totals[mnDiagram_804A076C.sorted_names[j]]) ||
-                 ((GetNameText(mnDiagram_804A076C.sorted_names[max_idx]) ==
+                 ((GetNameText(
+                       (0, mnDiagram_804A076C.sorted_names[max_idx])) ==
                    NULL) &&
                   (GetNameText(mnDiagram_804A076C.sorted_names[j]) != NULL))))
             {
@@ -980,8 +1013,8 @@ loop:
     return found;
 }
 
-static inline u8 mnDiagram_GetVisibleNameCursorFrom(u8* sorted, int start,
-                                                    int rank)
+static inline int mnDiagram_GetVisibleNameCursorFrom(u8* sorted, int start,
+                                                     int rank)
 {
     u8* p;
     u8* p2;
@@ -1006,7 +1039,9 @@ static inline u8 mnDiagram_GetVisibleNameCursorFrom(u8* sorted, int start,
         }
         remaining--;
     }
-    return *p;
+    p = sorted;
+    p += idx;
+    return p[0x1C];
 }
 
 static inline u8 mnDiagram_GetVisibleFighterCursorFrom(u8* sorted, int start,
@@ -1016,25 +1051,31 @@ static inline u8 mnDiagram_GetVisibleFighterCursorFrom(u8* sorted, int start,
     u8* p2;
     int remaining;
     int idx;
+    u8 result;
 
-    p = sorted + start;
     remaining = rank;
     idx = start;
-    while (remaining > 0) {
+    p = sorted + start;
+    while (remaining >= 0) {
+        if (remaining == 0) {
+            result = sorted[idx];
+            break;
+        }
         p2 = p;
     loop:
         idx++;
         p2++;
         p++;
         if (idx >= 0x19) {
-            return 0x19;
+            result = 0x19;
+            break;
         }
         if (mn_IsFighterUnlocked(*p2) == 0) {
             goto loop;
         }
         remaining--;
     }
-    return *p;
+    return result;
 }
 
 /// @brief Persists the current name/fighter cursor positions and mode into
@@ -1982,7 +2023,6 @@ void mnDiagram_80241730(HSD_GObj* arg0, int arg1, int arg2)
 ///          there's nothing to scroll to, shows them when there is.
 void mnDiagram_802417D0(HSD_GObj* gobj)
 {
-    u8* ptr2;
     u8 result2;
     Diagram* data = gobj->user_data;
     mnDiagram_AnimTable* tbl = (mnDiagram_AnimTable*) &mnDiagram_803EE728;
@@ -1992,13 +2032,15 @@ void mnDiagram_802417D0(HSD_GObj* gobj)
     u8* ptr;
     s32 count;
     s32 result;
+    u8* ptr2;
     HSD_JObj* jobj2;
     PAD_STACK(8);
 
     // Right arrow (jobjs[3])
     jobj = data->jobjs[3];
     mn_8022ED6C(jobj, &tbl->arrow_anim);
-    if (data->is_name_mode != 0) {
+    result = data->is_name_mode;
+    if (result != 0) {
         // Name mode - check if 10 more names exist
         count = 10;
         i = data->name_cursor_pos;
@@ -2277,9 +2319,10 @@ void mnDiagram_OnFrame(HSD_GObj* gobj)
 
 void mnDiagram_80241E78(void* arg0, u8 arg1, u8 arg2, int arg3)
 {
+    Diagram* data_alias;
+    f32 row_offset_adj;
     HSD_JObj* jobj;
     HSD_JObj* jobj2;
-    Diagram* user_data;
     Diagram* data;
     void** joint_data;
     s32 digit_count;
@@ -2287,16 +2330,15 @@ void mnDiagram_80241E78(void* arg0, u8 arg1, u8 arg2, int arg3)
     s32 i;
     f32 x_spacing;
     f32 y_spacing;
-    f32 y_offset;
     f32 base;
     f32 row_offset;
-    f32 row_offset_adj;
     f32 col_offset;
     u8 col = arg1;
     u8 row = arg2;
+    f32 y_offset;
 
-    user_data = ((HSD_GObj*) arg0)->user_data;
-    data = user_data;
+    data = ((HSD_GObj*) arg0)->user_data;
+    data_alias = data;
 
     jobj = data->jobjs[11];
     base = HSD_JObjGetTranslationX(jobj);
@@ -2324,7 +2366,8 @@ void mnDiagram_80241E78(void* arg0, u8 arg1, u8 arg2, int arg3)
         digit = mn_GetDigitAt(arg3, i);
         jobj = HSD_JObjLoadJoint(joint_data[0]);
         HSD_JObjAddAnimAll(jobj, joint_data[1], joint_data[2], joint_data[3]);
-        HSD_JObjReqAnimAll(jobj, (f32) digit);
+        base = (f32) digit;
+        HSD_JObjReqAnimAll(jobj, base);
         HSD_JObjAnimAll(jobj);
         if (col < 7) {
             HSD_JObjSetTranslateX(
@@ -2338,79 +2381,57 @@ void mnDiagram_80241E78(void* arg0, u8 arg1, u8 arg2, int arg3)
         } else {
             HSD_JObjSetTranslateY(jobj, row_offset_adj);
         }
-        HSD_JObjAddChild(data->jobjs[11], jobj);
+        HSD_JObjAddChild(data_alias->jobjs[11], jobj);
     }
 }
 
 void mnDiagram_8024227C(void* arg0, s32 arg1, s32 arg2, u8 arg3)
 {
     s32 var_r22_2;
-    void* gobj = arg0;
     s32 arg1_r = arg1;
     s32 arg2_r = arg2;
     u8 is_name = arg3;
     mnDiagram_Assets* assets = (mnDiagram_Assets*) &mnDiagram_804A0750;
     s32 cap = 0xF423F;
     s32 var_r16_6;
-    s32 var_r17_10;
-    s32 var_r17_11;
     s32 var_r17_7;
     s32 var_r17_8;
-    s32 var_r17_9;
-    s32 var_r18_10;
-    s32 var_r18_11;
-    s32 var_r18_12;
     s32 var_r18_3;
-    s32 var_r18_9;
     s32 var_r19_2;
-    s32 var_r19_3;
     s32 var_r22;
     s32 var_r22_3;
     s32 var_r30;
     s32 var_r3;
     s32 var_r17_4;
     s32 var_r19_5;
-    u8 var_r0;
-    u8 var_r0_2;
-    u8 var_r17_6;
-    u8 var_r21;
-    u8 var_r23;
+    unsigned long long var_r0_2;
+    s32 var_r17_6;
+    s32 var_r23;
     u8 var_r24;
-    u8* var_r15_2;
-    u8* var_r15_3;
-    u8* var_r16_5;
-    u8* var_r16_7;
-    PAD_STACK(32);
+    u8* sorted;
 
     var_r30 = 0;
     do {
         if (var_r30 == 0xA) {
             var_r22 = 0;
             do {
+                sorted = (u8*) assets;
                 if (is_name != 0) {
                     var_r3 = GetNameCount();
                     if (var_r3 > var_r22) {
-                        var_r0 = mnDiagram_GetVisibleNameCursorFrom(
-                            assets->sorted_fighters, arg2_r, var_r22);
-                        var_r19_2 = mnDiagram_SumNameFalls(var_r0);
-                        mnDiagram_80241E78(gobj, (u8) var_r22, (u8) var_r30,
+                        var_r19_2 = mnDiagram_SumNameFalls(
+                            mnDiagram_GetVisibleNameCursorFrom(sorted, arg2_r,
+                                                               var_r22));
+                        mnDiagram_80241E78(arg0, (u8) var_r22, (u8) var_r30,
                                            var_r19_2);
                     }
                 } else {
-                    var_r18_3 = 0;
-                    var_r19_3 = 0;
-                    do {
-                        var_r3 = mn_IsFighterUnlocked(var_r19_3);
-                        if (var_r3 != 0) {
-                            var_r18_3 += 1;
-                        }
-                        var_r19_3 += 1;
-                    } while (var_r19_3 < 0x19);
+                    var_r18_3 = mnDiagram_CountUnlockedFightersInline();
                     if (var_r18_3 > var_r22) {
-                        var_r21 = mnDiagram_GetVisibleFighterCursorFrom(
-                            assets->sorted_fighters, arg2_r, var_r22);
-                        var_r19_5 = mnDiagram_SumFighterFalls(var_r21);
-                        mnDiagram_80241E78(gobj, (u8) var_r22, (u8) var_r30,
+                        var_r19_5 = mnDiagram_SumFighterFalls(
+                            mnDiagram_GetVisibleFighterCursorFrom(
+                                sorted, arg2_r, var_r22));
+                        mnDiagram_80241E78(arg0, (u8) var_r22, (u8) var_r30,
                                            var_r19_5);
                     }
                 }
@@ -2421,126 +2442,52 @@ void mnDiagram_8024227C(void* arg0, s32 arg1, s32 arg2, u8 arg3)
             if (var_r3 > var_r30) {
                 var_r22_2 = 0;
                 do {
+                    sorted = (u8*) assets;
                     if ((var_r22_2 == 7) ||
                         (var_r3 = GetNameCount(), (var_r3 > var_r22_2)))
                     {
-                        var_r0_2 = mnDiagram_GetVisibleNameCursorFrom(
-                            assets->sorted_fighters, arg1_r, var_r30);
+                        var_r0_2 = (u8) mnDiagram_GetVisibleNameCursorFrom(
+                            sorted, arg1_r, var_r30);
                         if (var_r22_2 == 7) {
                             var_r17_4 = mnDiagram_GetNameTotalKOs(var_r0_2);
-                            mnDiagram_80241E78(gobj, (u8) var_r22_2,
+                            mnDiagram_80241E78(arg0, (u8) var_r22_2,
                                                (u8) var_r30, var_r17_4);
                         } else {
                             var_r17_6 = mnDiagram_GetVisibleNameCursorFrom(
-                                assets->sorted_fighters, arg2_r, var_r22_2);
+                                sorted, arg2_r, var_r22_2);
                             mnDiagram_80241E78(
-                                gobj, (u8) var_r22_2, (u8) var_r30,
+                                arg0, (u8) var_r22_2, (u8) var_r30,
                                 GetPersistentNameData((u8) var_r0_2)
-                                    ->vs_kos[var_r17_6]);
+                                    ->vs_kos[(u8) var_r17_6]);
                         }
                     }
                     var_r22_2 += 1;
                 } while (var_r22_2 <= 7);
             }
         } else {
-            var_r17_7 = 0;
-            var_r18_9 = 0;
-            do {
-                var_r3 = mn_IsFighterUnlocked(var_r18_9);
-                if (var_r3 != 0) {
-                    var_r17_7 += 1;
-                }
-                var_r18_9 += 1;
-            } while (var_r18_9 < 0x19);
+            var_r17_7 = mnDiagram_CountUnlockedFightersInline();
             if (var_r17_7 > var_r30) {
                 var_r22_3 = 0;
                 do {
+                    sorted = (u8*) assets;
                     if (var_r22_3 != 7) {
-                        var_r17_8 = 0;
-                        var_r18_10 = 0;
-                        do {
-                            var_r3 = mn_IsFighterUnlocked(var_r18_10);
-                            if (var_r3 != 0) {
-                                var_r17_8 += 1;
-                            }
-                            var_r18_10 += 1;
-                        } while (var_r18_10 < 0x19);
+                        var_r17_8 = mnDiagram_CountUnlockedFightersInline();
                         if (var_r17_8 > var_r22_3) {
                             goto block_83;
                         }
                     } else {
                     block_83:
-                        var_r18_11 = var_r30;
-                        var_r17_9 = arg1_r;
-                        var_r16_5 = &assets->sorted_fighters[arg1_r];
-                    loop_91:
-                        if (var_r18_11 >= 0) {
-                            if (var_r18_11 == 0) {
-                                var_r23 = assets->sorted_fighters[var_r17_9];
-                            } else {
-                                var_r15_2 = var_r16_5;
-                            loop_87:
-                                var_r17_9 += 1;
-                                var_r15_2 += 1;
-                                var_r16_5 += 1;
-                                if (var_r17_9 >= 0x19) {
-                                    var_r23 = 0x19;
-                                } else {
-                                    if (mn_IsFighterUnlocked(
-                                            (s32) *var_r15_2) != 0)
-                                    {
-                                        var_r18_11 -= 1;
-                                        goto loop_91;
-                                    }
-                                    goto loop_87;
-                                }
-                            }
-                        }
+                        var_r23 = mnDiagram_GetVisibleFighterCursorFrom(
+                            sorted, arg1_r, var_r30);
                         if (var_r22_3 == 7) {
-                            var_r16_6 = 0;
-                            var_r17_10 = 0;
-                            do {
-                                if (mn_IsFighterUnlocked(var_r17_10) != 0) {
-                                    var_r16_6 +=
-                                        GetPersistentFighterData((u8) var_r23)
-                                            ->fighter_kos[var_r17_10];
-                                }
-                                var_r17_10 += 1;
-                            } while (var_r17_10 < 0x19);
-                            if (var_r16_6 > cap) {
-                                var_r16_6 = cap;
-                            }
-                            mnDiagram_80241E78(gobj, (u8) var_r22_3,
-                                               (u8) var_r30, var_r16_6);
-                        } else {
-                            var_r18_12 = var_r22_3;
-                            var_r17_11 = arg2_r;
-                            var_r16_7 = &assets->sorted_fighters[arg2_r];
-                        loop_108:
-                            if (var_r18_12 >= 0) {
-                                if (var_r18_12 == 0) {
-                                    var_r24 = assets->sorted_fighters[var_r17_11];
-                                } else {
-                                    var_r15_3 = var_r16_7;
-                                loop_104:
-                                    var_r17_11 += 1;
-                                    var_r15_3 += 1;
-                                    var_r16_7 += 1;
-                                    if (var_r17_11 >= 0x19) {
-                                        var_r24 = 0x19;
-                                    } else {
-                                        if (mn_IsFighterUnlocked(
-                                                (s32) *var_r15_3) != 0)
-                                        {
-                                            var_r18_12 -= 1;
-                                            goto loop_108;
-                                        }
-                                        goto loop_104;
-                                    }
-                                }
-                            }
                             mnDiagram_80241E78(
-                                gobj, (u8) var_r22_3, (u8) var_r30,
+                                arg0, (u8) var_r22_3, (u8) var_r30,
+                                mnDiagram_SumFighterKOsClamped(var_r23));
+                        } else {
+                            var_r24 = mnDiagram_GetVisibleFighterCursorFrom(
+                                sorted, arg2_r, var_r22_3);
+                            mnDiagram_80241E78(
+                                arg0, (u8) var_r22_3, (u8) var_r30,
                                 GetPersistentFighterData((u8) var_r23)
                                     ->fighter_kos[var_r24]);
                         }
@@ -2646,39 +2593,50 @@ HSD_JObj* mnDiagram_80242B38(int idx, int arg1)
 void mnDiagram_80242C0C(void* arg0, int arg1, int arg2)
 {
     int count;
+    u8* pr;
     u8* p2;
-    int fighter_id;
+    int remr;
+    HSD_JObj* jobj;
     Diagram* data = GET_DIAGRAM(arg0);
     mnDiagram_Assets* assets = (mnDiagram_Assets*) &mnDiagram_804A0750;
-    void** joint_data = assets->FaceB;
-    HSD_JObj* jobj;
+    void** joint_data;
+    u8 stack_obj[8];
     HSD_JObj* sp_jobj;
-    HSD_JObj** jobjs;
-    int i;
+    u8 stack_obj2[4];
+    HSD_JObj* sp_jobj2;
+    u8 stack_obj3[20];
     int k;
-    s32 idx;
-    s32 remaining;
+    int idx;
+    int remaining;
     u8* p;
+    u8* sorted;
+    int fighter_id;
+    u8* pr2;
     f32 x_spacing;
     f32 y_spacing;
-    PAD_STACK(32);
+    int fighter_idr;
+    int i;
+
+    (void) &stack_obj;
+    (void) &stack_obj2;
+    (void) &stack_obj3;
 
     // Column headers (fighter icons)
+    joint_data = assets->FaceB;
     for (i = 0; i < 7; i++) {
-        count = 0;
-        for (k = 0; k < 0x19; k++) {
+        sorted = mnDiagram_804A0750.sorted_fighters;
+        for (count = k = 0; k < 0x19; k++) {
             if (mn_IsFighterUnlocked(k) != 0) {
                 count++;
             }
         }
         if (count > i) {
-            idx = arg2;
             remaining = i;
-            p = assets->sorted_fighters;
-            p += arg2;
+            idx = arg2;
+            p = sorted + idx;
             while (remaining >= 0) {
                 if (remaining == 0) {
-                    fighter_id = assets->sorted_fighters[idx];
+                    fighter_id = sorted[idx];
                     goto col_found;
                 }
                 p2 = p;
@@ -2702,7 +2660,7 @@ void mnDiagram_80242C0C(void* arg0, int arg1, int arg2)
             HSD_JObjReqAnimAll(jobj, 0.0f);
             HSD_JObjAnimAll(jobj);
             lb_80011E24(jobj, &sp_jobj, 2, -1);
-            HSD_JObjReqAnimAll(sp_jobj, (f32) fighter_id);
+            HSD_JObjReqAnimAll(sp_jobj, (f32) (fighter_id & 0xFF));
             HSD_JObjAnimAll(sp_jobj);
             x_spacing = HSD_JObjGetTranslationX(data->jobjs[8]) -
                         HSD_JObjGetTranslationX(data->jobjs[7]);
@@ -2712,7 +2670,9 @@ void mnDiagram_80242C0C(void* arg0, int arg1, int arg2)
     }
 
     // Row headers (fighter icons)
+    joint_data = assets->FaceB;
     for (i = 0; i < 0xA; i++) {
+        sorted = mnDiagram_804A0750.sorted_fighters;
         count = 0;
         for (k = 0; k < 0x19; k++) {
             if (mn_IsFighterUnlocked(k) != 0) {
@@ -2720,28 +2680,27 @@ void mnDiagram_80242C0C(void* arg0, int arg1, int arg2)
             }
         }
         if (count > i) {
+            remr = i;
             idx = arg1;
-            remaining = i;
-            p = assets->sorted_fighters;
-            p += arg1;
-            while (remaining >= 0) {
-                if (remaining == 0) {
-                    fighter_id = assets->sorted_fighters[idx];
+            pr = sorted + idx;
+            while (remr >= 0) {
+                if (remr == 0) {
+                    fighter_idr = sorted[idx];
                     goto row_found;
                 }
-                p2 = p;
+                pr2 = pr;
             row_inner:
                 idx++;
-                p2++;
-                p++;
+                pr2++;
+                pr++;
                 if (idx >= 0x19) {
-                    fighter_id = 0x19;
+                    fighter_idr = 0x19;
                     goto row_found;
                 }
-                if (mn_IsFighterUnlocked(*p2) == 0) {
+                if (mn_IsFighterUnlocked(*pr2) == 0) {
                     goto row_inner;
                 }
-                remaining--;
+                remr--;
             }
         row_found:
             jobj = HSD_JObjLoadJoint(joint_data[0]);
@@ -2749,14 +2708,13 @@ void mnDiagram_80242C0C(void* arg0, int arg1, int arg2)
                                joint_data[3]);
             HSD_JObjReqAnimAll(jobj, 0.0f);
             HSD_JObjAnimAll(jobj);
-            lb_80011E24(jobj, &sp_jobj, 2, -1);
-            HSD_JObjReqAnimAll(sp_jobj, (f32) fighter_id);
-            HSD_JObjAnimAll(sp_jobj);
+            lb_80011E24(jobj, &sp_jobj2, 2, -1);
+            HSD_JObjReqAnimAll(sp_jobj2, (f32) (fighter_idr & 0xFF));
+            HSD_JObjAnimAll(sp_jobj2);
             y_spacing = HSD_JObjGetTranslationY(data->jobjs[10]) -
                         HSD_JObjGetTranslationY(data->jobjs[9]);
             HSD_JObjSetTranslateY(jobj, y_spacing * i);
-            jobjs = data->jobjs;
-            HSD_JObjAddChild(jobjs[9], jobj);
+            HSD_JObjAddChild(data->jobjs[9], jobj);
         }
     }
 }

--- a/src/melee/mn/mndiagram2.c
+++ b/src/melee/mn/mndiagram2.c
@@ -24,9 +24,13 @@
 #include <melee/mn/mndiagram.h>
 #include <melee/mn/mndiagram3.h>
 #include <melee/mn/mnmain.h>
-#include <melee/mn/mnname.h>
 
 /* GetPersistentNameData and GetPersistentFighterData are in gm/gmmain_lib.h */
+
+/* From mnname.c; this TU sees a narrower GetNameText parameter (codegen
+ * requires the u8 view; same per-TU declaration as mnvibration.c). */
+char* GetNameText(u8 slot);
+int GetNameCount(void);
 
 /* Wrapper macros for index functions */
 #define mnDiagram_GetNameByIndex_s(x) ((int) mnDiagram_GetNameByIndex(x))
@@ -189,18 +193,18 @@ void mnDiagram2_ClearStatRows(HSD_GObj* gobj)
 void mnDiagram2_UpdateHeader(HSD_GObj* gobj, u8 is_name_mode, u8 entity_idx)
 {
     Vec3 sp18;
-    int name;
     Diagram2* data;
     HSD_Text* text;
     void* tmp;
     HSD_JObj* jobj;
+    u8 name;
     PAD_STACK(8);
 
     data = gobj->user_data;
     if (is_name_mode != 0) {
-        name = mnDiagram_GetNameByIndex_s(entity_idx);
+        name = mnDiagram_GetNameByIndex(entity_idx);
     } else {
-        name = mnDiagram_GetFighterByIndex_s(entity_idx);
+        name = mnDiagram_GetFighterByIndex(entity_idx);
     }
 
     if (is_name_mode == 0) {
@@ -237,18 +241,16 @@ void mnDiagram2_UpdateHeader(HSD_GObj* gobj, u8 is_name_mode, u8 entity_idx)
     }
     text->text_color = mnDiagram2_804D4FB8;
     {
-        f32 y = sp18.y;
+        f32 ny = -sp18.y;
         f32 z = sp18.z;
         text->pos_x = sp18.x;
-        text->pos_y = -y;
+        text->pos_y = ny;
         text->pos_z = z;
     }
     text->default_alignment = 1;
 
     if (is_name_mode != 0) {
-        char* str = GetNameText(name);
-        HSD_SisLib_803A6B98(text, mnDiagram2_804DBFCC, mnDiagram2_804DBFCC,
-                            str);
+        HSD_SisLib_803A6B98(text, 0.0f, 0.0f, GetNameText(name));
     } else {
         gm_80160B40(text, gm_8016400C(name), 0);
     }
@@ -297,13 +299,11 @@ void mnDiagram2_HandleInput(HSD_GObj* gobj)
     PAD_STACK(40);
 
     data = mnDiagram2_804D6C18->user_data;
-    result = mn_80229624(4);
-    ((s32*) &mn_804A04F0.buttons)[1] = result;
-    ((s32*) &mn_804A04F0.buttons)[0] = (var_r28 = 0);
+    result = mn_804A04F0.buttons = mn_80229624(4);
 
     if (result & 0x20) {
         lbAudioAx_80024030(0);
-        mn_804A04F0.entering_menu = var_r28;
+        mn_804A04F0.entering_menu = 0;
         data2 = mnDiagram2_804D6C18->user_data;
         x46 = data2->selected_fighter_idx;
         gmMainLib_8015CC34()->x12 = x46;
@@ -340,6 +340,7 @@ void mnDiagram2_HandleInput(HSD_GObj* gobj)
             return;
         }
         lbAudioAx_80024030(1);
+        var_r28 = 0;
         if (data->is_name_mode == 0) {
             var_r28 = 1;
         }
@@ -374,7 +375,6 @@ void mnDiagram2_HandleInput(HSD_GObj* gobj)
         return;
     }
 
-    data = mnDiagram2_804D6C18->user_data;
     if (data->is_name_mode != 0) {
         GetNameCount();
         if (result & 1) {
@@ -609,6 +609,8 @@ int mnDiagram2_GetStatValue(int is_name_mode, u8 stat_type, u8 entity_idx)
     return is_name_mode;
 }
 
+#undef __FILE__
+#define __FILE__ "jobj.h"
 /// @brief Creates a single stat row entry in the VS Records display.
 /// @param gobj The diagram GObj
 /// @param is_name_mode 0 = Fighter mode, 1 = Name mode
@@ -619,8 +621,7 @@ void mnDiagram2_CreateStatRow(HSD_GObj* gobj, u8 is_name_mode, u8 stat_type,
                               u8 row_idx, u8 entity_idx)
 {
     Vec3 sp20;
-    u8 str[4];
-    int pad[4];
+    u8 str[8];
     Diagram2* data;
     HSD_JObj* jobj;
     char* base;
@@ -628,7 +629,7 @@ void mnDiagram2_CreateStatRow(HSD_GObj* gobj, u8 is_name_mode, u8 stat_type,
     HSD_Text* text;
     f32 f31;
     f32 f30;
-    PAD_STACK(16);
+    int mode = is_name_mode;
 
     data = gobj->user_data;
     base = (char*) &mnDiagram2_803EEAD0;
@@ -641,22 +642,20 @@ void mnDiagram2_CreateStatRow(HSD_GObj* gobj, u8 is_name_mode, u8 stat_type,
     HSD_ASSERT(0x3EE, jobj);
     f30 = jobj->translate.y - f31;
 
-    lb_8000B1CC(data->row0_ref, (Vec3*) &mnDiagram2_803EEAD0[0xC], &sp20);
+    lb_8000B1CC(data->row0_ref, (Vec3*) (base + 0xC), &sp20);
 
     {
         u32 r22 = (u8) row_idx;
+        f32 ny = -sp20.y;
         f32 temp_f31 = -f30 * (f32) r22;
-        text = HSD_SisLib_803A5ACC(0, 1, sp20.x, -sp20.y + temp_f31, sp20.z,
+        text = HSD_SisLib_803A5ACC(0, 1, sp20.x, ny + temp_f31, sp20.z,
                                    mnDiagram2_804DBFD0, mnDiagram2_804DBFD4);
 
         {
-            int r29 = row_idx << 2;
-            Diagram2* temp_r22 = (Diagram2*) ((u8*) data + r29);
-            temp_r22->row_labels[0] = text;
+            data->row_labels[row_idx] = text;
 
             table = (u16*) (base + ((stat_type << 1) & 0x1FE));
             {
-                int r23 = (u8) stat_type;
                 HSD_SisLib_803A6368(text, table[0x18]);
 
                 {
@@ -664,33 +663,28 @@ void mnDiagram2_CreateStatRow(HSD_GObj* gobj, u8 is_name_mode, u8 stat_type,
                     if (r21 != 0xFFFF) {
                         HSD_Text* text2;
                         int var_r3;
-                        lb_8000B1CC(data->row0_ref, (Vec3*) &mnDiagram2_803EEAD0[0xC],
+                        lb_8000B1CC(data->row0_ref, (Vec3*) (base + 0xC),
                                     &sp20);
-                        text2 = HSD_SisLib_803A5ACC(
-                            0, 1, mnDiagram2_804DBFD8 + sp20.x,
-                            -sp20.y + temp_f31, sp20.z, mnDiagram2_804DBFDC,
-                            mnDiagram2_804DBFDC);
+                        {
+                            f32 py2 = -sp20.y + temp_f31;
+                            text2 = HSD_SisLib_803A5ACC(
+                                0, 1, mnDiagram2_804DBFD8 + sp20.x, py2,
+                                sp20.z, mnDiagram2_804DBFDC,
+                                mnDiagram2_804DBFDC);
+                        }
 
-                        temp_r22->row_icons[0] = text2;
+                        data->row_icons[row_idx] = text2;
                         text2->default_alignment = 1;
                         text2->text_color = mnDiagram2_804D4FBC;
 
-                        if (r23 >= 0x12) {
-                            var_r3 = 0;
-                        } else if (r23 >= 0xE) {
-                            var_r3 = 1;
-                        } else {
-                            var_r3 = 0;
-                        }
+                        var_r3 = mnDiagram2_IsDistanceStat(stat_type);
 
-                        if (var_r3 != 0) {
-                            u32 stat_val = mnDiagram2_GetStatValue(
-                                is_name_mode, stat_type, entity_idx);
-                            if (mnDiagram_IsDistanceOverflow(stat_val)) {
-                                HSD_SisLib_803A6368(text2, 0x7F);
-                            } else {
-                                HSD_SisLib_803A6368(text2, r21);
-                            }
+                        if (var_r3 != 0 &&
+                            mnDiagram_IsDistanceOverflow(
+                                mnDiagram2_GetStatValue(mode, stat_type,
+                                                        entity_idx)))
+                        {
+                            HSD_SisLib_803A6368(text2, 0x7F);
                         } else {
                             HSD_SisLib_803A6368(text2, r21);
                         }
@@ -698,27 +692,19 @@ void mnDiagram2_CreateStatRow(HSD_GObj* gobj, u8 is_name_mode, u8 stat_type,
                 }
 
                 {
-                    int var_r0;
-                    if (r23 >= 0x18) {
-                        var_r0 = 0;
-                    } else if (r23 >= 0x15) {
-                        var_r0 = 1;
-                    } else {
-                        var_r0 = 0;
-                    }
+                    int var_r0 = mnDiagram2_IsIconOnlyStat(stat_type);
 
-                    if (var_r0 != 0 &&
-                        (u32) mnDiagram2_GetStatValue(is_name_mode, stat_type,
-                                                      entity_idx) < 0x19)
+                    if (var_r0 != 0 && (u32) mnDiagram2_GetStatValue(
+                                           mode, stat_type, entity_idx) < 0x19)
                     {
                         HSD_JObj* jobj = mnDiagram_80242B38(
-                            (u8) mnDiagram2_GetStatValue(
-                                is_name_mode, stat_type, entity_idx),
+                            mnDiagram2_GetStatValue(mode, stat_type,
+                                                    entity_idx),
                             0);
-                        HSD_JObjSetTranslateX(jobj, -2.0f);
+                        HSD_JObjSetTranslateX(jobj, ((f32*) base)[9]);
                         HSD_JObjSetTranslateY(jobj, (f30 * (f32) row_idx) +
-                                                        0.0f);
-                        HSD_JObjSetTranslateZ(jobj, 0.0f);
+                                                        ((f32*) base)[10]);
+                        HSD_JObjSetTranslateZ(jobj, ((f32*) base)[11]);
 
                         HSD_JObjAddChild(data->icon_parent, jobj);
                         return;
@@ -727,73 +713,53 @@ void mnDiagram2_CreateStatRow(HSD_GObj* gobj, u8 is_name_mode, u8 stat_type,
 
                 {
                     HSD_Text* text3 = HSD_SisLib_803A6754(0, 1);
-                    temp_r22->row_values[0] = text3;
+                    data->row_values[row_idx] = text3;
                     text3->font_size.x = mnDiagram2_804DBFE0;
                     text3->font_size.y = mnDiagram2_804DBFE4;
-                    lb_8000B1CC(data->icon_parent, (Vec3*) &mnDiagram2_803EEAD0[0x18],
+                    lb_8000B1CC(data->icon_parent, (Vec3*) (base + 0x18),
                                 &sp20);
-                    text3->pos_x = sp20.x;
-                    text3->pos_y = -sp20.y + temp_f31;
-                    text3->pos_z = sp20.z;
+                    {
+                        f32 py = -sp20.y + temp_f31;
+                        text3->pos_x = sp20.x;
+                        text3->pos_y = py;
+                        text3->pos_z = sp20.z;
+                    }
                     text3->text_color = mnDiagram2_804D4FBC;
                     text3->default_alignment = 2;
 
-                    if (r23 == 0xB) {
-                        int val = mnDiagram2_GetStatValue(
-                            is_name_mode, stat_type, entity_idx);
+                    if (mnDiagram2_IsTimeStat(stat_type)) {
+                        int val = mnDiagram2_GetStatValue(mode, stat_type,
+                                                          entity_idx);
                         if ((u32) val > 0x927BF) {
                             val = 0x927BF;
                         }
                         mnDiagram_FormatTime((char*) str, val);
                     } else {
-                        int var_r0_3;
-                        if (r23 >= 0x12) {
-                            var_r0_3 = 0;
-                        } else if (r23 >= 0xE) {
-                            var_r0_3 = 1;
-                        } else {
-                            var_r0_3 = 0;
-                        }
+                        int var_r0_3 = mnDiagram2_IsDistanceStat(stat_type);
 
                         if (var_r0_3 != 0) {
-                            u32 val = mnDiagram2_GetStatValue(
-                                is_name_mode, stat_type, entity_idx);
+                            u32 val = mnDiagram2_GetStatValue(mode, stat_type,
+                                                              entity_idx);
                             val = mnDiagram_ConvertDistanceForDisplay(val);
                             if (val > 0x98967F) {
                                 val = 0x98967F;
                             }
                             mnDiagram_IntToStr((char*) str, val);
                         } else {
-                            int var_r0_4;
-                            if (r23 >= 0xC) {
-                                if (r23 < 0xE) {
-                                    var_r0_4 = 1;
-                                } else {
-                                    var_r0_4 = 0;
-                                }
-                            } else if (r23 == 3) {
-                                var_r0_4 = 1;
-                            } else {
-                                var_r0_4 = 0;
-                            }
+                            int var_r0_4 =
+                                mnDiagram2_IsPercentageStat(stat_type);
 
                             if (var_r0_4 != 0) {
                                 int val = mnDiagram2_GetStatValue(
-                                    is_name_mode, stat_type, entity_idx);
+                                    mode, stat_type, entity_idx);
                                 if ((u32) val > 0xF423F) {
                                     val = 0xF423F;
                                 }
                                 mnDiagram_FormatDecimalNumber((char*) str, val,
                                                               2);
                             } else {
-                                int var_r0_5;
-                                if (r23 >= 0x18) {
-                                    var_r0_5 = 0;
-                                } else if (r23 >= 0x15) {
-                                    var_r0_5 = 1;
-                                } else {
-                                    var_r0_5 = 0;
-                                }
+                                int var_r0_5 =
+                                    mnDiagram2_IsIconOnlyStat(stat_type);
 
                                 if (var_r0_5 != 0) {
                                     str[0] = mnDiagram2_804D4FD0[0];
@@ -801,7 +767,7 @@ void mnDiagram2_CreateStatRow(HSD_GObj* gobj, u8 is_name_mode, u8 stat_type,
                                     str[2] = mnDiagram2_804D4FD0[2];
                                 } else {
                                     int val = mnDiagram2_GetStatValue(
-                                        is_name_mode, stat_type, entity_idx);
+                                        mode, stat_type, entity_idx);
                                     if ((u32) val > 0x98967F) {
                                         val = 0x98967F;
                                     }
@@ -819,6 +785,8 @@ void mnDiagram2_CreateStatRow(HSD_GObj* gobj, u8 is_name_mode, u8 stat_type,
         }
     }
 }
+#undef __FILE__
+#define __FILE__ "mndiagram2.c"
 
 /// @brief Populates all 10 visible stat rows in the diagram.
 /// @param gobj The diagram GObj
@@ -1033,17 +1001,18 @@ void mnDiagram2_InitUserData(void* arg, int unused)
 /// @param arg0 Unused parameter
 void mnDiagram2_Create(int arg0)
 {
-    HSD_JObj* jobj;
+    Diagram2* user_data;
     mnDiagram_ArchiveData* archive = &mnDiagram_804A0834;
     HSD_GObj* gobj;
-    Diagram2* user_data;
+    Diagram2* new_var;
+    int j;
+    int entity_val;
     u32 is_name;
     u8 entity_idx;
-    u8 scroll;
-    u8 entity_val;
-    int threshold;
-    int j;
+    int scroll;
     int i;
+    int threshold;
+    HSD_JObj* jobj;
     int offset;
     Diagram2* user_data2;
 
@@ -1069,12 +1038,13 @@ void mnDiagram2_Create(int arg0)
     HSD_GObj_SetupProc(gobj, mnDiagram2_Think, 0);
 
     is_name = user_data->is_name_mode;
+    new_var = user_data;
     if (is_name) {
-        entity_idx = user_data->selected_name_idx;
+        entity_idx = new_var->selected_name_idx;
     } else {
-        entity_idx = user_data->selected_fighter_idx;
+        entity_idx = new_var->selected_fighter_idx;
     }
-    scroll = (u8) user_data->scroll_offset;
+    scroll = user_data->scroll_offset & 0xFF;
     if (is_name) {
         entity_val = mnDiagram_GetNameByIndex(entity_idx);
     } else {
@@ -1088,14 +1058,14 @@ void mnDiagram2_Create(int arg0)
 
     j = 0;
     do {
-        if ((s32) scroll >= threshold) {
+        if (scroll >= threshold) {
             offset = scroll - threshold;
         } else {
             offset = scroll;
         }
         mnDiagram2_CreateStatRow(gobj, is_name, offset, j, entity_val);
-        j++;
         scroll++;
+        j++;
     } while (j < 10);
 
     is_name = user_data->is_name_mode;
@@ -1108,7 +1078,7 @@ void mnDiagram2_Create(int arg0)
         HSD_JObjSetFlagsAll(user_data2->name_mode_header, JOBJ_HIDDEN);
     }
 
-    if (is_name) {
+    if ((u8) is_name) {
         entity_idx = user_data2->selected_name_idx;
     } else {
         entity_idx = user_data2->selected_fighter_idx;
@@ -1137,24 +1107,20 @@ void mnDiagram2_Init(void)
 /// @return Fighter ID at the given rank, or 25 if no data
 u8 mnDiagram2_GetRankedFighter(u8 stat_type, u8 rank)
 {
+    int zero;
     mnDiagram2_SortEntry entries[25];
-    f64 temp0;
-    f64 temp8;
-    u64 baseVal;
+    mnDiagram2_SortEntry temp;
     mnDiagram2_SortEntry* base;
     mnDiagram2_SortEntry* ptr;
-    mnDiagram2_SortEntry* curr;
     int i;
     int j;
     int k;
     int maxIdx;
-    int zero;
     int neg1;
     int name;
-    PAD_STACK(8);
 
-    base = entries;
-    ptr = base;
+    ptr = entries;
+    base = ptr;
     i = 0;
     zero = 0;
     neg1 = -1;
@@ -1173,48 +1139,37 @@ u8 mnDiagram2_GetRankedFighter(u8 stat_type, u8 rank)
     }
 
     // Selection sort with insertion shift
-    i = 0;
-    do {
+    for (i = 0; i < 25; i++) {
         k = i + 1;
-        curr = &entries[k];
         maxIdx = i;
-        baseVal = base->value;
         while (k < 25) {
             // Skip entries with -1 value
-            if (curr->value != (u64) neg1) {
-                // Update if curr > entries[maxIdx] OR base == -1
-                if (curr->value > entries[maxIdx].value ||
-                    baseVal == (u64) neg1)
+            if (entries[k].value != (u64) neg1) {
+                // Update if entries[k] > entries[maxIdx] OR entries[i] == -1
+                if (entries[k].value > entries[maxIdx].value ||
+                    entries[i].value == (u64) neg1)
                 {
                     maxIdx = k;
                 }
             }
-            curr++;
             k++;
         }
 
         if (maxIdx != i) {
             ptr = &entries[maxIdx];
-            j = maxIdx - i;
-            temp0 = ptr->d0;
-            temp8 = ptr->d8;
+            temp = *ptr;
 
-            while (j > 0) {
-                ptr->d0 = (ptr - 1)->d0;
-                ptr->d8 = (ptr - 1)->d8;
+            for (j = maxIdx; j > i; j--) {
+                *ptr = *(ptr - 1);
                 ptr--;
-                j--;
             }
-            base->d0 = temp0;
-            base->d8 = temp8;
+            *base = temp;
         }
         base++;
-        i++;
-    } while (i < 25);
+    }
 
     // Return
-    ptr = &entries[rank];
-    if (ptr->value == (u64) -1) {
+    if (entries[rank].value == (u64) -1) {
         return 25;
     }
     return entries[rank].name;
@@ -1230,7 +1185,6 @@ u8 mnDiagram2_GetRankedName(u8 stat_type, u8 rank)
     mnDiagram2_SortEntry temp;
     mnDiagram2_SortEntry* base;
     mnDiagram2_SortEntry* ptr;
-    mnDiagram2_SortEntry* inner;
     int count;
     int i;
     int j;
@@ -1259,24 +1213,20 @@ u8 mnDiagram2_GetRankedName(u8 stat_type, u8 rank)
     while (i < count) {
         j = i + 1;
         maxIdx = i;
-        inner = &entries[j];
         while (j < count) {
-            if (inner->value > entries[maxIdx].value) {
+            if (entries[maxIdx].value < entries[j].value) {
                 maxIdx = j;
             }
-            inner++;
             j++;
         }
 
         if (maxIdx != i) {
             ptr = &entries[maxIdx];
             temp = *ptr;
-            j = maxIdx - i;
 
-            while (j > 0) {
+            for (j = maxIdx; j > i; j--) {
                 *ptr = *(ptr - 1);
                 ptr--;
-                j--;
             }
             *base = temp;
         }
@@ -1295,99 +1245,86 @@ u8 mnDiagram2_GetRankedName(u8 stat_type, u8 rank)
 void mnDiagram2_GetAggregatedFighterRank(u8* out, u8 type, u8 idx)
 {
     mnDiagram2_SortEntry entries[25];
-    f64 temp0;
-    f64 temp8;
+    mnDiagram2_SortEntry temp;
     mnDiagram2_SortEntry* base;
     mnDiagram2_SortEntry* curr;
-    void* funcTable;
     int count;
-    int res;
     mnDiagram2_SortEntry* ptr;
-    mnDiagram2_SortEntry* arr;
     int i;
     int j;
     int k;
     int zero;
+    int n;
+    int m;
+    int res;
 
     base = entries;
     ptr = base;
-    i = 0;
+    n = 0;
     zero = 0;
 
     do {
-        ptr->name = mnDiagram_GetFighterByIndex(i);
-        i++;
+        ptr->name = mnDiagram_GetFighterByIndex(n);
+        n++;
         ptr->xC = zero;
         ptr->x8 = zero;
         ptr++;
-    } while (i < 25);
+    } while (n < 25);
 
     count = GetNameCount();
-    funcTable = (void*) mnDiagram_GetNamePlayTimeByFighter;
-    arr = entries;
 
-    i = 0;
-    while (i < count) {
+    for (i = 0; i < count; i++) {
         switch ((s32) type) {
         case 0x15:
-            res = mnDiagram_GetRankedFighterForName(0, i, funcTable);
+            res = mnDiagram_GetRankedFighterForName(
+                0, i, (void*) mnDiagram_GetNamePlayTimeByFighter);
             break;
         case 0x16:
-            res = mnDiagram_GetRankedFighterForName(1, i, funcTable);
+            res = mnDiagram_GetRankedFighterForName(
+                1, i, (void*) mnDiagram_GetNamePlayTimeByFighter);
             break;
         case 0x17:
             res = mnDiagram_GetLeastPlayedFighter((u8) i);
             break;
-        default:
-            goto next;
         }
 
         if (res != 25) {
             ptr = base;
             k = 0;
-            for (j = 25; j > 0; j--) {
+            for (m = 25; m > 0; m--) {
                 if (res == ptr->name) {
-                    arr[k].value += 1;
+                    ((s32) type, entries)[k].value += 1;
                     break;
                 }
                 ptr++;
                 k++;
             }
         }
-    next:
-        i++;
     }
 
     // Bubble sort
-    j = 0;
-    do {
+    for (j = 0; j < 25; j++) {
         k = j + 1;
         curr = &entries[k];
         while (k < 25) {
-            u64 a = base->value;
-            u64 b = curr->value;
-            if (a < b) {
-                temp0 = base->d0;
-                temp8 = base->d8;
-                base->d0 = curr->d0;
-                base->d8 = curr->d8;
-                curr->d0 = temp0;
-                curr->d8 = temp8;
+            if (base->value < curr->value) {
+                temp = *base;
+                *base = *curr;
+                *curr = temp;
             }
             curr++;
             k++;
         }
         base++;
-        j++;
-    } while (j < 25);
+    }
 
     // Write result to output buffer
-    curr = &entries[idx];
-    if (curr->value == 0) {
-        curr->name = 25;
+    if (entries[idx].value != 0) {
+        *(mnDiagram2_SortEntry*) out = entries[idx];
+    } else {
+        entries[idx].name = 25;
+        *(mnDiagram2_SortEntry*) out = entries[idx];
     }
-    ((mnDiagram2_SortEntry*) out)->d0 = curr->d0;
-    ((mnDiagram2_SortEntry*) out)->d8 = curr->d8;
 }
 
 /// @brief Clears the detail view by freeing text objects and removing JObj.

--- a/src/melee/mn/mndiagram3.c
+++ b/src/melee/mn/mndiagram3.c
@@ -32,13 +32,12 @@ void mnDiagram3_80245BA4(HSD_GObj* gobj)
     u8 sp28[0x10];
     Diagram3* data;
     char* base;
-    u16* table;
     HSD_JObj* row0;
-    HSD_JObj* row1;
     f32 neg_spacing;
     f32 row_spacing;
     f32 divider;
     f32 icon_x_offset;
+    float new_var;
     u8 stat_type;
     int i;
     HSD_Text* title_text;
@@ -48,25 +47,19 @@ void mnDiagram3_80245BA4(HSD_GObj* gobj)
     u32 max_distance;
     u32 max_time;
     u32 max_percentage;
-    PAD_STACK(8);
 
     data = gobj->user_data;
     base = (char*) &mnDiagram3_803EEC10;
 
     {
-        u8 is_name_mode = data->is_name_mode;
         u8 scroll = data->saved_selection;
         u8 offset = data->scroll_offset;
         u8 limit;
 
-        if (is_name_mode != 0) {
-            limit = 0x18;
-        } else {
-            limit = 0x15;
-        }
+        limit = (data->is_name_mode != 0) ? 0x18 : 0x15;
 
         {
-            int val = offset + scroll;
+            int val = scroll + offset;
             if (val >= limit) {
                 val = val - limit;
             } else {
@@ -77,20 +70,20 @@ void mnDiagram3_80245BA4(HSD_GObj* gobj)
         }
     }
 
-    row1 = data->jobjs[7];
     {
         f32 row0_y = HSD_JObjGetTranslationY(row0);
-        f32 row1_y = HSD_JObjGetTranslationY(row1);
+        f32 row1_y = HSD_JObjGetTranslationY(data->jobjs[7]);
 
         {
             u16* stat_table;
             stat_table = (u16*) (base + ((int) stat_type << 1));
             icon_x_offset = mnDiagram3_804DC010;
-            row_spacing = row1_y - row0_y;
+            row_spacing = row1_y;
+            row_spacing = row_spacing - row0_y;
             max_distance = 0x5F5E0FF;
             max_percentage = 0x98967F;
             divider = mnDiagram3_804DC008;
-            max_time = 0x5C8D7F;
+            max_time = 0x5B8D7F;
             neg_spacing = -row_spacing;
             stat_table += 0x36;
 
@@ -98,8 +91,8 @@ void mnDiagram3_80245BA4(HSD_GObj* gobj)
                 if (data->is_name_mode != 0) {
                     if (!mnDiagram2_IsIconOnlyStat(stat_type)) {
                         if (i == 0) {
-                            lb_8000B1CC(data->jobjs[6],
-                                        &mnDiagram3_803EEC28.xC, &sp6C);
+                            lb_8000B1CC(data->jobjs[6], (Vec3*) (base + 0x24),
+                                        &sp6C);
                             title_text = HSD_SisLib_803A6754(0, 1);
                             data->title_text = title_text;
                             title_text->font_size.x = divider;
@@ -108,7 +101,7 @@ void mnDiagram3_80245BA4(HSD_GObj* gobj)
                                 f32 y = sp6C.y;
                                 f32 z = sp6C.z;
                                 title_text->pos_x = sp6C.x;
-                                title_text->pos_y = -y;
+                                title_text->pos_y = (new_var = -y);
                                 title_text->pos_z = z;
                             }
                         }
@@ -133,7 +126,7 @@ void mnDiagram3_80245BA4(HSD_GObj* gobj)
                 }
 
                 if (i == 0) {
-                    lb_8000B1CC(data->jobjs[6], &mnDiagram3_803EEC28.x18, &sp6C);
+                    lb_8000B1CC(data->jobjs[6], (Vec3*) (base + 0x30), &sp6C);
                     value_text = HSD_SisLib_803A6754(0, 1);
                     data->value_text = value_text;
                     value_text->font_size.x = divider;
@@ -142,7 +135,7 @@ void mnDiagram3_80245BA4(HSD_GObj* gobj)
                         f32 y = sp6C.y;
                         f32 z = sp6C.z;
                         value_text->pos_x = sp6C.x;
-                        value_text->pos_y = -y;
+                        value_text->pos_y = (new_var = -y);
                         value_text->pos_z = z;
                     }
                     value_text->default_alignment = 2;
@@ -161,10 +154,13 @@ void mnDiagram3_80245BA4(HSD_GObj* gobj)
                     HSD_JObjSetTranslateY(icon, row_spacing * (f32) i);
                     HSD_JObjAddChild(data->jobjs[6], icon);
 
-                    mnDiagram2_GetAggregatedFighterRank(sp28, stat_type,
-                                                        (u8) i);
                     {
-                        int val = *(int*) (sp28 + 0xC);
+                        u8 ii = (u8) i;
+                        mnDiagram2_GetAggregatedFighterRank(sp28, stat_type,
+                                                            ii);
+                    }
+                    {
+                        int val = M2C_FIELD(sp28, int*, 0xC);
                         mnDiagram_FormatDecimalNumber((char*) sp58, val, 0);
                     }
                     {
@@ -218,11 +214,11 @@ void mnDiagram3_80245BA4(HSD_GObj* gobj)
                 {
                     u16 icon_id = *stat_table;
                     int r17 = icon_id;
-                    if ((u32) icon_id == 0xFFFF) {
+                    if (r17 == 0xFFFF) {
                         goto next;
                     }
 
-                    lb_8000B1CC(data->jobjs[6], &mnDiagram3_803EEC28.x18, &sp6C);
+                    lb_8000B1CC(data->jobjs[6], (Vec3*) (base + 0x30), &sp6C);
                     {
                         HSD_Text* icon_text;
                         f32 negated_y = -sp6C.y;
@@ -235,9 +231,11 @@ void mnDiagram3_80245BA4(HSD_GObj* gobj)
                         icon_text->text_color = mn_804D4B64;
 
                         if (mnDiagram2_IsDistanceStat(stat_type)) {
-                            u32 stat_val = mnDiagram2_GetStatValue(
-                                data->is_name_mode, stat_type, entity);
-                            if (mnDiagram_IsDistanceOverflow(stat_val)) {
+                            if (mnDiagram_IsDistanceOverflow(
+                                    mnDiagram2_GetStatValue(data->is_name_mode,
+                                                            stat_type,
+                                                            entity)))
+                            {
                                 HSD_SisLib_803A6368(icon_text, 0x7F);
                                 goto next;
                             }
@@ -440,16 +438,17 @@ static inline void HSD_JObjSetTranslateZ_Fake(HSD_JObj* jobj, f32 z)
 
 void mnDiagram3_8024714C(void* arg0)
 {
+    void* new_var;
+    int i;
+    u8 sp54[8];
     Vec3 sp48;
+    u8 sp40[8];
     Diagram3* data;
     HSD_GObj* gobj;
     HSD_JObj* row0;
-    HSD_JObj* row1;
     mnDiagram_ArchiveData* archive;
     f32 row_spacing;
     f32 neg_spacing;
-    int i;
-    PAD_STACK(64);
 
     {
         MenuFlow* flow = &mn_804A04F0;
@@ -464,8 +463,8 @@ void mnDiagram3_8024714C(void* arg0)
     data = gobj->user_data;
 
     {
-        HSD_GObj* popup;
         HSD_JObj* popup_jobj;
+        HSD_GObj* popup;
 
         popup = GObj_Create(6, 7, 0x80);
         data->popup_gobj = popup;
@@ -476,11 +475,11 @@ void mnDiagram3_8024714C(void* arg0)
         HSD_JObjReqAnimAll(popup_jobj, mnDiagram3_804DC00C);
         HSD_JObjAnimAll(popup_jobj);
 
-        data = gobj->user_data;
+        new_var = gobj->user_data;
+        data = new_var;
         row0 = data->jobjs[8];
-        row1 = data->jobjs[9];
-        row_spacing =
-            HSD_JObjGetTranslationY(row1) - HSD_JObjGetTranslationY(row0);
+        row_spacing = HSD_JObjGetTranslationY(data->jobjs[9]) -
+                      HSD_JObjGetTranslationY(row0);
 
         row0 = data->jobjs[8];
         HSD_JObjSetTranslateX_Fake(popup_jobj, HSD_JObjGetTranslationX(row0));
@@ -496,54 +495,52 @@ void mnDiagram3_8024714C(void* arg0)
 
     {
         Diagram3* d;
-        u8 scroll;
+        int scroll;
         u8 stat_idx;
-        u16* base;
 
         gobj = mnDiagram3_804D6C20;
         d = gobj->user_data;
         row0 = d->jobjs[8];
         scroll = d->scroll_offset;
 
-        row1 = d->jobjs[9];
-        row_spacing =
-            HSD_JObjGetTranslationY(row1) - HSD_JObjGetTranslationY(row0);
+        row_spacing = HSD_JObjGetTranslationY(d->jobjs[9]) -
+                      HSD_JObjGetTranslationY(row0);
+        neg_spacing = -row_spacing;
 
         lb_8000B1CC(d->jobjs[8], &mnDiagram3_803EEC28.x0, &sp48);
 
-        neg_spacing = -row_spacing;
-        base = mnDiagram3_803EEC4C.indices;
         row_spacing = mnDiagram3_804DBFF8;
-        stat_idx = scroll;
+        stat_idx = (u8) scroll;
         i = 0;
 
         do {
             f32 fi = (f32) i;
             HSD_Text* text = HSD_SisLib_803A5ACC(
                 0, 1, sp48.x - row_spacing, neg_spacing * fi + -sp48.y, sp48.z,
-                mnDiagram3_804DBFFC, mnDiagram3_804DBFFC);
+                row_spacing, mnDiagram3_804DBFFC);
 
             d->row_labels[i] = text;
             {
                 u8 type_idx = (u8) i;
                 int val;
-                u8 limit;
+                int limit;
 
                 if (d->is_name_mode != 0) {
                     limit = 0x18;
                 } else {
                     limit = 0x15;
                 }
+                limit = (u8) limit;
 
                 val = stat_idx + type_idx;
-                if (val >= (u8) limit) {
-                    val = val - (u8) limit;
+                if (val >= limit) {
+                    val = val - limit;
                 } else {
                     val = (u8) val;
                 }
 
                 {
-                    u16* entry = &base[(u8) val];
+                    u16* entry = &mnDiagram3_803EEC4C.indices[(u8) val];
                     HSD_SisLib_803A6368(text, *entry);
                 }
             }
@@ -582,14 +579,16 @@ void fn_802461BC(HSD_GObj* gobj)
         HSD_GObjPLink_80390228(data->popup_gobj);
         data = mnDiagram3_804D6C20->user_data;
         {
-            Diagram3* check_data = data;
-            Diagram3* text_data = data;
+            HSD_Text** check_cur = data->row_labels;
+            HSD_Text** text_cur = data->row_labels;
             i = 0;
             do {
-                if (check_data->row_labels[i] != NULL) {
-                    HSD_SisLib_803A5CC4(text_data->row_labels[i]);
-                    check_data->row_labels[i] = NULL;
+                if (*check_cur != NULL) {
+                    HSD_SisLib_803A5CC4(*text_cur);
+                    *check_cur = NULL;
                 }
+                check_cur++;
+                text_cur++;
             } while (++i < 0xA);
         }
         mn_80229894(0x1C, 0, 3);


### PR DESCRIPTION
## Summary
- Improve remaining `mnDiagram` match gaps, including `mnDiagram_8024227C`, `mnDiagram_80242C0C`, and `mnDiagram_80243434`.
- Add sanitized `mnDiagram2` follow-up matches, preserving symbolic `JOBJ_HIDDEN` and `HSD_ASSERTREPORT` source forms.
- Improve `mndiagram3` detail/setup functions, including `mnDiagram3_80245BA4` and `mnDiagram3_8024714C`.
- Keep the PR scoped to current-source match wins from the investigation branch; stale assert/string-table source shapes were not reintroduced.

## Match report changes vs current upstream
- `mn/mndiagram.c` `.text`: 98.418230 -> 99.271860
- `mnDiagram_8023FC28`: 97.824070 -> 99.351850
- `mnDiagram_802417D0`: 98.030304 -> 98.484850
- `mnDiagram_80241E78`: 99.805450 -> 99.844360
- `mnDiagram_8024227C`: 87.841320 -> 96.107790
- `mnDiagram_80242C0C`: 95.951310 -> 98.108610
- `mnDiagram_80243434`: 96.729960 -> 99.987340
- `mndiagram2.c` `.text`: 92.575300 -> 99.229190
- `mnDiagram2_UpdateHeader`: 94.175255 -> 100.000000
- `mnDiagram2_GetAggregatedFighterRank`: 81.910960 -> 100.000000
- `mnDiagram2_GetRankedName`: 97.873130 -> 100.000000
- `mnDiagram2_CreateStatRow`: 80.106950 -> 97.820854
- `mnDiagram2_GetRankedFighter`: 79.935070 -> 97.467530
- `mnDiagram2_HandleInput`: 97.460526 -> 99.105260
- `mnDiagram2_Create`: 93.746475 -> 99.274650
- `mndiagram3.c` `.text`: 95.141170 -> 97.843285
- `fn_802461BC`: 98.416560 -> 98.472180
- `mnDiagram3_80245BA4`: 90.561540 -> 95.417946
- `mnDiagram3_8024714C`: 86.644140 -> 97.500000

## Test plan
- `python3 tools/check/main.py src/melee/mn`
- `ninja build/GALE01/main.dol`
- `shasum -a 1 -c config/GALE01/build.sha1`
- `ninja build/GALE01/report.json`
- Compared `build/GALE01/report.json` against current upstream baseline: 0 regressions
