### PR TITLE
Use shared stage JObj setup helper

### DIFF
--- a/src/melee/gr/grbattle.c
+++ b/src/melee/gr/grbattle.c
@@ -244,11 +244,7 @@ static void grBattle_8021A118(Ground_GObj* arg0) {}
 
 static void grBattle_8021A11C(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* jobj = GET_JOBJ(gobj);
-
-    Ground_801C2ED0(jobj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grBattle_8021A16C(Ground_GObj* arg0)

--- a/src/melee/gr/grfigure1.c
+++ b/src/melee/gr/grfigure1.c
@@ -150,11 +150,7 @@ static void grFigure1_8020E1FC(Ground_GObj* arg0) {}
 
 static void grFigure1_8020E200(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* jobj = GET_JOBJ(gobj);
-
-    Ground_801C2ED0(jobj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grFigure1_8020E250(Ground_GObj* arg0)

--- a/src/melee/gr/grfigure2.c
+++ b/src/melee/gr/grfigure2.c
@@ -144,11 +144,7 @@ static void grFigure2_8020E490(Ground_GObj* arg0) {}
 
 static void grFigure2_8020E494(Ground_GObj* gobj)
 {
-    u8 _[8];
-
-    Ground* gp = gobj->user_data;
-    Ground_801C2ED0(gobj->hsd_obj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grFigure2_8020E4E4(Ground_GObj* arg0)

--- a/src/melee/gr/grfigure3.c
+++ b/src/melee/gr/grfigure3.c
@@ -147,11 +147,7 @@ static void grFigure3_8020E724(Ground_GObj* arg0) {}
 
 static void grFigure3_8020E728(Ground_GObj* gobj)
 {
-    u8 _[8];
-
-    Ground* gp = gobj->user_data;
-    Ground_801C2ED0(gobj->hsd_obj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grFigure3_8020E778(Ground_GObj* arg0)

--- a/src/melee/gr/grtcaptain.c
+++ b/src/melee/gr/grtcaptain.c
@@ -127,11 +127,7 @@ static void grTCaptain_8021FE24(Ground_GObj* arg0) {}
 
 static void grTCaptain_8021FE28(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* jobj = GET_JOBJ(gobj);
-
-    Ground_801C2ED0(jobj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grTCaptain_8021FE78(Ground_GObj* arg0)
@@ -149,11 +145,7 @@ static void grTCaptain_8021FEB4(Ground_GObj* arg0) {}
 
 static void grTCaptain_8021FEB8(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* jobj = GET_JOBJ(gobj);
-
-    Ground_801C2ED0(jobj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grTCaptain_8021FF08(Ground_GObj* arg0)

--- a/src/melee/gr/grtclink.c
+++ b/src/melee/gr/grtclink.c
@@ -131,12 +131,7 @@ void grTCLink_80220108(Ground_GObj* gobj)
 
 void grTCLink_8022010C(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* joint = (HSD_JObj*) gobj->hsd_obj;
-    PAD_STACK(8);
-
-    Ground_801C2ED0(joint, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, false);
+    Ground_JObjInline1(gobj);
 }
 
 bool grTCLink_8022015C(Ground_GObj* gobj)
@@ -157,12 +152,7 @@ void grTCLink_80220198(Ground_GObj* gobj)
 
 void grTCLink_8022019C(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* joint = (HSD_JObj*) gobj->hsd_obj;
-    PAD_STACK(8);
-
-    Ground_801C2ED0(joint, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, false);
+    Ground_JObjInline1(gobj);
 }
 
 bool grTCLink_802201EC(Ground_GObj* gobj)

--- a/src/melee/gr/grtdonkey.c
+++ b/src/melee/gr/grtdonkey.c
@@ -128,11 +128,7 @@ static void grTDonkey_802203EC(Ground_GObj* arg0) {}
 
 static void grTDonkey_802203F0(Ground_GObj* gobj)
 {
-    u8 _[8];
-
-    Ground* gp = GET_GROUND(gobj);
-    Ground_801C2ED0(gobj->hsd_obj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, false);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grTDonkey_80220440(Ground_GObj* arg0)
@@ -150,11 +146,7 @@ static void grTDonkey_8022047C(Ground_GObj* arg0) {}
 
 static void grTDonkey_80220480(Ground_GObj* gobj)
 {
-    u8 _[8];
-
-    Ground* gp = GET_GROUND(gobj);
-    Ground_801C2ED0(gobj->hsd_obj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, false);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grTDonkey_802204D0(Ground_GObj* arg0)

--- a/src/melee/gr/grtemblem.c
+++ b/src/melee/gr/grtemblem.c
@@ -139,10 +139,7 @@ static void grTRoy_802245B8(Ground_GObj* gobj) {}
 
 static void grTRoy_802245BC(Ground_GObj* gobj)
 {
-    u8 _[8];
-    Ground* gp = GET_GROUND(gobj);
-    Ground_801C2ED0(gobj->hsd_obj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, false);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grTRoy_8022460C(Ground_GObj* gobj)
@@ -160,10 +157,7 @@ static void grTRoy_80224648(Ground_GObj* gobj) {}
 
 static void grTRoy_8022464C(Ground_GObj* gobj)
 {
-    u8 _[8];
-    Ground* gp = GET_GROUND(gobj);
-    Ground_801C2ED0(gobj->hsd_obj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, false);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grTRoy_8022469C(Ground_GObj* gobj)

--- a/src/melee/gr/grtest.c
+++ b/src/melee/gr/grtest.c
@@ -119,11 +119,7 @@ void grTest_80207168(Ground_GObj* gobj) {}
 
 void grTest_8020716C(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* jobj = GET_JOBJ(gobj);
-
-    Ground_801C2ED0(jobj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 bool grTest_802071BC(Ground_GObj* gobj)

--- a/src/melee/gr/grtgamewatch.c
+++ b/src/melee/gr/grtgamewatch.c
@@ -111,12 +111,7 @@ void grTGameWatch_802242D4(Ground_GObj* gobj)
 
 void grTGameWatch_802242D8(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* joint = (HSD_JObj*) gobj->hsd_obj;
-    PAD_STACK(8);
-
-    Ground_801C2ED0(joint, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, false);
+    Ground_JObjInline1(gobj);
 }
 
 bool grTGameWatch_80224328(Ground_GObj* gobj)
@@ -137,12 +132,7 @@ void grTGameWatch_80224364(Ground_GObj* gobj)
 
 void grTGameWatch_80224368(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* joint = (HSD_JObj*) gobj->hsd_obj;
-    PAD_STACK(8);
-
-    Ground_801C2ED0(joint, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, false);
+    Ground_JObjInline1(gobj);
 }
 
 bool grTGameWatch_802243B8(Ground_GObj* gobj)

--- a/src/melee/gr/grtganon.c
+++ b/src/melee/gr/grtganon.c
@@ -123,12 +123,7 @@ void grTGanon_802248A4(Ground_GObj* gobj)
 
 void grTGanon_802248A8(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* joint = (HSD_JObj*) gobj->hsd_obj;
-    PAD_STACK(8);
-
-    Ground_801C2ED0(joint, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, false);
+    Ground_JObjInline1(gobj);
 }
 
 bool grTGanon_802248F8(Ground_GObj* gobj)
@@ -149,12 +144,7 @@ void grTGanon_80224934(Ground_GObj* gobj)
 
 void grTGanon_80224938(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* joint = (HSD_JObj*) gobj->hsd_obj;
-    PAD_STACK(8);
-
-    Ground_801C2ED0(joint, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, false);
+    Ground_JObjInline1(gobj);
 }
 
 bool grTGanon_80224988(Ground_GObj* gobj)

--- a/src/melee/gr/grtkoopa.c
+++ b/src/melee/gr/grtkoopa.c
@@ -126,11 +126,7 @@ static void grTKoopa_8022180C(Ground_GObj* arg0) {}
 
 static void grTKoopa_80221810(Ground_GObj* gobj)
 {
-    u8 _[8];
-
-    Ground* gp = gobj->user_data;
-    Ground_801C2ED0(gobj->hsd_obj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grTKoopa_80221860(Ground_GObj* arg0)
@@ -148,11 +144,7 @@ static void grTKoopa_8022189C(Ground_GObj* arg0) {}
 
 static void grTKoopa_802218A0(Ground_GObj* gobj)
 {
-    u8 _[8];
-
-    Ground* gp = gobj->user_data;
-    Ground_801C2ED0(gobj->hsd_obj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grTKoopa_802218F0(Ground_GObj* arg0)

--- a/src/melee/gr/grtmars.c
+++ b/src/melee/gr/grtmars.c
@@ -145,12 +145,7 @@ static void grTMars_802220B8(Ground_GObj* arg0)
 
 static void grTMars_802220BC(Ground_GObj* gobj)
 {
-    Ground* gp = gobj->user_data;
-
-    u8 _[8];
-
-    Ground_801C2ED0(gobj->hsd_obj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grTMars_8022210C(Ground_GObj* arg0)
@@ -168,12 +163,7 @@ static void grTMars_80222148(Ground_GObj* arg0) {}
 
 static void grTMars_8022214C(Ground_GObj* gobj)
 {
-    Ground* gp = gobj->user_data;
-
-    u8 _[8];
-
-    Ground_801C2ED0(gobj->hsd_obj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grTMars_8022219C(Ground_GObj* arg0)

--- a/src/melee/gr/grtmewtwo.c
+++ b/src/melee/gr/grtmewtwo.c
@@ -165,10 +165,7 @@ void grTMewtwo_802223A4(Ground_GObj* gobj) {}
 
 void grTMewtwo_802223A8(Ground_GObj* gobj)
 {
-    HSD_JObj* jobj = GET_JOBJ(gobj);
-    Ground* gp = GET_GROUND(gobj);
-    Ground_801C2ED0(jobj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 bool grTMewtwo_802223F8(Ground_GObj* gobj)
@@ -186,10 +183,7 @@ void grTMewtwo_80222434(Ground_GObj* gobj) {}
 
 void grTMewtwo_80222438(Ground_GObj* gobj)
 {
-    HSD_JObj* jobj = GET_JOBJ(gobj);
-    Ground* gp = GET_GROUND(gobj);
-    Ground_801C2ED0(jobj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 bool grTMewtwo_80222488(Ground_GObj* gobj)

--- a/src/melee/gr/grtness.c
+++ b/src/melee/gr/grtness.c
@@ -147,11 +147,7 @@ static void grTNess_80222794(Ground_GObj* arg0)
 
 static void grTNess_80222798(Ground_GObj* gobj)
 {
-    u8 _[8];
-
-    Ground* gp = gobj->user_data;
-    Ground_801C2ED0(gobj->hsd_obj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grTNess_802227E8(Ground_GObj* arg0)
@@ -172,11 +168,7 @@ static void grTNess_80222824(Ground_GObj* arg0)
 
 static void grTNess_80222828(Ground_GObj* gobj)
 {
-    u8 _[8];
-
-    Ground* gp = gobj->user_data;
-    Ground_801C2ED0(gobj->hsd_obj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grTNess_80222878(Ground_GObj* arg0)

--- a/src/melee/gr/grtpeach.c
+++ b/src/melee/gr/grtpeach.c
@@ -148,10 +148,7 @@ void grTPeach_80222A78(Ground_GObj* gobj) {}
 
 void grTPeach_80222A7C(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* jobj = GET_JOBJ(gobj);
-    Ground_801C2ED0(jobj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, false);
+    Ground_JObjInline1(gobj);
 }
 
 bool grTPeach_80222ACC(Ground_GObj* gobj)
@@ -169,10 +166,7 @@ void grTPeach_80222B08(Ground_GObj* gobj) {}
 
 void grTPeach_80222B0C(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* jobj = GET_JOBJ(gobj);
-    Ground_801C2ED0(jobj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, false);
+    Ground_JObjInline1(gobj);
 }
 
 bool grTPeach_80222B5C(Ground_GObj* gobj)

--- a/src/melee/gr/grtpichu.c
+++ b/src/melee/gr/grtpichu.c
@@ -142,11 +142,7 @@ static void grTPichu_80222D5C(Ground_GObj* arg0) {}
 
 static void grTPichu_80222D60(Ground_GObj* gobj)
 {
-    u8 _[4];
-
-    Ground* gp = GET_GROUND(gobj);
-    Ground_801C2ED0(gobj->hsd_obj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grTPichu_80222DB0(Ground_GObj* arg0)
@@ -164,11 +160,7 @@ static void grTPichu_80222DEC(Ground_GObj* arg0) {}
 
 static void grTPichu_80222DF0(Ground_GObj* gobj)
 {
-    u8 _[4];
-
-    Ground* gp = GET_GROUND(gobj);
-    Ground_801C2ED0(gobj->hsd_obj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grTPichu_80222E40(Ground_GObj* arg0)

--- a/src/melee/gr/grtpikachu.c
+++ b/src/melee/gr/grtpikachu.c
@@ -110,12 +110,7 @@ void grTPikachu_80223040(Ground_GObj* gobj)
 
 void grTPikachu_80223044(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* joint = (HSD_JObj*) gobj->hsd_obj;
-    PAD_STACK(8);
-
-    Ground_801C2ED0(joint, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, false);
+    Ground_JObjInline1(gobj);
 }
 
 bool grTPikachu_80223094(Ground_GObj* gobj)
@@ -136,12 +131,7 @@ void grTPikachu_802230D0(Ground_GObj* gobj)
 
 void grTPikachu_802230D4(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* joint = (HSD_JObj*) gobj->hsd_obj;
-    PAD_STACK(8);
-
-    Ground_801C2ED0(joint, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, false);
+    Ground_JObjInline1(gobj);
 }
 
 bool grTPikachu_80223124(Ground_GObj* gobj)

--- a/src/melee/gr/grtpurin.c
+++ b/src/melee/gr/grtpurin.c
@@ -120,12 +120,7 @@ void grTPurin_8022332C(Ground_GObj* gobj)
 
 void grTPurin_80223330(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* joint = (HSD_JObj*) gobj->hsd_obj;
-    PAD_STACK(8);
-
-    Ground_801C2ED0(joint, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, false);
+    Ground_JObjInline1(gobj);
 }
 
 bool grTPurin_80223380(Ground_GObj* gobj)
@@ -167,12 +162,7 @@ void grTPurin_80223478(Ground_GObj* gobj)
 
 void grTPurin_8022347C(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* joint = (HSD_JObj*) gobj->hsd_obj;
-    PAD_STACK(8);
-
-    Ground_801C2ED0(joint, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, false);
+    Ground_JObjInline1(gobj);
 }
 
 bool grTPurin_802234CC(Ground_GObj* gobj)

--- a/src/melee/gr/grtyoshi.c
+++ b/src/melee/gr/grtyoshi.c
@@ -140,11 +140,7 @@ static void grTYoshi_80223D0C(Ground_GObj* arg0) {}
 
 static void grTYoshi_80223D10(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* jobj = GET_JOBJ(gobj);
-
-    Ground_801C2ED0(jobj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grTYoshi_80223D60(Ground_GObj* arg0)
@@ -162,11 +158,7 @@ static void grTYoshi_80223D9C(Ground_GObj* arg0) {}
 
 static void grTYoshi_80223DA0(Ground_GObj* gobj)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_JObj* jobj = GET_JOBJ(gobj);
-
-    Ground_801C2ED0(jobj, gp->map_id);
-    grAnime_801C8138(gobj, gp->map_id, 0);
+    Ground_JObjInline1(gobj);
 }
 
 static bool grTYoshi_80223DF0(Ground_GObj* arg0)


### PR DESCRIPTION
From Codex:
> Replace the remaining 35 exact setup bodies with Ground_JObjInline1, completing the 55-function cluster. This also removes the manual PAD_STACK(8) matching shapes where the inline now provides the original stack behavior.
>
> All 35 changed functions remain 100% matching.