### PR TITLE
Improve fn_8019B458 match to ~99%

### DIFF
--- a/src/melee/gm/gmtou_1.c
+++ b/src/melee/gm/gmtou_1.c
@@ -2481,33 +2481,40 @@ void gm_8019B2DC_OnFrame(void)
 
 /// Transitions to results screen after a tournament match.
 /// Ranks players, preloads stage/character data, and starts audio.
+/// @todo ~99% — all 278 instructions/shapes match; residual is a pure
+/// callee-saved register rotation (rank/match colored r28/r27 vs target
+/// r29/r28, and the char/costume fill loop's two walkers swapped r28<->r29).
 void fn_8019B458(s32* arg0)
 {
+    struct Preload {
+        s32 stage;
+        s32 char_ids[4];
+        s32 costumes[4];
+    } req;
     TmData* tm = (TmData*) arg0;
     struct Lbl804799D8_t* d8 = &lbl_804799D8;
-    s32 i;
     s32 rank;
+    s32 i;
+    s32 j;
     s32 x24;
+    s32 entrants;
     TmData* td;
-
-    s32 costumes[4];
-    s32 charIDs[4];
     PAD_STACK(0x10);
 
-    rank = 0;
     tm->x24++;
-    d8->x0 = rank;
+    d8->x0 = rank = 0;
     tm->pad_x34[0] = tm->x33;
 
     td = gm_8018F634();
+    entrants = td->entrants;
     x24 = td->x24;
 
-    if (x24 > (s32) lbl_803DA0D0.rank_thresholds[td->entrants][5]) {
+    if (x24 > (s32) lbl_803DA0D0.rank_thresholds[entrants][5]) {
         rank = 6;
     } else {
-        for (i = 5; i >= 0; i--) {
-            if (x24 <= (s32) lbl_803DA0D0.rank_thresholds[td->entrants][i]) {
-                rank = i;
+        for (j = 5; j >= 0; j--) {
+            if (x24 <= (s32) lbl_803DA0D0.rank_thresholds[entrants][j]) {
+                rank = j;
             }
         }
     }
@@ -2515,13 +2522,17 @@ void fn_8019B458(s32* arg0)
     tm->x33 = rank;
 
     {
-        s32 match = fn_80196CF8();
-        TmData* td2 = gm_8018F634();
+        s32 match;
+        TmData* td2;
+
+        match = fn_80196CF8();
+        td2 = gm_8018F634();
         fn_80198D18();
 
         {
-            HSD_GObj* gobj = fn_8019035C(0, lbl_804D6670->models[3], match,
-                                         0x1A, 3, 1, fn_80196EEC, 0.0f);
+            HSD_GObj* gobj =
+                fn_8019035C(0, lbl_804D6670->models[3], match, 0x1A, 3, 1,
+                            fn_80196EEC, lbl_804DA808);
 
             if ((s32) td2->pad_x34[0] == match) {
                 HSD_JObjSetFlagsAll(gobj->hsd_obj, JOBJ_HIDDEN);
@@ -2537,23 +2548,25 @@ void fn_8019B458(s32* arg0)
         }
 
         fn_80198BA0();
-        fn_8018E618(tm->entrants, 4.5f, tm->x2C);
+        fn_8018E618(tm->entrants, lbl_804DA810, tm->x2C);
         fn_8018E85C(lbl_804D6670->models[4], tm->x2C);
         fn_8018FA24();
 
         tm->cur_option = 0x14;
         tm->x2C = 0;
 
-        for (i = 0; i < 4; i++) {
-            if (tm->x4B8[i].x0 != 3) {
-                charIDs[i] = fn_8018F6FC(tm->x4B8[i].x1);
-                costumes[i] = tm->x4B8[i].x3;
-            }
-        }
-
         {
-            volatile InternalStageId stageID;
             s32 use_random_stage;
+            /* declared here (not in the cache block below) to keep &req in
+             * a callee-saved register across both entry-fill loops */
+            struct Preload* q = &req;
+
+            for (i = 0; i < 4; i++) {
+                if (tm->x4B8[i].x0 != 3) {
+                    req.char_ids[i] = fn_8018F6FC(tm->x4B8[i].x1);
+                    req.costumes[i] = tm->x4B8[i].x3;
+                }
+            }
 
             if ((tm->stage_selection_type == 0 && tm->x32 == 0) ||
                 tm->stage_selection_type == 1)
@@ -2576,9 +2589,9 @@ void fn_8019B458(s32* arg0)
                     }
                 } while (true);
                 lbl_804D4194 = lbl_804D4190;
-                stageID = lbl_804D4190;
+                req.stage = lbl_804D4190;
             } else {
-                stageID = tm->x28;
+                req.stage = tm->x28;
             }
 
             {
@@ -2586,24 +2599,11 @@ void fn_8019B458(s32* arg0)
                 struct GameCache* gc = &scene->game_cache;
                 lbDvd_800174BC();
 
-                if (tm->x4B8[0].x0 != 3) {
-                    gc->entries[0].char_id = charIDs[0];
-                    gc->entries[0].color = costumes[0];
-                }
-
-                if (tm->x4B8[1].x0 != 3) {
-                    gc->entries[1].char_id = charIDs[1];
-                    gc->entries[1].color = costumes[1];
-                }
-
-                if (tm->x4B8[2].x0 != 3) {
-                    gc->entries[2].char_id = charIDs[2];
-                    gc->entries[2].color = costumes[2];
-                }
-
-                if (tm->x4B8[3].x0 != 3) {
-                    gc->entries[3].char_id = charIDs[3];
-                    gc->entries[3].color = costumes[3];
+                for (i = 0; i < 4; i++) {
+                    if (tm->x4B8[i].x0 != 3) {
+                        gc->entries[i].char_id = q->char_ids[i];
+                        gc->entries[i].color = q->costumes[i];
+                    }
                 }
 
                 {
@@ -2616,7 +2616,7 @@ void fn_8019B458(s32* arg0)
                         skip_stage_cache = 0;
                     }
                     if (skip_stage_cache == 0) {
-                        gc->stage_id = stageID;
+                        gc->stage_id = req.stage;
                     }
                 }
 
@@ -2627,10 +2627,10 @@ void fn_8019B458(s32* arg0)
                 u64 audio_mask = 0;
                 for (i = 0; i < 4; i++) {
                     if (tm->x4B8[i].x0 != 3) {
-                        audio_mask |= lbAudioAx_80026E84(charIDs[i]);
+                        audio_mask |= lbAudioAx_80026E84(req.char_ids[i]);
                     }
                 }
-                audio_mask |= lbAudioAx_80026EBC(stageID);
+                audio_mask |= lbAudioAx_80026EBC(req.stage);
                 lbAudioAx_80026F2C(0x1C);
                 lbAudioAx_8002702C(0xC, audio_mask);
                 lbAudioAx_80027168();


### PR DESCRIPTION
Decomp.me link: https://decomp.me/scratch/FL5ds remaining mismatch is register selection

From Claude:
> - The two arrays were one struct. charIDs[4]/costumes[4]/stageID are really one
  stack aggregate — struct Preload { s32 stage; s32 char_ids[4]; s32 costumes[4]; }.
  Indexing char_ids[i]/costumes[i] by the same counter is what produces the
  target's single walker with +4/+20 displacements.
> - A hidden pointer alias. The target keeps the buffer base in r31 from the fill
  loop all the way into the GameCache loop — only explicable as a user variable
  (struct Preload* q = &req;), declared before the fill loop even though it's
  only read in the cache loop. Adding it fixed the base register and the whole
  audio loop in one shot.
> - The gc-entries loop is a full 4x unroll (first iteration direct offsets, then
  three biased walkers) — and it turns out constant-trip loops unroll fine with
  s32; the wiki's int rule only bites on variable-bound loops like fn_8019AF50's.
> - The ranking loop needs its own counter and a hoisted local. Sharing i with the
  later loops biased rank's register via the rank = i copies — a separate j fixed
  that. And the idiomatic 2-D form (rank_thresholds[entrants][j], same as matched
  fn_80196CF8) only reproduces the unrolled biased-walker shape when entrants is
  hoisted into a local; with td->entrants inline the loop folds to fixed
  displacements instead.