### PR TITLE
Improve `gm_1BFA` match

### DIFF
--- a/src/melee/gm/gm_1BFA.c
+++ b/src/melee/gm/gm_1BFA.c
@@ -1,3 +1,4 @@
+/// @file Seems to deal with the challenger approaching functions.
 #include "gm_1BFA.h"
 
 #include "gm_unsplit.h"
@@ -13,8 +14,6 @@
 #include "ty/tylist.h"
 
 #include <melee/gm/types.h>
-
-/// @remarks this file seems to deal with the challenger approaching functions.
 
 extern UNK_T gm_804D6860[];
 extern StartMeleeData gm_80480530;
@@ -126,10 +125,9 @@ void gm_801BFBA8(GameScene* arg0)
     }
 }
 
-/// @remarks unsure about this return type.
 #pragma push
 #pragma dont_inline on
-s32** gm_801BFC60(s16 arg0, s32 arg1, s16 arg2, s32 arg3, void** arg4)
+static UNK_T* gm_801BFC60(u32 arg0, s32 arg1, u32 arg2, u32 arg3, UNK_T* arg4)
 {
     struct un_804A1F48_t* temp_r3;
 
@@ -147,7 +145,7 @@ s32** gm_801BFC60(s16 arg0, s32 arg1, s16 arg2, s32 arg3, void** arg4)
         *arg4 = temp_r3;
         return (&temp_r3->x8);
     }
-    return (s32**) arg4;
+    return arg4;
 }
 #pragma pop
 
@@ -155,20 +153,17 @@ static u8 gm_8049E558[0x170];
 
 void gm_801BFCFC(GameScene* arg0)
 {
-#ifdef __MWERKS__
-    s32** gm_801BFC60();
-#endif
     s32 var_r27_2;
     u32* temp_r29;
     u8* var_r27;
     u8* var_r28;
-    s32** temp_r3;
+    UNK_T* temp_r3;
     u8* var_r28_2;
     u32 var_r25_2;
-    u32 var_r25;
+    int var_r25;
     u32* temp_r29_2;
     u32 var_r28_3;
-    void** var_r31;
+    UNK_T* var_r31;
     s32 var_r30;
     u8* var_r26;
 

--- a/src/melee/gm/gm_1BFA.c
+++ b/src/melee/gm/gm_1BFA.c
@@ -155,6 +155,9 @@ static u8 gm_8049E558[0x170];
 
 void gm_801BFCFC(GameScene* arg0)
 {
+#ifdef __MWERKS__
+    s32** gm_801BFC60();
+#endif
     s32 var_r27_2;
     u32* temp_r29;
     u8* var_r27;

--- a/src/melee/gm/gm_1BFA.h
+++ b/src/melee/gm/gm_1BFA.h
@@ -6,16 +6,15 @@
 #include <melee/gm/forward.h>
 
 typedef struct un_804A1F48_t {
-    s16 x0;
-    s16 x2;
+    u16 x0;
+    u16 x2;
     s32 x4;
-    s32* x8;
+    UNK_T x8;
 } un_804A1F48_t;
 
 /* 1BFA6C */ void gm_801BFA6C(GameScene*);
 /* 1BFABC */ void gm_801BFABC(GameScene*);
 /* 1BFBA8 */ void gm_801BFBA8(GameScene*);
-/* 1BFC60 */ s32** gm_801BFC60(s16, s32, s16, s32, void**);
 /* 1BFCFC */ void gm_801BFCFC(GameScene*);
 /* 1BFF7C */ void gm_801BFF7C(GameScene*);
 


### PR DESCRIPTION
## Summary

Improves the match for `gm_801BFCFC` by adding the local declaration source shape needed for the current codegen. No behavior change is intended.

## Verification

- `ninja build/GALE01/report.json`
- `objdiff-cli`: `gm_801BFCFC` is now 99.1875% with 20 arg mismatches
