### PR TITLE
Match fn_802523D8 + misc gains

### DIFF
--- a/src/melee/it/itspawn.c
+++ b/src/melee/it/itspawn.c
@@ -143,6 +143,7 @@ bool it_8026C704(void)
 
 /// Decides item kind for spawned items - not sure in which context (i.e from
 /// pokeballs, from capsules, thin air, etc.)
+/// @todo Two callee-saved registers are swapped.
 ItemKind it_8026C75C(ItemPickTable* arg_struct)
 {
     s32 temp_r0;
@@ -151,6 +152,7 @@ ItemKind it_8026C75C(ItemPickTable* arg_struct)
     u16 var_r30;
     u8 temp_r4;
     ItemKind kind;
+    ItemKind ret;
     PAD_STACK(16);
 
     chk1 = false;
@@ -178,14 +180,15 @@ ItemKind it_8026C75C(ItemPickTable* arg_struct)
     }
     kind = arg_struct->x4[it_8026C530(HSD_Randi(arg_struct->x8), arg_struct, 0,
                                       arg_struct->x0)];
+    ret = kind;
     if (chk1 && chk2) {
         arg_struct->x8 = var_r30;
         arg_struct->x0 += 1;
         if (kind == It_Kind_M_Ball) {
-            kind = -1;
+            ret = -1;
         }
     }
-    return kind;
+    return ret;
 }
 
 void fn_8026C88C(HSD_GObj* gobj)

--- a/src/melee/mn/mninfo.c
+++ b/src/melee/mn/mninfo.c
@@ -371,130 +371,131 @@ void fn_802523B8(HSD_GObj* gobj)
     HSD_GObjPLink_80390228(gobj);
 }
 
-void fn_802523D8(HSD_GObj* gobj)
+static inline void fn_802523D8_inline(MnInfoData* data, HSD_GObj* gobj)
 {
-    HSD_JObj* sp1C;
     HSD_GObjProc* proc;
-    s32 i;
     HSD_JObj* jobj;
-    MnInfoData* data;
-    MnInfoTextCursor* cursor_base;
-    MnInfoTextCursor* read_cursor;
-    MnInfoTextCursor* write_cursor;
-    HSD_Text* zero_left;
-    HSD_Text* zero_right;
     PAD_STACK(16);
-
-    data = gobj->user_data;
     if (mn_804A04F0.cur_menu != MENU_KIND_DATA_SPECIAL) {
         HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
         proc = HSD_GObj_SetupProc(gobj, fn_802523B8, 0);
-        i = 0;
         proc->flags_3 = HSD_GObj_804D783C;
-        cursor_base = gobj->user_data;
-        write_cursor = cursor_base;
-        zero_left = (HSD_Text*) i;
-        zero_right = (HSD_Text*) i;
-        read_cursor = (MnInfoTextCursor*) &((HSD_Text**) cursor_base)[i];
-        do {
-            if (write_cursor->left != NULL) {
-                HSD_SisLib_803A5CC4(read_cursor->left);
-                write_cursor->left = zero_left;
+        {
+            MnInfoData* data2 = GET_MNINFO(gobj);
+            MnInfoData* data3 = data2;
+            int i;
+            HSD_Text* left_null = NULL;
+            HSD_Text* right_null = NULL;
+
+            for (i = 0; i < 4; i++) {
+                if (data2->left_column[i] != NULL) {
+                    HSD_SisLib_803A5CC4(data3->left_column[i]);
+                    data2->left_column[i] = left_null;
+                }
+                if (data2->right_column[i] != NULL) {
+                    HSD_SisLib_803A5CC4(data3->right_column[i]);
+                    data2->right_column[i] = right_null;
+                }
             }
-            if (write_cursor->right != NULL) {
-                HSD_SisLib_803A5CC4(read_cursor->right);
-                write_cursor->right = zero_right;
-            }
-            i += 1;
-            write_cursor = (MnInfoTextCursor*) &((HSD_Text**) write_cursor)[1];
-            read_cursor = (MnInfoTextCursor*) &((HSD_Text**) read_cursor)[1];
-        } while (i < 4);
-        HSD_SisLib_803A5CC4(data->description);
-        return;
-    }
-    jobj = gobj->hsd_obj;
-    lb_80011E24(jobj, &sp1C, 2, -1);
-    if (data->scroll_idx != 0) {
-        HSD_JObjClearFlagsAll(sp1C, JOBJ_HIDDEN);
+
+            HSD_SisLib_803A5CC4(data->description);
+        }
     } else {
-        HSD_JObjSetFlagsAll(sp1C, JOBJ_HIDDEN);
+        HSD_JObj* child;
+        jobj = gobj->hsd_obj;
+
+        lb_80011E24(jobj, &child, 2, -1);
+        if (data->scroll_idx != 0) {
+            HSD_JObjClearFlagsAll(child, JOBJ_HIDDEN);
+        } else {
+            HSD_JObjSetFlagsAll(child, JOBJ_HIDDEN);
+        }
+
+        lb_80011E24(jobj, &child, 1, -1);
+        if ((data->scroll_idx + 4) < mnInfo_80251AA4()) {
+            HSD_JObjClearFlagsAll(child, JOBJ_HIDDEN);
+        } else {
+            HSD_JObjSetFlagsAll(child, JOBJ_HIDDEN);
+        }
+
+        mn_8022ED6C(jobj, (AnimLoopSettings*) mnInfo_803EFC08);
     }
-    lb_80011E24(jobj, &sp1C, 1, -1);
-    if ((data->scroll_idx + 4) < mnInfo_80251AA4()) {
-        HSD_JObjClearFlagsAll(sp1C, JOBJ_HIDDEN);
-    } else {
-        HSD_JObjSetFlagsAll(sp1C, JOBJ_HIDDEN);
-    }
-    mn_8022ED6C(jobj, (AnimLoopSettings*) mnInfo_803EFC08);
 }
 
-void fn_80252548(HSD_GObj* gobj)
+void fn_802523D8(HSD_GObj* gobj)
 {
-    MnInfoData* data;
+    MnInfoData* data = GET_MNINFO(gobj);
+    PAD_STACK(4);
+    fn_802523D8_inline(data, gobj);
+}
+
+static inline void fn_80252548_inline(MnInfoData* data, HSD_GObj* gobj)
+{
     HSD_GObjProc* proc;
     HSD_JObj* jobj;
-    s32 i;
     u8* trophy;
-    MnInfoTextCursor* cursor_base;
-    MnInfoTextCursor* read_cursor;
-    MnInfoTextCursor* write_cursor;
-    HSD_Text* zero_left;
-    HSD_Text* zero_right;
-    PAD_STACK(24);
-
-    data = gobj->user_data;
+    s32 i;
+    PAD_STACK(16);
     if (mn_804A04F0.cur_menu != MENU_KIND_DATA_SPECIAL) {
         HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
         proc = HSD_GObj_SetupProc(gobj, fn_802523B8, 0);
-        i = 0;
         proc->flags_3 = HSD_GObj_804D783C;
-        cursor_base = gobj->user_data;
-        write_cursor = cursor_base;
-        zero_left = (HSD_Text*) i;
-        zero_right = (HSD_Text*) i;
-        read_cursor = (MnInfoTextCursor*) &((HSD_Text**) cursor_base)[i];
-        do {
-            if (write_cursor->left != NULL) {
-                HSD_SisLib_803A5CC4(read_cursor->left);
-                write_cursor->left = zero_left;
-            }
-            if (write_cursor->right != NULL) {
-                HSD_SisLib_803A5CC4(read_cursor->right);
-                write_cursor->right = zero_right;
-            }
-            i += 1;
-            write_cursor = (MnInfoTextCursor*) &((HSD_Text**) write_cursor)[1];
-            read_cursor = (MnInfoTextCursor*) &((HSD_Text**) read_cursor)[1];
-        } while (i < 4);
-        HSD_SisLib_803A5CC4(data->description);
-        return;
-    }
-    if ((s32) data->anim_timer != 0) {
-        data->anim_timer--;
-        return;
-    }
-    trophy = mnInfo_804A0968;
-    for (i = 0; i < 4; i++) {
-        if (mnInfo_80251A08(*trophy) != 0) {
-            u8 id = *trophy;
+        {
+            MnInfoData* data2 = GET_MNINFO(gobj);
+            MnInfoData* data3 = data2;
+            int j;
+            HSD_Text* left_null = NULL;
+            HSD_Text* right_null = NULL;
 
-            mnInfo_80251D58((MenuInfo_GObj*) gobj, i, id,
-                            *gmMainLib_8015D804(id));
-            mnInfo_80251F04((MenuInfo_GObj*) gobj, i, id);
+            for (j = 0; j < 4; j++) {
+                if (data2->left_column[j] != NULL) {
+                    HSD_SisLib_803A5CC4(data3->left_column[j]);
+                    data2->left_column[j] = left_null;
+                }
+                if (data2->right_column[j] != NULL) {
+                    HSD_SisLib_803A5CC4(data3->right_column[j]);
+                    data2->right_column[j] = right_null;
+                }
+            }
+
+            HSD_SisLib_803A5CC4(data->description);
         }
-        trophy++;
+    } else {
+        if ((s32) data->anim_timer != 0) {
+            data->anim_timer--;
+            return;
+        }
+        trophy = mnInfo_804A0968;
+        for (i = 0; i < 4; i++) {
+            if (mnInfo_80251A08(*trophy) != 0) {
+                u32 id = *trophy;
+
+                mnInfo_80251D58((MenuInfo_GObj*) gobj, i, id,
+                                *gmMainLib_8015D804(id));
+                mnInfo_80251F04((MenuInfo_GObj*) gobj, i, id);
+            }
+            trophy++;
+        }
+        jobj = HSD_JObjLoadJoint(mnInfo_804A0958.joint);
+        HSD_GObjObject_80390A70(gobj, HSD_GObj_804D7849, jobj);
+        GObj_SetupGXLink(gobj, HSD_GObj_JObjCallback, 4, 0x80);
+        HSD_JObjAddAnimAll(jobj, mnInfo_804A0958.animjoint,
+                           mnInfo_804A0958.matanim_joint,
+                           mnInfo_804A0958.shapeanim_joint);
+        HSD_JObjReqAnimAll(jobj, 0.0f);
+        mnInfo_802522B8(gobj);
+        HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
+        proc = HSD_GObj_SetupProc(gobj, fn_802523D8, 0);
+        proc->flags_3 = HSD_GObj_804D783C;
     }
-    jobj = HSD_JObjLoadJoint(mnInfo_804A0958.joint);
-    HSD_GObjObject_80390A70(gobj, HSD_GObj_804D7849, jobj);
-    GObj_SetupGXLink(gobj, HSD_GObj_JObjCallback, 4, 0x80);
-    HSD_JObjAddAnimAll(jobj, mnInfo_804A0958.animjoint,
-                       mnInfo_804A0958.matanim_joint,
-                       mnInfo_804A0958.shapeanim_joint);
-    HSD_JObjReqAnimAll(jobj, 0.0f);
-    mnInfo_802522B8(gobj);
-    HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
-    proc = HSD_GObj_SetupProc(gobj, fn_802523D8, 0);
-    proc->flags_3 = HSD_GObj_804D783C;
+}
+
+/// @todo Two callee-saved registers are swapped.
+void fn_80252548(HSD_GObj* gobj)
+{
+    MnInfoData* data = GET_MNINFO(gobj);
+    PAD_STACK(8);
+    fn_80252548_inline(data, gobj);
 }
 
 StaticModelDesc mnInfo_804A0958;

--- a/src/melee/mn/mninfo.h
+++ b/src/melee/mn/mninfo.h
@@ -18,6 +18,8 @@ typedef struct MnInfoData {
     /* +28 */ HSD_Text* description;
 } MnInfoData;
 
+#define GET_MNINFO(gobj) ((MnInfoData*) HSD_GObjGetUserData(gobj))
+
 /// was using this to try and fix some matches, unsuccessfully
 #ifdef M2C
 typedef struct MenuInfo_GObj MenuInfo_GObj;


### PR DESCRIPTION
Testing out the semantic search tool (https://github.com/MarkMcCaskey/decomp-search) some more

From Claude:
> 1. fn_802523D8 (mninfo) — full match, 94.4% → 100%. The decomp-search sweep pointed at mncount's fn_802514D8 (sim 0.991), whose matched asm turned out to be instruction-identical to our target modulo displacements and trip count. I transplanted its source structure wholesale: a wrapper + static inline (data, gobj) split, the text rows freed through MnInfoData's real left_column[4]/right_column[4] member arrays instead of the cast-pointer cursor walk, and a new GET_MNINFO accessor macro mirroring GET_MNCOUNT. No opacity hacks needed — the mystery slwi was just strength reduction on the member arrays. This is the tool's cleanest win yet (a previous session had plateaued at ~97.6% on this function); the pair is now in the eval set.
> 2. fn_80252548 (mninfo) — 92.9% → 99.79% with the same recipe, plus two levers: trophy declared before i, and the trophy temp typed u32 (matching the callee's params) instead of u8. Residual is a single trophy-register tie-break (4 rows), ~15 variants exhausted, one-line @todo.
> 3. it_8026C75C (itspawn) — 94.8% → 96.25% by splitting the return into ret = kind; so the picked kind stages through r0/r3 like the target. The remaining r28↔r29 swap survived ~60 variants across four sweep rounds, a 13-function twin-scan, and a refuted two-parameter-signature theory — it's the documented terminal swap class, @todo'd.