### PR TITLE
Switch progress report to data-value diffing

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1817,7 +1817,7 @@ config.progress_each_module = args.verbose
 config.progress_report_args = [
     # Marks relocations as mismatching if the target value is different
     # Default is "functionRelocDiffs=none", which is most lenient
-    # "--config functionRelocDiffs=data_value",
+    "--config functionRelocDiffs=data_value",
 ]
 
 if args.mode == "configure":


### PR DESCRIPTION
This is a stricter diffing type which additionally looks at the data the relocs are pointing to, rather than just the names of the relocs. Now that we're far along in progress, this should be the default as we focus more on matching the data. I usually set this locally, and have been encouraging others to do so as well, but setting it here will also benefit our CI and AI assistants.

As suggested in https://github.com/doldecomp/melee/pull/2782#discussion_r3509722175