### PR TITLE
Improve item, ftCommon, and gmmain_lib matches

### DIFF
--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -972,7 +972,7 @@ s32 ftCo_800A229C(Fighter* fp, Vec3* arg1)
     f32 mag;
     s32 var_r0;
 
-    PAD_STACK(8);
+    PAD_STACK(4);
 
     if (grGreatBay_801F66A4() != 0 && fp->cur_pos.x > -5.0) {
         *arg1 = fp->cur_pos;
@@ -1003,7 +1003,7 @@ s32 ftCo_800A229C(Fighter* fp, Vec3* arg1)
     grLib_801C9E60(&sp2C);
     if (stage == RCRUISE) {
         w = Stage_GetBlastZoneRightOffset() - Stage_GetBlastZoneLeftOffset();
-        if (sp2C.x < 0.0f) {
+        if (sp2C.x < 0.0) {
             if (fp->cur_pos.x < 0.4f * w + Stage_GetBlastZoneLeftOffset()) {
                 *arg1 = fp->cur_pos;
                 return 2;
@@ -1016,7 +1016,7 @@ s32 ftCo_800A229C(Fighter* fp, Vec3* arg1)
         }
     block_18:
         h = Stage_GetBlastZoneTopOffset() - Stage_GetBlastZoneBottomOffset();
-        if (sp2C.y > 0.0f) {
+        if (sp2C.y > 0.0) {
             if (fp->cur_pos.y > -(0.4f * h - Stage_GetBlastZoneTopOffset())) {
                 *arg1 = fp->cur_pos;
                 return 2;
@@ -1054,13 +1054,9 @@ s32 ftCo_800A229C(Fighter* fp, Vec3* arg1)
     if (stage == ICEMTN) {
         h = Stage_GetBlastZoneTopOffset() - Stage_GetBlastZoneBottomOffset();
         grLib_801C9E60(&sp20);
-        if (sp20.y < 0.0f) {
-            mag = -sp20.y;
-        } else {
-            mag = sp20.y;
-        }
+        mag = ABS(sp20.y);
         frac = 0.4 * mag + 0.4;
-        if (sp20.y < 0.0f) {
+        if (sp20.y < 0.0) {
             if (fp->cur_pos.y < h * frac + Stage_GetBlastZoneBottomOffset()) {
                 *arg1 = fp->cur_pos;
                 return 2;
@@ -1326,7 +1322,6 @@ s32 ftCo_800A2C80(Fighter* fp)
 {
     s32 result;
     s32 blocked;
-    struct Fighter_x1A88_t* data;
     Vec3 floor_pos;
     Vec3 floor_normal;
     Vec3 dir;
@@ -1344,8 +1339,7 @@ s32 ftCo_800A2C80(Fighter* fp)
     s32 is_small;
     s32 oob;
 
-    data = &fp->x1A88;
-    if (data->xFA_b6) {
+    if (fp->x1A88.xFA_b6) {
         return 0;
     }
     if (fp->ground_or_air == GA_Ground) {
@@ -1383,7 +1377,7 @@ s32 ftCo_800A2C80(Fighter* fp)
     if (lb_8000D008(vy, v) > -1.0471975430846214) {
         return 0;
     }
-    if (data->xFA_b5) {
+    if (fp->x1A88.xFA_b5) {
         return 0;
     }
     if (stage_info.internal_stage_id == INISHIE1) {
@@ -7101,6 +7095,7 @@ void ftCo_800AF78C(Fighter* fp)
     bool is_food;
     Fighter** target_slot;
     struct Fighter_x1A88_t* data;
+    struct Fighter_x1A88_t* item_data;
 
     PAD_STACK(8);
 
@@ -7158,8 +7153,8 @@ void ftCo_800AF78C(Fighter* fp)
     data->xF9_b1 = false;
 
     target = ftCo_800A4BEC(fp);
-    target_slot = &fp->x1A88.x44;
-    *target_slot = target;
+    *(target_slot = &fp->x1A88.x44) = target;
+    item_data = &fp->x1A88;
 
     item_gobj = fp->item_gobj;
     if (item_gobj != NULL) {
@@ -7174,16 +7169,16 @@ void ftCo_800AF78C(Fighter* fp)
             is_food = false;
         }
         if (is_food == false) {
-            data->x4C = NULL;
+            item_data->x4C = NULL;
         } else {
             goto maybe_find_item;
         }
     } else {
     maybe_find_item:
         if (fp->x2168 != 0) {
-            data->x4C = NULL;
+            item_data->x4C = NULL;
         } else {
-            data->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
+            item_data->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
         }
     }
     fp->x1A88.x50 = ftCo_800A648C(fp);
@@ -7961,9 +7956,8 @@ void ftCo_800B1478(Fighter* fp)
 
     data = &fp->x1A88;
     target = ftCo_800A5CE0(fp);
-    target_slot = &fp->x1A88.x44;
 
-    fp->x1A88.x44 = target;
+    *(target_slot = &fp->x1A88.x44) = target;
 
     if (target != NULL) {
         data->xF8_b0 = true;

--- a/src/melee/gm/gmmain_lib.c
+++ b/src/melee/gm/gmmain_lib.c
@@ -910,16 +910,16 @@ void gmMainLib_8015EA80(void)
         }
     }
     {
-        VsModeData* base = &gmMainLib_804D3EE0->unk_590;
+        char* base = (char*) gmMainLib_804D3EE0 + 0x588;
         s32 j;
         for (i = 0; i < 6; i++) {
             for (j = 0; j < 6; j++) {
-                base[i].data.players[j].handicap = 9;
+                base[0x78 + i * 0x140 + j * 0x24] = 9;
             }
         }
         for (i = 7; i < 13; i++) {
             for (j = 0; j < 6; j++) {
-                base[i].data.players[j].handicap = 9;
+                base[0x78 + i * 0x140 + j * 0x24] = 9;
             }
         }
     }
@@ -1131,13 +1131,18 @@ void gmMainLib_8015F150(void)
 {
     s32 i;
 
+    PAD_STACK(8);
+
     for (i = 0; i < 0x19; i++) {
         int j = 0;
-        struct FighterData* data = GetPersistentFighterData((u8) i);
+        struct FighterData* base = gmMainLib_804D3EE0->thing.x1F2C;
         for (; j < 0x19; j++) {
-            data->fighter_kos[j] = 0;
+            base[(u8) i].fighter_kos[j] = 0;
         }
-        gmMainLib_8015EF30((struct gmMainLib_8015EF30_s*) &data->sd_count);
+        gmMainLib_8015EF30(
+            (struct gmMainLib_8015EF30_s*) &gmMainLib_804D3EE0->thing
+                .x1F2C[(u8) i]
+                .sd_count);
     }
 }
 
@@ -1246,13 +1251,11 @@ static s8 gmMainLib_804D3EE4[] = { 0 };
 
 void gmMainLib_8015F600(int arg0, int arg1)
 {
-    s32 j;
-    s32 bank_offset;
     s32 lang;
-    PAD_STACK(104);
+    PAD_STACK(96);
 
     if (arg0 == 1) {
-        j = 0;
+        s32 j = 0;
         do {
             s32 i;
             struct FighterData* fdata = gmMainLib_804D3EE0->thing.x1F2C;
@@ -1298,9 +1301,9 @@ void gmMainLib_8015F600(int arg0, int arg1)
             gm_80164504(0x14U);
         }
     } else {
-        bank_offset = (arg0 - 2) * 19;
+        s32 bank_offset = (arg0 - 2) * 19;
+        s32 j = 0;
 
-        j = 0;
         do {
             struct NameTagData* data;
             struct NameTagDataBank* bank;
@@ -1320,6 +1323,8 @@ void gmMainLib_8015F600(int arg0, int arg1)
             }
             data->x1A2 = 5;
 
+            bank = gmMainLib_804D3EE0->thing.x2FF8;
+            data = &bank[(u8) idx / 19].inner[(u8) idx % 19];
             {
                 char* src = mnName_8023749C((s32) (u8) idx);
                 if (src != NULL) {

--- a/src/melee/it/items/itpikachuthunder.c
+++ b/src/melee/it/items/itpikachuthunder.c
@@ -64,15 +64,15 @@ Item_GObj* it_802B1DF8(Item_GObj* owner, Vec3* pos, Vec3* vel, s32 count,
     spawn.prev_pos.z = 0.0f;
     spawn.pos = spawn.prev_pos;
     spawn.vel.x = spawn.vel.y = spawn.vel.z = 0.0f;
-    cur_delay = 0;
     spawn.facing_dir = -1.0f;
-    spawn.x3C_damage = 0;
+    spawn.x3C_damage = (cur_delay = 0);
+    cur_delay = 0;
     spawn.x0_parent_gobj = owner;
     spawn.x4_parent_gobj2 = spawn.x0_parent_gobj;
     spawn.x44_flag.b0 = true;
     spawn.x40 = x40;
 
-    for (i = 0; i < count; i++) {
+    for (first = NULL, i = 0; i < count; i++) {
         item_gobj = Item_80268B18(&spawn);
         if (i == 0) {
             first = item_gobj;


### PR DESCRIPTION
## Summary

Improves several existing unmatched functions across item, ftCommon, and gmmain_lib code. `it_802B1DF8` and `ftCo_800B1478` are now full matches.

No behavior change is intended; the changes are source-shape adjustments for MWCC register allocation and scheduling.

## Matching

- `main/melee/it/items/itpikachuthunder`
  - `it_802B1DF8`: 99.35345% -> 100.0%

- `main/melee/ft/chara/ftCommon/ftCo_0A01`
  - `ftCo_800A229C`: 99.04181% -> 99.756096%
  - `ftCo_800A2C80`: 96.75083% -> 97.079735%
  - `ftCo_800AF78C`: 99.15947% -> 99.53488%
  - `ftCo_800B1478`: 99.06542% -> 100.0%

- `main/melee/gm/gmmain_lib`
  - `gmMainLib_8015EA80`: 89.37857% -> 89.84286%
  - `gmMainLib_8015F150`: 78.60294% -> 91.75%
  - `gmMainLib_8015F600`: 90.97026% -> 93.35688%

## Notes

`it_802B1DF8` needs an unusual assignment shape to make MWCC reuse the target zero register for both the `s16` spawn damage store and the loop-carried delay value.

## Verification

- `git diff --check -- src/melee/it/items/itpikachuthunder.c src/melee/ft/chara/ftCommon/ftCo_0A01.c src/melee/gm/gmmain_lib.c`
- `ninja build/GALE01/src/melee/it/items/itpikachuthunder.o build/GALE01/src/melee/ft/chara/ftCommon/ftCo_0A01.o build/GALE01/src/melee/gm/gmmain_lib.o`
- `objdiff-cli` checks for the listed functions
