### PR TITLE
Match fn_800204C8

### DIFF
--- a/src/melee/lb/lbbgflash.c
+++ b/src/melee/lb/lbbgflash.c
@@ -309,58 +309,48 @@ void fn_8001FEC4(HSD_GObj* gobj, s32 code)
 
 void fn_800204C8(void)
 {
-    f64 temp;
     BgFlashData* data = &lbl_80433658;
     s32 mode = data->state.mode;
 
-    if (mode == 5) {
-        return;
-    }
-    if (mode >= 5) {
-        return;
-    }
-    if (mode >= 3) {
-        goto case_3_4;
-    }
     switch (mode) {
     case 0:
     case 1:
     case 2:
-        goto case_0_1_2;
-    }
-    return;
+        fn_8001FC08();
+        data->xC.r = data->x10[0];
+        data->xC.g = data->x10[1];
+        data->xC.b = data->x10[2];
+        data->xC.a = data->x10[3];
+        return;
+    case 3:
+    case 4:
+        switch ((s32) data->x30) {
+        case 0: {
+            s32* pX;
+            s32* pY;
+            s32 i;
 
-case_0_1_2:
-    fn_8001FC08();
-    data->xC.r = data->x10[0];
-    data->xC.g = data->x10[1];
-    data->xC.b = data->x10[2];
-    data->xC.a = data->x10[3];
-    return;
+            pY = &data->x38;
+            pX = &data->x34;
 
-case_3_4:
-    switch ((s32) data->x30) {
-    case 0: {
-        s32* pX;
-        s32* pY;
-        s32 i;
-
-        pY = &data->x38;
-        pX = &data->x34;
-
-        for (i = 0; i < data->x3C; i++) {
-            if (*pX < 0x280) {
-                *pX = *pX + data->x31;
-            } else if (*pY < 0x1E0) {
-                *pY = *pY + data->x32;
-                *pX = 0;
-            } else {
-                data->x33 = 1;
-                return;
+            for (i = 0; i < data->x3C; i++) {
+                if (*pX < 0x280) {
+                    *pX = *pX + data->x31;
+                } else if (*pY < 0x1E0) {
+                    *pY = *pY + data->x32;
+                    *pX = 0;
+                } else {
+                    data->x33 = 1;
+                    return;
+                }
             }
+            break;
+        }
         }
         break;
-    }
+    case 5:
+    default:
+        return;
     }
 }
 


### PR DESCRIPTION
## What changed

- Restructure `fn_800204C8` around its mode switch.
- Group modes 0-2 and 3-4 directly in the switch instead of combining range checks with goto labels.
- Remove an unused `f64` local.

## Why

The previous control-flow reconstruction made CodeWarrior emit a redundant branch and left the function at 98.65%. The structured switch reproduces the original range dispatch, while removing the unused local restores the original stack frame.

## Validation

- `fn_800204C8`: 100.00% match (296 bytes)
- `ninja changes_all`
  - no regressions
  - total matched code: 76.55% -> 76.56%
  - `main/melee/lb/lbbgflash` matched code: 24.33% -> 27.85%
