### PR TITLE
Match ft_800C85B8

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -668,7 +668,7 @@ config.libs = [
             Object(Matching, "melee/ft/ftCo_800C7590.c"),
             Object(Matching, "melee/ft/ftCo_800C78B0.c"),
             Object(Matching, "melee/ft/ftCo_800C7CA0.c"),
-            Object(NonMatching, "melee/ft/ftmetal.c"),
+            Object(Matching, "melee/ft/ftmetal.c"),
             Object(Matching, "melee/ft/ft_0C88.c"),
             Object(Matching, "melee/ft/chara/ftCommon/ftCo_DownSpot.c"),
             Object(Matching, "melee/ft/ft_0C8C.c"),

--- a/src/melee/ft/ftmetal.c
+++ b/src/melee/ft/ftmetal.c
@@ -178,9 +178,7 @@ void ft_800C85B8(Fighter_GObj* gobj)
     fp = GET_FIGHTER(gobj);
     joint = fp->ft_data->x5C;
     sp20 = joint;
-    sp1C = (joint_idx = 0);
-    joint_idx = (dobj_count = 0);
-    dobj_count = 0;
+    joint_idx = (dobj_count = (sp1C = 0));
     while (sp20 != 0) {
         if (ftParts_8007506C(fp->kind, joint_idx) != 0) {
             joint_idx++;
@@ -190,9 +188,8 @@ void ft_800C85B8(Fighter_GObj* gobj)
             ftAnim_GetNextJointInTree(&sp20, &sp1C);
         }
     }
-    part_idx = 0;
     sp20 = joint;
-    sp1C = 0;
+    sp1C = (part_idx = 0);
     while (sp20 != 0) {
         if (ftParts_8007506C(fp->kind, part_idx) != 0) {
             part_idx += 1;

--- a/src/melee/ft/ftmetal.c
+++ b/src/melee/ft/ftmetal.c
@@ -12,8 +12,6 @@
 #include <melee/ft/types.h>
 #include <melee/lb/lb_00B0.h>
 
-static s8 ftCo_804D3C90 = 0;
-
 void ft_800C8170(Fighter* fp)
 {
     int i;


### PR DESCRIPTION
This is the last non-fully matched function in this TU! Is the linked metric a measure of the TUs with 100% matches weighted by size? Nice to be able to finish it off regardless

From Claude:
> Chain the zero initializations so both counters' reaching definitions are assignment expressions rather than literals. This stops constant propagation from pre-folding the strength-reduced dobj index (slwi r29, r26, 2 at the second loop's preheader), and lets the sp1C store recycle part_idx's zero register. All 165 instructions now match.