### PR TITLE
Improve `grpushon` match

### DIFF
--- a/src/melee/gr/grpushon.c
+++ b/src/melee/gr/grpushon.c
@@ -425,7 +425,8 @@ void grPushOn_802190D0(HSD_GObj* gobj)
     i = 0;
 
     while (i < 9 && lobj != NULL) {
-        HSD_ASSERT(698, HSD_LObjGetType(lobj)==LOBJ_POINT);
+        HSD_ASSERTMSG(698, (lobj->flags & LOBJ_TYPE_MASK) == LOBJ_POINT,
+                      "HSD_LObjGetType(lobj)==LOBJ_POINT");
         lobj->flags = LOBJ_POINT | LOBJ_DIFFUSE;
         color = entry->color;
         HSD_LObjSetColor(lobj, color);


### PR DESCRIPTION
## Summary

Improves the match for `grPushOn_802190D0` by matching the light type assert condition source shape while preserving the original assert text.

## Verification

- `ninja build/GALE01/src/melee/gr/grpushon.o`
- `objdiff-cli`: `grPushOn_802190D0` is now 99.19481% with 2 arg mismatches and 1 replace
