### PR TITLE
Match `Toy_8030813C` and `Toy_OnEnter_80311AB0`

### DIFF
--- a/src/melee/ty/toy.c
+++ b/src/melee/ty/toy.c
@@ -2133,7 +2133,7 @@ void _Toy_80307F64(s32 arg0, s32 arg1)
     }
 }
 
-char* Toy_8030813C(s16 arg0, enum_t unused)
+char* Toy_8030813C(int arg0, enum_t unused)
 {
     char* ptr;
     s32 i;
@@ -5960,19 +5960,19 @@ void Toy_OnEnter_80311AB0(void* arg0)
 
     _Toy_sbss_804D6E68 = HSD_MemAlloc(sizeof(*_Toy_sbss_804D6E68));
     Toy_sbss_804D6ED8 = HSD_MemAlloc(sizeof(*Toy_sbss_804D6ED8));
-    Toy_sbss_804D6ED4 = HSD_MemAlloc(sizeof(*Toy_sbss_804D6ED4));
-    Toy_sbss_804D6EDC = HSD_MemAlloc(sizeof(*Toy_sbss_804D6EDC));
-    _Toy_sbss_804D6E64 = HSD_MemAlloc(sizeof(*_Toy_sbss_804D6E64));
+    Toy_sbss_804D6ED4 = HSD_MemAlloc(0xE4);
+    Toy_sbss_804D6EDC = HSD_MemAlloc(0x24A);
+    _Toy_sbss_804D6E64 = HSD_MemAlloc(0x6DE);
     Toy_sbss_804D6EE0 = HSD_MemAlloc(sizeof(*Toy_sbss_804D6EE0));
-    _Toy_sbss_804D6E6C = HSD_MemAlloc(sizeof(*_Toy_sbss_804D6E6C));
+    _Toy_sbss_804D6E6C = HSD_MemAlloc(0x8);
 
     memzero(_Toy_sbss_804D6E68, sizeof(*_Toy_sbss_804D6E68));
     memzero(Toy_sbss_804D6ED8, sizeof(*Toy_sbss_804D6ED8));
-    memzero(Toy_sbss_804D6ED4, sizeof(*Toy_sbss_804D6ED4));
-    memzero(Toy_sbss_804D6EDC, sizeof(*Toy_sbss_804D6EDC));
-    memzero(_Toy_sbss_804D6E64, sizeof(*_Toy_sbss_804D6E64));
+    memzero(Toy_sbss_804D6ED4, 0xE4);
+    memzero(Toy_sbss_804D6EDC, 0x24A);
+    memzero(_Toy_sbss_804D6E64, 0x6DE);
     memzero(Toy_sbss_804D6EE0, sizeof(*Toy_sbss_804D6EE0));
-    memzero(_Toy_sbss_804D6E6C, sizeof(*_Toy_sbss_804D6E6C));
+    memzero(_Toy_sbss_804D6E6C, 0x8);
 
     Toy_8031263C();
 

--- a/src/melee/ty/toy.h
+++ b/src/melee/ty/toy.h
@@ -46,7 +46,7 @@
 /* 306EEC */ HSD_LObj* Toy_LoadLObjList(LightList**, s32*);
 /* 307470 */ void Toy_80307470(s32);
 /* 307E84 */ void Toy_80307E84(HSD_GObj* gobj);
-/* 30813C */ char* Toy_8030813C(s16 arg0, enum_t unused);
+/* 30813C */ char* Toy_8030813C(int arg0, enum_t unused);
 /* 308250 */ void Toy_80308250(u8* arg0, s32 arg1, s32 arg2);
 /* 3082F8 */ s32 Toy_803082F8(s16 idx);
 /* 308328 */ void Toy_80308328(s32 arg0);


### PR DESCRIPTION
Two function matches in `ty/toy`, plus a cascade into `gm_1601`.

> **`Toy_8030813C`** — change `arg0` from `s16` to `int`. The EABI passes
> `s16` parameters sign-extended, so `s32 id = arg0` compiles to a plain
> move rather than a redundant `extsh`. The local prototype inside
> `Toy_80308250` is kept `s16` so that caller still truncates its `s32`
> argument. This also removes the redundant `extsh` in the two `gm_1601`
> callers `gm_801604DC` and `gm_80160564`, which pass an `lha`-loaded
> (already sign-extended) value.
>
> **`Toy_OnEnter_80311AB0`** — the buffer allocations used `sizeof(*ptr)`,
> which is the wrong size for the array pointers (`s16*`, etc.). Replaced
> with the buffer sizes documented in the commented-out `STATIC_ASSERT`s
> in `toy.static.h`.

`main.dol` sha1 is unchanged and `diff_changes` reports no functions broken.

> Prepared with AI assistance (function matching only — no globals or struct
> fields named, no data sections).
