### PR TITLE
Reuse emitted baselib allocator accessors

### DIFF
--- a/src/sysdolphin/baselib/aobj.c
+++ b/src/sysdolphin/baselib/aobj.c
@@ -244,7 +244,7 @@ void HSD_AObjRemove(HSD_AObj* aobj)
 
 HSD_AObj* HSD_AObjAlloc(void)
 {
-    HSD_AObj* new = (HSD_AObj*) HSD_ObjAlloc(&aobj_alloc_data);
+    HSD_AObj* new = (HSD_AObj*) HSD_ObjAlloc(HSD_AObjGetAllocData());
     HSD_ASSERT(489, new);
 
     memset(new, 0, sizeof(HSD_AObj));
@@ -259,7 +259,7 @@ void HSD_AObjFree(HSD_AObj* aobj)
         return;
     }
 
-    HSD_ObjFree(&aobj_alloc_data, (HSD_ObjAllocLink*) aobj);
+    HSD_ObjFree(HSD_AObjGetAllocData(), (HSD_ObjAllocLink*) aobj);
 }
 
 static void callbackForeachFunc(HSD_AObj* aobj, void* obj, HSD_Type type,

--- a/src/sysdolphin/baselib/fobj.c
+++ b/src/sysdolphin/baselib/fobj.c
@@ -14,7 +14,7 @@ HSD_ObjAllocData* HSD_FObjGetAllocData(void)
 
 void HSD_FObjInitAllocData(void)
 {
-    HSD_ObjAllocInit(&fobj_alloc_data, sizeof(HSD_FObj), 4);
+    HSD_ObjAllocInit(HSD_FObjGetAllocData(), sizeof(HSD_FObj), 4);
 }
 
 void HSD_FObjRemove(HSD_FObj* fobj)
@@ -472,7 +472,7 @@ HSD_FObj* HSD_FObjLoadDesc(HSD_FObjDesc* desc)
 
 HSD_FObj* HSD_FObjAlloc(void)
 {
-    HSD_FObj* new = HSD_ObjAlloc(&fobj_alloc_data);
+    HSD_FObj* new = HSD_ObjAlloc(HSD_FObjGetAllocData());
     HSD_ASSERT(0x2F3, new);
     memset(new, 0, sizeof(HSD_FObj));
     return new;
@@ -480,5 +480,5 @@ HSD_FObj* HSD_FObjAlloc(void)
 
 void HSD_FObjFree(HSD_FObj* fobj)
 {
-    HSD_ObjFree(&fobj_alloc_data, fobj);
+    HSD_ObjFree(HSD_FObjGetAllocData(), fobj);
 }

--- a/src/sysdolphin/baselib/id.c
+++ b/src/sysdolphin/baselib/id.c
@@ -15,7 +15,7 @@ HSD_ObjAllocData* HSD_IDGetAllocData(void)
 
 void HSD_IDInitAllocData(void)
 {
-    HSD_ObjAllocInit(&hsd_iddata, sizeof(IDEntry), 4);
+    HSD_ObjAllocInit(HSD_IDGetAllocData(), sizeof(IDEntry), 4);
 }
 
 void HSD_IDSetup(void)
@@ -32,7 +32,7 @@ inline IDEntry* IDEntryAlloc(void)
 {
     IDEntry* entry;
 
-    entry = HSD_ObjAlloc(&hsd_iddata);
+    entry = HSD_ObjAlloc(HSD_IDGetAllocData());
     /// @todo Convert to @c HSD_ASSERT once a byte-matching form is found.
     if (entry == NULL) {
         __assert("id.c", 67, "entry");
@@ -72,7 +72,7 @@ void HSD_IDInsertToTable(HSD_IDTable* table, u32 id, void* data)
 
 inline void IDEntryFree(IDEntry* entry)
 {
-    HSD_ObjFree(&hsd_iddata, entry);
+    HSD_ObjFree(HSD_IDGetAllocData(), entry);
 }
 
 void HSD_IDRemoveByIDFromTable(HSD_IDTable* table, u32 id)

--- a/src/sysdolphin/baselib/list.c
+++ b/src/sysdolphin/baselib/list.c
@@ -29,7 +29,7 @@ HSD_SList* HSD_SListAlloc(void)
 {
     HSD_SList* list;
 
-    list = HSD_ObjAlloc(&slist_alloc_data);
+    list = HSD_ObjAlloc(HSD_SListGetAllocData());
     HSD_ASSERT(76, list);
 
     memset(list, 0, sizeof(HSD_SList));
@@ -83,7 +83,7 @@ HSD_SList* HSD_SListRemove(HSD_SList* list)
 
     if (list != NULL) {
         next = list->next;
-        HSD_ObjFree(&slist_alloc_data, list);
+        HSD_ObjFree(HSD_SListGetAllocData(), list);
         return next;
     }
 

--- a/src/sysdolphin/baselib/mtx.c
+++ b/src/sysdolphin/baselib/mtx.c
@@ -497,7 +497,7 @@ HSD_ObjAllocData* HSD_VecGetAllocData(void)
 
 void HSD_VecInitAllocData(void)
 {
-    HSD_ObjAllocInit(&HSD_Mtx_804C2310, 0xC, 4);
+    HSD_ObjAllocInit(HSD_VecGetAllocData(), 0xC, 4);
 }
 
 HSD_ObjAllocData* HSD_MtxGetAllocData(void)
@@ -507,5 +507,5 @@ HSD_ObjAllocData* HSD_MtxGetAllocData(void)
 
 void HSD_MtxInitAllocData(void)
 {
-    HSD_ObjAllocInit(&HSD_Mtx_804C233C, 0x30, 4);
+    HSD_ObjAllocInit(HSD_MtxGetAllocData(), 0x30, 4);
 }

--- a/src/sysdolphin/baselib/robj.c
+++ b/src/sysdolphin/baselib/robj.c
@@ -681,7 +681,7 @@ void HSD_RObjRemoveAll(HSD_RObj* robj)
 
 HSD_RObj* HSD_RObjAlloc(void)
 {
-    HSD_RObj* new = HSD_ObjAlloc(&robj_alloc_data);
+    HSD_RObj* new = HSD_ObjAlloc(HSD_RObjGetAllocData());
     HSD_ASSERT(1032, new);
     memset(new, 0, 0x1C);
     return new;
@@ -689,7 +689,7 @@ HSD_RObj* HSD_RObjAlloc(void)
 
 void HSD_RObjFree(HSD_RObj* robj)
 {
-    HSD_ObjFree(&robj_alloc_data, robj);
+    HSD_ObjFree(HSD_RObjGetAllocData(), robj);
 }
 
 static char HSD_RObj_80406F14[] = "(ptr && nitems) || !ptr";
@@ -825,7 +825,7 @@ static f32 dummy_func(void* unused)
 
 HSD_Rvalue* HSD_RvalueAlloc(void)
 {
-    HSD_Rvalue* rvalue = HSD_ObjAlloc(&rvalue_alloc_data);
+    HSD_Rvalue* rvalue = HSD_ObjAlloc(HSD_RvalueObjGetAllocData());
     HSD_ASSERT(1224, rvalue);
     memset(rvalue, 0, sizeof(HSD_Rvalue));
     return rvalue;
@@ -835,7 +835,7 @@ void HSD_RvalueRemove(HSD_Rvalue* rvalue)
 {
     if (rvalue != NULL) {
         HSD_JObjUnrefThis(rvalue->jobj);
-        HSD_ObjFree(&rvalue_alloc_data, rvalue);
+        HSD_ObjFree(HSD_RvalueObjGetAllocData(), rvalue);
     }
 }
 

--- a/src/sysdolphin/baselib/shadow.c
+++ b/src/sysdolphin/baselib/shadow.c
@@ -33,7 +33,7 @@ HSD_ObjAllocData* HSD_ShadowGetAllocData(void)
 
 void HSD_ShadowInitAllocData(void)
 {
-    HSD_ObjAllocInit(&shadow_alloc_data, sizeof(HSD_Shadow), 4);
+    HSD_ObjAllocInit(HSD_ShadowGetAllocData(), sizeof(HSD_Shadow), 4);
 }
 
 HSD_TObj* makeShadowTObj(void)
@@ -52,7 +52,7 @@ HSD_Shadow* HSD_ShadowAlloc(void)
 {
     HSD_Shadow* shadow;
 
-    shadow = HSD_ObjAlloc(&shadow_alloc_data);
+    shadow = HSD_ObjAlloc(HSD_ShadowGetAllocData());
     memset(shadow, 0, sizeof(HSD_Shadow));
     shadow->camera = HSD_CObjAlloc();
     shadow->texture = makeShadowTObj();
@@ -96,7 +96,7 @@ void HSD_ShadowRemove(HSD_Shadow* shadow)
     tobj = shadow->texture;
     HSD_ImageDescFree(tobj->imagedesc);
     HSD_TObjFree(tobj);
-    HSD_ObjFree(&shadow_alloc_data, shadow);
+    HSD_ObjFree(HSD_ShadowGetAllocData(), shadow);
 }
 
 void HSD_ShadowInit(HSD_Shadow* shadow)


### PR DESCRIPTION
From Codex:
> Route 19 allocator initialization, allocation, and free sites through their emitted HSD_*GetAllocData accessors across seven baselib translation units. All affected functions and inline callers remain exact matches.
>
> Keep initialization and allocation sites that precede their accessor definition on direct global access, since MWCC cannot inline a body it has not seen yet.