### PR TITLE
Deduplicate target stage initialization

### DIFF
--- a/src/melee/gr/grtcaptain.c
+++ b/src/melee/gr/grtcaptain.c
@@ -72,15 +72,7 @@ static void grTCaptain_OnDemoInit(int unused) {}
 
 static void grTCaptain_OnInit(void)
 {
-    stage_info.unk8C.b4 = false;
-    stage_info.unk8C.b5 = true;
-    grTCaptain_8021FD04(0);
-    grTCaptain_8021FD04(1);
-    grTCaptain_8021FD04(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTCaptain_8021FD04);
 }
 static void grTCaptain_OnLoad(void) {}
 

--- a/src/melee/gr/grtclink.c
+++ b/src/melee/gr/grtclink.c
@@ -65,16 +65,7 @@ void grTCLink_8021FF44(bool unused)
 
 void grTCLink_8021FF48(void)
 {
-    stage_info.unk8C.b4 = false;
-    stage_info.unk8C.b5 = true;
-
-    grTCLink_8021FFE8(0);
-    grTCLink_8021FFE8(1);
-    grTCLink_8021FFE8(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTCLink_8021FFE8);
 }
 
 void grTclink_UnkStage0_OnLoad(void)

--- a/src/melee/gr/grtdonkey.c
+++ b/src/melee/gr/grtdonkey.c
@@ -73,15 +73,7 @@ static void grTDonkey_80220228(bool arg0) {}
 
 static void grTDonkey_8022022C(void)
 {
-    stage_info.unk8C.b4 = 0;
-    stage_info.unk8C.b5 = 1;
-    grTDonkey_802202CC(0);
-    grTDonkey_802202CC(1);
-    grTDonkey_802202CC(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTDonkey_802202CC);
 }
 
 static void grTdonkey_UnkStage0_OnLoad(void) {}

--- a/src/melee/gr/grtdrmario.c
+++ b/src/melee/gr/grtdrmario.c
@@ -23,7 +23,7 @@ void grtDrMario_80220510(void);                  /* static */
 void grTdrmario_UnkStage0_OnLoad(void);          /* static */
 void grTdrmario_UnkStage0_OnStart(void);         /* static */
 bool grtDrMario_802205A8(void);                  /* static */
-HSD_GObj* grtDrMario_802205B0(s32);              /* static */
+HSD_GObj* grtDrMario_802205B0(int);              /* static */
 void grtDrMario_80220698(Ground_GObj*);          /* static */
 bool grtDrMario_802206C4(Ground_GObj*);          /* static */
 void grtDrMario_802206CC(Ground_GObj*);          /* static */
@@ -67,16 +67,7 @@ void grtDrMario_8022050C(bool unk0) {}
 
 void grtDrMario_80220510(void)
 {
-    stage_info.unk8C.b4 = false;
-    stage_info.unk8C.b5 = true;
-
-    grtDrMario_802205B0(0);
-    grtDrMario_802205B0(1);
-    grtDrMario_802205B0(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grtDrMario_802205B0);
 }
 
 void grTdrmario_UnkStage0_OnLoad(void) {}
@@ -91,7 +82,7 @@ bool grtDrMario_802205A8(void)
     return false;
 }
 
-HSD_GObj* grtDrMario_802205B0(s32 arg0)
+HSD_GObj* grtDrMario_802205B0(int arg0)
 {
     HSD_GObj* gobj;
     StageCallbacks* callbacks = &grTDr_803E8850[arg0];

--- a/src/melee/gr/grtemblem.c
+++ b/src/melee/gr/grtemblem.c
@@ -25,7 +25,7 @@ static void grTRoy_802243F8(void);
 static void grTemblem_UnkStage0_OnLoad(void);
 static void grTemblem_UnkStage0_OnStart(void);
 static bool grTRoy_80224490(void);
-static HSD_GObj* grTRoy_80224498(s32 gobj_id);
+static HSD_GObj* grTRoy_80224498(int gobj_id);
 static void grTRoy_80224580(Ground_GObj* gobj);
 static bool grTRoy_802245AC(Ground_GObj*);
 static void grTRoy_802245B4(Ground_GObj*);
@@ -83,15 +83,7 @@ static void grTRoy_802243F4(bool arg0) {}
 
 static void grTRoy_802243F8(void)
 {
-    stage_info.unk8C.b4 = 0;
-    stage_info.unk8C.b5 = 1;
-    grTRoy_80224498(0);
-    grTRoy_80224498(1);
-    grTRoy_80224498(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTRoy_80224498);
 }
 
 static void grTemblem_UnkStage0_OnLoad(void) {}
@@ -106,7 +98,7 @@ static bool grTRoy_80224490(void)
     return false;
 }
 
-static HSD_GObj* grTRoy_80224498(s32 gobj_id)
+static HSD_GObj* grTRoy_80224498(int gobj_id)
 {
     HSD_GObj* gobj;
     StageCallbacks* callbacks = &grTFe_803E97C0[gobj_id];

--- a/src/melee/gr/grtgamewatch.c
+++ b/src/melee/gr/grtgamewatch.c
@@ -45,16 +45,7 @@ void grTGameWatch_80224110(bool unused)
 
 void grTGameWatch_80224114(void)
 {
-    stage_info.unk8C.b4 = false;
-    stage_info.unk8C.b5 = true;
-
-    grTGameWatch_802241B4(0);
-    grTGameWatch_802241B4(1);
-    grTGameWatch_802241B4(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTGameWatch_802241B4);
 }
 
 void grTgamewatch_UnkStage0_OnLoad(void)

--- a/src/melee/gr/grticeclimber.c
+++ b/src/melee/gr/grticeclimber.c
@@ -64,16 +64,7 @@ void grTIceClimber_80220F10(bool unused) {}
 
 void grTIceClimber_80220F14(void)
 {
-    stage_info.unk8C.b4 = false;
-    stage_info.unk8C.b5 = true;
-
-    grTIceClimber_80220FB4(0);
-    grTIceClimber_80220FB4(1);
-    grTIceClimber_80220FB4(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTIceClimber_80220FB4);
 }
 
 void grTiceclimber_UnkStage0_OnLoad(void) {}

--- a/src/melee/gr/grtkirby.c
+++ b/src/melee/gr/grtkirby.c
@@ -24,7 +24,7 @@ void grTKirby_80221368(void);                  /* static */
 void grTkirby_UnkStage0_OnLoad(void);          /* static */
 void grTkirby_UnkStage0_OnStart(void);         /* static */
 bool grTKirby_80221400(void);                  /* static */
-HSD_GObj* grTKirby_80221408(s32);              /* static */
+HSD_GObj* grTKirby_80221408(int);              /* static */
 void grTKirby_802214F0(Ground_GObj*);          /* static */
 bool grTKirby_8022151C(Ground_GObj*);          /* static */
 void grTKirby_80221524(Ground_GObj*);          /* static */
@@ -68,16 +68,7 @@ void grTKirby_80221364(bool unk) {}
 
 void grTKirby_80221368(void)
 {
-    stage_info.unk8C.b4 = false;
-    stage_info.unk8C.b5 = true;
-
-    grTKirby_80221408(0);
-    grTKirby_80221408(1);
-    grTKirby_80221408(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTKirby_80221408);
 }
 
 void grTkirby_UnkStage0_OnLoad(void) {}
@@ -92,7 +83,7 @@ bool grTKirby_80221400(void)
     return false;
 }
 
-HSD_GObj* grTKirby_80221408(s32 arg0)
+HSD_GObj* grTKirby_80221408(int arg0)
 {
     HSD_GObj* gobj;
     StageCallbacks* callbacks = &grTKb_803E8BB0[arg0];

--- a/src/melee/gr/grtkoopa.c
+++ b/src/melee/gr/grtkoopa.c
@@ -72,15 +72,7 @@ static void grTKoopa_80221648(bool arg0) {}
 
 static void grTKoopa_8022164C(void)
 {
-    stage_info.unk8C.b4 = false;
-    stage_info.unk8C.b5 = true;
-    grTKoopa_802216EC(0);
-    grTKoopa_802216EC(1);
-    grTKoopa_802216EC(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTKoopa_802216EC);
 }
 static void grTkoopa_UnkStage0_OnLoad(void) {}
 

--- a/src/melee/gr/grtlink.c
+++ b/src/melee/gr/grtlink.c
@@ -25,7 +25,7 @@ void grTLink_80221930(void);                  /* static */
 void grTlink_UnkStage0_OnLoad(void);          /* static */
 void grTlink_UnkStage0_OnStart(void);         /* static */
 bool grTLink_802219C8(void);                  /* static */
-HSD_GObj* grTLink_802219D0(s32 arg0);         /* static */
+HSD_GObj* grTLink_802219D0(int arg0);         /* static */
 void grTLink_80221AB8(Ground_GObj*);          /* static */
 bool grTLink_80221AE4(Ground_GObj*);          /* static */
 void grTLink_80221AEC(Ground_GObj*);          /* static */
@@ -69,16 +69,7 @@ void grTLink_8022192C(bool unk0) {}
 
 void grTLink_80221930(void)
 {
-    stage_info.unk8C.b4 = false;
-    stage_info.unk8C.b5 = true;
-
-    grTLink_802219D0(0);
-    grTLink_802219D0(1);
-    grTLink_802219D0(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTLink_802219D0);
 }
 
 void grTlink_UnkStage0_OnLoad(void) {}
@@ -93,7 +84,7 @@ bool grTLink_802219C8(void)
     return 0;
 }
 
-HSD_GObj* grTLink_802219D0(s32 arg0)
+HSD_GObj* grTLink_802219D0(int arg0)
 {
     HSD_GObj* gobj;
     StageCallbacks* callbacks = &grTLk_803E8D30[arg0];

--- a/src/melee/gr/grtluigi.c
+++ b/src/melee/gr/grtluigi.c
@@ -54,16 +54,7 @@ void grTLuigi_80221C10(bool arg0) {}
 
 void grTLuigi_80221C14(void)
 {
-    stage_info.unk8C.b4 = false;
-    stage_info.unk8C.b5 = true;
-
-    grTLuigi_80221CB4(0);
-    grTLuigi_80221CB4(1);
-    grTLuigi_80221CB4(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTLuigi_80221CB4);
 }
 
 void grTluigi_UnkStage0_OnLoad(void) {}

--- a/src/melee/gr/grtmario.c
+++ b/src/melee/gr/grtmario.c
@@ -26,7 +26,7 @@
 /* 21F8B4 */ static void grTmario_UnkStage0_OnLoad(void);
 /* 21F8B8 */ static void grTmario_UnkStage0_OnStart(void);
 /* 21F8DC */ static bool grTMario_8021F8DC(void);
-/* 21F8E4 */ static HSD_GObj* grTMario_8021F8E4(s32);
+/* 21F8E4 */ static HSD_GObj* grTMario_8021F8E4(int);
 /* 21F9CC */ static void grTMario_8021F9CC(Ground_GObj*);
 /* 21F9F8 */ static bool grTMario_8021F9F8(Ground_GObj*);
 /* 21FA00 */ static void grTMario_8021FA00(Ground_GObj*);
@@ -90,16 +90,7 @@ void grTMario_8021F840(bool unk) {}
 
 void grTMario_8021F844(void)
 {
-    stage_info.unk8C.b4 = false;
-    stage_info.unk8C.b5 = true;
-
-    grTMario_8021F8E4(0);
-    grTMario_8021F8E4(1);
-    grTMario_8021F8E4(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTMario_8021F8E4);
 }
 
 void grTmario_UnkStage0_OnLoad(void) {}
@@ -114,7 +105,7 @@ bool grTMario_8021F8DC(void)
     return false;
 }
 
-HSD_GObj* grTMario_8021F8E4(s32 arg0)
+HSD_GObj* grTMario_8021F8E4(int arg0)
 {
     HSD_GObj* gobj;
     StageCallbacks* callbacks = &grTMr_803E8548[arg0];

--- a/src/melee/gr/grtmars.c
+++ b/src/melee/gr/grtmars.c
@@ -80,15 +80,7 @@ static void grTMars_80221EF4(bool arg0) {}
 
 static void grTMars_80221EF8(void)
 {
-    stage_info.unk8C.b4 = false;
-    stage_info.unk8C.b5 = true;
-    grTMars_80221F98(0);
-    grTMars_80221F98(1);
-    grTMars_80221F98(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTMars_80221F98);
 }
 
 static void grTmars_UnkStage0_OnLoad(void)

--- a/src/melee/gr/grtness.c
+++ b/src/melee/gr/grtness.c
@@ -82,15 +82,7 @@ static void grTNess_802225D0(bool arg0)
 
 static void grTNess_802225D4(void)
 {
-    stage_info.unk8C.b4 = 0;
-    stage_info.unk8C.b5 = 1;
-    grTNess_80222674(0);
-    grTNess_80222674(1);
-    grTNess_80222674(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTNess_80222674);
 }
 
 static void grTness_UnkStage0_OnLoad(void)

--- a/src/melee/gr/grtpeach.c
+++ b/src/melee/gr/grtpeach.c
@@ -92,16 +92,7 @@ void grTPeach_802228B4(bool arg0) {}
 
 void grTPeach_802228B8(void)
 {
-    stage_info.unk8C.b4 = false;
-    stage_info.unk8C.b5 = true;
-
-    grTPeach_80222958(0);
-    grTPeach_80222958(1);
-    grTPeach_80222958(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTPeach_80222958);
 }
 
 void grTpeach_UnkStage0_OnLoad(void) {}

--- a/src/melee/gr/grtpichu.c
+++ b/src/melee/gr/grtpichu.c
@@ -86,15 +86,7 @@ static void grTPichu_80222B98(bool arg0) {}
 
 static void grTPichu_80222B9C(void)
 {
-    stage_info.unk8C.b4 = false;
-    stage_info.unk8C.b5 = true;
-    grTPichu_80222C3C(0);
-    grTPichu_80222C3C(1);
-    grTPichu_80222C3C(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTPichu_80222C3C);
 }
 
 static void grTpichu_UnkStage0_OnLoad(void) {}

--- a/src/melee/gr/grtpikachu.c
+++ b/src/melee/gr/grtpikachu.c
@@ -44,16 +44,7 @@ void grTPikachu_80222E7C(bool unused)
 
 void grTPikachu_80222E80(void)
 {
-    stage_info.unk8C.b4 = false;
-    stage_info.unk8C.b5 = true;
-
-    grTPikachu_80222F20(0);
-    grTPikachu_80222F20(1);
-    grTPikachu_80222F20(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTPikachu_80222F20);
 }
 
 void grTpikachu_UnkStage0_OnLoad(void)

--- a/src/melee/gr/grtsamus.c
+++ b/src/melee/gr/grtsamus.c
@@ -23,7 +23,7 @@
 /* 2235F4 */ static void grTSamus_OnLoad(void);
 /* 2235F8 */ static void grTSamus_OnStart(void);
 /* 22361C */ static bool grTSamus_8022361C(void);
-/* 223624 */ static HSD_GObj* grTSamus_80223624(s32);
+/* 223624 */ static HSD_GObj* grTSamus_80223624(int);
 /* 22370C */ static void grTSamus_8022370C(Ground_GObj*);
 /* 223738 */ static bool grTSamus_80223738(Ground_GObj*);
 /* 223740 */ static void grTSamus_80223740(Ground_GObj*);
@@ -82,16 +82,7 @@ void grTSamus_OnDemoInit(int unused) {}
 
 void grTSamus_OnInit(void)
 {
-    stage_info.unk8C.b4 = false;
-    stage_info.unk8C.b5 = true;
-
-    grTSamus_80223624(0);
-    grTSamus_80223624(1);
-    grTSamus_80223624(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTSamus_80223624);
 }
 
 void grTSamus_OnLoad(void) {}
@@ -106,7 +97,7 @@ bool grTSamus_8022361C(void)
     return false;
 }
 
-HSD_GObj* grTSamus_80223624(s32 arg0)
+HSD_GObj* grTSamus_80223624(int arg0)
 {
     HSD_GObj* gobj;
     StageCallbacks* callbacks = &grTSs_803E93F8[arg0];

--- a/src/melee/gr/grtseak.c
+++ b/src/melee/gr/grtseak.c
@@ -23,7 +23,7 @@
 /* 2238D8 */ static void grTseak_OnLoad(void);
 /* 2238DC */ static void grTseak_OnStart(void);
 /* 223900 */ static bool grTSeak_80223900(void);
-/* 223908 */ static HSD_GObj* grTSeak_80223908(s32);
+/* 223908 */ static HSD_GObj* grTSeak_80223908(int);
 /* 2239F0 */ static void grTSeak_802239F0(Ground_GObj*);
 /* 223A1C */ static bool grTSeak_80223A1C(Ground_GObj*);
 /* 223A24 */ static void grTSeak_80223A24(Ground_GObj*);
@@ -82,16 +82,7 @@ void grTSeak_OnDemoInit(bool unk0) {}
 
 void grTSeak_OnInit(void)
 {
-    stage_info.unk8C.b4 = false;
-    stage_info.unk8C.b5 = true;
-
-    grTSeak_80223908(0);
-    grTSeak_80223908(1);
-    grTSeak_80223908(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTSeak_80223908);
 }
 
 void grTseak_OnLoad(void) {}
@@ -106,7 +97,7 @@ bool grTSeak_80223900(void)
     return false;
 }
 
-HSD_GObj* grTSeak_80223908(s32 arg0)
+HSD_GObj* grTSeak_80223908(int arg0)
 {
     HSD_GObj* gobj;
     StageCallbacks* callbacks = &grTSk_803E94B8[arg0];

--- a/src/melee/gr/grtyoshi.c
+++ b/src/melee/gr/grtyoshi.c
@@ -84,15 +84,7 @@ static void grTYoshi_OnDemoInit(bool arg0) {}
 
 static void grTYoshi_OnInit(void)
 {
-    stage_info.unk8C.b4 = 0;
-    stage_info.unk8C.b5 = 1;
-    grTYoshi_80223BEC(0);
-    grTYoshi_80223BEC(1);
-    grTYoshi_80223BEC(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTYoshi_80223BEC);
 }
 
 static void grTYoshi_OnLoad(void) {}

--- a/src/melee/gr/grtzelda.c
+++ b/src/melee/gr/grtzelda.c
@@ -25,7 +25,7 @@ void grTZelda_OnInit(void);                               /* static */
 void grTZelda_OnLoad(void);                               /* static */
 void grTZelda_OnStart(void);                              /* static */
 bool grTZelda_80223EC8(void);                             /* static */
-HSD_GObj* grTZelda_80223ED0(s32);                         /* static */
+HSD_GObj* grTZelda_80223ED0(int);                         /* static */
 void grTZelda_80223FB8(Ground_GObj*);                     /* static */
 bool grTZelda_80223FE4(Ground_GObj*);                     /* static */
 void grTZelda_80223FEC(Ground_GObj*);                     /* static */
@@ -69,16 +69,7 @@ void grTZelda_OnDemoInit(int unused) {}
 
 void grTZelda_OnInit(void)
 {
-    stage_info.unk8C.b4 = false;
-    stage_info.unk8C.b5 = true;
-
-    grTZelda_80223ED0(0);
-    grTZelda_80223ED0(1);
-    grTZelda_80223ED0(2);
-    Ground_801C39C0();
-    Ground_801C3BB4();
-    Ground_801C4210();
-    Ground_801C42AC();
+    Ground_InitTargetStage(grTZelda_80223ED0);
 }
 
 void grTZelda_OnLoad(void) {}
@@ -93,7 +84,7 @@ bool grTZelda_80223EC8(void)
     return false;
 }
 
-HSD_GObj* grTZelda_80223ED0(s32 arg0)
+HSD_GObj* grTZelda_80223ED0(int arg0)
 {
     HSD_GObj* gobj;
     StageCallbacks* callbacks = &grTZd_803E9638[arg0];

--- a/src/melee/gr/inlines.h
+++ b/src/melee/gr/inlines.h
@@ -41,6 +41,19 @@ static inline void Ground_SetupStageCallbacks(HSD_GObj* gobj,
     }
 }
 
+static inline void Ground_InitTargetStage(HSD_GObj* (*create_gobj)(int) )
+{
+    stage_info.unk8C.b4 = false;
+    stage_info.unk8C.b5 = true;
+    create_gobj(0);
+    create_gobj(1);
+    create_gobj(2);
+    Ground_801C39C0();
+    Ground_801C3BB4();
+    Ground_801C4210();
+    Ground_801C42AC();
+}
+
 #define ZRANDI(n) ((n) != 0 ? HSD_Randi(n) : 0)
 
 static inline int rand_range(int a, int b)


### PR DESCRIPTION
From Codex:
> Share the common 21-function target-stage initialization sequence through Ground_InitTargetStage. Normalize eight private constructor index parameters from s32 to int so their function-pointer types match the majority convention without casts.
>
> All 21 initializers and all eight retagged constructors remain 100% matching.