### PR TITLE
Match functions in mplib + correct data size

### DIFF
--- a/src/melee/mp/mplib.c
+++ b/src/melee/mp/mplib.c
@@ -87,7 +87,7 @@ struct mpLib_803BF248_t {
 /* 4D64DC */ static s32 mpLib_804D64DC;
 /* 4D64E0 */ static s32 mpLib_804D64E0;
 /* 4D64E4 */ static s32 mpLib_804D64E4;
-/* 458888 */ Vec3 mpLib_80458888[0x200];
+/* 458888 */ Vec3 mpLib_80458888[0x80];
 
 struct mpLib_803BF248_t_x4 mpLib_803BD3D8 = {
     1.0F,         { -1, -1, -1, -1 }, { 0, -1, 0 }, { -1, -1, -1, -1 },
@@ -252,7 +252,7 @@ static struct mpLib_803BF248_t_x4* mpLib_803BDCB8[20] = {
     &mpLib_803BD538, &mpLib_803BD590, &mpLib_803BD5E8, &mpLib_803BD640,
     &mpLib_803BD698, &mpLib_803BD6F0, &mpLib_803BD748, &mpLib_803BD8A8,
     &mpLib_803BD900, &mpLib_803BD958, &mpLib_803BD9B0, &mpLib_803BDA60,
-    &mpLib_803BDAB8, &mpLib_803BDB10, &mpLib_803BDB68,
+    &mpLib_803BDAB8, &mpLib_803BDB10, &mpLib_803BDB68, &mpLib_803BDBC0,
 };
 static struct mpLib_803BF248_t_x4* mpLib_803BDD08[20] = {
     &mpLib_803BD3D8, &mpLib_803BD430, &mpLib_803BD488, &mpLib_803BD4E0,
@@ -6576,13 +6576,6 @@ void mpLib_80059554(void)
     }
 }
 
-static const GXColor mpLib_804D8128 = { 0x7D, 0x7D, 0xFF, 0xFF };
-static const GXColor mpLib_804D812C = { 0x7D, 0xFF, 0x80, 0xFF };
-static const GXColor mpLib_804D8130 = { 0xFF, 0xFF, 0x80, 0xFF };
-static const GXColor mpLib_804D8134 = { 0xFF, 0x40, 0x40, 0xFF };
-static const GXColor mpLib_804D8138 = { 0xFF, 0x40, 0xC0, 0xFF };
-static const GXColor mpLib_804D813C = { 0xFF, 0xFF, 0xFF, 0xFF };
-
 void mpLib_80059E60(void)
 {
     Mtx sp104;
@@ -6667,6 +6660,13 @@ void mpLib_DrawCrosses(s16* idx, int len, GXColor arg2)
     }
 }
 
+static const GXColor mpLib_804D8128 = { 0x7D, 0x7D, 0xFF, 0xFF };
+static const GXColor mpLib_804D812C = { 0x7D, 0xFF, 0x80, 0xFF };
+static const GXColor mpLib_804D8130 = { 0xFF, 0xFF, 0x80, 0xFF };
+static const GXColor mpLib_804D8134 = { 0xFF, 0x40, 0x40, 0xFF };
+static const GXColor mpLib_804D8138 = { 0xFF, 0x40, 0xC0, 0xFF };
+static const GXColor mpLib_804D813C = { 0xFF, 0xFF, 0xFF, 0xFF };
+
 enum {
     mpLib_EnemySpawnVtxIds = 0x16,
     mpLib_TrophySpawnVtxIds = 0x66,
@@ -6695,7 +6695,7 @@ char mpLib_803BF6E0[] =
     "map coll under=%d upper=%d left=%d right=%d bbox=%d\n";
 
 static s16 mpLib_SpawnVtxIds[4] = { 0, 1, 2, 3 };
-static s16 mpLib_RespawnVtxIds[4] = { 4, 5, 6, 7 };
+SDATA s16 mpLib_RespawnVtxIds[6] = { 4, 5, 6, 7, 0, 0 };
 
 void mpLib_DrawSpecialPoints(void)
 {
@@ -6726,7 +6726,7 @@ void mpLib_8005A2DC(void)
 Vec2 mpLib_803BF718[2] = { { -1.0F, -400.0F }, { 1.0F, -400.0F } };
 MapLine mpLib_803BF728 = { 0, 1, -1, -1, -1, -1, 1, 0 };
 MapJoint mpLib_803BF738 = {
-    1, 0, 0, 0, 0, -9.0F, -408.0F, 9.0F, -392.0F, 2,
+    0, 1, 0, 0, 0, 0, 0, 0, 0, 0, -9.0F, -408.0F, 9.0F, -392.0F, 0, 2,
 };
 MapCollData mpLib_803BF760 = {
     /*  +0 */ mpLib_803BF718,
@@ -6752,7 +6752,10 @@ static const GXColor mpLib_804D8140 = { 0xFF, 0xFF, 0xC0, 0xFF };
 static const GXColor mpLib_804D8144 = { 0xFF, 0xFF, 0xFF, 0x80 };
 static const GXColor mpLib_804D8148 = { 0x80, 0xC0, 0xC0, 0xFF };
 static const GXColor mpLib_804D814C = { 0xC0, 0xFF, 0xFF, 0x80 };
-static const GXColor mpLib_804D8150 = { 0x40, 0x40, 0xFF, 0x00 };
+static const GXColor mpLib_804D8150[2] = {
+    { 0x40, 0x40, 0xFF, 0x00 },
+    { 0, 0, 0, 0 },
+};
 
 /// blast zones, camera bounds, etc
 void mpLib_DrawZones(void)
@@ -6850,7 +6853,7 @@ void mpLib_DrawZones(void)
 
     GXEnd();
 
-    mpLib_SetupDraw(mpLib_804D8150);
+    mpLib_SetupDraw(mpLib_804D8150[0]);
 
     GXSetZMode(0, GX_LEQUAL, 0);
     GXSetLineWidth(0x10, GX_TO_ZERO);

--- a/src/melee/mp/mplib.c
+++ b/src/melee/mp/mplib.c
@@ -885,8 +885,16 @@ void mpLibLoad(MapCollData* coll_data)
     float f31;
     CollJoint* joint_prev; // r27
     CollJoint* joint;      // r26
-    int start;
-    int count;
+    int floor_start;
+    int floor_count;
+    int ceiling_start;
+    int ceiling_count;
+    int right_wall_start;
+    int right_wall_count;
+    int left_wall_start;
+    int left_wall_count;
+    int dynamic_start;
+    int dynamic_count;
     int i;
 
     joint_prev = NULL;
@@ -930,49 +938,51 @@ void mpLibLoad(MapCollData* coll_data)
     jointListEnd = joint;
     mpPruneEmptyLines(coll_data);
 
-    count = coll_data->floor_count;
-    start = coll_data->floor_start;
-    for (; count > 0; count--) {
-        groundCollLine[start].flags =
-            coll_data->lines[start].hi_flags | LINE_FLAG_ENABLED;
-        groundCollLine[start].x0 = &coll_data->lines[start];
-        start++;
+    floor_count = coll_data->floor_count;
+    floor_start = coll_data->floor_start;
+    for (; floor_count > 0; floor_count--) {
+        groundCollLine[floor_start].flags =
+            coll_data->lines[floor_start].hi_flags | LINE_FLAG_ENABLED;
+        groundCollLine[floor_start].x0 = &coll_data->lines[floor_start];
+        floor_start++;
     }
 
-    count = coll_data->ceiling_count;
-    start = coll_data->ceiling_start;
-    while (count-- > 0) {
-        groundCollLine[start].flags =
-            coll_data->lines[start].hi_flags | LINE_FLAG_ENABLED;
-        groundCollLine[start].x0 = &coll_data->lines[start];
-        start++;
+    ceiling_count = coll_data->ceiling_count;
+    ceiling_start = coll_data->ceiling_start;
+    for (; ceiling_count > 0; ceiling_count--) {
+        groundCollLine[ceiling_start].flags =
+            coll_data->lines[ceiling_start].hi_flags | LINE_FLAG_ENABLED;
+        groundCollLine[ceiling_start].x0 = &coll_data->lines[ceiling_start];
+        ceiling_start++;
     }
 
-    count = coll_data->right_wall_count;
-    start = coll_data->right_wall_start;
-    while (count-- > 0) {
-        groundCollLine[start].flags =
-            coll_data->lines[start].hi_flags | LINE_FLAG_ENABLED;
-        groundCollLine[start].x0 = &coll_data->lines[start];
-        start++;
+    right_wall_count = coll_data->right_wall_count;
+    right_wall_start = coll_data->right_wall_start;
+    for (; right_wall_count > 0; right_wall_count--) {
+        groundCollLine[right_wall_start].flags =
+            coll_data->lines[right_wall_start].hi_flags | LINE_FLAG_ENABLED;
+        groundCollLine[right_wall_start].x0 =
+            &coll_data->lines[right_wall_start];
+        right_wall_start++;
     }
 
-    count = coll_data->left_wall_count;
-    start = coll_data->left_wall_start;
-    while (count-- > 0) {
-        groundCollLine[start].flags =
-            coll_data->lines[start].hi_flags | LINE_FLAG_ENABLED;
-        groundCollLine[start].x0 = &coll_data->lines[start];
-        start++;
+    left_wall_count = coll_data->left_wall_count;
+    left_wall_start = coll_data->left_wall_start;
+    for (; left_wall_count > 0; left_wall_count--) {
+        groundCollLine[left_wall_start].flags =
+            coll_data->lines[left_wall_start].hi_flags | LINE_FLAG_ENABLED;
+        groundCollLine[left_wall_start].x0 =
+            &coll_data->lines[left_wall_start];
+        left_wall_start++;
     }
 
-    count = coll_data->dynamic_count;
-    start = coll_data->dynamic_start;
-    while (count-- > 0) {
-        groundCollLine[start].flags =
-            coll_data->lines[start].hi_flags | LINE_FLAG_ENABLED;
-        groundCollLine[start].x0 = &coll_data->lines[start];
-        start++;
+    dynamic_count = coll_data->dynamic_count;
+    dynamic_start = coll_data->dynamic_start;
+    for (; dynamic_count > 0; dynamic_count--) {
+        groundCollLine[dynamic_start].flags =
+            coll_data->lines[dynamic_start].hi_flags | LINE_FLAG_ENABLED;
+        groundCollLine[dynamic_start].x0 = &coll_data->lines[dynamic_start];
+        dynamic_start++;
     }
 
     i = 0;
@@ -5885,6 +5895,8 @@ static HSD_Chan mpLib_803BF540 = {
     NULL,
 };
 
+static char lbl_803BF570[] = "B(%d,%d)-(%d,%d)\n";
+
 void mpLib_SetupDraw(GXColor color)
 {
     HSD_TevDesc spC;
@@ -6679,6 +6691,9 @@ static s16 mpLib_ItemSpawnVtxIds[] = {
     0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6,
 };
 
+char mpLib_803BF6E0[] =
+    "map coll under=%d upper=%d left=%d right=%d bbox=%d\n";
+
 static s16 mpLib_SpawnVtxIds[4] = { 0, 1, 2, 3 };
 static s16 mpLib_RespawnVtxIds[4] = { 4, 5, 6, 7 };
 
@@ -6702,9 +6717,8 @@ void mpLib_8005A2DC(void)
     mpLib_80059E60();
     if (mpLib_804D64D0 == 0) {
         mpLib_804D64D0 = 1;
-        OSReport("map coll under=%d upper=%d left=%d right=%d bbox=%d\n",
-                 mpLib_804D64D4, mpLib_804D64D8, mpLib_804D64DC,
-                 mpLib_804D64E0, mpLib_804D64E4);
+        OSReport(mpLib_803BF6E0, mpLib_804D64D4, mpLib_804D64D8,
+                 mpLib_804D64DC, mpLib_804D64E0, mpLib_804D64E4);
     }
     HSD_StateInvalidate(-1);
 }

--- a/src/melee/mp/mplib.c
+++ b/src/melee/mp/mplib.c
@@ -3881,46 +3881,28 @@ int mpLib_80053448_Floor(int line_id)
     return -1;
 }
 
-static inline int mpLineGetNextInline(int line_id)
-{
-    MapLine* line = groundCollLine[line_id].x0;
-    int result = line->next_id1;
-
-    if (result != -1) {
-        u32 flags = groundCollLine[result].flags;
-
-        if ((flags & LINE_FLAG_ENABLED) && !(flags & LINE_FLAG_HIDDEN)) {
-            CollVtx* v1 = &groundCollVtx[line->v1_idx];
-            CollVtx* v0 = &groundCollVtx[groundCollLine[result].x0->v0_idx];
-
-            if (SQ(v1->pos.x - v0->pos.x) + SQ(v1->pos.y - v0->pos.y) < 4.0) {
-                return result;
-            }
-        }
-    }
-
-    return line->next_id0;
-}
-
 int mpLib_800534FC_Floor(int line_id)
 {
+    int result;
     int new_id;
     LINEID_CHECK(4272, line_id);
-    new_id = mpLineGetNextInline(line_id);
+    new_id = mpLineGetNext(line_id);
     while (new_id != -1) {
         if (!(groundCollLine[new_id].flags & CollLine_Floor)) {
             new_id = -1;
         } else if (new_id != groundCollLine[line_id].x0->next_id1) {
             line_id = new_id;
-            new_id = mpLineGetNextInline(new_id);
+            new_id = mpLineGetNext(new_id);
             continue;
         }
         break;
     }
     if (new_id != -1) {
-        return new_id;
+        result = new_id;
+    } else {
+        result = -1;
     }
-    return -1;
+    return result;
 }
 
 int mpLib_800536CC_Floor(int line_id)
@@ -3977,6 +3959,7 @@ int mpLib_80053950_Ceiling(int line_id)
 
 int mpLib_80053A04_Ceiling(int line_id)
 {
+    int result;
     int new_id;
     LINEID_CHECK(4334, line_id);
     new_id = mpLineGetPrev(line_id);
@@ -3991,9 +3974,11 @@ int mpLib_80053A04_Ceiling(int line_id)
         break;
     }
     if (new_id != -1) {
-        return new_id;
+        result = new_id;
+    } else {
+        result = -1;
     }
-    return -1;
+    return result;
 }
 
 int mpLib_80053BD4_Ceiling(int line_id)
@@ -4022,26 +4007,25 @@ int mpLib_80053BD4_Ceiling(int line_id)
 
 void mpLib_80053DA4_Floor(int line_id, Vec3* pos_out)
 {
-    int r29 = line_id;
-    s16 r5;
-    CollVtx* temp_r3;
+    s16 next_id;
+    CollVtx* vtx;
 
-    LINEID_CHECK(4428, r29);
+    LINEID_CHECK(4428, line_id);
 
     goto skip;
 loop:
-    r29 = r5;
+    line_id = next_id;
 skip:
-    r5 = groundCollLine[r29].x0->next_id0;
-    if (r5 != -1 && (groundCollLine[r5].flags & CollLine_Floor)) {
+    next_id = groundCollLine[line_id].x0->next_id0;
+    if (next_id != -1 && (groundCollLine[next_id].flags & CollLine_Floor)) {
         goto loop;
     }
 
-    LINEID_CHECK(4433, r29);
+    LINEID_CHECK(4433, line_id);
 
-    temp_r3 = &groundCollVtx[groundCollLine[r29].x0->v1_idx];
-    pos_out->x = temp_r3->pos.x;
-    pos_out->y = temp_r3->pos.y;
+    vtx = &groundCollVtx[groundCollLine[line_id].x0->v1_idx];
+    pos_out->x = vtx->pos.x;
+    pos_out->y = vtx->pos.y;
     pos_out->z = 0.0F;
 }
 


### PR DESCRIPTION
From Codex:
> Aligned related floor and ceiling traversal functions with established matched loop and return shapes. Gave each mpLibLoad collision range independent loop state so allocator lifetimes match retail. Recovered missing strings and corrected table entries, object sizes, initializers, small-data placement, and constant ordering from retail layouts. Together, these changes produce four new exact function matches and exact .data, .sdata, and .sdata2 sections.