### PR TITLE
Share item lifetime tick logic

### DIFF
--- a/src/melee/it/inlines.h
+++ b/src/melee/it/inlines.h
@@ -19,6 +19,15 @@ static inline void itResetVelocity(Item* ip)
     ip->x40_vel.x = ip->x40_vel.y = ip->x40_vel.z = 0.0F;
 }
 
+static inline bool Item_TickLifetime(Item* ip)
+{
+    if (ip->xD44_lifeTimer <= 0.0f) {
+        return true;
+    }
+    ip->xD44_lifeTimer -= 1.0f;
+    return false;
+}
+
 /// Check whether the grapple chain from @p head to the tip @p pos or to its
 /// owner @p fp collides with terrain (shared by Link's hookshot and Samus's
 /// grapple beam).

--- a/src/melee/it/items/itclimbersice.c
+++ b/src/melee/it/items/itclimbersice.c
@@ -242,11 +242,7 @@ void it_802C1AE4(Item_GObj* gobj)
 bool itClimbersice_UnkMotion2_Anim(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
-    if (ip->xD44_lifeTimer <= 0.0f) {
-        return true;
-    }
-    ip->xD44_lifeTimer -= 1.0f;
-    return false;
+    return Item_TickLifetime(ip);
 }
 
 static inline void itClimbersice_Phys_inline(Item_GObj* gobj)
@@ -297,11 +293,7 @@ void fn_802C1D44(Item_GObj* gobj)
 bool itClimbersice_UnkMotion3_Anim(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
-    if (ip->xD44_lifeTimer <= 0.0f) {
-        return true;
-    }
-    ip->xD44_lifeTimer -= 1.0f;
-    return false;
+    return Item_TickLifetime(ip);
 }
 
 void itClimbersice_UnkMotion3_Phys(Item_GObj* gobj)

--- a/src/melee/it/items/ithouou.c
+++ b/src/melee/it/items/ithouou.c
@@ -400,11 +400,7 @@ void it_802D2EF0(Item_GObj* gobj)
 bool it_802D2F3C(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
-    if (ip->xD44_lifeTimer <= 0.0f) {
-        return true;
-    }
-    ip->xD44_lifeTimer -= 1.0f;
-    return false;
+    return Item_TickLifetime(ip);
 }
 
 void it_802D2F70(Item_GObj* gobj)

--- a/src/melee/it/items/itlizardon.c
+++ b/src/melee/it/items/itlizardon.c
@@ -456,11 +456,7 @@ void it_802CC5D4(Item_GObj* gobj)
 bool it_802CC650(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
-    if (ip->xD44_lifeTimer <= 0.0f) {
-        return true;
-    }
-    ip->xD44_lifeTimer -= 1.0f;
-    return false;
+    return Item_TickLifetime(ip);
 }
 
 void it_802CC684(Item_GObj* gobj)

--- a/src/melee/it/items/itlugia.c
+++ b/src/melee/it/items/itlugia.c
@@ -530,11 +530,7 @@ void it_802D23F4(Item_GObj* gobj)
 bool it_802D246C(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
-    if (ip->xD44_lifeTimer <= 0.0f) {
-        return true;
-    }
-    ip->xD44_lifeTimer -= 1.0f;
-    return false;
+    return Item_TickLifetime(ip);
 }
 
 void it_802D24A0(Item_GObj* gobj)

--- a/src/melee/it/items/itmatadogas.c
+++ b/src/melee/it/items/itmatadogas.c
@@ -242,11 +242,7 @@ ItemStateTable it_803F7BB0[] = { {
 bool it_802CB810(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
-    if (ip->xD44_lifeTimer <= 0.0f) {
-        return true;
-    }
-    ip->xD44_lifeTimer -= 1.0f;
-    return false;
+    return Item_TickLifetime(ip);
 }
 
 void it_802CB844(Item_GObj* gobj)

--- a/src/melee/it/items/itmball.c
+++ b/src/melee/it/items/itmball.c
@@ -220,11 +220,7 @@ void itMball_OnAccessory(Item_GObj* arg0)
 bool itMball_Motion5_Anim(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
-    if (ip->xD44_lifeTimer <= 0.0f) {
-        return true;
-    }
-    ip->xD44_lifeTimer -= 1.0f;
-    return false;
+    return Item_TickLifetime(ip);
 }
 
 void itMball_Motion5_Phys(Item_GObj* gobj) {}
@@ -262,11 +258,7 @@ void itMball_80297E8C(Item_GObj* gobj)
 bool itMball_Motion6_Anim(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
-    if (ip->xD44_lifeTimer <= 0.0f) {
-        return true;
-    }
-    ip->xD44_lifeTimer -= 1.0f;
-    return false;
+    return Item_TickLifetime(ip);
 }
 
 void itMball_Motion6_Phys(Item_GObj* arg0)


### PR DESCRIPTION
Small chunk of code but could be useful to edit in bulk.

From Codex:
> Replace eight duplicated lifetime expiry and decrement bodies across six item files with a call-free inline helper. Preserve the caller-side item access shape; all affected complete objects remain exact and no fallback helper is emitted.