### PR TITLE
Improve lbHeap_80015900 match to 99.77%

### DIFF
--- a/src/melee/lb/lbheap.c
+++ b/src/melee/lb/lbheap.c
@@ -84,21 +84,26 @@ int lbHeap_800158E8(int arg0)
     return lbHeap_80431FA0.heap_array[arg0].transient;
 }
 
+/// @todo 99.77%: one two-register color swap in the destroy loop — the
+///       compiler walker for heap_array[destroy_i].transient and heap_offset
+///       trade r28/r27. Exhausted: full decl-position sweep, split offset
+///       vars, init/increment orders and spellings, view-macro check forms,
+///       view-local elimination and block scoping.
 void lbHeap_80015900(void)
 {
     s32 temp_r0;
     struct lbHeap_HeapOffsetView* destroy_view;
+    s32 bounds_i;
     struct Heap* bounds_heap;
     struct lbHeap_HeapOffsetView* create_view;
-    s32 destroy_i;
     s32 heap_offset;
-    s32 bounds_i;
     s32 create_i;
     u32 arena_lo;
     u32 aram_lo;
     u32 aram_hi;
     u32 arena_hi;
     struct Heap* main_heap;
+    s32 destroy_i;
     struct Heap* aram_heap;
 
     /// @remarks 0 and 1 are reserved for HSD and ARAM
@@ -116,34 +121,9 @@ void lbHeap_80015900(void)
     aram_lo = lbHeap_80431FA0.aram_lo;
     aram_hi = lbHeap_80431FA0.aram_hi;
 
-    for (bounds_i = 2; bounds_i < 4; bounds_i++) {
-        bounds_heap = &lbHeap_80431FA0.heap_array[bounds_i * 2 - 2];
-        if (bounds_heap->transient == 0) {
-            switch (bounds_heap->type) {
-            case 1:
-                temp_r0 = bounds_heap->start + bounds_heap->size;
-                if (arena_lo < temp_r0) {
-                    arena_lo = temp_r0;
-                }
-                break;
-
-            case 2:
-                if (arena_hi > bounds_heap->start) {
-                    arena_hi = bounds_heap->start;
-                }
-                break;
-
-            case 4:
-                temp_r0 = bounds_heap->start + bounds_heap->size;
-                if (aram_lo < temp_r0) {
-                    aram_lo = temp_r0;
-                }
-                break;
-            }
-        }
-
-        bounds_heap++;
-        if (bounds_heap->transient == 0) {
+    for (bounds_i = 2; bounds_i < 6; bounds_i++) {
+        bounds_heap = &lbHeap_80431FA0.heap_array[bounds_i];
+        if (lbHeap_80431FA0.heap_array[bounds_i].transient == 0) {
             switch (bounds_heap->type) {
             case 1:
                 temp_r0 = bounds_heap->start + bounds_heap->size;


### PR DESCRIPTION
Couldn't quite get 100% to link this TU but got close and cleaned up this function.

From Claude:
> The main discovery: MWCC does 2× partial unrolls. The middle "bounds" loop was written in the repo as two switch bodies per iteration indexed by heap pair (heap_array[bounds_i * 2 - 2], then ++). No source shape in that family could reproduce the target's mr r4,r30 pointer IV stepping +0x1c twice, or the mysterious dead counter (li r5,2; addi r5,r5,1, never read). The breakthrough came from a twin-scan: I scripted an objdump scan over every built target object for "bdnz loop that keeps a dead li/addi+1 counter" and found MakeColorGenTExp in tobj.c — a Matching TU — where the source is just for (i = 0; i < 4; i++) switch (in[i]). MWCC 2×-unrolls a big-bodied constant-trip-4 loop: two bodies, biased second-body displacements, and a vestigial dead counter. Rewriting our loop as the plain for (bounds_i = 2; bounds_i < 6; bounds_i++) over single heaps matched the entire middle section in one shot.
>
> Two smaller fixes on top: bounds_i had to be s32 rather than int — mixed index types block the IV-init CSE that produces mr r4,r30 from the shared base register — and destroy_i declared second-to-last in the decl list is the one position (of 14) that puts it in r25.
>
> The residual is a single callee-saved swap in the destroy loop: the compiler's transient-walker IV and heap_offset trade r28↔r27. It survived ~200 variants — a full single-decl-move sweep, split per-loop offset variables, type changes, every init/increment order and spelling, view-macro check forms, view-local elimination and block scoping.