### PR TITLE
nix: attempt to speed up builds

### DIFF
--- a/.nix/melee.nix
+++ b/.nix/melee.nix
@@ -1,12 +1,12 @@
 { lib
-, stdenv
+, stdenvNoCC
 , decomp-toolkit
 , devkitppc
 , fetchurl
 , mwcc
 , objdiff
 , ninja
-, python3
+, python3Minimal
 , wibo
 }:
 let
@@ -15,7 +15,7 @@ let
     hash = "sha256-6GMMjcxhTSKzFmS6MyQvEkO7m+T91ATtbDXYt9pI8hk=";
   };
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   name = "doldecomp-melee";
 
   src = lib.cleanSourceWith {
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
     decomp-toolkit
     devkitppc
     ninja
-    python3
+    python3Minimal
     wibo
   ];
 
@@ -62,8 +62,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out
-    cp build/GALE01/main.dol $out/
+    ninja progress > $out
     runHook postInstall
   '';
 }

--- a/.nix/mwcc.nix
+++ b/.nix/mwcc.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation {
 
   installPhase = ''
     runHook preInstall
-    cp -r . $out/
+    mkdir -p $out/GC
+    cp -r GC/{1.1p1,1.2.5,1.2.5n,1.3.2} $out/GC/
     runHook postInstall
   '';
 }

--- a/.nix/objdiff.nix
+++ b/.nix/objdiff.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoBuildFlags = [
-    "--workspace" "--exclude objdiff-wasm"
+    "--workspace" "--exclude objdiff-wasm" "--exclude objdiff-gui"
   ];
 
   cargoTestFlags = cargoBuildFlags;


### PR DESCRIPTION
by reducing build-time closure size

Nix is a little slower than the other CI builds, and I'm guessing it's mostly because of having to download a bunch of individual dev tools instead of pulling a single docker image. That's pretty unavoidable, but I'm going to see how much of a difference reducing the download size makes. Specifically:

* use stdenvNoCC - we don't need a native compiler, we're only compiling using our special gamecube toolchain
* use python3Minimal - we don't need any fancy python bells and whistles, we just need to run configure.py
* declutter compilers - we don't need Wii or ProDG compilers, or any GC tools other than the specific versions we've selected
* disable objdiff-gui - not needed by the CLI-only nix sandbox build, and in a shell, I can use a separate objdiff-gui from my PATH

Altogether that should shave a couple hundred megs off the download.