### PR TITLE
Match ft_0899

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -543,7 +543,7 @@ config.libs = [
             Object(Matching, "melee/ft/ft_0877.c"),
             Object(Matching, "melee/ft/ft_0881.c"),
             Object(Matching, "melee/ft/ft_0892.c"),
-            Object(NonMatching, "melee/ft/ft_0899.c"),
+            Object(Matching, "melee/ft/ft_0899.c"),
             Object(Matching, "melee/ft/ft_08A1.c"),
             # Common
             Object(Matching, "melee/ft/chara/ftCommon/ftCo_Wait.c"),

--- a/src/melee/ft/fighter.c
+++ b/src/melee/ft/fighter.c
@@ -6,6 +6,7 @@
 #include "ft_081B.h"
 #include "ft_0852.h"
 #include "ft_0877.h"
+#include "ft_0899.h"
 #include "ft_0D31.h"
 #include "ftaction.h"
 #include "ftanim.h"

--- a/src/melee/ft/forward.h
+++ b/src/melee/ft/forward.h
@@ -28,6 +28,7 @@ typedef struct ftCo_DatAttrs_xBC_t ftCo_DatAttrs_xBC_t;
 typedef struct ftCommonData ftCommonData;
 typedef struct ftData ftData;
 typedef struct ftData_UnkCountStruct ftData_UnkCountStruct;
+typedef struct ftData_x58_t ftData_x58_t;
 typedef struct ftData_x8 ftData_x8;
 typedef struct ftData_x8_x8 ftData_x8_x8;
 typedef struct ftDynamics ftDynamics;

--- a/src/melee/ft/ft_0892.h
+++ b/src/melee/ft/ft_0892.h
@@ -15,9 +15,6 @@
 /* 0898B4 */ ft_800898B4_t* ft_800898B4(Fighter_GObj* gobj);
 /* 0898C0 */ bool ft_800898C0(HSD_GObj*);
 /* 089914 */ s32 ft_80089914(HSD_GObj* gobj, int msid);
-/* 08998C */ s32 fn_8008998C(Fighter*, IKState*, Vec3*);
-/* 089B08 */ void ft_80089B08(Fighter_GObj* gobj);
-/* 08A1B8 */ void ft_8008A1B8(Fighter_GObj* gobj, int);
 /* 08A1FC */ bool ft_8008A1FC(Fighter_GObj* gobj);
 /* 08A244 */ bool ft_8008A244(Fighter_GObj* gobj);
 /* 08A2BC */ void ft_8008A2BC(Fighter_GObj* gobj);

--- a/src/melee/ft/ft_0899.c
+++ b/src/melee/ft/ft_0899.c
@@ -192,9 +192,10 @@ void ft_80089B08(Fighter_GObj* gobj)
             mpLineGetV1Pos(line_id, &sp38);
             mpLineGetV0Pos(line_id, &sp2C);
             dy = sp38.y - sp2C.y;
-            dx = sp38.x - sp2C.x;
-            line_len = dy * dy;
-            line_len += dx * dx;
+            dx = sp38.x;
+            dx -= sp2C.x;
+            line_len = dx * dx + dy * dy;
+            (void) line_len;
             if (line_len > 0.0f) {
                 f64 guess = __frsqrte((f64) line_len);
                 guess = 0.5 * guess * (3.0 - guess * guess * line_len);
@@ -204,19 +205,24 @@ void ft_80089B08(Fighter_GObj* gobj)
                 line_len = ((volatile f32*) &sp1C)[-1];
             }
             if (line_len < 5.0f) {
-                s32 next_id, prev_id;
                 adj_angle = 0.0f;
-                next_id = mpLineGetNext(line_id);
-                if (next_id != -1 && (mpLineGetKind(next_id) & 1)) {
-                    mpLineGetNormal(next_id, &sp1C);
-                    adj_angle = fp->facing_dir * atan2f(sp1C.x, sp1C.y);
+                {
+                    s32 next_check = mpLineGetNext(line_id);
+                    s32 next_id = next_check;
+                    if (next_check != -1 && (mpLineGetKind(next_id) & 1)) {
+                        mpLineGetNormal(next_id, &sp1C);
+                        adj_angle = fp->facing_dir * atan2f(sp1C.x, sp1C.y);
+                    }
                 }
-                prev_id = mpLineGetPrev(line_id);
-                if (prev_id != -1 && (mpLineGetKind(prev_id) & 1)) {
-                    mpLineGetNormal(prev_id, &sp1C);
-                    adj_angle =
-                        0.5f * ((fp->facing_dir * atan2f(sp1C.x, sp1C.y)) +
-                                adj_angle);
+                {
+                    s32 prev_check = mpLineGetPrev(line_id);
+                    s32 prev_id = prev_check;
+                    if (prev_check != -1 && (mpLineGetKind(prev_id) & 1)) {
+                        mpLineGetNormal(prev_id, &sp1C);
+                        adj_angle =
+                            0.5f * ((fp->facing_dir * atan2f(sp1C.x, sp1C.y)) +
+                                    adj_angle);
+                    }
                 }
                 {
                     f32 diff = adj_angle - angle;

--- a/src/melee/ft/ft_0899.c
+++ b/src/melee/ft/ft_0899.c
@@ -1,4 +1,5 @@
-#include "ft_0892.h"
+#include "ft_0899.h"
+
 #include "math.h"
 
 #include "db/dbsound.h"
@@ -15,22 +16,9 @@
 #include <MSL/math_ppc.h>
 #include <MSL/trigf.h>
 
-typedef struct ftData_x58_t {
-    /* 0x00 */ u8 x0;
-    /* 0x01 */ u8 x1;
-    /* 0x02 */ u8 pad_02[2];
-    /* 0x04 */ f32 x4;
-    /* 0x08 */ u8 x8;
-    /* 0x09 */ u8 x9;
-    /* 0x0A */ u8 pad_0A[2];
-    /* 0x0C */ f32 xC;
-    /* 0x10 */ u8 x10;
-    /* 0x11 */ u8 x11;
-    /* 0x12 */ u8 pad_12[6];
-    /* 0x18 */ f32 x18;
-} ftData_x58_t;
+/* 08998C */ static bool fn_8008998C(Fighter* fp, IKState* ik, Vec3* normal);
 
-s32 fn_8008998C(Fighter* fp, IKState* ik, Vec3* normal)
+static bool fn_8008998C(Fighter* fp, IKState* ik, Vec3* normal)
 {
     u8 _[12];
     Vec3 jobj_pos;
@@ -246,11 +234,11 @@ void ft_80089B08(Fighter_GObj* gobj)
     PAD_STACK(16);
 }
 
-void ft_8008A1B8(Fighter_GObj* gobj, int flags)
+void ft_8008A1B8(Fighter_GObj* gobj, u32 flags)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     fp->x221C_u16_y = flags;
-    if (!(flags & 0x4)) {
+    if (!(flags & (1 << 2))) {
         ftPartSetRotX(fp, 0, 0.0F);
     }
 }

--- a/src/melee/ft/ft_0899.h
+++ b/src/melee/ft/ft_0899.h
@@ -1,0 +1,9 @@
+#ifndef GALE01_08A1B8
+#define GALE01_08A1B8
+
+#include "ft/forward.h"
+
+/* 089B08 */ void ft_80089B08(Fighter_GObj* gobj);
+/* 08A1B8 */ void ft_8008A1B8(Fighter_GObj* gobj, u32 flags);
+
+#endif

--- a/src/melee/ft/ftaction.c
+++ b/src/melee/ft/ftaction.c
@@ -10,7 +10,7 @@
 #include "ft/ft_081B.h"
 #include "ft/ft_0877.h"
 #include "ft/ft_0881.h"
-#include "ft/ft_0892.h"
+#include "ft/ft_0899.h"
 #include "ft/ft_0C88.h"
 #include "ft/ft_0DF0.h"
 #include "ft/ftanim.h"

--- a/src/melee/ft/types.h
+++ b/src/melee/ft/types.h
@@ -661,7 +661,7 @@ struct ftData {
     /* +4C */ FtSFX* x4C_sfx;
     /* +50 */ Vec2* x50;
     /* +54 */ int x54;
-    /* +58 */ void* x58;
+    /* +58 */ struct ftData_x58_t* x58;
     /* +5C */ HSD_Joint* x5C;
 };
 
@@ -1921,5 +1921,20 @@ typedef struct DmgLogEntry {
     /* +24 */ size_t size_of_xC;
 } DmgLogEntry;
 STATIC_ASSERT(sizeof(struct DmgLogEntry) == 0x28);
+
+struct ftData_x58_t {
+    /* 0x00 */ u8 x0;
+    /* 0x01 */ u8 x1;
+    /* 0x02 */ u8 pad_02[2];
+    /* 0x04 */ f32 x4;
+    /* 0x08 */ u8 x8;
+    /* 0x09 */ u8 x9;
+    /* 0x0A */ u8 pad_0A[2];
+    /* 0x0C */ f32 xC;
+    /* 0x10 */ u8 x10;
+    /* 0x11 */ u8 x11;
+    /* 0x12 */ u8 pad_12[6];
+    /* 0x18 */ f32 x18;
+};
 
 #endif


### PR DESCRIPTION
## Summary

Matches `ft_80089B08` in `ft_0899.c`.

This adjusts local variable lifetimes and the `line_len` expression shape so MWCC selects the target GPR and FPR allocation. No behavior change is intended.

## Matching

`main/melee/ft/ft_0899`

- `.text`: 100.0%, 2160/2160 code bytes
- `ft_80089B08`: 100.0%, 1712/1712 code bytes
- Translation unit: 100.0%, 3/3 functions matched

## Notes

The final mismatch was an FPR allocation issue around the fused multiply-add used for `dx * dx + dy * dy`, not instruction scheduling. Writing the expression as a single add and keeping the local visibly consumed gives the target `fmuls`/`fmadds` register choice without adding an extra move.

## Verification

- `git diff --check -- src/melee/ft/ft_0899.c`
- `ninja build/GALE01/src/melee/ft/ft_0899.o build/GALE01/report.json`
- `build/tools/objdiff-cli diff -p . -u main/melee/ft/ft_0899 --format json-pretty -o build/ft_0899-pr-check.diff.json ft_80089B08`
- `ninja`
