### PR TITLE
Match fn_8019A86C to 99.86%

### DIFF
--- a/src/melee/gm/gmtou_1.c
+++ b/src/melee/gm/gmtou_1.c
@@ -2021,7 +2021,9 @@ void gm_8019A828(void)
 /// loop's x2A walker copies its base instead of reusing it) plus a
 /// callee-saved rotation (tm/arg2 swapped one slot down the r25-r29 order).
 /// The ((u8*) d8)[i + 0x44] form is required for the x44 strength-reduction
-/// walker; d8->x44[i] compiles to per-site address computation instead.
+/// walker (base must be the register variable d8 itself, displacement 0x44):
+/// d8->x44[i] scores 95.61%, a u8* alias of d8->x44 scores 96.66%, and
+/// lbl_804799D8.x44[i] scores 98.51%, vs 98.90% for this form.
 void fn_8019A86C(TmData* tm, u32 arg1, u32 arg2)
 {
     s32 ready_count = 0;

--- a/src/melee/gm/gmtou_1.c
+++ b/src/melee/gm/gmtou_1.c
@@ -2016,17 +2016,24 @@ void gm_8019A828(void)
     gm_8018F634()->cur_option = 0x1B;
 }
 
-void fn_8019A86C(s32* arg0, u32 arg1, u32 arg2)
+/// @todo 98.90%: all instruction shapes match except two coalescing artifacts
+/// (the &lbl_804799D8 materialization takes a temp+copy, and the ready-check
+/// loop's x2A walker copies its base instead of reusing it) plus a
+/// callee-saved rotation (tm/arg2 swapped one slot down the r25-r29 order).
+/// The ((u8*) d8)[i + 0x44] form is required for the x44 strength-reduction
+/// walker; d8->x44[i] compiles to per-site address computation instead.
+void fn_8019A86C(TmData* tm, u32 arg1, u32 arg2)
 {
     s32 ready_count = 0;
-    s32 pad_err = 0;
-    TmData* tm = (TmData*) arg0;
     struct Lbl804799D8_t* d8 = &lbl_804799D8;
+    s32 pad_err = 0;
     s32 i;
     PAD_STACK(0x28);
 
-    if (tm->cur_option == 0x1B) {
-        fn_8019B81C(arg0);
+    switch (tm->cur_option) {
+    case 0x1B:
+        fn_8019B81C((s32*) tm);
+        break;
     }
 
     if (tm->cur_option == 0x1D) {
@@ -2131,39 +2138,12 @@ void fn_8019A86C(s32* arg0, u32 arg1, u32 arg2)
                     ent->xA6 = t2->x4B8[2].x0;
                     ent->xD2 = t2->x4B8[3].x0;
 
-                    {
-                        u8 s0 = tm->x4B8[0].x0;
-                        if (s0 == 0) {
+                    for (i = 0; i < 4; i++) {
+                        u8 st = tm->x4B8[i].x0;
+                        if (st == 0) {
                             hmn_count += 1;
                         }
-                        if (s0 != 3) {
-                            active_count += 1;
-                        }
-                    }
-                    {
-                        u8 s1 = tm->x4B8[1].x0;
-                        if (s1 == 0) {
-                            hmn_count += 1;
-                        }
-                        if (s1 != 3) {
-                            active_count += 1;
-                        }
-                    }
-                    {
-                        u8 s2 = tm->x4B8[2].x0;
-                        if (s2 == 0) {
-                            hmn_count += 1;
-                        }
-                        if (s2 != 3) {
-                            active_count += 1;
-                        }
-                    }
-                    {
-                        u8 s3 = tm->x4B8[3].x0;
-                        if (s3 == 0) {
-                            hmn_count += 1;
-                        }
-                        if (s3 != 3) {
+                        if (st != 3) {
                             active_count += 1;
                         }
                     }
@@ -2181,10 +2161,11 @@ void fn_8019A86C(s32* arg0, u32 arg1, u32 arg2)
 
                     {
                         TmData* t3 = gm_8018F634();
-                        s32 stype2 = t3->stage_selection_type;
+                        s32 stype2;
                         s32 cond2;
 
                         t3->x2D = 1;
+                        stype2 = t3->stage_selection_type;
                         if ((stype2 == 2 && (u8) t3->x32 == 0) || stype2 == 3)
                         {
                             cond2 = 1;
@@ -2215,7 +2196,7 @@ void fn_8019A86C(s32* arg0, u32 arg1, u32 arg2)
         } else {
             d8->x0 = 0;
 
-            for (i = 0; i < (s32) tm->x30;) {
+            for (i = 0; i < (s32) tm->x30; i++) {
                 if ((s8) (u8) HSD_PadMasterStatus[(u8) i].err == 0 &&
                     tm->x4B8[i].x0 == 0)
                 {
@@ -2223,9 +2204,9 @@ void fn_8019A86C(s32* arg0, u32 arg1, u32 arg2)
 
                     if (buttons & 0x1100) {
                         lbAudioAx_80024030(1);
-                        if (d8->x44[i] == 7) {
-                            d8->x44[i] = 6;
-                        } else if (d8->x44[i] == 8) {
+                        if (((u8*) d8)[i + 0x44] == 7) {
+                            ((u8*) d8)[i + 0x44] = 6;
+                        } else if (((u8*) d8)[i + 0x44] == 8) {
                             u8 np = gm_8018F634()->x30;
                             s32 count4 = 0;
                             s32 j;
@@ -2236,7 +2217,7 @@ void fn_8019A86C(s32* arg0, u32 arg1, u32 arg2)
                                 }
                             }
                             if (count4 < (s32) (tm->x30 - 1)) {
-                                d8->x44[i] = 6;
+                                ((u8*) d8)[i + 0x44] = 6;
                                 d8->x2A[i].state = 4;
                             }
                         } else {
@@ -2256,9 +2237,9 @@ void fn_8019A86C(s32* arg0, u32 arg1, u32 arg2)
                             }
                         }
                     } else if (buttons & 0x400) {
-                        if (d8->x44[i] != 6) {
+                        if (((u8*) d8)[i + 0x44] != 6) {
                             lbAudioAx_80024030(0);
-                            d8->x44[i] = 6;
+                            ((u8*) d8)[i + 0x44] = 6;
                         } else {
                             u8 pstate2 = d8->x2A[i].state;
                             if (pstate2 == 0 || pstate2 == 3 || pstate2 == 5) {
@@ -2273,7 +2254,7 @@ void fn_8019A86C(s32* arg0, u32 arg1, u32 arg2)
                                 }
                                 if (count5 < (s32) (tm->x30 - 1)) {
                                     lbAudioAx_80024030(0);
-                                    d8->x44[i] = 7;
+                                    ((u8*) d8)[i + 0x44] = 7;
                                 }
                             } else if (pstate2 == 2) {
                                 lbAudioAx_80024030(0);
@@ -2282,18 +2263,17 @@ void fn_8019A86C(s32* arg0, u32 arg1, u32 arg2)
                             }
                         }
                     } else if ((buttons & 0x10000) || (buttons & 8)) {
-                        if (d8->x44[i] == 8) {
+                        if (((u8*) d8)[i + 0x44] == 8) {
                             lbAudioAx_80024030(2);
-                            d8->x44[i] = 7;
+                            ((u8*) d8)[i + 0x44] = 7;
                         }
                     } else if (((buttons & 0x20000) || (buttons & 4)) &&
-                               d8->x44[i] == 7)
+                               ((u8*) d8)[i + 0x44] == 7)
                     {
                         lbAudioAx_80024030(2);
-                        d8->x44[i] = 8;
+                        ((u8*) d8)[i + 0x44] = 8;
                     }
                 }
-                i++;
             }
         }
     }
@@ -2445,7 +2425,7 @@ void gm_8019B2DC_OnFrame(void)
             cond = 0;
         }
         if (cond != 0) {
-            fn_8019A86C((s32*) data, arg1, arg2);
+            fn_8019A86C(data, arg1, arg2);
         } else {
             fn_8019AF50((s32*) data, arg1, arg2);
         }

--- a/src/melee/gm/gmtou_1.c
+++ b/src/melee/gm/gmtou_1.c
@@ -2016,18 +2016,14 @@ void gm_8019A828(void)
     gm_8018F634()->cur_option = 0x1B;
 }
 
-/// @todo 98.90%: all instruction shapes match except two coalescing artifacts
-/// (the &lbl_804799D8 materialization takes a temp+copy, and the ready-check
-/// loop's x2A walker copies its base instead of reusing it) plus a
-/// callee-saved rotation (tm/arg2 swapped one slot down the r25-r29 order).
-/// The ((u8*) d8)[i + 0x44] form is required for the x44 strength-reduction
-/// walker (base must be the register variable d8 itself, displacement 0x44):
-/// d8->x44[i] scores 95.61%, a u8* alias of d8->x44 scores 96.66%, and
-/// lbl_804799D8.x44[i] scores 98.51%, vs 98.90% for this form.
+/// @todo 99.86%: all instruction shapes and callee-saved registers match;
+/// two scratch-register tie-breaks remain (the ready loop's err/state temps
+/// trade r7/r3, and the bracket-entry fill's address/value temps trade
+/// r0/r4). Decl orders, block-scope promotion, split counters, and comma
+/// expressions all compile to identical instructions with the same colors.
 void fn_8019A86C(TmData* tm, u32 arg1, u32 arg2)
 {
     s32 ready_count = 0;
-    struct Lbl804799D8_t* d8 = &lbl_804799D8;
     s32 pad_err = 0;
     s32 i;
     PAD_STACK(0x28);
@@ -2039,8 +2035,8 @@ void fn_8019A86C(TmData* tm, u32 arg1, u32 arg2)
     }
 
     if (tm->cur_option == 0x1D) {
-        d8->x0 += 1;
-        if ((arg2 & 0x600) || (d8->x0 >= 0x12CU)) {
+        lbl_804799D8.x0 += 1;
+        if ((arg2 & 0x600) || (lbl_804799D8.x0 >= 0x12CU)) {
             lbAudioAx_80024030(0);
             fn_8018EC48();
             tm->x2D = 0;
@@ -2088,9 +2084,11 @@ void fn_8019A86C(TmData* tm, u32 arg1, u32 arg2)
                     pad_err = 1;
                 }
                 {
-                    u8 state = d8->x2A[i].state;
-                    if (((state == 2 && (u8) d8->x2A[i].cur >= 0x3CU) ||
-                         (state == 4 && (u8) d8->x2A[i].cur == 0x82)) &&
+                    u8 state = lbl_804799D8.x2A[i].state;
+                    if (((state == 2 &&
+                          (u8) lbl_804799D8.x2A[i].cur >= 0x3CU) ||
+                         (state == 4 &&
+                          (u8) lbl_804799D8.x2A[i].cur == 0x82)) &&
                         (s8) err == 0)
                     {
                         ready_count += 1;
@@ -2121,10 +2119,11 @@ void fn_8019A86C(TmData* tm, u32 arg1, u32 arg2)
         }
 
         if (ready_count == (s32) tm->x30) {
-            d8->x0 += 1;
-            if (d8->x0 >= 0x1EU) {
+            lbl_804799D8.x0 += 1;
+            if (lbl_804799D8.x0 >= 0x1EU) {
                 for (i = 0; i < (s32) tm->x30; i++) {
-                    if (tm->x4B8[i].x0 == 0 && d8->x2A[i].state == 4) {
+                    if (tm->x4B8[i].x0 == 0 && lbl_804799D8.x2A[i].state == 4)
+                    {
                         tm->x4B8[i].x0 = 3;
                     }
                 }
@@ -2196,7 +2195,7 @@ void fn_8019A86C(TmData* tm, u32 arg1, u32 arg2)
                 }
             }
         } else {
-            d8->x0 = 0;
+            lbl_804799D8.x0 = 0;
 
             for (i = 0; i < (s32) tm->x30; i++) {
                 if ((s8) (u8) HSD_PadMasterStatus[(u8) i].err == 0 &&
@@ -2206,26 +2205,26 @@ void fn_8019A86C(TmData* tm, u32 arg1, u32 arg2)
 
                     if (buttons & 0x1100) {
                         lbAudioAx_80024030(1);
-                        if (((u8*) d8)[i + 0x44] == 7) {
-                            ((u8*) d8)[i + 0x44] = 6;
-                        } else if (((u8*) d8)[i + 0x44] == 8) {
+                        if (lbl_804799D8.x44[i] == 7) {
+                            lbl_804799D8.x44[i] = 6;
+                        } else if (lbl_804799D8.x44[i] == 8) {
                             u8 np = gm_8018F634()->x30;
                             s32 count4 = 0;
                             s32 j;
 
                             for (j = 0; j < (s32) np; j++) {
-                                if (d8->x2A[j].state == 4) {
+                                if (lbl_804799D8.x2A[j].state == 4) {
                                     count4 += 1;
                                 }
                             }
                             if (count4 < (s32) (tm->x30 - 1)) {
-                                ((u8*) d8)[i + 0x44] = 6;
-                                d8->x2A[i].state = 4;
+                                lbl_804799D8.x44[i] = 6;
+                                lbl_804799D8.x2A[i].state = 4;
                             }
                         } else {
-                            u8 pstate = d8->x2A[i].state;
+                            u8 pstate = lbl_804799D8.x2A[i].state;
                             if (pstate == 4) {
-                                d8->x2A[i].state = 5;
+                                lbl_804799D8.x2A[i].state = 5;
                             } else if (pstate == 0 || pstate == 3 ||
                                        pstate == 5)
                             {
@@ -2235,45 +2234,45 @@ void fn_8019A86C(TmData* tm, u32 arg1, u32 arg2)
                                 } else {
                                     gm_80167858(i, 0x78, 0xB, 0x14);
                                 }
-                                d8->x2A[i].state = 1;
+                                lbl_804799D8.x2A[i].state = 1;
                             }
                         }
                     } else if (buttons & 0x400) {
-                        if (((u8*) d8)[i + 0x44] != 6) {
+                        if (lbl_804799D8.x44[i] != 6) {
                             lbAudioAx_80024030(0);
-                            ((u8*) d8)[i + 0x44] = 6;
+                            lbl_804799D8.x44[i] = 6;
                         } else {
-                            u8 pstate2 = d8->x2A[i].state;
+                            u8 pstate2 = lbl_804799D8.x2A[i].state;
                             if (pstate2 == 0 || pstate2 == 3 || pstate2 == 5) {
                                 u8 np2 = gm_8018F634()->x30;
                                 s32 count5 = 0;
                                 s32 k;
 
                                 for (k = 0; k < (s32) np2; k++) {
-                                    if (d8->x2A[k].state == 4) {
+                                    if (lbl_804799D8.x2A[k].state == 4) {
                                         count5 += 1;
                                     }
                                 }
                                 if (count5 < (s32) (tm->x30 - 1)) {
                                     lbAudioAx_80024030(0);
-                                    ((u8*) d8)[i + 0x44] = 7;
+                                    lbl_804799D8.x44[i] = 7;
                                 }
                             } else if (pstate2 == 2) {
                                 lbAudioAx_80024030(0);
-                                d8->x2A[i].state = 3;
-                                d8->x2A[i].done = 0;
+                                lbl_804799D8.x2A[i].state = 3;
+                                lbl_804799D8.x2A[i].done = 0;
                             }
                         }
                     } else if ((buttons & 0x10000) || (buttons & 8)) {
-                        if (((u8*) d8)[i + 0x44] == 8) {
+                        if (lbl_804799D8.x44[i] == 8) {
                             lbAudioAx_80024030(2);
-                            ((u8*) d8)[i + 0x44] = 7;
+                            lbl_804799D8.x44[i] = 7;
                         }
                     } else if (((buttons & 0x20000) || (buttons & 4)) &&
-                               ((u8*) d8)[i + 0x44] == 7)
+                               lbl_804799D8.x44[i] == 7)
                     {
                         lbAudioAx_80024030(2);
-                        ((u8*) d8)[i + 0x44] = 8;
+                        lbl_804799D8.x44[i] = 8;
                     }
                 }
             }

--- a/src/melee/gm/gmtoulib.h
+++ b/src/melee/gm/gmtoulib.h
@@ -135,7 +135,7 @@
 /* 19A158 */ void fn_8019A158(void);
 /* 19A71C */ void fn_8019A71C(s32* arg0, u32 arg1, u32 arg2);
 /* 19A828 */ void gm_8019A828(void);
-/* 19A86C */ void fn_8019A86C(s32*, u32, u32);
+/* 19A86C */ void fn_8019A86C(TmData*, u32, u32);
 /* 19AF50 */ void fn_8019AF50(s32*, u32, u32);
 /* 19B2DC */ void gm_8019B2DC_OnFrame(void);
 /* 19B458 */ void fn_8019B458(s32* arg0);


### PR DESCRIPTION
Almost at 100% but not quite. I'll follow up with a decomp.me link later to sort out the final scratch register permutations but I tried a bunch of tricks to fix it and none worked so this PR is good to ship as-is, getting to 100% might be a big task.

From Claude:
> Take TmData* directly (the target's mr param-home shape), use a switch for the 0x1B dispatch, convert the hmn/active count blocks to their original 4-iteration loop, single-store ternary-style xC ordering, and index x44 as ((u8*) d8)[i + 0x44] to trigger the stride-1 strength reduction walker. Residual is two coalescing artifacts and a callee-saved rotation.

> The d8 pointer was the root cause of all three documented residuals. Its function-length web forced the materialization temp+copy, kept the base register alive so the fix loop couldn't destructively reuse it as a walker, and swapped the ready_count/i vs d8 register colors. With it gone, MWCC's own CSE of &lbl_804799D8 reproduces the target's exact base+copy structure — all three fixed in one edit. The old "cast-index form required" finding was an artifact of measuring with d8 still present; the stride-1 walker reduces fine from plain member syntax once nothing competes.