### PR TITLE
Share common falling item physics

### DIFF
--- a/src/melee/it/inlines.h
+++ b/src/melee/it/inlines.h
@@ -1,6 +1,8 @@
 #ifndef MELEE_IT_INLINES_H
 #define MELEE_IT_INLINES_H
 
+#include "it/it_2725.h"
+#include "it/it_3F14.h"
 #include "it/types.h"
 #include "mp/mplib.h"
 
@@ -17,6 +19,13 @@ static inline Item* GetItemData(HSD_GObj* gobj)
 static inline void itResetVelocity(Item* ip)
 {
     ip->x40_vel.x = ip->x40_vel.y = ip->x40_vel.z = 0.0F;
+}
+
+static inline void Item_ApplyFallingPhysics(Item_GObj* gobj)
+{
+    ItemAttr* attrs = GET_ITEM(gobj)->xCC_item_attr;
+    it_80272860(gobj, attrs->x10_fall_speed, attrs->x14_fall_speed_max);
+    it_80274658(gobj, it_804D6D28->x68_float);
 }
 
 /// Check whether the grapple chain from @p head to the tip @p pos or to its

--- a/src/melee/it/items/itbombhei.c
+++ b/src/melee/it/items/itbombhei.c
@@ -493,9 +493,7 @@ bool itBombhei_UnkMotion6_Anim(Item_GObj* gobj)
 
 void itBombhei_UnkMotion6_Phys(Item_GObj* gobj)
 {
-    ItemAttr* attr = ((Item*) gobj->user_data)->xCC_item_attr;
-    it_80272860(gobj, attr->x10_fall_speed, attr->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 static inline void fn_8028007C_inline(Item_GObj* gobj)
@@ -593,9 +591,7 @@ bool itBombhei_UnkMotion10_Anim(Item_GObj* gobj)
 
 void itBombhei_UnkMotion10_Phys(Item_GObj* gobj)
 {
-    ItemAttr* attr = ((Item*) gobj->user_data)->xCC_item_attr;
-    it_80272860(gobj, attr->x10_fall_speed, attr->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 void fn_80280974(Item_GObj* gobj)

--- a/src/melee/it/items/itbox.c
+++ b/src/melee/it/items/itbox.c
@@ -305,9 +305,7 @@ void itBox_Logic1_Thrown(Item_GObj* gobj)
 
 void itBox_UnkMotion4_Phys(Item_GObj* gobj)
 {
-    ItemAttr* attr = ((Item*) gobj->user_data)->xCC_item_attr;
-    it_80272860(gobj, attr->x10_fall_speed, attr->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 /// Inline helper: spawn break effect and roll for item spawn.

--- a/src/melee/it/items/itclimbersice.c
+++ b/src/melee/it/items/itclimbersice.c
@@ -306,10 +306,7 @@ bool itClimbersice_UnkMotion3_Anim(Item_GObj* gobj)
 
 void itClimbersice_UnkMotion3_Phys(Item_GObj* gobj)
 {
-    Item* ip = GET_ITEM(gobj);
-    ItemAttr* attrs = ip->xCC_item_attr;
-    it_80272860(gobj, attrs->x10_fall_speed, attrs->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
     itClimbersice_Phys_inline(gobj);
 }
 

--- a/src/melee/it/items/itdosei.c
+++ b/src/melee/it/items/itdosei.c
@@ -477,10 +477,7 @@ bool itDosei_UnkMotion5_Anim(Item_GObj* gobj)
 }
 void itDosei_UnkMotion5_Phys(Item_GObj* gobj)
 {
-    Item* ip = gobj->user_data;
-    ItemAttr* attrs = ip->xCC_item_attr;
-    it_80272860(gobj, attrs->x10_fall_speed, attrs->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 void itDosei_Logic7_EnteredAir(Item_GObj* gobj)

--- a/src/melee/it/items/itegg.c
+++ b/src/melee/it/items/itegg.c
@@ -191,9 +191,7 @@ void itEgg_Logic3_Thrown(Item_GObj* gobj)
 
 void itEgg_UnkMotion3_Phys(Item_GObj* gobj)
 {
-    ItemAttr* attr = GET_ITEM(gobj)->xCC_item_attr;
-    it_80272860(gobj, attr->x10_fall_speed, attr->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 bool itEgg_UnkMotion3_Coll(Item_GObj* gobj)

--- a/src/melee/it/items/itevyoshiegg.c
+++ b/src/melee/it/items/itevyoshiegg.c
@@ -144,10 +144,7 @@ void itEvYoshiEgg_Logic42_Thrown(Item_GObj* gobj)
 
 void itEvyoshiegg_UnkMotion3_Phys(Item_GObj* gobj)
 {
-    ItemAttr* attrs = GET_ITEM(gobj)->xCC_item_attr;
-
-    it_80272860(gobj, attrs->x10_fall_speed, attrs->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 bool itEvyoshiegg_UnkMotion3_Coll(Item_GObj* gobj)

--- a/src/melee/it/items/itharisen.c
+++ b/src/melee/it/items/itharisen.c
@@ -173,9 +173,7 @@ void itHarisen_Logic24_Thrown(Item_GObj* gobj)
 
 void itHarisen_UnkMotion8_Phys(Item_GObj* gobj)
 {
-    ItemAttr* attr = ((Item*) gobj->user_data)->xCC_item_attr;
-    it_80272860(gobj, attr->x10_fall_speed, attr->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 bool itHarisen_UnkMotion7_Coll(Item_GObj* gobj)

--- a/src/melee/it/items/itkusudama.c
+++ b/src/melee/it/items/itkusudama.c
@@ -529,9 +529,7 @@ bool itKusudama_UnkMotion6_Anim(Item_GObj* gobj)
 
 void itKusudama_UnkMotion6_Phys(Item_GObj* gobj)
 {
-    ItemAttr* attr = GET_ITEM(gobj)->xCC_item_attr;
-    it_80272860(gobj, attr->x10_fall_speed, attr->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 static inline void itKusudama_UnkMotion5_Coll_inline(Item_GObj* gobj)

--- a/src/melee/it/items/itkyasarinegg.c
+++ b/src/melee/it/items/itkyasarinegg.c
@@ -87,10 +87,7 @@ void itKyasarinEgg_Logic28_Thrown(Item_GObj* gobj)
 
 void itKyasarinegg_UnkMotion3_Phys(Item_GObj* gobj)
 {
-    ItemAttr* attrs = GET_ITEM(gobj)->xCC_item_attr;
-
-    it_80272860(gobj, attrs->x10_fall_speed, attrs->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 int itKyasarinegg_UnkMotion3_Coll(Item_GObj* gobj)
@@ -112,10 +109,7 @@ void it_802EFCC0(Item_GObj* gobj)
 
 void itKyasarinegg_UnkMotion1_Phys(Item_GObj* gobj)
 {
-    ItemAttr* attrs = GET_ITEM(gobj)->xCC_item_attr;
-
-    it_80272860(gobj, attrs->x10_fall_speed, attrs->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 int itKyasarinegg_UnkMotion1_Coll(Item_GObj* gobj)

--- a/src/melee/it/items/itlgun.c
+++ b/src/melee/it/items/itlgun.c
@@ -160,10 +160,7 @@ void itLGun_Logic16_Thrown(Item_GObj* gobj)
 
 void itLgun_UnkMotion4_Phys(Item_GObj* gobj)
 {
-    ItemAttr* item_comm_attr = GET_ITEM(gobj)->xCC_item_attr;
-    it_80272860(gobj, item_comm_attr->x10_fall_speed,
-                item_comm_attr->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 bool itLGun_Logic16_DmgDealt(Item_GObj* gobj)

--- a/src/melee/it/items/itlinkbomb.c
+++ b/src/melee/it/items/itlinkbomb.c
@@ -340,11 +340,7 @@ bool itLinkbomb_UnkMotion2_Anim(HSD_GObj* gobj)
 
 void itLinkbomb_UnkMotion2_Phys(Item_GObj* gobj)
 {
-    ItemAttr* temp_r4;
-
-    temp_r4 = GET_ITEM(gobj)->xCC_item_attr;
-    it_80272860(gobj, temp_r4->x10_fall_speed, temp_r4->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 static inline int it_LinkBomb_Inline_VelocityCompare(HSD_GObj* gobj, Vec3* vel)
@@ -432,10 +428,7 @@ bool itLinkbomb_UnkMotion3_Anim(Item_GObj* gobj)
 
 void itLinkbomb_UnkMotion3_Phys(Item_GObj* gobj)
 {
-    ItemAttr* temp_r4;
-    temp_r4 = GET_ITEM(gobj)->xCC_item_attr;
-    it_80272860(gobj, temp_r4->x10_fall_speed, temp_r4->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 bool itLinkbomb_UnkMotion3_Coll(HSD_GObj* gobj)

--- a/src/melee/it/items/itlipstick.c
+++ b/src/melee/it/items/itlipstick.c
@@ -132,9 +132,7 @@ void itLipstick_Logic23_Thrown(Item_GObj* gobj)
 
 void itLipstick_UnkMotion4_Phys(Item_GObj* gobj)
 {
-    ItemAttr* attr = ((Item*) gobj->user_data)->xCC_item_attr;
-    it_80272860(gobj, attr->x10_fall_speed, attr->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 bool itLipstick_UnkMotion3_Coll(Item_GObj* gobj)

--- a/src/melee/it/items/itluigifireball.c
+++ b/src/melee/it/items/itluigifireball.c
@@ -73,9 +73,7 @@ bool itLuigifireball_UnkMotion0_Anim(Item_GObj* gobj)
 
 void itLuigifireball_UnkMotion0_Phys(Item_GObj* gobj)
 {
-    ItemAttr* attrs = GET_ITEM(gobj)->xCC_item_attr;
-    it_80272860(gobj, attrs->x10_fall_speed, attrs->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 static double calc_dist_2d_accurate(Vec3* v)

--- a/src/melee/it/items/itmariofireball.c
+++ b/src/melee/it/items/itmariofireball.c
@@ -70,9 +70,7 @@ bool itMariofireball_UnkMotion0_Anim(Item_GObj* gobj)
 
 void itMariofireball_UnkMotion0_Phys(Item_GObj* gobj)
 {
-    ItemAttr* attrs = GET_ITEM(gobj)->xCC_item_attr;
-    it_80272860(gobj, attrs->x10_fall_speed, attrs->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 static double calc_dist_2d_accurate(Vec3* v)

--- a/src/melee/it/items/itmball.c
+++ b/src/melee/it/items/itmball.c
@@ -136,10 +136,7 @@ void itMball_Thrown(Item_GObj* arg0)
 
 void itMball_Motion3_Phys(Item_GObj* arg0)
 {
-    Item* item = GET_ITEM(arg0);
-    it_80272860(arg0, item->xCC_item_attr->x10_fall_speed,
-                item->xCC_item_attr->x14_fall_speed_max);
-    it_80274658(arg0, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(arg0);
 }
 
 bool itMball_Motion3_Coll(Item_GObj* arg0)

--- a/src/melee/it/items/itmsbomb.c
+++ b/src/melee/it/items/itmsbomb.c
@@ -116,9 +116,7 @@ void itMSBomb_Logic19_Thrown(Item_GObj* gobj)
 
 void itMsbomb_UnkMotion3_Phys(Item_GObj* gobj)
 {
-    ItemAttr* attr = GET_ITEM(gobj)->xCC_item_attr;
-    it_80272860(gobj, attr->x10_fall_speed, attr->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 bool itMsbomb_UnkMotion3_Coll(Item_GObj* gobj)
@@ -202,9 +200,7 @@ void it_8029047C(Item_GObj* gobj)
 
 void itMsbomb_UnkMotion5_Phys(Item_GObj* gobj)
 {
-    ItemAttr* attr = GET_ITEM(gobj)->xCC_item_attr;
-    it_80272860(gobj, attr->x10_fall_speed, attr->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 bool itMsbomb_UnkMotion5_Coll(Item_GObj* gobj)

--- a/src/melee/it/items/itpeachturnip.c
+++ b/src/melee/it/items/itpeachturnip.c
@@ -224,11 +224,7 @@ bool itPeachturnip_UnkMotion3_Anim(Item_GObj* item_gobj)
 /// ProjectilePhysics_TurnipVelocity
 void itPeachturnip_UnkMotion3_Phys(Item_GObj* item_gobj)
 {
-    ItemAttr* attr;
-
-    attr = GET_ITEM(item_gobj)->xCC_item_attr;
-    it_80272860(item_gobj, attr->x10_fall_speed, attr->x14_fall_speed_max);
-    it_80274658(item_gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(item_gobj);
 }
 
 bool itPeachturnip_UnkMotion3_Coll(Item_GObj* item_gobj)

--- a/src/melee/it/items/itscball.c
+++ b/src/melee/it/items/itscball.c
@@ -116,10 +116,7 @@ bool itScball_UnkMotion3_Anim(HSD_GObj* gobj)
 }
 void itScball_UnkMotion3_Phys(Item_GObj* gobj)
 {
-    ItemAttr* attr = GET_ITEM(gobj)->xCC_item_attr;
-
-    it_80272860(gobj, attr->x10_fall_speed, attr->x14_fall_speed_max);
-    it_80274658((HSD_GObj*) gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 bool itScball_UnkMotion3_Coll(Item_GObj* gobj)

--- a/src/melee/it/items/itsscope.c
+++ b/src/melee/it/items/itsscope.c
@@ -255,9 +255,7 @@ void itSScope_Logic21_Thrown(Item_GObj* gobj)
 
 void itSscope_UnkMotion3_Phys(Item_GObj* gobj)
 {
-    ItemAttr* temp_r4 = (GET_ITEM(gobj))->xCC_item_attr;
-    it_80272860(gobj, temp_r4->x10_fall_speed, temp_r4->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 bool itSScope_Logic21_DmgDealt(Item_GObj* gobj)

--- a/src/melee/it/items/itstarrod.c
+++ b/src/melee/it/items/itstarrod.c
@@ -136,9 +136,7 @@ void itStarRod_Logic22_Thrown(Item_GObj* gobj)
 
 void itStarrod_UnkMotion4_Phys(Item_GObj* gobj)
 {
-    ItemAttr* x = GET_ITEM(gobj)->xCC_item_attr;
-    it_80272860(gobj, x->x10_fall_speed, x->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 bool itStarrod_UnkMotion3_Coll(Item_GObj* gobj)

--- a/src/melee/it/items/itsword.c
+++ b/src/melee/it/items/itsword.c
@@ -405,9 +405,7 @@ bool itSword_UnkMotion3_Anim(Item_GObj* gobj)
 
 void itSword_UnkMotion3_Phys(Item_GObj* gobj)
 {
-    ItemAttr* attrs = GET_ITEM(gobj)->xCC_item_attr;
-    it_80272860(gobj, attrs->x10_fall_speed, attrs->x14_fall_speed_max);
-    it_80274658(gobj, it_804D6D28->x68_float);
+    Item_ApplyFallingPhysics(gobj);
 }
 
 bool itSword_UnkMotion3_Coll(Item_GObj* gobj)


### PR DESCRIPTION
From Codex:
> Use Item_ApplyFallingPhysics at 25 sites across 21 item files to share common gravity, terminal velocity, and drag setup. All affected complete objects remain exact and no fallback helper is emitted.
> 
> Keep Bat and Hammer Head explicit because their caller-side GET_ITEM access produces the target 0x20 frame instead of the helper's 0x18 frame. Keep Capsule explicit because it calls capsule-specific physics, and Dr. Mario's pill explicit because its item pointer is retained across a preceding call; those few shapes do not justify a second helper.