### PR TITLE
Match fn_8019AF50

### DIFF
--- a/src/melee/gm/gmtou_1.c
+++ b/src/melee/gm/gmtou_1.c
@@ -2345,6 +2345,8 @@ extern u8 lbl_803B7D04[20];
 
 /// Tournament match timer display/audio state machine.
 /// Handles match countdown, audio transitions, and end conditions.
+/// @todo 99.9% — two encodings differ in the timer-copy loop guard
+/// (cmplwi 0/ble vs cmplwi 1/blt, semantically identical).
 void fn_8019AF50(s32* arg0, u32 arg1, u32 arg2)
 {
     typedef struct {
@@ -2353,7 +2355,6 @@ void fn_8019AF50(s32* arg0, u32 arg1, u32 arg2)
     TimerFmt sp_buf;
     u32 buttons;
     TmData* tm = (TmData*) arg0;
-    u32* counter = &lbl_804799D8.x0;
     s32 bracketIdx;
 
     sp_buf = *(TimerFmt*) lbl_803B7D04;
@@ -2375,18 +2376,17 @@ void fn_8019AF50(s32* arg0, u32 arg1, u32 arg2)
         } else if (lbl_804D6680[0] == 0) {
             u8* bp = (u8*) &lbl_80473AB8[bracketIdx];
             s32 j = 0;
-            s32 n = 4;
+            s32 n;
 
-            do {
+            for (n = 4; n != 0; n--) {
                 if (bp[0x30] != 0 && bp[0x4C] == 0) {
-                    u8* entry = (u8*) &lbl_80473AB8[bracketIdx];
-                    lbl_804D6680[1] = entry[j * 0x2C + 0x4D];
+                    lbl_804D6680[1] =
+                        (&lbl_80473AB8[bracketIdx].x4D)[j * 0x2C];
                     break;
                 }
                 bp += 0x2C;
                 j++;
-                n--;
-            } while (n != 0);
+            }
 
             lbAudioAx_80023F28(fn_80160400(fn_8018F6FC(lbl_804D6680[1])));
             lbl_804D6680[0] = 1;
@@ -2406,13 +2406,13 @@ void fn_8019AF50(s32* arg0, u32 arg1, u32 arg2)
     }
 
     if (lbl_80473AB8[bracketIdx].x18 != 0) {
-        if (*counter < 0xFAU) {
-            (*counter)++;
-            if (*counter >= 0x64U) {
-                s32 count = (u32) (*counter - 0x64) / 15;
-                u8* base = (u8*) counter;
+        if (lbl_804799D8.x0 < 0xFAU) {
+            lbl_804799D8.x0++;
+            if (lbl_804799D8.x0 >= 0x64U) {
+                u32 count = (u32) (lbl_804799D8.x0 - 0x64) / 15;
+                u8* base = (u8*) &lbl_804799D8;
                 u8* dest = (u8*) &sp_buf;
-                while (count > 0) {
+                while (count >= 1) {
                     dest[0] = base[0x4E];
                     dest[1] = base[0x4F];
                     base += 2;
@@ -2422,24 +2422,24 @@ void fn_8019AF50(s32* arg0, u32 arg1, u32 arg2)
             }
             HSD_SisLib_803A70A0(tm->x524[3], 0, (char*) &sp_buf);
         } else {
-            *counter += 2;
+            lbl_804799D8.x0 += 2;
             if (lbl_804799D8.x4D != 1) {
-                if (*counter > 0xFAU) {
-                    *counter = 0xFA;
+                if (lbl_804799D8.x0 > 0xFAU) {
+                    lbl_804799D8.x0 = 0xFA;
                 }
             }
-            HSD_SisLib_803A70A0(tm->x524[3], 0, (char*) counter + 0x4E);
+            HSD_SisLib_803A70A0(tm->x524[3], 0, (char*) &lbl_804799D8 + 0x4E);
         }
     } else {
-        if (*counter < 0xFAU) {
-            *counter = 0xFA;
+        if (lbl_804799D8.x0 < 0xFAU) {
+            lbl_804799D8.x0 = 0xFA;
         }
     }
 
     if (*arg0 == 0x27) {
-        if (*counter >= 0xFAU) {
+        if (lbl_804799D8.x0 >= 0xFAU) {
             if (tm->x33 == 6) {
-                if (*counter >= 0x1C20U || (buttons & 0x1100)) {
+                if (lbl_804799D8.x0 >= 0x1C20U || (buttons & 0x1100)) {
                     gm_801A42F8(1);
                     gm_801A4B60();
                 }

--- a/src/melee/gm/gmtou_1.c
+++ b/src/melee/gm/gmtou_1.c
@@ -2345,8 +2345,6 @@ extern u8 lbl_803B7D04[20];
 
 /// Tournament match timer display/audio state machine.
 /// Handles match countdown, audio transitions, and end conditions.
-/// @todo 99.9% — two encodings differ in the timer-copy loop guard
-/// (cmplwi 0/ble vs cmplwi 1/blt, semantically identical).
 void fn_8019AF50(s32* arg0, u32 arg1, u32 arg2)
 {
     typedef struct {
@@ -2409,15 +2407,15 @@ void fn_8019AF50(s32* arg0, u32 arg1, u32 arg2)
         if (lbl_804799D8.x0 < 0xFAU) {
             lbl_804799D8.x0++;
             if (lbl_804799D8.x0 >= 0x64U) {
+                int i;
                 u32 count = (u32) (lbl_804799D8.x0 - 0x64) / 15;
                 u8* base = (u8*) &lbl_804799D8;
                 u8* dest = (u8*) &sp_buf;
-                while (count >= 1) {
+                for (i = 0; i < count; i++) {
                     dest[0] = base[0x4E];
                     dest[1] = base[0x4F];
                     base += 2;
                     dest += 2;
-                    count--;
                 }
             }
             HSD_SisLib_803A70A0(tm->x524[3], 0, (char*) &sp_buf);


### PR DESCRIPTION
Just need to change a blt -> ble here https://decomp.me/scratch/vQBp9 but changing the >= 1 to > 1, changes the instructions before it making it less of a match

From Claude:

> 1. Removed the u32* counter = &lbl_804799D8.x0 pointer local — all accesses direct now. This was the big one: killed a duplicate base-pointer register and the 8-byte frame phantom in one shot (the same &global-pointer tax we quantified in 8EBC).
> 2. Scan loop: for (n = 4; n != 0; n--) instead of do/while(n--) (gets the CTR mtctr/bdnz form), and the hit-branch assignment anchored at the struct field — (&lbl_80473AB8[bracketIdx].x4D)[j * 0x2C] — whose different expression tree stops MWCC from caching the array base across the loop, reproducing the target's rematerialization exactly.
> 3. Timer-copy loop guard: while (count >= 1) — defeats MWCC's >0 → !=0 record-form folding that was merging the guard into the division's final shift.