### PR TITLE
Disable auto-inlining for if/textdraw.c and if/textlib.c

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1395,8 +1395,16 @@ config.libs = [
             Object(NonMatching, "melee/if/ifprize.c"),
             Object(NonMatching, "melee/if/ifcoget.c"),
             Object(NonMatching, "melee/if/soundtest.c"),
-            Object(NonMatching, "melee/if/textdraw.c"),
-            Object(NonMatching, "melee/if/textlib.c"),
+            Object(
+                NonMatching,
+                "melee/if/textdraw.c",
+                extra_cflags=["-inline noauto"],
+            ),
+            Object(
+                NonMatching,
+                "melee/if/textlib.c",
+                extra_cflags=["-inline noauto"],
+            ),
         ],
     ),
     MeleeLib(

--- a/src/melee/if/textdraw.c
+++ b/src/melee/if/textdraw.c
@@ -123,8 +123,6 @@ HSD_GObj* DevText_GetGObj(void)
     return devtext_gobj;
 }
 
-#pragma push
-#pragma dont_inline on
 void DevText_InitPool(void)
 {
     DevText* text = devtext_pool.entries;
@@ -138,7 +136,6 @@ void DevText_InitPool(void)
     devtext_poolhead = devtext_pool.entries;
     devtext_drawlist = NULL;
 }
-#pragma pop
 
 void DevText_Remove(DevText** ptext)
 {
@@ -275,8 +272,6 @@ void DevText_DrawAll(HSD_GObj* gobj, int pass)
     }
 }
 
-#pragma push
-#pragma dont_inline on
 void DevText_CreateCObj(int classifier, int p_link, int gobj_priority,
                         int gx_link, u8 gx_priority)
 {
@@ -292,7 +287,6 @@ void DevText_CreateCObj(int classifier, int p_link, int gobj_priority,
         }
     }
 }
-#pragma pop
 
 HSD_GObj* DevText_Setup(int classifier, int p_link, int priority, int gx_link,
                         int render_priority, u8 camera_priority)

--- a/src/melee/if/textlib.c
+++ b/src/melee/if/textlib.c
@@ -146,8 +146,6 @@ inline int DevText_Clamp(int val, int max)
     }
 }
 
-#pragma push
-#pragma dont_inline on
 void DevText_SetCursorXY(DevText* text, int x, int y)
 {
     if (text->w <= x) {
@@ -163,7 +161,6 @@ void DevText_SetCursorXY(DevText* text, int x, int y)
     }
     text->cursor_y = y;
 }
-#pragma pop
 
 void DevText_SetCursorX(DevText* text, int x)
 {
@@ -180,37 +177,25 @@ void DevText_80302AC0(DevText* text)
     text->flags |= (1 << 5);
 }
 
-#pragma push
-#pragma dont_inline on
 void DevText_ShowBackground(DevText* text)
 {
     text->flags &= ~(1 << 6);
 }
-#pragma pop
 
-#pragma push
-#pragma dont_inline on
 void DevText_HideBackground(DevText* text)
 {
     text->flags |= (1 << 6);
 }
-#pragma pop
 
-#pragma push
-#pragma dont_inline on
 void DevText_ShowText(DevText* text)
 {
     text->flags &= ~(1 << 7);
 }
-#pragma pop
 
-#pragma push
-#pragma dont_inline on
 void DevText_HideText(DevText* text)
 {
     text->flags |= (1 << 7);
 }
-#pragma pop
 
 void DevText_SetScale(DevText* text, f32 x, f32 y)
 {
@@ -230,18 +215,13 @@ void DevText_SetXY(DevText* text, int x, int y)
     text->y = y;
 }
 
-#pragma push
-#pragma dont_inline on
 u8 DevText_StoreColorIndex(DevText* text, u8 index)
 {
     u8 old = text->current_color;
     text->current_color = index;
     return old;
 }
-#pragma pop
 
-#pragma push
-#pragma dont_inline on
 GXColor DevText_SetTextColor(DevText* text, GXColor color)
 {
     int index = text->current_color;
@@ -249,25 +229,18 @@ GXColor DevText_SetTextColor(DevText* text, GXColor color)
     text->text_colors[index] = color;
     return old;
 }
-#pragma pop
 
-#pragma push
-#pragma dont_inline on
 GXColor DevText_SetBGColor(DevText* text, GXColor color)
 {
     GXColor old = text->bg_color;
     text->bg_color = color;
     return old;
 }
-#pragma pop
 
-#pragma push
-#pragma dont_inline on
 void DevText_Erase(DevText* text)
 {
     memzero(text->buf, 2 * text->w * text->h);
 }
-#pragma pop
 
 inline void DevText_AdvanceLine(DevText* text)
 {
@@ -308,15 +281,12 @@ void DevText_Print(DevText* text, char* str)
     }
 }
 
-#pragma push
-#pragma dont_inline on
 void DevText_PrintInt(DevText* text, int num)
 {
     char str[16];
     DevText_NumToStr(num, str);
     DevText_Print(text, str);
 }
-#pragma pop
 
 void DevText_Printf(DevText* text, char* format, ...)
 {
@@ -815,8 +785,6 @@ void fn_80303EF4(HSD_GObj* gobj)
     }
 }
 
-#pragma push
-#pragma dont_inline on
 void un_80303FD4(HSD_GObj* arg0, struct un_80304138_objalloc_t* arg1,
                  struct un_80304138_objalloc_t_x8* arg2, int arg3, int arg4,
                  int arg5)
@@ -876,7 +844,6 @@ void un_80303FD4(HSD_GObj* arg0, struct un_80304138_objalloc_t* arg1,
         }
     }
 }
-#pragma pop
 
 void un_80304138(void)
 {


### PR DESCRIPTION
This came up while investigating something else and based on local testing I believe this keeps the match rate the same while removing manually opting out of inlining which seems like a code smell. That pattern is not uncommon elsewhere in the repo but I don't think any original source code would bother with opting out code from inlining, it was probably compiled with different flags which is what this change represents.

If this is intentional / a stylistic choice of the project we can close this PR.