### PR TITLE
Match ftKb_SpecialN_800F10D4, ftColl_80079AB0, and it_802A3630

### DIFF
--- a/src/melee/ft/chara/ftKirby/ftkirby.c
+++ b/src/melee/ft/chara/ftKirby/ftkirby.c
@@ -4232,28 +4232,26 @@ void ftKb_SpecialN_800F10A4(Fighter_GObj* gobj)
     ftKb_SpecialN_800EF69C(gobj, 3, ft_80459B88.hats[FTKIND_CAPTAIN]);
 }
 
-static void ftKb_SpecialN_800EF040_noinline(Fighter_GObj* gobj, int arg1,
-                                            KirbyHatStruct* hat)
-{
-    ftKb_SpecialN_800EF040(gobj, arg1, hat);
-}
-
+/// Load Yoshi's hat for Kirby copy ability.
+/// @note The split Fighter* locals are required for register allocation.
+#pragma push
+#pragma dont_inline on
 void ftKb_SpecialN_800F10D4(Fighter_GObj* gobj)
 {
-    u8 sp14[0x90];
+    u8 part_dobj_indices[0x88];
     Fighter* fp = gobj->user_data;
     Fighter* fp2 = gobj->user_data;
     KirbyHatStruct* temp_r28;
-    PAD_STACK(4);
-    if (fp->fv.kb.hat.x14.data != NULL) {
+    PAD_STACK(8);
+    if (fp2->fv.kb.hat.x14.data != NULL) {
         return;
     }
     temp_r28 = ft_80459B88.hats[14];
-    ftKb_SpecialN_800EF040_noinline(gobj, 0xF, temp_r28);
-    fp->fv.kb.hat.x14.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);
-    fp->fv.kb.hat.x1C.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);
-    ftKb_SpecialN_800EF0E4(gobj, 0xF, sp14);
-    ftKb_SpecialN_800EF35C(gobj, 0xF, sp14);
+    ftKb_SpecialN_800EF040(gobj, 0xF, temp_r28);
+    fp2->fv.kb.hat.x14.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);
+    fp2->fv.kb.hat.x1C.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);
+    ftKb_SpecialN_800EF0E4(gobj, 0xF, part_dobj_indices);
+    ftKb_SpecialN_800EF35C(gobj, 0xF, part_dobj_indices);
     ftKb_SpecialN_800EF438(gobj, temp_r28);
     ftParts_8007487C((FtPartsDesc*) temp_r28, &fp->fv.kb.hat.x24,
                      fp->x619_costume_id, &fp->fv.kb.hat.x14,
@@ -4262,6 +4260,7 @@ void ftKb_SpecialN_800F10D4(Fighter_GObj* gobj)
                     &fp->fv.kb.x44, &fp->fv.kb.hat.x14);
     ftCo_8009D81C(fp2);
 }
+#pragma pop
 
 void ftKb_SpecialN_800F11AC(Fighter_GObj* gobj)
 {

--- a/src/melee/ft/chara/ftKirby/ftkirby.c
+++ b/src/melee/ft/chara/ftKirby/ftkirby.c
@@ -4201,29 +4201,37 @@ void ftKb_SpecialN_800F0F5C(Fighter_GObj* gobj)
     ftKb_SpecialN_800EFAF0_inline(gobj);
     ftCo_UnloadDynamicBones(fp);
 }
+/// Shared body of the Kirby hat loaders: load the hat model/parts for
+/// @p kind and start its animation.
+/// @remarks Using an @c inline function shifts register allocation.
+#define LOAD_HAT(gobj, fp, fp2, kind, hat, part_dobj_indices)                 \
+    do {                                                                      \
+        (hat) = ft_80459B88.hats[kind];                                       \
+        ftKb_SpecialN_800EF040(gobj, (kind) + 1, hat);                        \
+        (fp2)->fv.kb.hat.x14.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);  \
+        (fp2)->fv.kb.hat.x1C.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);  \
+        ftKb_SpecialN_800EF0E4(gobj, (kind) + 1, part_dobj_indices);          \
+        ftKb_SpecialN_800EF35C(gobj, (kind) + 1, part_dobj_indices);          \
+        ftKb_SpecialN_800EF438(gobj, hat);                                    \
+        ftParts_8007487C((FtPartsDesc*) (hat), &(fp)->fv.kb.hat.x24,          \
+                         (fp)->x619_costume_id, &(fp)->fv.kb.hat.x14,         \
+                         &(fp)->fv.kb.hat.x1C);                               \
+        ftAnim_80070200(fp, (ftData_x8_x8*) &(hat)->desc.vis_table,           \
+                        &(fp)->fv.kb.x44, &(fp)->fv.kb.hat.x14);              \
+    } while (0)
+
 #pragma push
 #pragma dont_inline on
 void ftKb_SpecialN_800F0FC0(Fighter_GObj* gobj)
 {
-    u8 sp14[0x90];
+    u8 part_dobj_indices[0x90];
     Fighter* fp = fp = gobj->user_data;
-    KirbyHatStruct* temp_r29;
+    KirbyHatStruct* hat;
     PAD_STACK(8);
     if (fp->fv.kb.hat.x14.data != NULL) {
         return;
     }
-    temp_r29 = ft_80459B88.hats[FTKIND_CAPTAIN];
-    ftKb_SpecialN_800EF040(gobj, 3, temp_r29);
-    fp->fv.kb.hat.x14.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);
-    fp->fv.kb.hat.x1C.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);
-    ftKb_SpecialN_800EF0E4(gobj, 3, sp14);
-    ftKb_SpecialN_800EF35C(gobj, 3, sp14);
-    ftKb_SpecialN_800EF438(gobj, temp_r29);
-    ftParts_8007487C((FtPartsDesc*) temp_r29, &fp->fv.kb.hat.x24,
-                     fp->x619_costume_id, &fp->fv.kb.hat.x14,
-                     &fp->fv.kb.hat.x1C);
-    ftAnim_80070200(fp, (ftData_x8_x8*) &temp_r29->desc.vis_table,
-                    &fp->fv.kb.x44, &fp->fv.kb.hat.x14);
+    LOAD_HAT(gobj, fp, fp, FTKIND_CAPTAIN, hat, part_dobj_indices);
 }
 #pragma pop
 
@@ -4241,23 +4249,12 @@ void ftKb_SpecialN_800F10D4(Fighter_GObj* gobj)
     u8 part_dobj_indices[0x88];
     Fighter* fp = gobj->user_data;
     Fighter* fp2 = gobj->user_data;
-    KirbyHatStruct* temp_r28;
+    KirbyHatStruct* hat;
     PAD_STACK(8);
     if (fp2->fv.kb.hat.x14.data != NULL) {
         return;
     }
-    temp_r28 = ft_80459B88.hats[14];
-    ftKb_SpecialN_800EF040(gobj, 0xF, temp_r28);
-    fp2->fv.kb.hat.x14.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);
-    fp2->fv.kb.hat.x1C.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);
-    ftKb_SpecialN_800EF0E4(gobj, 0xF, part_dobj_indices);
-    ftKb_SpecialN_800EF35C(gobj, 0xF, part_dobj_indices);
-    ftKb_SpecialN_800EF438(gobj, temp_r28);
-    ftParts_8007487C((FtPartsDesc*) temp_r28, &fp->fv.kb.hat.x24,
-                     fp->x619_costume_id, &fp->fv.kb.hat.x14,
-                     &fp->fv.kb.hat.x1C);
-    ftAnim_80070200(fp, (ftData_x8_x8*) &temp_r28->desc.vis_table,
-                    &fp->fv.kb.x44, &fp->fv.kb.hat.x14);
+    LOAD_HAT(gobj, fp, fp2, FTKIND_YOSHI, hat, part_dobj_indices);
     ftCo_8009D81C(fp2);
 }
 #pragma pop
@@ -4278,23 +4275,12 @@ void ftKb_SpecialN_800F11F0(Fighter_GObj* gobj)
     u8 part_dobj_indices[0x88];
     Fighter* fp = gobj->user_data;
     Fighter* fp2 = gobj->user_data;
-    KirbyHatStruct* temp_r28;
+    KirbyHatStruct* hat;
     PAD_STACK(8);
     if (fp2->fv.kb.hat.x14.data != NULL) {
         return;
     }
-    temp_r28 = ft_80459B88.hats[15];
-    ftKb_SpecialN_800EF040(gobj, 0x10, temp_r28);
-    fp2->fv.kb.hat.x14.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);
-    fp2->fv.kb.hat.x1C.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);
-    ftKb_SpecialN_800EF0E4(gobj, 0x10, part_dobj_indices);
-    ftKb_SpecialN_800EF35C(gobj, 0x10, part_dobj_indices);
-    ftKb_SpecialN_800EF438(gobj, temp_r28);
-    ftParts_8007487C((FtPartsDesc*) temp_r28, &fp->fv.kb.hat.x24,
-                     fp->x619_costume_id, &fp->fv.kb.hat.x14,
-                     &fp->fv.kb.hat.x1C);
-    ftAnim_80070200(fp, (ftData_x8_x8*) &temp_r28->desc.vis_table,
-                    &fp->fv.kb.x44, &fp->fv.kb.hat.x14);
+    LOAD_HAT(gobj, fp, fp2, FTKIND_PURIN, hat, part_dobj_indices);
     ftCo_8009DB50(fp2);
 }
 #pragma pop
@@ -4312,25 +4298,14 @@ void ftKb_SpecialN_800F12C8(Fighter_GObj* gobj)
 #pragma dont_inline on
 void ftKb_SpecialN_800F130C(Fighter_GObj* gobj)
 {
-    u8 sp14[0x90];
+    u8 part_dobj_indices[0x90];
     Fighter* fp = fp = gobj->user_data;
-    KirbyHatStruct* temp_r29;
+    KirbyHatStruct* hat;
     PAD_STACK(8);
     if (fp->fv.kb.hat.x14.data != NULL) {
         return;
     }
-    temp_r29 = ft_80459B88.hats[FTKIND_DRMARIO];
-    ftKb_SpecialN_800EF040(gobj, 0x16, temp_r29);
-    fp->fv.kb.hat.x14.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);
-    fp->fv.kb.hat.x1C.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);
-    ftKb_SpecialN_800EF0E4(gobj, 0x16, sp14);
-    ftKb_SpecialN_800EF35C(gobj, 0x16, sp14);
-    ftKb_SpecialN_800EF438(gobj, temp_r29);
-    ftParts_8007487C((FtPartsDesc*) temp_r29, &fp->fv.kb.hat.x24,
-                     fp->x619_costume_id, &fp->fv.kb.hat.x14,
-                     &fp->fv.kb.hat.x1C);
-    ftAnim_80070200(fp, (ftData_x8_x8*) &temp_r29->desc.vis_table,
-                    &fp->fv.kb.x44, &fp->fv.kb.hat.x14);
+    LOAD_HAT(gobj, fp, fp, FTKIND_DRMARIO, hat, part_dobj_indices);
 }
 #pragma pop
 
@@ -4375,33 +4350,21 @@ u8* ftKb_SpecialN_800F1420(Fighter_GObj* gobj, u32* arg1)
 #pragma dont_inline on
 void ftKb_SpecialN_800F14B4(Fighter_GObj* gobj)
 {
-    u8 sp14[0x88];
+    u8 part_dobj_indices[0x88];
     Fighter* fp = fp = gobj->user_data;
-    KirbyHatStruct* new_var;
-    FtPartsVisLookup* temp;
+    KirbyHatStruct* hat;
+    FtPartsVisLookup* lookup;
     PAD_STACK(8);
     if (fp->fv.kb.hat.x14.data != NULL) {
         return;
     }
-    new_var = ft_80459B88.hats[FTKIND_PICHU];
-    ftKb_SpecialN_800EF040(gobj, 0x18, new_var);
-    fp->fv.kb.hat.x14.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);
-    fp->fv.kb.hat.x1C.data = HSD_ObjAlloc(&fighter_x2040_alloc_data);
-    ftKb_SpecialN_800EF0E4(gobj, 0x18, sp14);
-    ftKb_SpecialN_800EF35C(gobj, 0x18, sp14);
-    ftKb_SpecialN_800EF438(gobj, new_var);
-    ftParts_8007487C((FtPartsDesc*) new_var, &fp->fv.kb.hat.x24,
-                     fp->x619_costume_id, &fp->fv.kb.hat.x14,
-                     &fp->fv.kb.hat.x1C);
-    ftAnim_80070200(fp, (ftData_x8_x8*) &new_var->desc.vis_table,
-                    &fp->fv.kb.x44, &fp->fv.kb.hat.x14);
-    temp = (FtPartsVisLookup*) new_var->hat_dynamics[3];
-    fp->fv.kb.hat.x24.xC[4] = temp;
-    fp->x5AC.xC[4] = temp;
+    LOAD_HAT(gobj, fp, fp, FTKIND_PICHU, hat, part_dobj_indices);
+    lookup = (FtPartsVisLookup*) hat->hat_dynamics[3];
+    fp->fv.kb.hat.x24.xC[4] = lookup;
+    fp->x5AC.xC[4] = lookup;
     ftParts_80074D7C(&fp->fv.kb.hat.x24, 4, &fp->fv.kb.hat.x14);
-    ftKb_SpecialN_800F1420(gobj, (u32*) ((u8*) new_var->hat_dynamics[4] + 4));
-    *(u32*) &fp->x610_color_rgba[1] =
-        *(u32*) ((u8*) new_var->hat_dynamics[4] + 8);
+    ftKb_SpecialN_800F1420(gobj, (u32*) ((u8*) hat->hat_dynamics[4] + 4));
+    *(u32*) &fp->x610_color_rgba[1] = *(u32*) ((u8*) hat->hat_dynamics[4] + 8);
     Fighter_UpdateModelScale(gobj);
 }
 #pragma pop

--- a/src/melee/ft/chara/ftKirby/ftkirby.c
+++ b/src/melee/ft/chara/ftKirby/ftkirby.c
@@ -4203,7 +4203,8 @@ void ftKb_SpecialN_800F0F5C(Fighter_GObj* gobj)
 }
 /// Shared body of the Kirby hat loaders: load the hat model/parts for
 /// @p kind and start its animation.
-/// @remarks Using an @c inline function shifts register allocation.
+/// @todo Should be an inline function (which would also allow removing the
+/// callers' @c dont_inline pragmas), but that shifts register allocation.
 #define LOAD_HAT(gobj, fp, fp2, kind, hat, part_dobj_indices)                 \
     do {                                                                      \
         (hat) = ft_80459B88.hats[kind];                                       \

--- a/src/melee/ft/ftcoll.c
+++ b/src/melee/ft/ftcoll.c
@@ -2091,55 +2091,53 @@ float ftColl_80079AB0(Fighter* fp, HitCapsule* hit, u32 unk_count, float arg3,
                       float attack, float defense, float weight)
 {
     ftCommonData* ftd = p_ftCommonData;
-    float w = weight * ftd->xF4;
     float decay;
     float result;
+    float w = weight;
+    PAD_STACK(8);
+    w *= ftd->xF4;
 
     if (hit->x28 != 0) {
-        float x24_f;
+        float x118;
 
         decay = ftd->xF8;
-        result = (w * decay) / (1.0F + w);
-        decay -= result;
+        x118 = ftd->x118;
 
-        result = ftd->x118 * (float) (u32) hit->x28;
-        result = ftd->x118 * ftd->x110 + ftd->x114 * result;
-        result = decay * result;
-        result = ftd->x11C * result + ftd->x120;
-        x24_f = 0.01F * (float) (u32) hit->x24;
-        result = x24_f * result + (float) (u32) hit->x2C;
-        result = arg3 * result;
-        result = attack * result;
-        result = defense * result;
+        result =
+            defense *
+            (attack *
+             (arg3 *
+              ((0.01F * hit->x24 *
+                (ftd->x11C *
+                     ((ftd->xF8 - ((w * ftd->xF8) / (1.0F + w))) *
+                      (x118 * ftd->x110 + ftd->x114 * (x118 * hit->x28))) +
+                 ftd->x120)) +
+               hit->x2C)));
     } else {
         s32 count;
-        float damage;
-        float x24_f;
 
         if (fp->x2225_b7) {
             if (fp->x2224_b2) {
                 count = (s32) ftd->x6D8[0];
             } else {
-                count = (s32) ftd->x6D4;
+                count = ftd->x6D4;
             }
         } else {
             count = (s32) fp->dmg.x1830_percent;
         }
 
-        decay = ftd->xF8;
-        result = (w * decay) / (1.0F + w);
-        decay -= result;
-        damage = (float) count + fp->dmg.x1838_percentTemp;
-        result = (float) (u32) unk_count * damage;
-        result = ftd->x110 * damage + ftd->x114 * result;
-        result = decay * result;
-        result = ftd->x11C * result + ftd->x120;
-        x24_f = 0.01F * (float) (u32) hit->x24;
-        (void) x24_f;
-        result = x24_f * result + (float) (u32) hit->x2C;
-        result = arg3 * result;
-        result = attack * result;
-        result = defense * result;
+        result =
+            defense *
+            (attack *
+             (arg3 *
+              ((0.01F * hit->x24 *
+                (ftd->x11C *
+                     ((ftd->xF8 - ((w * ftd->xF8) / (1.0F + w))) *
+                      (ftd->x110 * (count + fp->dmg.x1838_percentTemp) +
+                       ftd->x114 * (unk_count *
+                                    (count + fp->dmg.x1838_percentTemp)))) +
+                 ftd->x120)) +
+               hit->x2C)));
     }
 
     if (result >= ftd->x108) {

--- a/src/melee/ft/ftcoll.c
+++ b/src/melee/ft/ftcoll.c
@@ -2087,6 +2087,32 @@ void ftColl_8007925C(Fighter_GObj* gobj)
 } // clang-format on
 #pragma dont_inline off
 
+/// Select the accumulated-damage count for knockback (shared by the
+/// ftColl_80079AB0 family).
+static inline s32 ftColl_GetDamageCount(Fighter* fp, ftCommonData* ftd)
+{
+    if (fp->x2225_b7) {
+        if (fp->x2224_b2) {
+            return (s32) ftd->x6D8[0];
+        }
+        return ftd->x6D4;
+    }
+    return (s32) fp->dmg.x1830_percent;
+}
+
+/// Shared knockback formula shell. @p inner is the per-branch scaling term.
+/// @remarks Must stay one nested expression; step assignments change the
+/// float register webs (see ftColl_80079C70).
+#define KNOCKBACK(defense, attack, arg3, one, ftd, hit, w, inner)             \
+    ((defense) *                                                              \
+     ((attack) *                                                              \
+      ((arg3) * ((0.01F * (hit)->x24 *                                        \
+                  ((ftd)->x11C *                                              \
+                       (((ftd)->xF8 - (((w) * (ftd)->xF8) / ((one) + (w)))) * \
+                        (inner)) +                                            \
+                   (ftd)->x120)) +                                            \
+                 (hit)->x2C))))
+
 float ftColl_80079AB0(Fighter* fp, HitCapsule* hit, u32 unk_count, float arg3,
                       float attack, float defense, float weight)
 {
@@ -2094,7 +2120,6 @@ float ftColl_80079AB0(Fighter* fp, HitCapsule* hit, u32 unk_count, float arg3,
     float decay;
     float result;
     float w = weight;
-    PAD_STACK(8);
     w *= ftd->xF4;
 
     if (hit->x28 != 0) {
@@ -2103,41 +2128,17 @@ float ftColl_80079AB0(Fighter* fp, HitCapsule* hit, u32 unk_count, float arg3,
         decay = ftd->xF8;
         x118 = ftd->x118;
 
-        result =
-            defense *
-            (attack *
-             (arg3 *
-              ((0.01F * hit->x24 *
-                (ftd->x11C *
-                     ((ftd->xF8 - ((w * ftd->xF8) / (1.0F + w))) *
-                      (x118 * ftd->x110 + ftd->x114 * (x118 * hit->x28))) +
-                 ftd->x120)) +
-               hit->x2C)));
+        result = KNOCKBACK(defense, attack, arg3, 1.0F, ftd, hit, w,
+                           x118 * ftd->x110 + ftd->x114 * (x118 * hit->x28));
     } else {
         s32 count;
 
-        if (fp->x2225_b7) {
-            if (fp->x2224_b2) {
-                count = (s32) ftd->x6D8[0];
-            } else {
-                count = ftd->x6D4;
-            }
-        } else {
-            count = (s32) fp->dmg.x1830_percent;
-        }
+        count = ftColl_GetDamageCount(fp, ftd);
 
-        result =
-            defense *
-            (attack *
-             (arg3 *
-              ((0.01F * hit->x24 *
-                (ftd->x11C *
-                     ((ftd->xF8 - ((w * ftd->xF8) / (1.0F + w))) *
-                      (ftd->x110 * (count + fp->dmg.x1838_percentTemp) +
-                       ftd->x114 * (unk_count *
-                                    (count + fp->dmg.x1838_percentTemp)))) +
-                 ftd->x120)) +
-               hit->x2C)));
+        result = KNOCKBACK(
+            defense, attack, arg3, 1.0F, ftd, hit, w,
+            ftd->x110 * (count + fp->dmg.x1838_percentTemp) +
+                ftd->x114 * (unk_count * (count + fp->dmg.x1838_percentTemp)));
     }
 
     if (result >= ftd->x108) {
@@ -2181,15 +2182,7 @@ float ftColl_80079C70(Fighter* fp, Fighter* attacker, HitCapsule* hit,
         float damage;
         float x24_f;
 
-        if (fp->x2225_b7) {
-            if (fp->x2224_b2) {
-                count = (s32) ftd->x6D8[0];
-            } else {
-                count = (s32) ftd->x6D4;
-            }
-        } else {
-            count = (s32) fp->dmg.x1830_percent;
-        }
+        count = ftColl_GetDamageCount(fp, ftd);
 
         decay = ftd->xF8;
         result = (w * decay) / (1.0F + w);
@@ -2220,7 +2213,6 @@ float ftColl_80079EA8(Fighter* fp, HitCapsule* hit, u32 unk_count)
     float decay;
     float result;
     float w = fp->co_attrs.weight;
-    PAD_STACK(8);
     w *= ftd->xF4;
 
     if (hit->x28 != 0) {
@@ -2230,44 +2222,21 @@ float ftColl_80079EA8(Fighter* fp, HitCapsule* hit, u32 unk_count)
         decay = ftd->xF8;
         x118 = ftd->x118;
 
-        result =
-            one *
-            (one *
-             (one * ((0.01F * hit->x24 *
-                      (ftd->x11C * ((ftd->xF8 - ((w * ftd->xF8) / (one + w))) *
-                                    (x118 * ftd->x110 +
-                                     ftd->x114 * (x118 * hit->x28))) +
-                       ftd->x120)) +
-                     hit->x2C)));
+        result = KNOCKBACK(one, one, one, one, ftd, hit, w,
+                           x118 * ftd->x110 + ftd->x114 * (x118 * hit->x28));
     } else {
         s32 count;
 
-        if (fp->x2225_b7) {
-            if (fp->x2224_b2) {
-                count = (s32) ftd->x6D8[0];
-            } else {
-                count = ftd->x6D4;
-            }
-        } else {
-            count = (s32) fp->dmg.x1830_percent;
-        }
+        count = ftColl_GetDamageCount(fp, ftd);
 
         {
             float one = 1.0F;
 
-            result =
-                one *
-                (one *
-                 (one *
-                  ((0.01F * hit->x24 *
-                    (ftd->x11C *
-                         ((ftd->xF8 - ((w * ftd->xF8) / (one + w))) *
-                          (ftd->x110 * (count + fp->dmg.x1838_percentTemp) +
-                           ftd->x114 *
-                               (unk_count *
-                                (count + fp->dmg.x1838_percentTemp)))) +
-                     ftd->x120)) +
-                   hit->x2C)));
+            result = KNOCKBACK(
+                one, one, one, one, ftd, hit, w,
+                ftd->x110 * (count + fp->dmg.x1838_percentTemp) +
+                    ftd->x114 *
+                        (unk_count * (count + fp->dmg.x1838_percentTemp)));
         }
     }
 

--- a/src/melee/it/inlines.h
+++ b/src/melee/it/inlines.h
@@ -2,6 +2,7 @@
 #define MELEE_IT_INLINES_H
 
 #include "it/types.h"
+#include "mp/mplib.h"
 
 #include <baselib/gobj.h>
 
@@ -16,6 +17,27 @@ static inline Item* GetItemData(HSD_GObj* gobj)
 static inline void itResetVelocity(Item* ip)
 {
     ip->x40_vel.x = ip->x40_vel.y = ip->x40_vel.z = 0.0F;
+}
+
+/// Check whether the grapple chain from @p head to the tip @p pos or to its
+/// owner @p fp collides with terrain (shared by Link's hookshot and Samus's
+/// grapple beam).
+static inline bool itGrappleCheckCollision(ItemLink* head, Fighter* fp,
+                                           Vec3* pos)
+{
+    Vec3* head_pos = &head->pos;
+
+    if (mpCheckAllRemap(NULL, NULL, NULL, NULL, -1, -1, pos->x, pos->y,
+                        head->pos.x, head->pos.y))
+    {
+        return true;
+    } else if (mpCheckAllRemap(NULL, NULL, NULL, NULL, -1, -1, fp->cur_pos.x,
+                               fp->cur_pos.y, head_pos->x, head_pos->y))
+    {
+        return true;
+    } else {
+        return false;
+    }
 }
 
 /// @todo Rename; probably gets a specific joint for items

--- a/src/melee/it/items/itlinkhookshot.c
+++ b/src/melee/it/items/itlinkhookshot.c
@@ -706,7 +706,7 @@ void itLinkhookshot_UnkMotion5_Phys(Item_GObj* arg0)
     item->xDD4_itemVar.linkhookshot.x10 = it_802A3500;
 }
 
-static inline bool it_802A3630_inline(Item* item, Vec3* cur_pos, Vec3* pos)
+static inline bool it_802A3630_inline(Item* item, Fighter* fp, Vec3* pos)
 {
     ItemLink* item_link;
     Vec3* item_link_pos;
@@ -717,8 +717,9 @@ static inline bool it_802A3630_inline(Item* item, Vec3* cur_pos, Vec3* pos)
                         item_link->pos.y) != 0)
     {
         return 1;
-    } else if (mpCheckAllRemap(0, 0, 0, 0, -1, -1, cur_pos->x, cur_pos->y,
-                               item_link_pos->x, item_link_pos->y) != 0)
+    } else if (mpCheckAllRemap(0, 0, 0, 0, -1, -1, fp->cur_pos.x,
+                               fp->cur_pos.y, item_link_pos->x,
+                               item_link_pos->y) != 0)
     {
         return 1;
     } else {
@@ -729,15 +730,18 @@ static inline bool it_802A3630_inline(Item* item, Vec3* cur_pos, Vec3* pos)
 void it_802A3630(Item_GObj* arg0)
 {
     Vec3 pos;
+    u8 _pad[4];
     Item* item = GET_ITEM(arg0);
     itLinkHookshotAttributes* attr =
         item->xC4_article_data->x4_specialAttributes;
     Fighter* fp = item->owner->user_data;
     ItemLink* item_link = item->xDD4_itemVar.linkhookshot.x4;
+    Fighter* fp2;
 
-    it_802A2EE4_inline_alt(item->xDD4_itemVar.linkhookshot.x4, &pos);
+    fp2 = fp;
+    it_802A2EE4_inline_alt(item_link, &pos);
 
-    if (it_802A3630_inline(item, &fp->cur_pos, &pos) != 0) {
+    if (it_802A3630_inline(item, fp2, &pos) != 0) {
         ftCo_80090780(item->owner);
         it_802A2B10(arg0);
         return;
@@ -745,15 +749,15 @@ void it_802A3630(Item_GObj* arg0)
 
     if (it_802A5AE0(item->xDD4_itemVar.linkhookshot.x0, &pos, attr) != 0) {
         it_802A7A04(arg0);
-        it_802A7168(item, &pos, fp->x34_scale.y);
+        it_802A7168(item, &pos, fp2->x34_scale.y);
         return;
     }
-    it_802A7384(item, &pos, fp->x34_scale.y);
-    if (fp->ground_or_air != 1) {
+    it_802A7384(item, &pos, fp2->x34_scale.y);
+    if (fp2->ground_or_air != 1) {
         it_802A77DC(arg0);
         return;
     }
-    if (fp->input.x668 & HSD_PAD_A) {
+    if (fp2->input.x668 & HSD_PAD_A) {
         it_802A79A0(arg0);
     }
 }

--- a/src/melee/it/items/itlinkhookshot.c
+++ b/src/melee/it/items/itlinkhookshot.c
@@ -706,27 +706,6 @@ void itLinkhookshot_UnkMotion5_Phys(Item_GObj* arg0)
     item->xDD4_itemVar.linkhookshot.x10 = it_802A3500;
 }
 
-static inline bool it_802A3630_inline(Item* item, Fighter* fp, Vec3* pos)
-{
-    ItemLink* item_link;
-    Vec3* item_link_pos;
-    item_link = item->xDD4_itemVar.linkhookshot.x0;
-    item_link_pos = &item_link->pos;
-
-    if (mpCheckAllRemap(0, 0, 0, 0, -1, -1, pos->x, pos->y, item_link->pos.x,
-                        item_link->pos.y) != 0)
-    {
-        return 1;
-    } else if (mpCheckAllRemap(0, 0, 0, 0, -1, -1, fp->cur_pos.x,
-                               fp->cur_pos.y, item_link_pos->x,
-                               item_link_pos->y) != 0)
-    {
-        return 1;
-    } else {
-        return 0;
-    }
-}
-
 void it_802A3630(Item_GObj* arg0)
 {
     Vec3 pos;
@@ -741,7 +720,8 @@ void it_802A3630(Item_GObj* arg0)
     fp2 = fp;
     it_802A2EE4_inline_alt(item_link, &pos);
 
-    if (it_802A3630_inline(item, fp2, &pos) != 0) {
+    if (itGrappleCheckCollision(item->xDD4_itemVar.linkhookshot.x0, fp2, &pos))
+    {
         ftCo_80090780(item->owner);
         it_802A2B10(arg0);
         return;

--- a/src/melee/it/items/itsamusgrapple.c
+++ b/src/melee/it/items/itsamusgrapple.c
@@ -787,23 +787,6 @@ void itSamusgrapple_UnkMotion5_Phys(Item_GObj* gobj)
     GET_ITEM(gobj)->xDD4_itemVar.samusgrapple.unk_10 = fn_802B8814;
 }
 
-static inline bool fn_802B895C_inline(Item* ip, Fighter* fp, Vec3* pos)
-{
-    ItemLink* head = ip->xDD4_itemVar.samusgrapple.x0;
-    Vec3* head_pos = &head->pos;
-    if (mpCheckAllRemap(NULL, NULL, NULL, NULL, -1, -1, pos->x, pos->y,
-                        head->pos.x, head->pos.y))
-    {
-        return true;
-    } else if (mpCheckAllRemap(NULL, NULL, NULL, NULL, -1, -1, fp->cur_pos.x,
-                               fp->cur_pos.y, head_pos->x, head_pos->y))
-    {
-        return true;
-    } else {
-        return false;
-    }
-}
-
 void fn_802B895C(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
@@ -820,7 +803,7 @@ void fn_802B895C(Item_GObj* gobj)
     fp2 = fp;
     samus_grapple_setup_pos(link, &pos, m);
 
-    if (fn_802B895C_inline(ip, fp2, &pos)) {
+    if (itGrappleCheckCollision(ip->xDD4_itemVar.samusgrapple.x0, fp2, &pos)) {
         ftCo_80090780(ip->owner);
         it_802B7B84(gobj);
         return;
@@ -916,7 +899,7 @@ void fn_802B8D38(Item_GObj* gobj)
     fp2 = fp;
     samus_grapple_setup_pos(link, &pos, m);
 
-    if (fn_802B895C_inline(ip, fp2, &pos)) {
+    if (itGrappleCheckCollision(ip->xDD4_itemVar.samusgrapple.x0, fp2, &pos)) {
         ftCo_80090780(ip->owner);
         it_802B7B84(gobj);
         return;


### PR DESCRIPTION
Found some similar already matched functions with the semantic search tool. Quite neat to see how it can identify that the assembly for Link's hookshot is very similar to Samus's grapple.

From Claude:
> - ftKb_SpecialN_800F10D4 → 100% (was 97.7). Token-identical to the Jigglypuff hat loader 800F11F0; transplanted its #pragma dont_inline + fp2-check shape and deleted the one-user _noinline wrapper. It's the Yoshi hat loader.
> - ftColl_80079AB0 → 99.82% calibrated-full (was 95.9). The donor ftColl_80079EA8 writes the knockback formula as one giant nested expression with one = 1.0F where ours has real ratio params — the nesting itself is the codegen lever (keeps more float-conversion temps live).
> - it_802A3630 → 99.96% calibrated-full (was 99.4). Cross-file donor fn_802B895C (samusgrapple): the fixes were passing fp2 = fp into the checking inline, passing the item_link variable instead of re-spelling the field expression, and a 4-byte pad above pos.