### PR TITLE
Match fn_801967E0

### DIFF
--- a/src/melee/gm/gmtou_1.c
+++ b/src/melee/gm/gmtou_1.c
@@ -224,7 +224,7 @@ void fn_801967E0(s32 arg0)
         return;
     }
 
-    if (rand < (s32) (lbl_80473AB8[arg0].x7D + lbl_80473AB8[arg0].x51)) {
+    if (rand < (s32) (lbl_80473AB8[arg0].x51 + lbl_80473AB8[arg0].x7D)) {
         lbl_80473AB8[arg0].x78 = 0;
         rand = HSD_Randi(lbl_80473AB8[arg0].x51 + lbl_80473AB8[arg0].xA9 +
                          lbl_80473AB8[arg0].xD5);
@@ -264,8 +264,8 @@ void fn_801967E0(s32 arg0)
         return;
     }
 
-    if (rand < (s32) (lbl_80473AB8[arg0].xA9 + lbl_80473AB8[arg0].x51 +
-                      lbl_80473AB8[arg0].x7D))
+    if (rand < (s32) (lbl_80473AB8[arg0].xA9 +
+                      (lbl_80473AB8[arg0].x51 + lbl_80473AB8[arg0].x7D)))
     {
         lbl_80473AB8[arg0].xA4 = 0;
         rand = HSD_Randi(lbl_80473AB8[arg0].x51 + lbl_80473AB8[arg0].x7D +


### PR DESCRIPTION
Function was matched except for a single register selection. Refactoring the code to create a common sub-expression of `(lbl_80473AB8[arg0].x51 + lbl_80473AB8[arg0].x7D)` allows the compiler to pick the same register and get to a 100% match.