### PR TITLE
Match SimplifyByMerge

### DIFF
--- a/src/sysdolphin/baselib/texpdag.c
+++ b/src/sysdolphin/baselib/texpdag.c
@@ -970,6 +970,7 @@ int SimplifyByMerge(HSD_TExp* arg0)
                       arg0->tev.c_in[3].exp->tev.a_clamp != 0)))
                 {
                     type = arg0->tev.c_in[0].type;
+                    (void) type;
                     switch ((s32) type) {
                     case HSD_TE_TEX:
                     case HSD_TE_RAS:


### PR DESCRIPTION
## Summary

- Match `SimplifyByMerge` in `src/sysdolphin/baselib/texpdag.c` by adding a fake use for `type` before the switch.
- This moves the function from `99.99388%` to `100.00000%` in local objdiff.

## WIP note

This is intentionally a draft PR. I am still working on other local files, so please do not merge this yet.

## Verification

- `ninja build/GALE01/src/sysdolphin/baselib/texpdag.o`
- `build/tools/objdiff-cli diff -p . -u main/sysdolphin/baselib/texpdag SimplifyByMerge --format json -o -`
  - `SimplifyByMerge`: `100.0`
- Commit hook checks: `clang-format`, `style-check`

## Local scan notes

Other dirty local files were checked but not included here because they were not verified improvements in their current state:

- `src/melee/ft/chara/ftYoshi/ftYs_SpecialS.c`: current local change did not improve the remaining non-100 functions.
- `src/melee/gr/grgreens.c`: current local change compiled, but direct objdiff for `grGreens_80214FA8` regressed.
- `src/melee/ft/chara/ftCommon/ftCo_0A01.c`: no verified local diff remained after compile investigation.
