### PR TITLE
Match gm_8016247C, gm_801604DC and gm_80160564 in gm_1601

### DIFF
--- a/src/melee/gm/gm_1601.c
+++ b/src/melee/gm/gm_1601.c
@@ -1330,10 +1330,10 @@ s32 gm_8016247C(s32 arg0)
 
     temp_r5 = &gmMainLib_8015EDBC()->x14;
 
-    var_r4 = MAX(-1U, *temp_r30 + arg0);
+    var_r4 = (*temp_r30 + arg0 > -1U) ? -1U : *temp_r30 + arg0;
     *temp_r30 = var_r4;
 
-    var_r3 = MAX(-1U, *temp_r5 + arg0);
+    var_r3 = (*temp_r5 + arg0 > -1U) ? -1U : *temp_r5 + arg0;
     *temp_r5 = var_r3;
 
     arg0 = temp_r29 + arg0;

--- a/src/melee/gm/gm_1601.c
+++ b/src/melee/gm/gm_1601.c
@@ -511,7 +511,7 @@ bool gm_80160474(CharacterKind ckind, GameModeKind scene)
 
 char* gm_801604DC(CharacterKind ckind, GameModeKind scene)
 {
-    s32 var_r3;
+    s16 var_r3;
 
     switch (scene) {
     case GM_CLASSIC_GOVER:
@@ -531,7 +531,7 @@ char* gm_801604DC(CharacterKind ckind, GameModeKind scene)
 
 char* gm_80160564(CharacterKind ckind, GameModeKind scene)
 {
-    s32 var_r3;
+    s16 var_r3;
 
     switch (scene) {
     case GM_CLASSIC_GOVER:


### PR DESCRIPTION
Three code matches in `gm_1601.c`, no data sections touched and no new symbol names introduced.

- **gm_8016247C** — the saturating-add clamp was written as `MAX(-1U, *p + arg0)`, which doesn't match and is also wrong (it always evaluates to `0xFFFFFFFF`). Rewriting it as `(*p + arg0 > -1U) ? -1U : *p + arg0` produces the original `cmplw` operand order while keeping the same register allocation.
- **gm_801604DC** and **gm_80160564** — both read `s16` arrays and pass the result to `Toy_8030813C`, whose first parameter is `s16`. The local was `s32`, forcing a redundant `extsh` to narrow the value at the call. Declaring it `s16` (matching the array element and the parameter) drops the `extsh`.

All three confirmed 100% with objdiff; the linked DOL still matches retail. clang-format clean.