### PR TITLE
Refactor CPU code for lots of code reuse

### DIFF
--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -6426,6 +6426,19 @@ static inline void ftCo_CpuUpdateSpecialItemTarget(Fighter* fp)
     fp->x1A88.x50 = ftCo_800A648C(fp);
 }
 
+static inline bool ftCo_CpuDataShouldAct(struct Fighter_x1A88_t* data)
+{
+    if (data->x18 != data->x20 && data->x18 != data->x1C) {
+        data->x60 = 0;
+    }
+    if (data->x18 == 4) {
+        return false;
+    } else {
+        data->xFA_b2 = false;
+        return true;
+    }
+}
+
 void ftCo_800AE7AC(Fighter* fp, Vec3* arg1, int arg2)
 {
     struct Fighter_x1A88_t* data0 = &fp->x1A88;
@@ -6462,15 +6475,7 @@ void ftCo_800AE7AC(Fighter* fp, Vec3* arg1, int arg2)
     ftCo_CpuUpdateCommonItemTarget(fp);
     ftCo_CpuUpdateSpecialItemTarget(fp);
     data2 = &fp->x1A88;
-    if (data2->x18 != data2->x20 && data2->x18 != data2->x1C) {
-        data2->x60 = 0;
-    }
-    if (data2->x18 == 4) {
-        do_act = 0;
-    } else {
-        data2->xFA_b2 = false;
-        do_act = 1;
-    }
+    do_act = ftCo_CpuDataShouldAct(data2);
     if (do_act != 0) {
         if (arg2 >= 0) {
             ftCo_800A8210(fp, arg1);
@@ -6527,15 +6532,7 @@ void ftCo_800AEA8C(Fighter* fp)
     ftCo_CpuUpdateCommonItemTarget(fp);
     ftCo_CpuUpdateSpecialItemTarget(fp);
     data2 = &fp->x1A88;
-    if (data2->x18 != data2->x20 && data2->x18 != data2->x1C) {
-        data2->x60 = 0;
-    }
-    if (data2->x18 == 4) {
-        do_floor = 0;
-    } else {
-        data2->xFA_b2 = false;
-        do_floor = 1;
-    }
+    do_floor = ftCo_CpuDataShouldAct(data2);
     if (do_floor != 0) {
         s32 result;
         f32 x = fp->cur_pos.x;
@@ -6883,19 +6880,6 @@ void ftCo_800AF290(Fighter* fp)
         }
     }
     ftCo_800ADE48(fp);
-}
-
-static inline bool ftCo_CpuDataShouldAct(struct Fighter_x1A88_t* data)
-{
-    if (data->x18 != data->x20 && data->x18 != data->x1C) {
-        data->x60 = 0;
-    }
-    if (data->x18 == 4) {
-        return false;
-    } else {
-        data->xFA_b2 = false;
-        return true;
-    }
 }
 
 void ftCo_800AF78C(Fighter* fp)
@@ -7739,15 +7723,7 @@ void ftCo_800B17D0(Fighter* fp)
     ftCo_CpuUpdateCommonItemTarget(fp);
     ftCo_CpuUpdateSpecialItemTarget(fp);
     data2 = &fp->x1A88;
-    if (data2->x18 != data2->x20 && data2->x18 != data2->x1C) {
-        data2->x60 = 0;
-    }
-    if (data2->x18 == 4) {
-        do_act = 0;
-    } else {
-        data2->xFA_b2 = false;
-        do_act = 1;
-    }
+    do_act = ftCo_CpuDataShouldAct(data2);
     if (do_act != 0) {
         if (data->x4C != NULL && fp->item_gobj == NULL) {
             ftCo_800A866C(fp);
@@ -7800,15 +7776,7 @@ void ftCo_800B1AB8(Fighter* fp)
     ftCo_CpuUpdateCommonItemTarget(fp);
     ftCo_CpuUpdateSpecialItemTarget(fp);
     data2 = &fp->x1A88;
-    if (data2->x18 != data2->x20 && data2->x18 != data2->x1C) {
-        data2->x60 = 0;
-    }
-    if (data2->x18 == 4) {
-        do_act = 0;
-    } else {
-        data2->xFA_b2 = false;
-        do_act = 1;
-    }
+    do_act = ftCo_CpuDataShouldAct(data2);
     if (do_act != 0) {
         if (data->x4C != NULL && fp->item_gobj == NULL) {
             ftCo_800A866C(fp);
@@ -7914,15 +7882,7 @@ void ftCo_800B21C8(Fighter* fp)
     ftCo_CpuUpdateTargetDistance(fp);
 
     data2 = &fp->x1A88;
-    if (data2->x18 != data2->x20 && data2->x18 != data2->x1C) {
-        data2->x60 = 0;
-    }
-    if (data2->x18 == 4) {
-        do_act = 0;
-    } else {
-        data2->xFA_b2 = false;
-        do_act = 1;
-    }
+    do_act = ftCo_CpuDataShouldAct(data2);
     if (do_act != 0) {
         attack_target = ftCo_800A53DC(fp);
         if (attack_target == NULL) {

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -6927,6 +6927,20 @@ static inline void ftCo_CpuTargetAct(Fighter* fp)
     }
 }
 
+static inline void ftCo_CpuSetTargetFlags(Fighter* fp)
+{
+    struct Fighter_x1A88_t* data = &fp->x1A88;
+
+    data->xF8_b0 = true;
+    data->xF9_b2 = false;
+    data->xF9_b4 = false;
+    data->xF9_b3 = false;
+    data->xF9_b5 = false;
+    data->xF9_b6 = false;
+    data->xF9_b7 = false;
+    data->xF9_b1 = true;
+}
+
 void ftCo_800AECF0(Fighter* fp)
 {
     struct Fighter_x1A88_t* data2;
@@ -6948,14 +6962,7 @@ void ftCo_800AECF0(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        data->xF8_b0 = true;
-        data->xF9_b2 = false;
-        data->xF9_b4 = false;
-        data->xF9_b3 = false;
-        data->xF9_b5 = false;
-        data->xF9_b6 = false;
-        data->xF9_b7 = false;
-        data->xF9_b1 = true;
+        ftCo_CpuSetTargetFlags(fp);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -7117,12 +7124,12 @@ void ftCo_800AEFB8(Fighter* fp)
     ftCo_CpuUpdateNoTarget(fp, true);
 }
 
-static inline void ftCo_800AF290_update_target(Fighter* fp)
+static inline void ftCo_CpuUpdateTargetDistance(Fighter* fp)
 {
     struct Fighter_x1A88_t* data;
 
     data = &fp->x1A88;
-    if (ftCo_800A1C44_dontinline(fp)) {
+    if (ftCo_800A1C44(fp)) {
         data->xF8_b6 = false;
     } else {
         if ((data->x44 != NULL) && (fp->ground_or_air == GA_Ground)) {
@@ -7196,14 +7203,7 @@ void ftCo_800AF290(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        data->xF8_b0 = true;
-        data->xF9_b2 = false;
-        data->xF9_b4 = false;
-        data->xF9_b3 = false;
-        data->xF9_b5 = false;
-        data->xF9_b6 = false;
-        data->xF9_b7 = false;
-        data->xF9_b1 = true;
+        ftCo_CpuSetTargetFlags(fp);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -7233,7 +7233,7 @@ void ftCo_800AF290(Fighter* fp)
     *(target_slot = &fp->x1A88.x44) = target;
     ftCo_800AF290_inline0(fp, is_food);
     fp->x1A88.x50 = ftCo_800A648C(fp);
-    ftCo_800AF290_update_target(fp);
+    ftCo_CpuUpdateTargetDistance(fp);
     target = data->x44;
     if (target != NULL) {
         if (ftCo_800A1AB4(fp, target) > data->x40) {
@@ -7285,25 +7285,6 @@ static inline bool inlineI1_alt(Fighter* fp)
     } else {
         data->xFA_b2 = false;
         return true;
-    }
-}
-
-static inline void ftCo_800AF78C_inline0(Fighter* fp)
-{
-    struct Fighter_x1A88_t* data = &fp->x1A88;
-    if (ftCo_800A1C44_dontinline(fp)) {
-        data->xF8_b6 = false;
-    } else {
-        if ((data->x44 != NULL) && (fp->ground_or_air == GA_Ground)) {
-            if (ftCo_800A1AB4(fp, data->x44) < Fighter_804D64FC->x20[fp->kind])
-            {
-                data->xF8_b6 = true;
-            } else {
-                data->xF8_b6 = false;
-            }
-        } else {
-            data->xF8_b6 = false;
-        }
     }
 }
 
@@ -7366,14 +7347,7 @@ void ftCo_800AF78C(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        data->xF8_b0 = true;
-        data->xF9_b2 = false;
-        data->xF9_b4 = false;
-        data->xF9_b3 = false;
-        data->xF9_b5 = false;
-        data->xF9_b6 = false;
-        data->xF9_b7 = false;
-        data->xF9_b1 = true;
+        ftCo_CpuSetTargetFlags(fp);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -7403,7 +7377,7 @@ void ftCo_800AF78C(Fighter* fp)
     ftCo_800AF78C_inline1(fp, is_food);
     fp->x1A88.x50 = ftCo_800A648C(fp);
 
-    ftCo_800AF78C_inline0(fp);
+    ftCo_CpuUpdateTargetDistance(fp);
     if (inlineI1_alt(fp)) {
         if (data->x4C != NULL) {
             ftCo_800A866C(fp);
@@ -7505,14 +7479,7 @@ void ftCo_800AFE3C(Fighter* fp, int arg1)
     temp_r3_2 = ftCo_800A5CE0(fp);
     temp_r31->x44 = temp_r3_2;
     if (temp_r3_2 != NULL) {
-        temp_r31->xF8_b0 = true;
-        temp_r31->xF9_b2 = false;
-        temp_r31->xF9_b4 = false;
-        temp_r31->xF9_b3 = false;
-        temp_r31->xF9_b5 = false;
-        temp_r31->xF9_b6 = false;
-        temp_r31->xF9_b7 = false;
-        temp_r31->xF9_b1 = true;
+        ftCo_CpuSetTargetFlags(fp);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -7575,14 +7542,7 @@ void ftCo_800B00F8(Fighter* fp)
     temp_r3 = ftCo_800A5CE0(fp);
     temp_r31->x44 = temp_r3;
     if (temp_r3 != NULL) {
-        temp_r31->xF8_b0 = true;
-        temp_r31->xF9_b2 = false;
-        temp_r31->xF9_b4 = false;
-        temp_r31->xF9_b3 = false;
-        temp_r31->xF9_b5 = false;
-        temp_r31->xF9_b6 = false;
-        temp_r31->xF9_b7 = false;
-        temp_r31->xF9_b1 = true;
+        ftCo_CpuSetTargetFlags(fp);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -8162,14 +8122,7 @@ void ftCo_800B1478(Fighter* fp)
     *(target_slot = &fp->x1A88.x44) = target;
 
     if (target != NULL) {
-        data->xF8_b0 = true;
-        data->xF9_b2 = false;
-        data->xF9_b4 = false;
-        data->xF9_b3 = false;
-        data->xF9_b5 = false;
-        data->xF9_b6 = false;
-        data->xF9_b7 = false;
-        data->xF9_b1 = true;
+        ftCo_CpuSetTargetFlags(fp);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -8212,7 +8165,7 @@ void ftCo_800B1478(Fighter* fp)
     }
     fp->x1A88.x50 = ftCo_800A648C(fp);
 
-    ftCo_800AF78C_inline0(fp);
+    ftCo_CpuUpdateTargetDistance(fp);
 
     if (inlineI1_alt(fp)) {
         if (data->x4C != NULL) {
@@ -8250,14 +8203,7 @@ void ftCo_800B17D0(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        data->xF8_b0 = true;
-        data->xF9_b2 = false;
-        data->xF9_b4 = false;
-        data->xF9_b3 = false;
-        data->xF9_b5 = false;
-        data->xF9_b6 = false;
-        data->xF9_b7 = false;
-        data->xF9_b1 = true;
+        ftCo_CpuSetTargetFlags(fp);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -8344,14 +8290,7 @@ void ftCo_800B1AB8(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        data->xF8_b0 = true;
-        data->xF9_b2 = false;
-        data->xF9_b4 = false;
-        data->xF9_b3 = false;
-        data->xF9_b5 = false;
-        data->xF9_b6 = false;
-        data->xF9_b7 = false;
-        data->xF9_b1 = true;
+        ftCo_CpuSetTargetFlags(fp);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -8491,14 +8430,7 @@ void ftCo_800B21C8(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        data->xF8_b0 = true;
-        data->xF9_b2 = false;
-        data->xF9_b4 = false;
-        data->xF9_b3 = false;
-        data->xF9_b5 = false;
-        data->xF9_b6 = false;
-        data->xF9_b7 = false;
-        data->xF9_b1 = true;
+        ftCo_CpuSetTargetFlags(fp);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -162,6 +162,12 @@ static inline void ftCo_CpuRetapR(Fighter* fp)
     ftCo_800B463C(fp, CpuCmd_Done);
 }
 
+static inline void ftCo_CpuTapRAndWait(Fighter* fp)
+{
+    ftCo_CpuTapR(fp);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+}
+
 void ftCo_800A0148(Fighter* fp)
 {
     struct Fighter_x1A88_t* x1A88 = &fp->x1A88;
@@ -5990,32 +5996,27 @@ void ftCo_800ADC28(Fighter* fp)
         }
     } else if (fp->kind == FTKIND_SAMUS) {
         if (fp->motion_id == ftSs_MS_SpecialNHold) {
-            ftCo_CpuTapR(fp);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+            ftCo_CpuTapRAndWait(fp);
         }
     } else if (fp->kind == FTKIND_MEWTWO) {
         if (fp->motion_id == ftMt_MS_SpecialNLoop ||
             fp->motion_id == ftMt_MS_SpecialNLoopFull)
         {
-            ftCo_CpuTapR(fp);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+            ftCo_CpuTapRAndWait(fp);
         }
     } else if (fp->kind == FTKIND_KIRBY) {
         FighterKind kind = fp->fv.kb.hat.kind;
         if (kind == FTKIND_DONKEY && fp->motion_id == ftKb_MS_DkSpecialNLoop) {
-            ftCo_CpuTapR(fp);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+            ftCo_CpuTapRAndWait(fp);
         } else if (kind == FTKIND_SAMUS &&
                    fp->motion_id == ftKb_MS_SsSpecialNHold)
         {
-            ftCo_CpuTapR(fp);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+            ftCo_CpuTapRAndWait(fp);
         } else if (kind == FTKIND_MEWTWO &&
                    (fp->motion_id == ftKb_MS_MtSpecialNLoop ||
                     fp->motion_id == ftKb_MS_MtSpecialNLoopFull))
         {
-            ftCo_CpuTapR(fp);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+            ftCo_CpuTapRAndWait(fp);
         }
     }
 }
@@ -6732,9 +6733,7 @@ void ftCo_800AEFB8(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        ftCo_CpuSetTargetActive(data);
-        ftCo_CpuClearTargetModes(data);
-        ftCo_CpuSetTargetReady(data);
+        ftCo_CpuSetTargetFlags(data);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -7832,9 +7831,7 @@ void ftCo_800B1EF0(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        ftCo_CpuSetTargetActive(data);
-        ftCo_CpuClearTargetModes(data);
-        ftCo_CpuSetTargetReady(data);
+        ftCo_CpuSetTargetFlags(data);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -7909,9 +7906,7 @@ void ftCo_800B24B8(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        ftCo_CpuSetTargetActive(data);
-        ftCo_CpuClearTargetModes(data);
-        ftCo_CpuSetTargetReady(data);
+        ftCo_CpuSetTargetFlags(data);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -125,6 +125,14 @@ static inline void ftCo_CpuTapA(Fighter* fp)
     ftCo_800B463C(fp, CpuCmd_ReleaseA);
 }
 
+static inline void ftCo_CpuRetapA(Fighter* fp)
+{
+    ftCo_800B463C(fp, CpuCmd_ReleaseA);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_CpuTapA(fp);
+    ftCo_800B463C(fp, CpuCmd_Done);
+}
+
 static inline void ftCo_CpuTapB(Fighter* fp)
 {
     ftCo_800B463C(fp, CpuCmd_PressB);
@@ -144,6 +152,14 @@ static inline void ftCo_CpuTapR(Fighter* fp)
     ftCo_800B463C(fp, CpuCmd_PressR);
     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
     ftCo_800B463C(fp, CpuCmd_ReleaseR);
+}
+
+static inline void ftCo_CpuRetapR(Fighter* fp)
+{
+    ftCo_800B463C(fp, CpuCmd_ReleaseR);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_CpuTapR(fp);
+    ftCo_800B463C(fp, CpuCmd_Done);
 }
 
 void ftCo_800A0148(Fighter* fp)
@@ -336,15 +352,9 @@ void ftCo_800A0AF4(Fighter* fp)
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         ftCo_CpuFinishWithNeutralY(fp);
     } else if (rand < 0.8f) {
-        ftCo_800B463C(fp, CpuCmd_ReleaseR);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_CpuTapR(fp);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuRetapR(fp);
     } else if (rand < 0.9f) {
-        ftCo_800B463C(fp, CpuCmd_ReleaseA);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_CpuTapA(fp);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuRetapA(fp);
     } else {
         ftCo_800B463C(fp, CpuCmd_ReleaseY);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
@@ -5670,10 +5680,7 @@ void ftCo_800AC7D4(Fighter* fp)
         if (HSD_Randf() < 0.1F * data->level) {
             ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
             ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-            ftCo_800B463C(fp, CpuCmd_ReleaseA);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_CpuTapA(fp);
-            ftCo_800B463C(fp, CpuCmd_Done);
+            ftCo_CpuRetapA(fp);
         } else {
             if (temp_r3->cur_pos.x - fp->cur_pos.x < 0.0F) {
                 ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0x50);
@@ -5724,15 +5731,9 @@ void ftCo_800ACB44(Fighter* fp)
     temp_f1_2 = ftCo_800A1AB4(fp, temp_r3);
     if (data->xF9_b2 && temp_f1_2 < 30.0) {
         if (0.1F * data->level > HSD_Randf()) {
-            ftCo_800B463C(fp, CpuCmd_ReleaseR);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_CpuTapR(fp);
-            ftCo_800B463C(fp, CpuCmd_Done);
+            ftCo_CpuRetapR(fp);
         } else {
-            ftCo_800B463C(fp, CpuCmd_ReleaseA);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_CpuTapA(fp);
-            ftCo_800B463C(fp, CpuCmd_Done);
+            ftCo_CpuRetapA(fp);
         }
     } else {
         ftCo_800A0AF4(fp);
@@ -8050,10 +8051,7 @@ void ftCo_800B2790(Fighter* fp)
                     ftCo_CpuReturnToPreviousBehavior(fp, data);
                 } else {
                     ftCo_CpuSetNeutralStick(fp);
-                    ftCo_800B463C(fp, CpuCmd_ReleaseA);
-                    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                    ftCo_CpuTapA(fp);
-                    ftCo_800B463C(fp, CpuCmd_Done);
+                    ftCo_CpuRetapA(fp);
                     data->x18 = data->x1C;
                 }
                 break;

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -4195,6 +4195,13 @@ static inline int angle_y_units(float angle)
     return 127.0F * sinf(angle);
 }
 
+static inline void ftCo_CpuAimPkThunder(Fighter* fp, float angle, int frames)
+{
+    ftCo_800B46B8(fp, CpuCmd_SetLstickX, angle_x_units(angle));
+    ftCo_800B46B8(fp, CpuCmd_SetLstickY, angle_y_units(angle));
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, frames);
+}
+
 /**
  * Ness recovery PK thunder logic
  */
@@ -4213,44 +4220,28 @@ void ftCo_800A8EB0(Fighter* fp)
     ftCo_800B463C(fp, CpuCmd_ReleaseB);
     if (data->x54.x - fp->cur_pos.x > 0.0) {
         angle = M_PI;
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, angle_x_units(angle));
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, angle_y_units(angle));
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 20);
+        ftCo_CpuAimPkThunder(fp, angle, 20);
 
         angle = -M_PI_2;
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, angle_x_units(angle));
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, angle_y_units(angle));
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 35);
+        ftCo_CpuAimPkThunder(fp, angle, 35);
 
         angle = 0.0F;
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, angle_x_units(angle));
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, angle_y_units(angle));
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 20);
+        ftCo_CpuAimPkThunder(fp, angle, 20);
 
         angle = M_PI_2;
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, angle_x_units(angle));
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, angle_y_units(angle));
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 20);
+        ftCo_CpuAimPkThunder(fp, angle, 20);
     } else {
         angle = 0.0F;
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, angle_x_units(angle));
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, angle_y_units(angle));
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 20);
+        ftCo_CpuAimPkThunder(fp, angle, 20);
 
         angle = -M_PI_2;
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, angle_x_units(angle));
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, angle_y_units(angle));
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 35);
+        ftCo_CpuAimPkThunder(fp, angle, 35);
 
         angle = M_PI;
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, angle_x_units(angle));
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, angle_y_units(angle));
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 20);
+        ftCo_CpuAimPkThunder(fp, angle, 20);
 
         angle = M_PI_2;
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, angle_x_units(angle));
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, angle_y_units(angle));
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 20);
+        ftCo_CpuAimPkThunder(fp, angle, 20);
     }
     ftCo_800B463C(fp, CpuCmd_Done);
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -909,11 +909,6 @@ void ftCo_800A20A0(Fighter* fp)
     }
 }
 
-static inline void ftCo_800A20A0_dontinline(Fighter* fp)
-{
-    ftCo_800A20A0(fp);
-}
-
 bool ftCo_800A2170(Fighter* fp0, Fighter* fp1)
 {
     mp_UnkStruct0* temp_r3;
@@ -3972,11 +3967,6 @@ void ftCo_800A80E4(Fighter* fp)
     }
 }
 
-static inline void ftCo_800A80E4_dontinline(Fighter* fp)
-{
-    ftCo_800A80E4(fp);
-}
-
 static inline void ftCo_800A8210_inline0(Fighter* fp, Vec3* out)
 {
     struct Fighter_x1A88_t* data = &fp->x1A88;
@@ -6913,6 +6903,30 @@ void ftCo_800AEA8C(Fighter* fp)
     ftCo_800ADE48(fp);
 }
 
+static inline bool ftCo_CpuShouldAct(Fighter* fp)
+{
+    struct Fighter_x1A88_t* data;
+
+    data = &fp->x1A88;
+    if (data->x18 != data->x20 && data->x18 != data->x1C) {
+        data->x60 = 0;
+    }
+    if (data->x18 == 4) {
+        return false;
+    } else {
+        data->xFA_b2 = false;
+        return true;
+    }
+}
+
+static inline void ftCo_CpuTargetAct(Fighter* fp)
+{
+    ftCo_800A20A0(fp);
+    if (ftCo_CpuShouldAct(fp)) {
+        ftCo_800A80E4(fp);
+    }
+}
+
 void ftCo_800AECF0(Fighter* fp)
 {
     struct Fighter_x1A88_t* data2;
@@ -6942,19 +6956,7 @@ void ftCo_800AECF0(Fighter* fp)
         data->xF9_b6 = false;
         data->xF9_b7 = false;
         data->xF9_b1 = true;
-        ftCo_800A20A0_dontinline(fp);
-        if (data->x18 != data->x20 && data->x18 != data->x1C) {
-            data->x60 = 0;
-        }
-        if (data->x18 == 4) {
-            do_act = 0;
-        } else {
-            data->xFA_b2 = false;
-            do_act = 1;
-        }
-        if (do_act != 0) {
-            ftCo_800A80E4_dontinline(fp);
-        }
+        ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
     }
@@ -7090,7 +7092,6 @@ void ftCo_800AEFB8(Fighter* fp)
     Vec3 sp28;
     s32 cmd;
     Fighter* target;
-    s32 do_act;
     PAD_STACK(0x10);
 
     cmd = ftCo_800A229C(fp, &sp28);
@@ -7109,19 +7110,7 @@ void ftCo_800AEFB8(Fighter* fp)
         data->xF9_b6 = false;
         data->xF9_b7 = false;
         data->xF9_b1 = true;
-        ftCo_800A20A0_dontinline(fp);
-        if (data->x18 != data->x20 && data->x18 != data->x1C) {
-            data->x60 = 0;
-        }
-        if (data->x18 == 4) {
-            do_act = 0;
-        } else {
-            data->xFA_b2 = false;
-            do_act = 1;
-        }
-        if (do_act != 0) {
-            ftCo_800A80E4_dontinline(fp);
-        }
+        ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
     }
@@ -7146,22 +7135,6 @@ static inline void ftCo_800AF290_update_target(Fighter* fp)
         } else {
             data->xF8_b6 = false;
         }
-    }
-}
-
-static inline bool ftCo_800AF290_should_act(Fighter* fp)
-{
-    struct Fighter_x1A88_t* data;
-
-    data = &fp->x1A88;
-    if (data->x18 != data->x20 && data->x18 != data->x1C) {
-        data->x60 = 0;
-    }
-    if (data->x18 == 4) {
-        return false;
-    } else {
-        data->xFA_b2 = false;
-        return true;
     }
 }
 
@@ -7231,10 +7204,7 @@ void ftCo_800AF290(Fighter* fp)
         data->xF9_b6 = false;
         data->xF9_b7 = false;
         data->xF9_b1 = true;
-        ftCo_800A20A0_dontinline(fp);
-        if (ftCo_800AF290_should_act(fp)) {
-            ftCo_800A80E4_dontinline(fp);
-        }
+        ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
     }
@@ -7271,7 +7241,7 @@ void ftCo_800AF290(Fighter* fp)
             return;
         }
     }
-    if (ftCo_800AF290_should_act(fp)) {
+    if (ftCo_CpuShouldAct(fp)) {
         if (data->x4C != NULL) {
             ftCo_800A866C(fp);
         } else {
@@ -7380,7 +7350,6 @@ void ftCo_800AF78C(Fighter* fp)
     f32 dy;
     f32 dist;
     s32 cmd;
-    s32 do_act;
     s32 should_escape;
     Fighter** target_slot;
     struct Fighter_x1A88_t* data;
@@ -7405,19 +7374,7 @@ void ftCo_800AF78C(Fighter* fp)
         data->xF9_b6 = false;
         data->xF9_b7 = false;
         data->xF9_b1 = true;
-        ftCo_800A20A0_dontinline(fp);
-        if (data->x18 != data->x20 && data->x18 != data->x1C) {
-            data->x60 = 0;
-        }
-        if (data->x18 == 4) {
-            do_act = false;
-        } else {
-            data->xFA_b2 = false;
-            do_act = true;
-        }
-        if (do_act) {
-            ftCo_800A80E4_dontinline(fp);
-        }
+        ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
     }
@@ -7556,10 +7513,7 @@ void ftCo_800AFE3C(Fighter* fp, int arg1)
         temp_r31->xF9_b6 = false;
         temp_r31->xF9_b7 = false;
         temp_r31->xF9_b1 = true;
-        ftCo_800A20A0_dontinline(fp);
-        if (inlineI1_alt(fp)) {
-            ftCo_800A80E4_dontinline(fp);
-        }
+        ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
     }
@@ -7596,9 +7550,7 @@ void ftCo_800B00F8(Fighter* fp)
 {
     Vec3 sp28;
     Fighter* temp_r3;
-    s32 temp_r3_2;
     s32 temp_r3_4;
-    s32 var_r0;
     s32 var_r0_2;
     s32 var_r0_3;
     int var_r0_10;
@@ -7631,20 +7583,7 @@ void ftCo_800B00F8(Fighter* fp)
         temp_r31->xF9_b6 = false;
         temp_r31->xF9_b7 = false;
         temp_r31->xF9_b1 = true;
-        ftCo_800A20A0_dontinline(fp);
-        temp_r3_2 = temp_r31->x18;
-        if ((temp_r3_2 != temp_r31->x20) && (temp_r3_2 != temp_r31->x1C)) {
-            temp_r31->x60 = 0;
-        }
-        if (temp_r31->x18 == 4) {
-            var_r0 = 0;
-        } else {
-            temp_r31->xFA_b2 = false;
-            var_r0 = 1;
-        }
-        if (var_r0 != 0) {
-            ftCo_800A80E4_dontinline(fp);
-        }
+        ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
     }
@@ -8231,10 +8170,7 @@ void ftCo_800B1478(Fighter* fp)
         data->xF9_b6 = false;
         data->xF9_b7 = false;
         data->xF9_b1 = true;
-        ftCo_800A20A0_dontinline(fp);
-        if (inlineI1_alt(fp)) {
-            ftCo_800A80E4_dontinline(fp);
-        }
+        ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
     }
@@ -8322,19 +8258,7 @@ void ftCo_800B17D0(Fighter* fp)
         data->xF9_b6 = false;
         data->xF9_b7 = false;
         data->xF9_b1 = true;
-        ftCo_800A20A0_dontinline(fp);
-        if (data->x18 != data->x20 && data->x18 != data->x1C) {
-            data->x60 = 0;
-        }
-        if (data->x18 == 4) {
-            do_act = 0;
-        } else {
-            data->xFA_b2 = false;
-            do_act = 1;
-        }
-        if (do_act != 0) {
-            ftCo_800A80E4_dontinline(fp);
-        }
+        ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
     }
@@ -8428,19 +8352,7 @@ void ftCo_800B1AB8(Fighter* fp)
         data->xF9_b6 = false;
         data->xF9_b7 = false;
         data->xF9_b1 = true;
-        ftCo_800A20A0_dontinline(fp);
-        if (data->x18 != data->x20 && data->x18 != data->x1C) {
-            data->x60 = 0;
-        }
-        if (data->x18 == 4) {
-            do_act = 0;
-        } else {
-            data->xFA_b2 = false;
-            do_act = 1;
-        }
-        if (do_act != 0) {
-            ftCo_800A80E4_dontinline(fp);
-        }
+        ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
     }
@@ -8533,7 +8445,6 @@ void ftCo_800B1EF0(Fighter* fp)
     Vec3 sp28;
     s32 cmd;
     Fighter* target;
-    s32 do_act;
     PAD_STACK(0x10);
 
     cmd = ftCo_800A229C(fp, &sp28);
@@ -8552,19 +8463,7 @@ void ftCo_800B1EF0(Fighter* fp)
         data->xF9_b6 = false;
         data->xF9_b7 = false;
         data->xF9_b1 = true;
-        ftCo_800A20A0_dontinline(fp);
-        if (data->x18 != data->x20 && data->x18 != data->x1C) {
-            data->x60 = 0;
-        }
-        if (data->x18 == 4) {
-            do_act = 0;
-        } else {
-            data->xFA_b2 = false;
-            do_act = 1;
-        }
-        if (do_act != 0) {
-            ftCo_800A80E4_dontinline(fp);
-        }
+        ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
     }
@@ -8600,19 +8499,7 @@ void ftCo_800B21C8(Fighter* fp)
         data->xF9_b6 = false;
         data->xF9_b7 = false;
         data->xF9_b1 = true;
-        ftCo_800A20A0_dontinline(fp);
-        if (data->x18 != data->x20 && data->x18 != data->x1C) {
-            data->x60 = 0;
-        }
-        if (data->x18 == 4) {
-            do_act = 0;
-        } else {
-            data->xFA_b2 = false;
-            do_act = 1;
-        }
-        if (do_act != 0) {
-            ftCo_800A80E4_dontinline(fp);
-        }
+        ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
     }
@@ -8671,7 +8558,6 @@ void ftCo_800B24B8(Fighter* fp)
     Vec3 sp28;
     s32 cmd;
     Fighter* target;
-    s32 do_act;
     PAD_STACK(0x10);
 
     cmd = ftCo_800A229C(fp, &sp28);
@@ -8690,19 +8576,7 @@ void ftCo_800B24B8(Fighter* fp)
         data->xF9_b6 = false;
         data->xF9_b7 = false;
         data->xF9_b1 = true;
-        ftCo_800A20A0_dontinline(fp);
-        if (data->x18 != data->x20 && data->x18 != data->x1C) {
-            data->x60 = 0;
-        }
-        if (data->x18 == 4) {
-            do_act = 0;
-        } else {
-            data->xFA_b2 = false;
-            do_act = 1;
-        }
-        if (do_act != 0) {
-            ftCo_800A80E4_dontinline(fp);
-        }
+        ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
     }

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -2340,32 +2340,6 @@ Fighter* ftCo_800A4A40(Fighter* fp)
     return cur_fp;
 }
 
-static inline bool ftCo_800A4E8C_inline0(Fighter* fp)
-{
-    if (fp->x2219_b1) {
-        return true;
-    }
-    if (fp->x2164 != 0) {
-        return true;
-    }
-    if (fp->x2168 != 0 && fp->x2338.x == 0) {
-        return true;
-    }
-    if (fp->x221F_b3) {
-        return true;
-    }
-    return false;
-}
-
-static inline f32 ftCo_800A4BEC_inline0(Fighter* fp, Fighter* arg1)
-{
-    f32 dx;
-    f32 dy;
-    dx = fp->cur_pos.x - arg1->cur_pos.x;
-    dy = fp->cur_pos.y - arg1->cur_pos.y;
-    return sqrtf(dx * dx + dy * dy);
-}
-
 Fighter* ftCo_800A4BEC(Fighter* fp)
 {
     Fighter* cur_fp;
@@ -2385,7 +2359,7 @@ Fighter* ftCo_800A4BEC(Fighter* fp)
         if (fp->gobj != cur) {
             cur_fp = GET_FIGHTER(cur);
             if (!inlineD0(fp, cur_fp) && !ftCo_IsAlly_dontinline(fp, cur_fp)) {
-                if (!ftCo_800A4E8C_inline0(cur_fp)) {
+                if (!ftCo_800A1C44(cur_fp)) {
                     if (!inlineD1(cur_fp)) {
                         if (data->xF9_b0) {
                             if (cur_fp == data->x48) {
@@ -2393,10 +2367,10 @@ Fighter* ftCo_800A4BEC(Fighter* fp)
                             }
                         } else if (closest == NULL) {
                             closest = cur_fp;
-                            best = ftCo_800A4BEC_inline0(fp, cur_fp);
+                            best = ftCo_800A1AB4(fp, cur_fp);
                         } else {
                             cur_fp = GET_FIGHTER(cur);
-                            dist = ftCo_800A4BEC_inline0(fp, cur_fp);
+                            dist = ftCo_800A1AB4(fp, cur_fp);
                             if (best > dist) {
                                 best = dist;
                                 closest = cur_fp;
@@ -2439,7 +2413,7 @@ Fighter* ftCo_800A4E8C(Fighter* fp, Vec3* arg1)
         if (fp->gobj != cur) {
             cur_fp = GET_FIGHTER(cur);
             if (!inlineD0(fp, cur_fp) && !ftCo_IsAlly_dontinline(fp, cur_fp)) {
-                if (!ftCo_800A4E8C_inline0(cur_fp)) {
+                if (!ftCo_800A1C44(cur_fp)) {
                     if (!inlineD1(cur_fp)) {
                         if (closest_fp == NULL) {
                             closest_fp = cur_fp;
@@ -2540,11 +2514,6 @@ Fighter* ftCo_800A5294(Fighter* fp, int player_id)
         }
     }
     return NULL;
-}
-
-static inline Fighter* ftCo_800A5294_dontinline(Fighter* fp, int player_id)
-{
-    return ftCo_800A5294(fp, player_id);
 }
 
 Fighter* ftCo_800A53DC(Fighter* fp)
@@ -4561,7 +4530,7 @@ void ftCo_800A96B8(Fighter* fp)
 }
 #pragma pop
 
-static inline bool is_small(float x)
+static inline bool ftCo_IsNearlyZero(float x)
 {
     if (x < 0.00001F && x > -0.00001F) {
         return true;
@@ -4623,13 +4592,13 @@ void ftCo_800A9904(Fighter* fp)
     } else if (data->xFA_b5) {
         f32* grav_p;
         f32 dx = data->x54.x - fp->cur_pos.x;
-        if (is_small(fp->pos_delta.x)) {
+        if (ftCo_IsNearlyZero(fp->pos_delta.x)) {
             x_time = 1000.0F;
         } else {
             x_time = dx / fp->pos_delta.x;
         }
         gravity = *(grav_p = &fp->co_attrs.grav);
-        if (is_small(gravity)) {
+        if (ftCo_IsNearlyZero(gravity)) {
             terminal_time = 1000.0F;
         } else {
             terminal_time =
@@ -4675,14 +4644,6 @@ void ftCo_800A9904(Fighter* fp)
 }
 
 #undef ftCo_800A9904_sqrtf_store
-
-static inline bool ftCo_800A9CB4_is_small(f32 x)
-{
-    if (x < 1.0e-5f && x > -1.0e-5f) {
-        return true;
-    }
-    return false;
-}
 
 #define ftCo_800A9CB4_sqrtf_store(dst, x, store)                              \
     do {                                                                      \
@@ -4821,7 +4782,7 @@ void ftCo_800A9CB4(Fighter* fp)
     }
     dx = data->x54.x - fp->cur_pos.x;
     x_delta_abs = ABS(dx);
-    if (!ftCo_800A9CB4_is_small(fp->pos_delta.x)) {
+    if (!ftCo_IsNearlyZero(fp->pos_delta.x)) {
         x_time = dx / fp->pos_delta.x;
     } else if (x_delta_abs > 0.0) {
         x_time = -1.0f;
@@ -4829,7 +4790,7 @@ void ftCo_800A9CB4(Fighter* fp)
         x_time = 0.0f;
     }
     gravity = *(grav_p = &fp->co_attrs.grav);
-    if (ftCo_800A9CB4_is_small(gravity)) {
+    if (ftCo_IsNearlyZero(gravity)) {
         terminal_time = 1000.0f;
     } else {
         terminal_time =
@@ -5783,14 +5744,6 @@ void ftCo_800AC434(Fighter* fp)
     }
 }
 
-static inline bool ftCo_800AC5A0_is_small(float x)
-{
-    if (x < 0.00001F && x > -0.00001F) {
-        return true;
-    }
-    return false;
-}
-
 void ftCo_800AC5A0(Fighter* fp)
 {
     struct Fighter_x1A88_t* data;
@@ -5816,7 +5769,7 @@ void ftCo_800AC5A0(Fighter* fp)
         float kb_mag;
         kb_mag = kb_x * kb_x + (kb_mag = kb_y * kb_y);
         kb_mag = sqrtf(kb_mag);
-        if (!ftCo_800AC5A0_is_small(kb_mag)) {
+        if (!ftCo_IsNearlyZero(kb_mag)) {
             float x = kb_x * (1.0F / kb_mag);
             float y = kb_y * (1.0F / kb_mag);
             if (kb_x > 0.0F) {
@@ -7264,22 +7217,8 @@ void ftCo_800AF290(Fighter* fp)
     ftCo_800ADE48(fp);
 }
 
-static inline bool inlineI1(struct Fighter_x1A88_t* data)
+static inline bool ftCo_CpuDataShouldAct(struct Fighter_x1A88_t* data)
 {
-    if (data->x18 != data->x20 && data->x18 != data->x1C) {
-        data->x60 = 0;
-    }
-    if (data->x18 == 4) {
-        return false;
-    } else {
-        data->xFA_b2 = false;
-        return true;
-    }
-}
-
-static inline bool inlineI1_alt(Fighter* fp)
-{
-    struct Fighter_x1A88_t* data = &fp->x1A88;
     if (data->x18 != data->x20 && data->x18 != data->x1C) {
         data->x60 = 0;
     }
@@ -7381,7 +7320,7 @@ void ftCo_800AF78C(Fighter* fp)
     fp->x1A88.x50 = ftCo_800A648C(fp);
 
     ftCo_CpuUpdateTargetDistance(fp);
-    if (inlineI1_alt(fp)) {
+    if (ftCo_CpuShouldAct(fp)) {
         if (data->x4C != NULL) {
             ftCo_800A866C(fp);
         } else {
@@ -7450,7 +7389,7 @@ void ftCo_800AFC40(Fighter* fp)
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
     ftCo_800AFC40_inline0(fp);
     temp_r4 = &fp->x1A88;
-    if (inlineI1(temp_r4)) {
+    if (ftCo_CpuDataShouldAct(temp_r4)) {
         temp_r3_3 = ftCo_800A50D4(fp);
         if (temp_r3_3 != NULL) {
             ftCo_800A75DC(fp, temp_r3_3);
@@ -7461,6 +7400,19 @@ void ftCo_800AFC40(Fighter* fp)
     ftCo_800ADE48(fp);
 }
 
+static inline void ftCo_CpuActOnPlayer(Fighter* fp,
+                                      struct Fighter_x1A88_t* data,
+                                      int player_id)
+{
+    Fighter* target = ftCo_800A5294(fp, player_id);
+
+    if (target != NULL) {
+        ftCo_800A75DC(fp, target);
+    } else {
+        ftCo_800A75DC(fp, data->x44);
+    }
+}
+
 void ftCo_800AFE3C(Fighter* fp, int arg1)
 {
     struct Fighter_x1A88_t* temp_r31;
@@ -7468,7 +7420,6 @@ void ftCo_800AFE3C(Fighter* fp, int arg1)
     Vec3 sp2C;
 
     Fighter* temp_r3_2;
-    Fighter* temp_r3_6;
     s32 temp_r3;
 
     PAD_STACK(0x14);
@@ -7506,12 +7457,8 @@ void ftCo_800AFE3C(Fighter* fp, int arg1)
         }
     }
     fp->x1A88.x50 = ftCo_800A648C(fp);
-    if (inlineI1_alt(fp)) {
-        if ((temp_r3_6 = ftCo_800A5294_dontinline(fp, arg1))) {
-            ftCo_800A75DC(fp, temp_r3_6);
-        } else {
-            ftCo_800A75DC(fp, temp_r31->x44);
-        }
+    if (ftCo_CpuShouldAct(fp)) {
+        ftCo_CpuActOnPlayer(fp, temp_r31, arg1);
     }
     ftCo_800ADE48(fp);
 }
@@ -7682,7 +7629,7 @@ void ftCo_800B04DC(Fighter* fp)
     }
     fp->x1A88.x50 = ftCo_800A648C(fp);
 
-    if (inlineI1_alt(fp)) {
+    if (ftCo_CpuShouldAct(fp)) {
         target = *target_slot;
         if (target != NULL && fp->ground_or_air != GA_Air) {
             f32 dy = fp->cur_pos.y - target->cur_pos.y;
@@ -7714,7 +7661,7 @@ static inline void inlineI0(Fighter* fp, struct Fighter_x1A88_t* data)
 static inline void inlineI3(Fighter* fp, struct Fighter_x1A88_t* data)
 {
     struct Fighter_x1A88_t* fp_data = &fp->x1A88;
-    if (inlineI1(fp_data)) {
+    if (ftCo_CpuDataShouldAct(fp_data)) {
         if (data->xFB_b0) {
             ftCo_800A8DE4(fp);
         } else {
@@ -7961,7 +7908,7 @@ bool ftCo_800B0E98(Fighter* fp0, Fighter* fp1)
         if (data->xFB_b0 || inlineK0(fp0)) {
             return false;
         }
-        if (!inlineI1_alt(fp0) && fp0->motion_id != ftCo_MS_Wait) {
+        if (!ftCo_CpuShouldAct(fp0) && fp0->motion_id != ftCo_MS_Wait) {
             return false;
         }
         {
@@ -8097,7 +8044,7 @@ void ftCo_800B126C(Fighter* fp)
     }
     fp->x1A88.x50 = ftCo_800A648C(fp);
 
-    if (inlineI1_alt(fp)) {
+    if (ftCo_CpuShouldAct(fp)) {
         if (data->x4C != NULL && fp->item_gobj == NULL) {
             ftCo_800A866C(fp);
         } else if ((data->x7C % 60) * 5 == 0 && HSD_Randf() < 0.5) {
@@ -8170,7 +8117,7 @@ void ftCo_800B1478(Fighter* fp)
 
     ftCo_CpuUpdateTargetDistance(fp);
 
-    if (inlineI1_alt(fp)) {
+    if (ftCo_CpuShouldAct(fp)) {
         if (data->x4C != NULL) {
             ftCo_800A866C(fp);
         } else {
@@ -8375,7 +8322,9 @@ void ftCo_800B1DA0(Fighter* fp)
     struct Fighter_x1A88_t* data = &fp->x1A88;
     PAD_STACK(6 * 4);
     inlineI0(fp, data);
-    if (inlineI1(data) && data->x7C % 60 * 5 == 0 && HSD_Randf() < 0.5) {
+    if (ftCo_CpuDataShouldAct(data) && data->x7C % 60 * 5 == 0 &&
+        HSD_Randf() < 0.5)
+    {
         ftCo_800A8940(fp);
     }
     ftCo_800ADE48(fp);

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -1082,48 +1082,6 @@ block_43:
     return 0;
 }
 
-static inline bool inlineL0(mp_UnkStruct0* arg0)
-{
-    Item_GObj* cur;
-    Item* cur_ip;
-
-    for (cur = HSD_GObj_Entities->items; cur != NULL; cur = cur->next) {
-        cur_ip = GET_ITEM(cur);
-        if (it_8026C1B4(cur) == 0) {
-            continue;
-        }
-        if (!ftCo_800A5944(cur_ip)) {
-            continue;
-        }
-        if (arg0 == mpIsland_8005AB54(cur_ip->x378_itemColl.floor.index)) {
-            return true;
-        }
-    }
-
-    switch (stage_info.internal_stage_id) {
-    case STORY:
-        return mpIsland_8005AC8C(arg0);
-    case ZEBES:
-        if (ftCo_800A1F98(0x5A, arg0->x14.y) != 0) {
-            return true;
-        }
-        if (ftCo_800A1F98(0x5A, arg0->x8.y) != 0) {
-            return true;
-        }
-        return false;
-    case ONETT:
-        return arg0->x14.y <= 5.0 && Ground_801C5794() != 0;
-    default:
-        return false;
-    }
-}
-
-static inline bool inlineL1(mp_UnkStruct0* arg0)
-{
-    return stage_info.internal_stage_id == ONETT && arg0->x8.y <= 5.0 &&
-           Ground_801C5794() != 0;
-}
-
 #pragma dont_inline on
 bool ftCo_800A2718(mp_UnkStruct0* arg0)
 {
@@ -4895,15 +4853,6 @@ static inline int ftCo_800AA42C_inline0(float clamp, float dist, float near,
             new_clamp = clamp;
         }
         return new_clamp;
-    }
-}
-
-static inline bool isFacingDestination(Fighter* fp)
-{
-    if (fp->facing_dir * (fp->x1A88.x54.x - fp->cur_pos.x) >= 0.0) {
-        return true;
-    } else {
-        return false;
     }
 }
 

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -203,11 +203,6 @@ void ftCo_800A0508(Fighter* fp)
     ftCo_800B463C(fp, CpuCmd_Done);
 }
 
-static inline void ftCo_800A0508_dontinline(Fighter* fp)
-{
-    ftCo_800A0508(fp);
-}
-
 void ftCo_800A05F4(Fighter* fp)
 {
     if (fp->cur_pos.y + fp->x1A88.x558 > Stage_GetBlastZoneTopOffset()) {
@@ -4020,17 +4015,10 @@ void ftCo_800A866C(Fighter* fp)
                 }
             }
             if (found != 0) {
-                struct Fighter_x1A88_t* data2 = &fp->x1A88;
                 f32 x;
                 f32 y = floor_pos.y;
                 x = floor_pos.x;
-                if (fp->x1A88.x60 == 0) {
-                    data2->x54.x = x;
-                    data2->x54.y = y;
-                    data2->x38 = 1.0f;
-                    ftCo_800A1CC4(fp,
-                                  ftCo_803C6594[stage_info.internal_stage_id]);
-                }
+                ftCo_800A1F3C(fp, x, y, 1.0f);
             }
             if (fp->ground_or_air == GA_Air) {
                 same_island = 0;
@@ -4054,32 +4042,16 @@ void ftCo_800A866C(Fighter* fp)
                 if (data->x54.x - fp->cur_pos.x > 0.0) {
                     f32 x = island->x8.x;
                     if (fp->cur_pos.x < x) {
-                        struct Fighter_x1A88_t* data2 = &fp->x1A88;
                         f32 y = island->x8.y;
                         x = 5.0 + x;
-                        if (fp->x1A88.x60 == 0) {
-                            data2->x54.x = x;
-                            data2->x54.y = y;
-                            data2->x38 = 1.0f;
-                            ftCo_800A1CC4(
-                                fp,
-                                ftCo_803C6594[stage_info.internal_stage_id]);
-                        }
+                        ftCo_800A1F3C(fp, x, y, 1.0f);
                     }
                 } else {
                     f32 x = island->x14.x;
                     if (fp->cur_pos.x > x) {
-                        struct Fighter_x1A88_t* data2 = &fp->x1A88;
                         f32 y = island->x14.y;
                         x = x - 5.0;
-                        if (fp->x1A88.x60 == 0) {
-                            data2->x54.x = x;
-                            data2->x54.y = y;
-                            data2->x38 = 1.0f;
-                            ftCo_800A1CC4(
-                                fp,
-                                ftCo_803C6594[stage_info.internal_stage_id]);
-                        }
+                        ftCo_800A1F3C(fp, x, y, 1.0f);
                     }
                 }
             }
@@ -4182,16 +4154,10 @@ void ftCo_800A8940(Fighter* fp)
     }
     if (result != 0) {
         if (!ftCo_800A6700_inline0(fp, floor_pos.x, floor_pos.y)) {
-            struct Fighter_x1A88_t* data = &fp->x1A88;
             f32 x;
             f32 y = floor_pos.y;
             x = floor_pos.x;
-            if (data->x60 == 0) {
-                data->x54.x = x;
-                data->x54.y = y;
-                data->x38 = 5.0f;
-                ftCo_800A1CC4(fp, ftCo_803C6594[stage_info.internal_stage_id]);
-            }
+            ftCo_800A1F3C(fp, x, y, 5.0f);
         }
     }
 }
@@ -4628,6 +4594,29 @@ static inline bool ftCo_800A9CB4_inline1(Fighter* fp, Vec3* stage_pos)
     return false;
 }
 
+static inline void ftCo_CpuUseAvailableJump(Fighter* fp,
+                                            struct Fighter_x1A88_t* data)
+{
+    if (data->xFA_b6) {
+        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0x7F);
+        ftCo_800B463C(fp, CpuCmd_PressY);
+        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+        ftCo_800B463C(fp, CpuCmd_ReleaseY);
+        ftCo_800B463C(fp, CpuCmd_Done);
+    } else if (fp->kind == FTKIND_YOSHI && fp->x34_scale.y < 1.0 &&
+               ABS(data->x54.x - fp->cur_pos.x) < 20.0f)
+    {
+        ftCo_800A0508(fp);
+    } else {
+        ftCo_800B46B8(fp, CpuCmd_LstickTowardDestination, 0x7F);
+        ftCo_800B463C(fp, CpuCmd_PressY);
+        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+        ftCo_800B463C(fp, CpuCmd_ReleaseY);
+        ftCo_800B463C(fp, CpuCmd_Done);
+    }
+}
+
 void ftCo_800A9CB4(Fighter* fp)
 {
     u8 _[0x38];
@@ -4660,24 +4649,7 @@ void ftCo_800A9CB4(Fighter* fp)
     }
     if (ftCo_800A3234(fp)) {
         if (fp->co_attrs.max_jumps > fp->x1968_jumpsUsed) {
-            if (data->xFA_b6) {
-                ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-                ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0x7F);
-                ftCo_800B463C(fp, CpuCmd_PressY);
-                ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                ftCo_800B463C(fp, CpuCmd_ReleaseY);
-                ftCo_800B463C(fp, CpuCmd_Done);
-            } else if (fp->kind == FTKIND_YOSHI && fp->x34_scale.y < 1.0 &&
-                       ABS(data->x54.x - fp->cur_pos.x) < 20.0f)
-            {
-                ftCo_800A0508_dontinline(fp);
-            } else {
-                ftCo_800B46B8(fp, CpuCmd_LstickTowardDestination, 0x7F);
-                ftCo_800B463C(fp, CpuCmd_PressY);
-                ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                ftCo_800B463C(fp, CpuCmd_ReleaseY);
-                ftCo_800B463C(fp, CpuCmd_Done);
-            }
+            ftCo_CpuUseAvailableJump(fp, data);
             return;
         }
         if ((var_r0_2 = ftCo_800A9CB4_inline0(fp))) {
@@ -5389,17 +5361,11 @@ void ftCo_800ABBA8(Fighter* fp)
         return;
     }
     if (target != NULL && ftCo_800A6700(fp, &target->cur_pos, &sp50.v) != 0) {
-        struct Fighter_x1A88_t* data2 = &fp->x1A88;
         f32 x;
         f32 y;
         y = sp50.v.y;
         x = sp50.v.x;
-        if (fp->x1A88.x60 == 0) {
-            data2->x54.x = x;
-            data2->x54.y = y;
-            data2->x38 = 5.0f;
-            ftCo_800A1CC4(fp, ftCo_803C6594[stage_info.internal_stage_id]);
-        }
+        ftCo_800A1F3C(fp, x, y, 5.0f);
     }
     if (data->level > 7) {
         cx = fp->cur_pos.x;
@@ -6547,13 +6513,7 @@ void ftCo_800AE7AC(Fighter* fp, Vec3* arg1, int arg2)
                     f32 y;
                     y = out.y;
                     x = out.x;
-                    if (fp->x1A88.x60 == 0) {
-                        data3->x54.x = x;
-                        data3->x54.y = y;
-                        data3->x38 = 5.0f;
-                        ftCo_800A1CC4(
-                            fp, ftCo_803C6594[stage_info.internal_stage_id]);
-                    }
+                    ftCo_800A1F3C(fp, x, y, 5.0f);
                 } else {
                     ftCo_800A75DC(fp, data3->x44);
                 }
@@ -6616,17 +6576,11 @@ void ftCo_800AEA8C(Fighter* fp)
             found = result;
         }
         if (found != 0) {
-            struct Fighter_x1A88_t* data3 = &fp->x1A88;
             f32 floor_x;
             f32 floor_y;
             floor_y = floor_pos.y;
             floor_x = floor_pos.x;
-            if (fp->x1A88.x60 == 0) {
-                data3->x54.x = floor_x;
-                data3->x54.y = floor_y;
-                data3->x38 = 5.0f;
-                ftCo_800A1CC4(fp, ftCo_803C6594[stage_info.internal_stage_id]);
-            }
+            ftCo_800A1F3C(fp, floor_x, floor_y, 5.0f);
         }
     }
     ftCo_800ADE48(fp);
@@ -6837,7 +6791,7 @@ static inline void ftCo_CpuUpdateTargetDistance(Fighter* fp)
     }
 }
 
-static inline void ftCo_800AF290_inline0(Fighter* fp, bool is_food)
+static inline void ftCo_CpuUpdateFoodItemTarget(Fighter* fp, bool is_food)
 {
     Item_GObj* item_gobj;
     ItemKind kind;
@@ -6923,8 +6877,8 @@ void ftCo_800AF290(Fighter* fp)
 
     target = ftCo_800A4BEC(fp);
     *(target_slot = &fp->x1A88.x44) = target;
-    ftCo_800AF290_inline0(fp, is_food);
-    fp->x1A88.x50 = ftCo_800A648C(fp);
+    ftCo_CpuUpdateFoodItemTarget(fp, is_food);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
     ftCo_CpuUpdateTargetDistance(fp);
     target = data->x44;
     if (target != NULL) {
@@ -6963,37 +6917,6 @@ static inline bool ftCo_CpuDataShouldAct(struct Fighter_x1A88_t* data)
     } else {
         data->xFA_b2 = false;
         return true;
-    }
-}
-
-static inline void ftCo_800AF78C_inline1(Fighter* fp, bool is_food)
-{
-    Item_GObj* item_gobj;
-    ItemKind kind;
-    struct Fighter_x1A88_t* data;
-
-    data = &fp->x1A88;
-    item_gobj = fp->item_gobj;
-    if (item_gobj != NULL) {
-        kind = GET_ITEM(item_gobj)->kind;
-        if (kind == It_Kind_Heart) {
-            is_food = true;
-        } else if (kind == It_Kind_Tomato) {
-            is_food = true;
-        } else if (kind == It_Kind_Foods) {
-            is_food = true;
-        } else {
-            is_food = false;
-        }
-        if (is_food == false) {
-            data->x4C = NULL;
-            return;
-        }
-    }
-    if (fp->x2168 != 0) {
-        data->x4C = NULL;
-    } else {
-        data->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
     }
 }
 
@@ -7052,8 +6975,8 @@ void ftCo_800AF78C(Fighter* fp)
 
     *(target_slot = &fp->x1A88.x44) = ftCo_800A4BEC(fp);
 
-    ftCo_800AF78C_inline1(fp, is_food);
-    fp->x1A88.x50 = ftCo_800A648C(fp);
+    ftCo_CpuUpdateFoodItemTarget(fp, is_food);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
 
     ftCo_CpuUpdateTargetDistance(fp);
     if (ftCo_CpuShouldAct(fp)) {
@@ -7219,7 +7142,7 @@ void ftCo_800B00F8(Fighter* fp)
             temp_r31->x4C = ftCo_800A61D8(fp);
         }
     }
-    fp->x1A88.x50 = ftCo_800A648C(fp);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
     temp_r4 = &fp->x1A88;
     temp_r3_4 = fp->x1A88.x18;
     if (temp_r3_4 != fp->x1A88.x20 && temp_r3_4 != temp_r4->x1C) {
@@ -7334,7 +7257,7 @@ void ftCo_800B04DC(Fighter* fp)
             data->x4C = ftCo_800A61D8(fp);
         }
     }
-    fp->x1A88.x50 = ftCo_800A648C(fp);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
 
     if (ftCo_CpuShouldAct(fp)) {
         target = *target_slot;
@@ -7398,11 +7321,6 @@ void ftCo_800B0760(Fighter* fp)
     ftCo_CpuUpdateSpecialItemTarget(fp);
     inlineI3(fp, data);
     ftCo_800ADE48(fp);
-}
-
-static inline void ftCo_800B0760_dontinline(Fighter* fp)
-{
-    ftCo_800B0760(fp);
 }
 
 /// @todo Maybe a macro?
@@ -7661,6 +7579,18 @@ static inline bool ftCo_800B101C_inline0(Fighter* fp, Fighter* other)
     }
 }
 
+static inline void ftCo_CpuUpdateNanaFollow(Fighter* fp, Fighter* popo,
+                                            struct Fighter_x1A88_t* data)
+{
+    ftCo_800B0760(fp);
+    if (ftCo_800B0E98(fp, popo)) {
+        data->x18 = 0;
+        data->xFA_b7 = true;
+        data->xF9_b2 = false;
+        data->xF9_b4 = false;
+    }
+}
+
 void ftCo_800B101C(Fighter* fp)
 {
     HSD_GObj* var_r4;
@@ -7705,13 +7635,7 @@ void ftCo_800B101C(Fighter* fp)
             fp->x1A88.rtrigger = 0;
         }
     } else {
-        ftCo_800B0760_dontinline(fp);
-        if (ftCo_800B0E98(fp, var_r29)) {
-            temp_r31->x18 = 0;
-            temp_r31->xFA_b7 = true;
-            temp_r31->xF9_b2 = false;
-            temp_r31->xF9_b4 = false;
-        }
+        ftCo_CpuUpdateNanaFollow(fp, var_r29, temp_r31);
     }
     if (fp->ground_or_air == GA_Ground) {
         temp_r31->xFB_b0 = false;
@@ -8008,7 +7932,7 @@ void ftCo_800B21C8(Fighter* fp)
     data->xF9_b7 = false;
     data->xF9_b1 = false;
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    fp->x1A88.x50 = ftCo_800A648C(fp);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
     ftCo_CpuUpdateTargetDistance(fp);
 
     data2 = &fp->x1A88;
@@ -8527,14 +8451,20 @@ void ftCo_800B2AFC(Fighter* fp)
     }
 }
 
-static inline void ftCo_800A0CB0_dontinline(Fighter* fp)
-{
-    ftCo_800A0CB0(fp);
-}
-
 static inline int ftCo_800B33B0_IsIgnoredFloor(int line1)
 {
     return ftCo_800A1B38_noinline(line1) != 0;
+}
+
+static inline void ftCo_CpuUpdateRecoveryScale(Fighter* fp,
+                                               struct Fighter_x1A88_t* data,
+                                               int* timer)
+{
+    if (*timer % 30 == 0) {
+        f32 rand = HSD_Randf();
+        data->x570 = 0.05 * (data->level + 1) + 0.05 * rand;
+    }
+    ftCo_800A0CB0(fp);
 }
 
 void ftCo_800B33B0(Fighter* fp)
@@ -8688,12 +8618,7 @@ void ftCo_800B33B0(Fighter* fp)
         data->x54.y += floor_vel.y;
     }
     temp_data = &fp->x1A88;
-    if (*timer % 30 == 0) {
-        f32 rand;
-        rand = HSD_Randf();
-        temp_data->x570 = 0.05 * (temp_data->level + 1) + 0.05 * rand;
-    }
-    ftCo_800A0CB0_dontinline(fp);
+    ftCo_CpuUpdateRecoveryScale(fp, temp_data, timer);
     {
         temp_data2 = &fp->x1A88;
         if (fp->x1A88.xFA_b6) {

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -6922,18 +6922,31 @@ static inline void ftCo_CpuTargetAct(Fighter* fp)
     }
 }
 
-static inline void ftCo_CpuSetTargetFlags(Fighter* fp)
+static inline void ftCo_CpuSetTargetActive(struct Fighter_x1A88_t* data)
 {
-    struct Fighter_x1A88_t* data = &fp->x1A88;
-
     data->xF8_b0 = true;
+}
+
+static inline void ftCo_CpuClearTargetModes(struct Fighter_x1A88_t* data)
+{
     data->xF9_b2 = false;
     data->xF9_b4 = false;
     data->xF9_b3 = false;
     data->xF9_b5 = false;
     data->xF9_b6 = false;
     data->xF9_b7 = false;
+}
+
+static inline void ftCo_CpuSetTargetReady(struct Fighter_x1A88_t* data)
+{
     data->xF9_b1 = true;
+}
+
+static inline void ftCo_CpuSetTargetFlags(struct Fighter_x1A88_t* data)
+{
+    ftCo_CpuSetTargetActive(data);
+    ftCo_CpuClearTargetModes(data);
+    ftCo_CpuSetTargetReady(data);
 }
 
 void ftCo_800AECF0(Fighter* fp)
@@ -6957,7 +6970,7 @@ void ftCo_800AECF0(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        ftCo_CpuSetTargetFlags(fp);
+        ftCo_CpuSetTargetFlags(data);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -7104,14 +7117,9 @@ void ftCo_800AEFB8(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        data->xF8_b0 = true;
-        data->xF9_b2 = false;
-        data->xF9_b4 = false;
-        data->xF9_b3 = false;
-        data->xF9_b5 = false;
-        data->xF9_b6 = false;
-        data->xF9_b7 = false;
-        data->xF9_b1 = true;
+        ftCo_CpuSetTargetActive(data);
+        ftCo_CpuClearTargetModes(data);
+        ftCo_CpuSetTargetReady(data);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -7198,7 +7206,7 @@ void ftCo_800AF290(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        ftCo_CpuSetTargetFlags(fp);
+        ftCo_CpuSetTargetFlags(data);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -7342,7 +7350,7 @@ void ftCo_800AF78C(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        ftCo_CpuSetTargetFlags(fp);
+        ftCo_CpuSetTargetFlags(data);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -7474,7 +7482,7 @@ void ftCo_800AFE3C(Fighter* fp, int arg1)
     temp_r3_2 = ftCo_800A5CE0(fp);
     temp_r31->x44 = temp_r3_2;
     if (temp_r3_2 != NULL) {
-        ftCo_CpuSetTargetFlags(fp);
+        ftCo_CpuSetTargetFlags(temp_r31);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -7537,7 +7545,7 @@ void ftCo_800B00F8(Fighter* fp)
     temp_r3 = ftCo_800A5CE0(fp);
     temp_r31->x44 = temp_r3;
     if (temp_r3 != NULL) {
-        ftCo_CpuSetTargetFlags(fp);
+        ftCo_CpuSetTargetFlags(temp_r31);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -8117,7 +8125,7 @@ void ftCo_800B1478(Fighter* fp)
     *(target_slot = &fp->x1A88.x44) = target;
 
     if (target != NULL) {
-        ftCo_CpuSetTargetFlags(fp);
+        ftCo_CpuSetTargetFlags(data);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -8198,7 +8206,7 @@ void ftCo_800B17D0(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        ftCo_CpuSetTargetFlags(fp);
+        ftCo_CpuSetTargetFlags(data);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -8285,7 +8293,7 @@ void ftCo_800B1AB8(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        ftCo_CpuSetTargetFlags(fp);
+        ftCo_CpuSetTargetFlags(data);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -8389,14 +8397,9 @@ void ftCo_800B1EF0(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        data->xF8_b0 = true;
-        data->xF9_b2 = false;
-        data->xF9_b4 = false;
-        data->xF9_b3 = false;
-        data->xF9_b5 = false;
-        data->xF9_b6 = false;
-        data->xF9_b7 = false;
-        data->xF9_b1 = true;
+        ftCo_CpuSetTargetActive(data);
+        ftCo_CpuClearTargetModes(data);
+        ftCo_CpuSetTargetReady(data);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -8423,7 +8426,7 @@ void ftCo_800B21C8(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        ftCo_CpuSetTargetFlags(fp);
+        ftCo_CpuSetTargetFlags(data);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;
@@ -8476,14 +8479,9 @@ void ftCo_800B24B8(Fighter* fp)
     target = ftCo_800A5CE0(fp);
     data->x44 = target;
     if (target != NULL) {
-        data->xF8_b0 = true;
-        data->xF9_b2 = false;
-        data->xF9_b4 = false;
-        data->xF9_b3 = false;
-        data->xF9_b5 = false;
-        data->xF9_b6 = false;
-        data->xF9_b7 = false;
-        data->xF9_b1 = true;
+        ftCo_CpuSetTargetActive(data);
+        ftCo_CpuClearTargetModes(data);
+        ftCo_CpuSetTargetReady(data);
         ftCo_CpuTargetAct(fp);
         ftCo_800ADE48(fp);
         return;

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -6461,7 +6461,7 @@ static bool ftCo_800ADE48(Fighter* fp)
     return true;
 }
 
-static inline void ftCo_CpuUpdateItemTargets(Fighter* fp)
+static inline void ftCo_CpuUpdateCommonItemTarget(Fighter* fp)
 {
     struct Fighter_x1A88_t* data;
 
@@ -6475,6 +6475,10 @@ static inline void ftCo_CpuUpdateItemTargets(Fighter* fp)
             data->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
         }
     }
+}
+
+static inline void ftCo_CpuUpdateSpecialItemTarget(Fighter* fp)
+{
     fp->x1A88.x50 = ftCo_800A648C(fp);
 }
 
@@ -6511,7 +6515,8 @@ void ftCo_800AE7AC(Fighter* fp, Vec3* arg1, int arg2)
         data0->xF9_b6 = true;
     }
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    ftCo_CpuUpdateItemTargets(fp);
+    ftCo_CpuUpdateCommonItemTarget(fp);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
     data2 = &fp->x1A88;
     if (data2->x18 != data2->x20 && data2->x18 != data2->x1C) {
         data2->x60 = 0;
@@ -6581,7 +6586,8 @@ void ftCo_800AEA8C(Fighter* fp)
     data->xF9_b7 = true;
     data->xF9_b1 = false;
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    ftCo_CpuUpdateItemTargets(fp);
+    ftCo_CpuUpdateCommonItemTarget(fp);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
     data2 = &fp->x1A88;
     if (data2->x18 != data2->x20 && data2->x18 != data2->x1C) {
         data2->x60 = 0;
@@ -6710,7 +6716,8 @@ void ftCo_800AECF0(Fighter* fp)
     data->xF9_b7 = true;
     data->xF9_b1 = false;
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    ftCo_CpuUpdateItemTargets(fp);
+    ftCo_CpuUpdateCommonItemTarget(fp);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
     data2 = &fp->x1A88;
     if ((data2->x18 != data2->x20) && (data2->x18 != (data2->x1C))) {
         data2->x60 = 0;
@@ -6731,19 +6738,12 @@ void ftCo_800AECF0(Fighter* fp)
     ftCo_800ADE48(fp);
 }
 
-/// Shared no-fight-target half of ftCo_800AEFB8/ftCo_800B1EF0/ftCo_800B24B8:
-/// look for items to grab and threats to dodge, then act on them. The common
-/// head and with-target half of those functions stay open-coded: making them
-/// smaller lets MWCC inline them into their callers, breaking the match.
-static inline void ftCo_CpuUpdateNoTarget(Fighter* fp, bool fear_flag)
+/// @note These phases must be called directly from their three users. Wrapping
+/// them in another inline prevents MWCC from inlining the outer helper.
+static inline void ftCo_CpuInitNoTarget(Fighter* fp, bool fear_flag)
 {
-    struct Fighter_x1A88_t* data2 = &fp->x1A88;
     struct Fighter_x1A88_t* data = &fp->x1A88;
-    Fighter* attack_target;
-    s32 do_act;
     s32 is_food;
-    Item_GObj* item_gobj;
-    ItemKind kind;
 
     data->xF8_b0 = false;
     data->xF9_b2 = (is_food = 1);
@@ -6754,30 +6754,15 @@ static inline void ftCo_CpuUpdateNoTarget(Fighter* fp, bool fear_flag)
     data->xF9_b7 = true;
     data->xF9_b1 = false;
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    item_gobj = fp->item_gobj;
-    if (item_gobj != NULL) {
-        kind = GET_ITEM(item_gobj)->kind;
-        if (kind == It_Kind_Heart) {
-            is_food = 1;
-        } else if (kind == It_Kind_Tomato) {
-            is_food = 1;
-        } else if (kind == It_Kind_Foods) {
-            is_food = 1;
-        } else {
-            is_food = 0;
-        }
-        if (is_food == 0) {
-            data->x4C = NULL;
-            goto skip_search;
-        }
-    }
-    if (fp->x2168 != 0) {
-        data->x4C = NULL;
-    } else {
-        data->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
-    }
-skip_search:
-    fp->x1A88.x50 = ftCo_800A648C(fp);
+}
+
+static inline void ftCo_CpuActOnNoTarget(Fighter* fp,
+                                         struct Fighter_x1A88_t* data)
+{
+    struct Fighter_x1A88_t* data2 = &fp->x1A88;
+    Fighter* attack_target;
+    s32 do_act;
+
     data2 = &fp->x1A88;
     if (data2->x18 != data2->x20 && data2->x18 != data2->x1C) {
         data2->x60 = 0;
@@ -6808,7 +6793,7 @@ void ftCo_800AEFB8(Fighter* fp)
     Vec3 sp28;
     s32 cmd;
     Fighter* target;
-    PAD_STACK(0x10);
+    PAD_STACK(0x14);
 
     cmd = ftCo_800A229C(fp, &sp28);
     if (cmd != 0) {
@@ -6825,7 +6810,10 @@ void ftCo_800AEFB8(Fighter* fp)
         ftCo_800ADE48(fp);
         return;
     }
-    ftCo_CpuUpdateNoTarget(fp, true);
+    ftCo_CpuInitNoTarget(fp, true);
+    ftCo_CpuUpdateCommonItemTarget(fp);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
+    ftCo_CpuActOnNoTarget(fp, data);
 }
 
 static inline void ftCo_CpuUpdateTargetDistance(Fighter* fp)
@@ -7119,7 +7107,8 @@ void ftCo_800AFC40(Fighter* fp)
     temp_r31->xF9_b7 = false;
     temp_r31->xF9_b1 = false;
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    ftCo_CpuUpdateItemTargets(fp);
+    ftCo_CpuUpdateCommonItemTarget(fp);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
     temp_r4 = &fp->x1A88;
     if (ftCo_CpuDataShouldAct(temp_r4)) {
         temp_r3_3 = ftCo_800A50D4(fp);
@@ -7178,7 +7167,8 @@ void ftCo_800AFE3C(Fighter* fp, int arg1)
     temp_r31->xF9_b7 = true;
     temp_r31->xF9_b1 = false;
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    ftCo_CpuUpdateItemTargets(fp);
+    ftCo_CpuUpdateCommonItemTarget(fp);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
     if (ftCo_CpuShouldAct(fp)) {
         ftCo_CpuActOnPlayer(fp, temp_r31, arg1);
     }
@@ -7404,7 +7394,8 @@ void ftCo_800B0760(Fighter* fp)
 
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
 
-    ftCo_CpuUpdateItemTargets(fp);
+    ftCo_CpuUpdateCommonItemTarget(fp);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
     inlineI3(fp, data);
     ftCo_800ADE48(fp);
 }
@@ -7744,7 +7735,8 @@ void ftCo_800B126C(Fighter* fp)
     PAD_STACK(0x10);
 
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    ftCo_CpuUpdateItemTargets(fp);
+    ftCo_CpuUpdateCommonItemTarget(fp);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
 
     if (ftCo_CpuShouldAct(fp)) {
         if (data->x4C != NULL && fp->item_gobj == NULL) {
@@ -7788,7 +7780,8 @@ void ftCo_800B1478(Fighter* fp)
     data->xF9_b1 = false;
 
     *target_slot = ftCo_800A4BEC(fp);
-    ftCo_CpuUpdateItemTargets(fp);
+    ftCo_CpuUpdateCommonItemTarget(fp);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
 
     ftCo_CpuUpdateTargetDistance(fp);
 
@@ -7841,7 +7834,8 @@ void ftCo_800B17D0(Fighter* fp)
     data->x2C = is_food;
     data->xF9_b1 = false;
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    ftCo_CpuUpdateItemTargets(fp);
+    ftCo_CpuUpdateCommonItemTarget(fp);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
     data2 = &fp->x1A88;
     if (data2->x18 != data2->x20 && data2->x18 != data2->x1C) {
         data2->x60 = 0;
@@ -7901,7 +7895,8 @@ void ftCo_800B1AB8(Fighter* fp)
     data->x2C = is_food;
     data->xF9_b1 = false;
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    ftCo_CpuUpdateItemTargets(fp);
+    ftCo_CpuUpdateCommonItemTarget(fp);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
     data2 = &fp->x1A88;
     if (data2->x18 != data2->x20 && data2->x18 != data2->x1C) {
         data2->x60 = 0;
@@ -7957,7 +7952,7 @@ void ftCo_800B1EF0(Fighter* fp)
     Vec3 sp28;
     s32 cmd;
     Fighter* target;
-    PAD_STACK(0x10);
+    PAD_STACK(0x14);
 
     cmd = ftCo_800A229C(fp, &sp28);
     if (cmd != 0) {
@@ -7974,7 +7969,10 @@ void ftCo_800B1EF0(Fighter* fp)
         ftCo_800ADE48(fp);
         return;
     }
-    ftCo_CpuUpdateNoTarget(fp, false);
+    ftCo_CpuInitNoTarget(fp, false);
+    ftCo_CpuUpdateCommonItemTarget(fp);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
+    ftCo_CpuActOnNoTarget(fp, data);
 }
 
 void ftCo_800B21C8(Fighter* fp)
@@ -8039,7 +8037,7 @@ void ftCo_800B24B8(Fighter* fp)
     Vec3 sp28;
     s32 cmd;
     Fighter* target;
-    PAD_STACK(0x10);
+    PAD_STACK(0x14);
 
     cmd = ftCo_800A229C(fp, &sp28);
     if (cmd != 0) {
@@ -8056,7 +8054,10 @@ void ftCo_800B24B8(Fighter* fp)
         ftCo_800ADE48(fp);
         return;
     }
-    ftCo_CpuUpdateNoTarget(fp, true);
+    ftCo_CpuInitNoTarget(fp, true);
+    ftCo_CpuUpdateCommonItemTarget(fp);
+    ftCo_CpuUpdateSpecialItemTarget(fp);
+    ftCo_CpuActOnNoTarget(fp, data);
 }
 
 void ftCo_800B2790(Fighter* fp)

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -168,6 +168,18 @@ static inline void ftCo_CpuTapRAndWait(Fighter* fp)
     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
 }
 
+static inline void ftCo_CpuDoubleJumpAfterDelay(Fighter* fp)
+{
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 10);
+    ftCo_800B463C(fp, CpuCmd_ReleaseY);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B463C(fp, CpuCmd_PressY);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 10);
+    ftCo_800B463C(fp, CpuCmd_ReleaseY);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B463C(fp, CpuCmd_Done);
+}
+
 void ftCo_800A0148(Fighter* fp)
 {
     struct Fighter_x1A88_t* x1A88 = &fp->x1A88;
@@ -176,14 +188,7 @@ void ftCo_800A0148(Fighter* fp)
         ftCo_CpuFinishWithNeutralStick(fp);
     } else if (ftCo_800A1CA8(fp)) {
         ftCo_CpuSetNeutralStick(fp);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 10);
-        ftCo_800B463C(fp, CpuCmd_ReleaseY);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B463C(fp, CpuCmd_PressY);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 10);
-        ftCo_800B463C(fp, CpuCmd_ReleaseY);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuDoubleJumpAfterDelay(fp);
     } else if (ABS(x1A88->x54.x - fp->cur_pos.x) > 30.0) {
         ftCo_800B463C(fp, CpuCmd_ReleaseY);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
@@ -211,14 +216,7 @@ void ftCo_800A0384(Fighter* fp)
         ftCo_CpuFinishWithNeutralStick(fp);
     } else if (ftCo_800A1CA8(fp)) {
         ftCo_CpuSetNeutralStick(fp);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 10);
-        ftCo_800B463C(fp, CpuCmd_ReleaseY);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B463C(fp, CpuCmd_PressY);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 10);
-        ftCo_800B463C(fp, CpuCmd_ReleaseY);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuDoubleJumpAfterDelay(fp);
     } else {
         ftCo_800B463C(fp, CpuCmd_ReleaseY);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
@@ -253,14 +251,7 @@ void ftCo_800A05F4(Fighter* fp)
         ftCo_CpuFinishWithNeutralStick(fp);
     } else if (ftCo_800A1CA8(fp)) {
         ftCo_CpuSetNeutralStick(fp);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 10);
-        ftCo_800B463C(fp, CpuCmd_ReleaseY);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B463C(fp, CpuCmd_PressY);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 10);
-        ftCo_800B463C(fp, CpuCmd_ReleaseY);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuDoubleJumpAfterDelay(fp);
     } else {
         ftCo_CpuSetNeutralStick(fp);
         ftCo_800B463C(fp, CpuCmd_ReleaseY);

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -103,6 +103,13 @@ static inline void ftCo_CpuFinishWithNeutralStick(Fighter* fp)
     ftCo_800B463C(fp, CpuCmd_Done);
 }
 
+static inline void
+ftCo_CpuReturnToPreviousBehavior(Fighter* fp, struct Fighter_x1A88_t* data)
+{
+    data->x18 = data->x1C;
+    ftCo_800B463C(fp, CpuCmd_Done);
+}
+
 static inline void ftCo_CpuHoldUpForOneFrame(Fighter* fp)
 {
     ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
@@ -5424,8 +5431,7 @@ void ftCo_800ABBA8(Fighter* fp)
     }
     below = ftCo_800A4BEC(fp);
     if (below == NULL) {
-        data->x18 = data->x1C;
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuReturnToPreviousBehavior(fp, data);
         return;
     }
     if (below->cur_pos.y < fp->cur_pos.y) {
@@ -5525,8 +5531,7 @@ void ftCo_800AC30C(Fighter* fp)
     struct Fighter_x1A88_t* data = &fp->x1A88;
     PAD_STACK(4 * 4);
     if (!inlineG0(fp)) {
-        data->x18 = data->x1C;
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuReturnToPreviousBehavior(fp, data);
         return;
     }
     if (data->x7C % 3 == 0 && !(data->level * 0.1F < HSD_Randf())) {
@@ -5569,8 +5574,7 @@ void ftCo_800AC434(Fighter* fp)
     PAD_STACK(5 * 4);
 
     if (barrel_state == 0) {
-        data->x18 = data->x1C;
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuReturnToPreviousBehavior(fp, data);
         return;
     }
     if (barrel_state == 1) {
@@ -5647,8 +5651,7 @@ void ftCo_800AC7D4(Fighter* fp)
 
     var_r0 = ftCo_800A3134(fp);
     if (var_r0 == 0) {
-        data->x18 = data->x1C;
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuReturnToPreviousBehavior(fp, data);
         return;
     }
     if (var_r0 == 1) {
@@ -5706,8 +5709,7 @@ void ftCo_800ACB44(Fighter* fp)
         return;
     }
     if (var_r0 == 0) {
-        data->x18 = data->x1C;
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuReturnToPreviousBehavior(fp, data);
         return;
     }
     if (data->xC == 0xF || data->xC == 0) {
@@ -5767,8 +5769,7 @@ void ftCo_800ACD5C(Fighter* fp)
         return;
     }
     if (ftCo_800A3554(fp, 1.0f) == 0) {
-        data->x18 = data->x1C;
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuReturnToPreviousBehavior(fp, data);
         return;
     }
     if ((fp->kind == FTKIND_ZELDA || fp->kind == FTKIND_SEAK) && data->xF8_b5)
@@ -5850,8 +5851,7 @@ void ftCo_800AD42C(Fighter* fp)
 {
     struct Fighter_x1A88_t* data = &fp->x1A88;
     if (!ftCo_800A3554(fp, 1.0F)) {
-        data->x18 = data->x1C;
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuReturnToPreviousBehavior(fp, data);
     } else if (fp->ground_or_air == GA_Air) {
         ftCo_CpuFinishWithNeutralStick(fp);
     } else {
@@ -5916,8 +5916,7 @@ void ftCo_800AD7FC(Fighter* fp)
 
     data = &fp->x1A88;
     if (fp->item_gobj == NULL) {
-        data->x18 = data->x1C;
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuReturnToPreviousBehavior(fp, data);
         return;
     }
 
@@ -8015,8 +8014,7 @@ void ftCo_800B2790(Fighter* fp)
                         on_ground = 0;
                     }
                     if (on_ground != 0) {
-                        data->x18 = data->x1C;
-                        ftCo_800B463C(fp, CpuCmd_Done);
+                        ftCo_CpuReturnToPreviousBehavior(fp, data);
                         data->xFA_b2 = false;
                     } else {
                         ftCo_800A9904(fp);
@@ -8049,8 +8047,7 @@ void ftCo_800B2790(Fighter* fp)
                 break;
             case 13:
                 if (fp->item_gobj != NULL) {
-                    data->x18 = data->x1C;
-                    ftCo_800B463C(fp, CpuCmd_Done);
+                    ftCo_CpuReturnToPreviousBehavior(fp, data);
                 } else {
                     ftCo_CpuSetNeutralStick(fp);
                     ftCo_800B463C(fp, CpuCmd_ReleaseA);
@@ -8079,8 +8076,7 @@ void ftCo_800B2790(Fighter* fp)
                     special_floor = 2;
                 }
                 if (special_floor == 0) {
-                    data->x18 = data->x1C;
-                    ftCo_800B463C(fp, CpuCmd_Done);
+                    ftCo_CpuReturnToPreviousBehavior(fp, data);
                 } else {
                     ftCo_CpuFinishWithNeutralStick(fp);
                 }

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -7404,12 +7404,7 @@ void ftCo_800B04DC(Fighter* fp)
 
     data = &fp->x1A88;
     data->xF8_b0 = (is_food = true);
-    data->xF9_b2 = false;
-    data->xF9_b4 = false;
-    data->xF9_b3 = false;
-    data->xF9_b5 = false;
-    data->xF9_b6 = false;
-    data->xF9_b7 = false;
+    ftCo_CpuClearTargetModes(data);
     data->xF9_b1 = true;
 
     target = ftCo_800A4BEC(fp);
@@ -7458,7 +7453,8 @@ void ftCo_800B04DC(Fighter* fp)
     ftCo_800ADE48(fp);
 }
 
-static inline void inlineI0(Fighter* fp, struct Fighter_x1A88_t* data)
+static inline void ftCo_CpuInitEnemyTarget(Fighter* fp,
+                                           struct Fighter_x1A88_t* data)
 {
     data->xF8_b0 = false;
     data->xF9_b2 = true;
@@ -8134,7 +8130,7 @@ void ftCo_800B1DA0(Fighter* fp)
 {
     struct Fighter_x1A88_t* data = &fp->x1A88;
     PAD_STACK(6 * 4);
-    inlineI0(fp, data);
+    ftCo_CpuInitEnemyTarget(fp, data);
     if (ftCo_CpuDataShouldAct(data) && data->x7C % 60 * 5 == 0 &&
         HSD_Randf() < 0.5)
     {
@@ -8433,12 +8429,7 @@ void ftCo_800B2AFC(Fighter* fp)
         s32 x18;
 
         data->xF8_b0 = false;
-        data->xF9_b2 = false;
-        data->xF9_b4 = false;
-        data->xF9_b3 = false;
-        data->xF9_b5 = false;
-        data->xF9_b6 = false;
-        data->xF9_b7 = false;
+        ftCo_CpuClearTargetModes(data);
         data->xF9_b1 = false;
         x18 = fp->x1A88.x18;
         if (x18 != data->x20 && x18 != data->x1C) {
@@ -8481,12 +8472,7 @@ void ftCo_800B2AFC(Fighter* fp)
         s32 x18;
 
         data->xF8_b0 = false;
-        data->xF9_b2 = false;
-        data->xF9_b4 = false;
-        data->xF9_b3 = false;
-        data->xF9_b5 = false;
-        data->xF9_b6 = false;
-        data->xF9_b7 = false;
+        ftCo_CpuClearTargetModes(data);
         data->xF9_b1 = false;
         x18 = fp->x1A88.x18;
         if (x18 != data->x20 && x18 != data->x1C) {
@@ -8537,12 +8523,7 @@ void ftCo_800B2AFC(Fighter* fp)
         s32 x18;
 
         data->xF8_b0 = false;
-        data->xF9_b2 = false;
-        data->xF9_b4 = false;
-        data->xF9_b3 = false;
-        data->xF9_b5 = false;
-        data->xF9_b6 = false;
-        data->xF9_b7 = false;
+        ftCo_CpuClearTargetModes(data);
         data->xF9_b1 = false;
         x18 = fp->x1A88.x18;
         if (x18 != data->x20 && x18 != data->x1C) {
@@ -8633,15 +8614,7 @@ void ftCo_800B2AFC(Fighter* fp)
         s32 do_act;
         s32 x18;
 
-        data->xF8_b0 = false;
-        data->xF9_b2 = true;
-        data->xF9_b4 = true;
-        data->xF9_b3 = false;
-        data->xF9_b5 = false;
-        data->xF9_b6 = false;
-        data->xF9_b7 = false;
-        data->xF9_b1 = false;
-        fp->x1A88.x44 = ftCo_800A4BEC(fp);
+        ftCo_CpuInitEnemyTarget(fp, data);
         x18 = data->x18;
         if (x18 != data->x20 && x18 != data->x1C) {
             data->x60 = 0;
@@ -8666,15 +8639,7 @@ void ftCo_800B2AFC(Fighter* fp)
         s32 do_act;
         s32 x18;
 
-        data->xF8_b0 = false;
-        data->xF9_b2 = true;
-        data->xF9_b4 = true;
-        data->xF9_b3 = false;
-        data->xF9_b5 = false;
-        data->xF9_b6 = false;
-        data->xF9_b7 = false;
-        data->xF9_b1 = false;
-        fp->x1A88.x44 = ftCo_800A4BEC(fp);
+        ftCo_CpuInitEnemyTarget(fp, data);
         x18 = data->x18;
         if (x18 != data->x20 && x18 != data->x1C) {
             data->x60 = 0;
@@ -8698,15 +8663,7 @@ void ftCo_800B2AFC(Fighter* fp)
         s32 do_act;
         s32 x18;
 
-        data->xF8_b0 = false;
-        data->xF9_b2 = true;
-        data->xF9_b4 = true;
-        data->xF9_b3 = false;
-        data->xF9_b5 = false;
-        data->xF9_b6 = false;
-        data->xF9_b7 = false;
-        data->xF9_b1 = false;
-        fp->x1A88.x44 = ftCo_800A4BEC(fp);
+        ftCo_CpuInitEnemyTarget(fp, data);
         x18 = data->x18;
         if (x18 != data->x20 && x18 != data->x1C) {
             data->x60 = 0;

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -103,6 +103,27 @@ static inline void ftCo_CpuFinishWithNeutralStick(Fighter* fp)
     ftCo_800B463C(fp, CpuCmd_Done);
 }
 
+static inline void ftCo_CpuTapA(Fighter* fp)
+{
+    ftCo_800B463C(fp, CpuCmd_PressA);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B463C(fp, CpuCmd_ReleaseA);
+}
+
+static inline void ftCo_CpuTapB(Fighter* fp)
+{
+    ftCo_800B463C(fp, CpuCmd_PressB);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B463C(fp, CpuCmd_ReleaseB);
+}
+
+static inline void ftCo_CpuTapR(Fighter* fp)
+{
+    ftCo_800B463C(fp, CpuCmd_PressR);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B463C(fp, CpuCmd_ReleaseR);
+}
+
 void ftCo_800A0148(Fighter* fp)
 {
     struct Fighter_x1A88_t* x1A88 = &fp->x1A88;
@@ -171,16 +192,12 @@ void ftCo_800A0508(Fighter* fp)
     ftCo_CpuSetNeutralStick(fp);
     ftCo_800B463C(fp, CpuCmd_PressY);
     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-
     ftCo_800B463C(fp, CpuCmd_ReleaseY);
     ftCo_800B46B8(fp, CpuCmd_WaitFor, 30);
 
     ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0x50);
     ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x7F);
-    ftCo_800B463C(fp, CpuCmd_PressR);
-    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-
-    ftCo_800B463C(fp, CpuCmd_ReleaseR);
+    ftCo_CpuTapR(fp);
     ftCo_CpuFinishWithNeutralY(fp);
 
     ftCo_800B463C(fp, CpuCmd_Done);
@@ -304,16 +321,12 @@ void ftCo_800A0AF4(Fighter* fp)
     } else if (rand < 0.8f) {
         ftCo_800B463C(fp, CpuCmd_ReleaseR);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B463C(fp, CpuCmd_PressR);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B463C(fp, CpuCmd_ReleaseR);
+        ftCo_CpuTapR(fp);
         ftCo_800B463C(fp, CpuCmd_Done);
     } else if (rand < 0.9f) {
         ftCo_800B463C(fp, CpuCmd_ReleaseA);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B463C(fp, CpuCmd_PressA);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B463C(fp, CpuCmd_ReleaseA);
+        ftCo_CpuTapA(fp);
         ftCo_800B463C(fp, CpuCmd_Done);
     } else {
         ftCo_800B463C(fp, CpuCmd_ReleaseY);
@@ -5651,9 +5664,7 @@ static inline enum_t inlineH0(Fighter* fp)
 static inline void inlineH1(Fighter* fp, struct Fighter_x1A88_t* data)
 {
     if (data->x7C % ((10 - data->level) * 5) == 0 && HSD_Randf() < 0.5f) {
-        ftCo_800B463C(fp, CpuCmd_PressA);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B463C(fp, CpuCmd_ReleaseA);
+        ftCo_CpuTapA(fp);
         ftCo_800B463C(fp, CpuCmd_Done);
     } else {
         ftCo_800B463C(fp, CpuCmd_Done);
@@ -5681,9 +5692,7 @@ void ftCo_800AC434(Fighter* fp)
         return;
     }
     if (f >= -0.26179938577115536 && f <= 0.0) {
-        ftCo_800B463C(fp, CpuCmd_PressA);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B463C(fp, CpuCmd_ReleaseA);
+        ftCo_CpuTapA(fp);
         ftCo_800B463C(fp, CpuCmd_Done);
     } else {
         ftCo_800B463C(fp, CpuCmd_Done);
@@ -5777,9 +5786,7 @@ void ftCo_800AC7D4(Fighter* fp)
             ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
             ftCo_800B463C(fp, CpuCmd_ReleaseA);
             ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_PressA);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_ReleaseA);
+            ftCo_CpuTapA(fp);
             ftCo_800B463C(fp, CpuCmd_Done);
         } else {
             if (temp_r3->cur_pos.x - fp->cur_pos.x < 0.0F) {
@@ -5837,16 +5844,12 @@ void ftCo_800ACB44(Fighter* fp)
         if (0.1F * data->level > HSD_Randf()) {
             ftCo_800B463C(fp, CpuCmd_ReleaseR);
             ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_PressR);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_ReleaseR);
+            ftCo_CpuTapR(fp);
             ftCo_800B463C(fp, CpuCmd_Done);
         } else {
             ftCo_800B463C(fp, CpuCmd_ReleaseA);
             ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_PressA);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_ReleaseA);
+            ftCo_CpuTapA(fp);
             ftCo_800B463C(fp, CpuCmd_Done);
         }
     } else {
@@ -5912,18 +5915,14 @@ void ftCo_800ACD5C(Fighter* fp)
     if (fp->kind == FTKIND_DONKEY) {
         if (fp->motion_id != ftDk_MS_SpecialNLoop && fp->fv.dk.x222C == 0) {
             ftCo_CpuSetNeutralStick(fp);
-            ftCo_800B463C(fp, CpuCmd_PressB);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_ReleaseB);
+            ftCo_CpuTapB(fp);
             ftCo_800B463C(fp, CpuCmd_Done);
             return;
         }
     } else if (fp->kind == FTKIND_SAMUS) {
         if (fp->motion_id != ftSs_MS_SpecialNHold && fp->fv.ss.x2230 == 0) {
             ftCo_CpuSetNeutralStick(fp);
-            ftCo_800B463C(fp, CpuCmd_PressB);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_ReleaseB);
+            ftCo_CpuTapB(fp);
             ftCo_800B463C(fp, CpuCmd_Done);
             return;
         }
@@ -5935,9 +5934,7 @@ void ftCo_800ACD5C(Fighter* fp)
             if (fp->motion_id == ftMt_MS_SpecialNLoop ||
                 fp->motion_id == ftMt_MS_SpecialNLoopFull)
             {
-                ftCo_800B463C(fp, CpuCmd_PressR);
-                ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                ftCo_800B463C(fp, CpuCmd_ReleaseR);
+                ftCo_CpuTapR(fp);
                 ftCo_800B463C(fp, CpuCmd_Done);
                 return;
             }
@@ -5945,9 +5942,7 @@ void ftCo_800ACD5C(Fighter* fp)
                    fp->fv.mt.x2234_shadowBallCharge == 0)
         {
             ftCo_CpuSetNeutralStick(fp);
-            ftCo_800B463C(fp, CpuCmd_PressB);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_ReleaseB);
+            ftCo_CpuTapB(fp);
             ftCo_800B463C(fp, CpuCmd_Done);
             return;
         }
@@ -5956,9 +5951,7 @@ void ftCo_800ACD5C(Fighter* fp)
             if (fp->motion_id != ftKb_MS_DkSpecialNLoop && fp->fv.kb.xBC == 0)
             {
                 ftCo_CpuSetNeutralStick(fp);
-                ftCo_800B463C(fp, CpuCmd_PressB);
-                ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                ftCo_800B463C(fp, CpuCmd_ReleaseB);
+                ftCo_CpuTapB(fp);
                 ftCo_800B463C(fp, CpuCmd_Done);
                 return;
             }
@@ -5966,9 +5959,7 @@ void ftCo_800ACD5C(Fighter* fp)
             if (fp->motion_id != ftKb_MS_SsSpecialNHold && fp->fv.kb.xA8 == 0)
             {
                 ftCo_CpuSetNeutralStick(fp);
-                ftCo_800B463C(fp, CpuCmd_PressB);
-                ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                ftCo_800B463C(fp, CpuCmd_ReleaseB);
+                ftCo_CpuTapB(fp);
                 ftCo_800B463C(fp, CpuCmd_Done);
                 return;
             }
@@ -5978,18 +5969,14 @@ void ftCo_800ACD5C(Fighter* fp)
                 if (fp->motion_id == ftKb_MS_MtSpecialNLoop ||
                     fp->motion_id == ftKb_MS_MtSpecialNLoopFull)
                 {
-                    ftCo_800B463C(fp, CpuCmd_PressR);
-                    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                    ftCo_800B463C(fp, CpuCmd_ReleaseR);
+                    ftCo_CpuTapR(fp);
                     return;
                 }
             } else if (fp->motion_id != ftKb_MS_MtSpecialNLoop &&
                        fp->fv.kb.x9C == 0)
             {
                 ftCo_CpuSetNeutralStick(fp);
-                ftCo_800B463C(fp, CpuCmd_PressB);
-                ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                ftCo_800B463C(fp, CpuCmd_ReleaseB);
+                ftCo_CpuTapB(fp);
                 ftCo_800B463C(fp, CpuCmd_Done);
                 return;
             }
@@ -6138,47 +6125,35 @@ void ftCo_800ADC28(Fighter* fp)
 
     if (fp->kind == FTKIND_DONKEY) {
         if (fp->motion_id == ftDk_MS_SpecialNLoop) {
-            ftCo_800B463C(fp, CpuCmd_PressR);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_ReleaseR);
+            ftCo_CpuTapR(fp);
         }
     } else if (fp->kind == FTKIND_SAMUS) {
         if (fp->motion_id == ftSs_MS_SpecialNHold) {
-            ftCo_800B463C(fp, CpuCmd_PressR);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_ReleaseR);
+            ftCo_CpuTapR(fp);
             ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         }
     } else if (fp->kind == FTKIND_MEWTWO) {
         if (fp->motion_id == ftMt_MS_SpecialNLoop ||
             fp->motion_id == ftMt_MS_SpecialNLoopFull)
         {
-            ftCo_800B463C(fp, CpuCmd_PressR);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_ReleaseR);
+            ftCo_CpuTapR(fp);
             ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         }
     } else if (fp->kind == FTKIND_KIRBY) {
         FighterKind kind = fp->fv.kb.hat.kind;
         if (kind == FTKIND_DONKEY && fp->motion_id == ftKb_MS_DkSpecialNLoop) {
-            ftCo_800B463C(fp, CpuCmd_PressR);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_ReleaseR);
+            ftCo_CpuTapR(fp);
             ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         } else if (kind == FTKIND_SAMUS &&
                    fp->motion_id == ftKb_MS_SsSpecialNHold)
         {
-            ftCo_800B463C(fp, CpuCmd_PressR);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_ReleaseR);
+            ftCo_CpuTapR(fp);
             ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         } else if (kind == FTKIND_MEWTWO &&
                    (fp->motion_id == ftKb_MS_MtSpecialNLoop ||
                     fp->motion_id == ftKb_MS_MtSpecialNLoopFull))
         {
-            ftCo_800B463C(fp, CpuCmd_PressR);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_ReleaseR);
+            ftCo_CpuTapR(fp);
             ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         }
     }
@@ -8452,9 +8427,7 @@ void ftCo_800B2790(Fighter* fp)
                     ftCo_CpuSetNeutralStick(fp);
                     ftCo_800B463C(fp, CpuCmd_ReleaseA);
                     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                    ftCo_800B463C(fp, CpuCmd_PressA);
-                    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                    ftCo_800B463C(fp, CpuCmd_ReleaseA);
+                    ftCo_CpuTapA(fp);
                     ftCo_800B463C(fp, CpuCmd_Done);
                     data->x18 = data->x1C;
                 }

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -4202,6 +4202,14 @@ static inline void ftCo_CpuAimPkThunder(Fighter* fp, float angle, int frames)
     ftCo_800B46B8(fp, CpuCmd_WaitFor, frames);
 }
 
+static inline void ftCo_CpuStartUpSpecial(Fighter* fp)
+{
+    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x7F);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
+    ftCo_800B46B8(fp, CpuCmd_PressBFor, 1);
+    ftCo_800B463C(fp, CpuCmd_ReleaseB);
+}
+
 /**
  * Ness recovery PK thunder logic
  */
@@ -4214,10 +4222,7 @@ void ftCo_800A8EB0(Fighter* fp)
         ftCo_800B463C(fp, CpuCmd_Done);
         return;
     }
-    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x7F);
-    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-    ftCo_800B46B8(fp, CpuCmd_PressBFor, 1);
-    ftCo_800B463C(fp, CpuCmd_ReleaseB);
+    ftCo_CpuStartUpSpecial(fp);
     if (data->x54.x - fp->cur_pos.x > 0.0) {
         angle = M_PI;
         ftCo_CpuAimPkThunder(fp, angle, 20);
@@ -4257,10 +4262,7 @@ void ftCo_800A92CC(Fighter* fp)
         // the side.
 
         // Start the up-B
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x7F);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_PressBFor, 1);
-        ftCo_800B463C(fp, CpuCmd_ReleaseB);
+        ftCo_CpuStartUpSpecial(fp);
 
         // Go diagonally upward
         ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x58);
@@ -4276,10 +4278,7 @@ void ftCo_800A92CC(Fighter* fp)
         // Otherwise, go straight up, then randomly horizontal or diagonal.
 
         // Start the up-B
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x7F);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_PressBFor, 1);
-        ftCo_800B463C(fp, CpuCmd_ReleaseB);
+        ftCo_CpuStartUpSpecial(fp);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 15);
 
         if (HSD_Randf() > 0.5) {
@@ -4338,9 +4337,21 @@ static void ftCo_800A949C(Fighter* fp, bool unused)
     ftCo_800B463C(fp, CpuCmd_Done);
 }
 
+static inline void ftCo_CpuRecoverDiagonally(Fighter* fp)
+{
+    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x58);
+    ftCo_800B46B8(fp, CpuCmd_LstickXTowardDestination, 0x58);
+    ftCo_800B46B8(fp, CpuCmd_PressBFor, 1);
+    ftCo_800B463C(fp, CpuCmd_ReleaseB);
+    ftCo_800B46B8(fp, CpuCmd_LstickXTowardDestination, 0x7F);
+    ftCo_800B463C(fp, CpuCmd_Done);
+}
+
 /**
  * Samus recovery logic
  */
+#pragma push
+#pragma dont_inline on
 static void ftCo_800A963C(Fighter* fp, bool unused)
 {
     PAD_STACK(4 * 14);
@@ -4355,9 +4366,8 @@ static void ftCo_800A963C(Fighter* fp, bool unused)
     ftCo_800B46B8(fp, CpuCmd_LstickXTowardDestination, 0x7F);
     ftCo_800B463C(fp, CpuCmd_Done);
 }
+#pragma pop
 
-#pragma push
-#pragma dont_inline on
 /**
  * Handles CPU recovery / up-B logic for each character
  */
@@ -4371,12 +4381,7 @@ void ftCo_800A96B8(Fighter* fp)
 
     switch (fp->kind) {
     case FTKIND_MARIO:
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x58);
-        ftCo_800B46B8(fp, CpuCmd_LstickXTowardDestination, 0x58);
-        ftCo_800B46B8(fp, CpuCmd_PressBFor, 1);
-        ftCo_800B463C(fp, CpuCmd_ReleaseB);
-        ftCo_800B46B8(fp, CpuCmd_LstickXTowardDestination, 0x7F);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuRecoverDiagonally(fp);
         break;
     case FTKIND_PIKACHU:
     case FTKIND_PICHU:
@@ -4422,17 +4427,10 @@ void ftCo_800A96B8(Fighter* fp)
     default:
         // For all other characters, diagonally up-B toward the stage,
         // with full inward drift
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x58);
-        ftCo_800B46B8(fp, CpuCmd_LstickXTowardDestination, 0x58);
-        ftCo_800B46B8(fp, CpuCmd_PressBFor, 1);
-        ftCo_800B463C(fp, CpuCmd_ReleaseB);
-        ftCo_800B46B8(fp, CpuCmd_LstickXTowardDestination, 0x7F);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuRecoverDiagonally(fp);
         break;
     }
 }
-#pragma pop
-
 static inline bool ftCo_IsNearlyZero(float x)
 {
     if (x < 0.00001F && x > -0.00001F) {

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -7400,9 +7400,8 @@ void ftCo_800AFC40(Fighter* fp)
     ftCo_800ADE48(fp);
 }
 
-static inline void ftCo_CpuActOnPlayer(Fighter* fp,
-                                      struct Fighter_x1A88_t* data,
-                                      int player_id)
+static inline void
+ftCo_CpuActOnPlayer(Fighter* fp, struct Fighter_x1A88_t* data, int player_id)
 {
     Fighter* target = ftCo_800A5294(fp, player_id);
 

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -4795,6 +4795,17 @@ static inline bool isInTeeter(Fighter* fp)
     return false;
 }
 
+static inline void ftCo_CpuTurnAwayFromLedge(Fighter* fp)
+{
+    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0x7F);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
+    ftCo_800B463C(fp, CpuCmd_Done);
+}
+
 static inline void ftCo_CpuTurnAround(Fighter* fp)
 {
     ftCo_CpuSetNeutralStick(fp);
@@ -4852,13 +4863,7 @@ void ftCo_800AA42C(Fighter* fp)
     data = &fp->x1A88;
     ftCo_800AA320(fp, &stick, &clamp);
     if (isInTeeter(fp)) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0x7F);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuTurnAwayFromLedge(fp);
         return;
     }
     if (fp->facing_dir * (fp->x1A88.x54.x - fp->cur_pos.x) >= 0.0) {
@@ -4922,13 +4927,7 @@ void ftCo_800AA844(Fighter* fp)
 
     data = &fp->x1A88;
     if (isInTeeter(fp)) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0x7F);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuTurnAwayFromLedge(fp);
         return;
     }
     ftCo_800AA320(fp, &sp38, &sp34);
@@ -4964,6 +4963,8 @@ void ftCo_800AA844(Fighter* fp)
 void ftCo_800AABC8(Fighter* fp)
 {
     PAD_STACK(2 * 4);
+    /// @todo Using ftCo_CpuTurnAwayFromLedge here changes inlining in
+    /// ftCo_800AB224.
     if (isInTeeter(fp)) {
         ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
         ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
@@ -5002,13 +5003,7 @@ void ftCo_800AACD0(Fighter* fp)
     PAD_STACK(0xC);
 
     if (isInTeeter(fp)) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0x7F);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuTurnAwayFromLedge(fp);
         return;
     }
     ftCo_800AA320(fp, &stick, &clamp);

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -85,17 +85,32 @@ typedef struct ftCo_803C6594_t {
 /* static */ extern ftCo_803C6594_t* ftCo_803C6594[];
 /* 0A2638 */ static void ftCo_800B1DA0(Fighter* fp);
 
+static inline void ftCo_CpuSetNeutralStick(Fighter* fp)
+{
+    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+}
+
+static inline void ftCo_CpuFinishWithNeutralY(Fighter* fp)
+{
+    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+    ftCo_800B463C(fp, CpuCmd_Done);
+}
+
+static inline void ftCo_CpuFinishWithNeutralStick(Fighter* fp)
+{
+    ftCo_CpuSetNeutralStick(fp);
+    ftCo_800B463C(fp, CpuCmd_Done);
+}
+
 void ftCo_800A0148(Fighter* fp)
 {
     struct Fighter_x1A88_t* x1A88 = &fp->x1A88;
 
     if (fp->cur_pos.y + x1A88->x558 > Stage_GetBlastZoneTopOffset()) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuFinishWithNeutralStick(fp);
     } else if (ftCo_800A1CA8(fp)) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 10);
         ftCo_800B463C(fp, CpuCmd_ReleaseY);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
@@ -115,8 +130,7 @@ void ftCo_800A0148(Fighter* fp)
         ftCo_800B463C(fp, CpuCmd_Done);
     } else {
         ftCo_800B463C(fp, CpuCmd_ReleaseY);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         ftCo_800B463C(fp, CpuCmd_PressY);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 10);
@@ -129,12 +143,9 @@ void ftCo_800A0148(Fighter* fp)
 void ftCo_800A0384(Fighter* fp)
 {
     if (fp->cur_pos.y + fp->x1A88.x558 > Stage_GetBlastZoneTopOffset()) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuFinishWithNeutralStick(fp);
     } else if (ftCo_800A1CA8(fp)) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 10);
         ftCo_800B463C(fp, CpuCmd_ReleaseY);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
@@ -157,8 +168,7 @@ void ftCo_800A0384(Fighter* fp)
 
 void ftCo_800A0508(Fighter* fp)
 {
-    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+    ftCo_CpuSetNeutralStick(fp);
     ftCo_800B463C(fp, CpuCmd_PressY);
     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
 
@@ -171,8 +181,7 @@ void ftCo_800A0508(Fighter* fp)
     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
 
     ftCo_800B463C(fp, CpuCmd_ReleaseR);
-    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-    ftCo_800B463C(fp, CpuCmd_Done);
+    ftCo_CpuFinishWithNeutralY(fp);
 
     ftCo_800B463C(fp, CpuCmd_Done);
 }
@@ -185,12 +194,9 @@ static inline void ftCo_800A0508_dontinline(Fighter* fp)
 void ftCo_800A05F4(Fighter* fp)
 {
     if (fp->cur_pos.y + fp->x1A88.x558 > Stage_GetBlastZoneTopOffset()) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuFinishWithNeutralStick(fp);
     } else if (ftCo_800A1CA8(fp)) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 10);
         ftCo_800B463C(fp, CpuCmd_ReleaseY);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
@@ -200,8 +206,7 @@ void ftCo_800A05F4(Fighter* fp)
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         ftCo_800B463C(fp, CpuCmd_Done);
     } else {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B463C(fp, CpuCmd_ReleaseY);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         ftCo_800B46B8(fp, CpuCmd_LstickTowardFighter, 0x7F);
@@ -216,8 +221,7 @@ void ftCo_800A05F4(Fighter* fp)
 void ftCo_800A0798(Fighter* fp)
 {
     if (ftCo_800A1CA8(fp)) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 10);
         ftCo_800B463C(fp, CpuCmd_ReleaseY);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
@@ -227,8 +231,7 @@ void ftCo_800A0798(Fighter* fp)
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         ftCo_800B463C(fp, CpuCmd_Done);
     } else {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B463C(fp, CpuCmd_ReleaseY);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         ftCo_800B46B8(fp, CpuCmd_LstickXTowardFighter, 0x7F);
@@ -242,8 +245,7 @@ void ftCo_800A0798(Fighter* fp)
 
 void ftCo_800A08F0(Fighter* fp)
 {
-    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+    ftCo_CpuSetNeutralStick(fp);
     if (fp->motion_id == ftCo_MS_SquatRv || fp->motion_id == ftCo_MS_Squat ||
         fp->motion_id == ftCo_MS_SquatWait)
     {
@@ -255,8 +257,7 @@ void ftCo_800A08F0(Fighter* fp)
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         ftCo_800B46B8(fp, CpuCmd_SetLstickY, -0x7F);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 5);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         ftCo_800B463C(fp, CpuCmd_Done);
         return;
@@ -287,8 +288,7 @@ void ftCo_800A08F0(Fighter* fp)
     }
     ftCo_800B46B8(fp, CpuCmd_SetLstickY, -0x7F);
     ftCo_800B46B8(fp, CpuCmd_WaitFor, 5);
-    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+    ftCo_CpuSetNeutralStick(fp);
     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
     ftCo_800B463C(fp, CpuCmd_Done);
 }
@@ -300,8 +300,7 @@ void ftCo_800A0AF4(Fighter* fp)
         ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
         ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x50);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuFinishWithNeutralY(fp);
     } else if (rand < 0.8f) {
         ftCo_800B463C(fp, CpuCmd_ReleaseR);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
@@ -712,6 +711,11 @@ bool ftCo_800A1B38(enum_t arg0)
         return true;
     }
     return false;
+}
+
+static inline bool ftCo_IsIgnoredFloor(int line_id)
+{
+    return ftCo_800A1B38(line_id);
 }
 
 bool ftCo_800A1BA8(Fighter* fp)
@@ -1966,7 +1970,7 @@ bool ftCo_800A3908(Fighter* fp, bool arg1)
     return 0;
 }
 
-static inline float ftCo_800A4038_inline0(Fighter* fp)
+static inline float ftCo_GetTerminalVelocity(Fighter* fp)
 {
     return fp->co_attrs.terminal_vel;
 }
@@ -2056,7 +2060,7 @@ bool ftCo_800A4038(Fighter* fp, bool arg1)
                 land_y = fp->cur_pos.y +
                          ((fp->pos_delta.y * frames -
                            0.5 * (fp->co_attrs.grav * sqrtf((f32) frames))) -
-                          (f32) (t - frames) * ftCo_800A4038_inline0(fp));
+                          (f32) (t - frames) * ftCo_GetTerminalVelocity(fp));
             }
             if (arg1 != 0) {
                 if (!(land_y + data->x558 < ey)) {
@@ -2876,7 +2880,7 @@ Fighter* ftCo_800A5CE0(Fighter* fp)
     return closest_enemy;
 }
 
-static inline float itemDist(Fighter* fp, Item* ip)
+static inline float ftCo_GetItemDistance(Fighter* fp, Item* ip)
 {
     float dx, dy;
     if (ip == NULL) {
@@ -2931,7 +2935,7 @@ Item* ftCo_800A5F4C(Fighter* fp, ItemKind arg1)
         /// and remember its distance.
         if (closest_ip == NULL) {
             closest_ip = cur_ip;
-            closest = itemDist(fp, cur_ip);
+            closest = ftCo_GetItemDistance(fp, cur_ip);
             continue;
         }
 
@@ -2940,25 +2944,13 @@ Item* ftCo_800A5F4C(Fighter* fp, ItemKind arg1)
             continue;
         }
 
-        distance = itemDist(fp, cur_ip);
+        distance = ftCo_GetItemDistance(fp, cur_ip);
         if (closest > distance) {
             closest = distance;
             closest_ip = cur_ip;
         }
     }
     return closest_ip;
-}
-
-static inline f32 ftCo_800A648C_inline0(Fighter* fp, Item* ip)
-{
-    f32 dx;
-    f32 dy;
-    if (ip == NULL) {
-        return 10000.0f;
-    }
-    dx = fp->cur_pos.x - ip->pos.x;
-    dy = fp->cur_pos.y - ip->pos.y;
-    return sqrtf(dx * dx + dy * dy);
 }
 
 Item* ftCo_800A61D8(Fighter* fp)
@@ -2996,11 +2988,11 @@ Item* ftCo_800A61D8(Fighter* fp)
         }
         if (closest == NULL) {
             closest = ip;
-            best = itemDist(fp, ip);
+            best = ftCo_GetItemDistance(fp, ip);
             continue;
         }
         if (ftCo_803C5A68[ip->kind] >= ftCo_803C5A68[closest->kind]) {
-            dist = itemDist(fp, ip);
+            dist = ftCo_GetItemDistance(fp, ip);
             if (best > dist) {
                 best = dist;
                 closest = ip;
@@ -3051,9 +3043,9 @@ int ftCo_800A648C(Fighter* fp)
             if (!inlineD0_it(fp, ip)) {
                 if (closest == NULL) {
                     closest = ip;
-                    best = ftCo_800A648C_inline0(fp, ip);
+                    best = ftCo_GetItemDistance(fp, ip);
                 } else {
-                    dist = ftCo_800A648C_inline0(fp, ip);
+                    dist = ftCo_GetItemDistance(fp, ip);
                     if (best > dist) {
                         best = dist;
                         closest = ip;
@@ -3063,16 +3055,6 @@ int ftCo_800A648C(Fighter* fp)
         }
     }
     return (int) closest;
-}
-
-static inline bool ftCo_800A6A98_inline0(int line_id)
-{
-    if (grBigBlue_801EF844(line_id) || grInishie1_801FCAAC(line_id) ||
-        grCorneria_801E2D90(line_id) || grVenom_80206D10(line_id))
-    {
-        return true;
-    }
-    return false;
 }
 
 static inline bool ftCo_800A6700_inline0(Fighter* fp, f32 x, f32 y)
@@ -3086,11 +3068,6 @@ static inline bool ftCo_800A6700_inline0(Fighter* fp, f32 x, f32 y)
         return true;
     }
     return false;
-}
-
-static inline bool ftCo_800A6700_inline1(int line_id)
-{
-    return ftCo_800A6A98_inline0(line_id);
 }
 
 bool ftCo_800A6700(Fighter* fp, Vec3* arg1, Vec3* arg2)
@@ -3123,7 +3100,7 @@ bool ftCo_800A6700(Fighter* fp, Vec3* arg1, Vec3* arg2)
             result = mpCheckFloor(px, ay + 5.0, px, ay - 5.0, 0.0f, &floor_pos,
                                   &line_id, &flags, &floor_normal, -1, -1, -1,
                                   NULL, NULL);
-            if (result != 0 && ftCo_800A6700_inline1(line_id)) {
+            if (result != 0 && ftCo_IsIgnoredFloor(line_id)) {
                 result = 0;
             }
             if (result != 0) {
@@ -3147,7 +3124,7 @@ bool ftCo_800A6700(Fighter* fp, Vec3* arg1, Vec3* arg2)
             result = mpCheckFloor(px, ay + 5.0, px, ay - 5.0, 0.0f, &floor_pos,
                                   &line_id, &flags, &floor_normal, -1, -1, -1,
                                   NULL, NULL);
-            if (result != 0 && ftCo_800A6A98_inline0(line_id)) {
+            if (result != 0 && ftCo_800A1B38(line_id)) {
                 result = 0;
             }
             if (result != 0) {
@@ -4402,8 +4379,7 @@ static void ftCo_800A949C(Fighter* fp, bool unused)
     struct Fighter_x1A88_t* data = &fp->x1A88;
     if (ABS(data->x54.x - fp->cur_pos.x) > 30.0) {
         // Wait a frame with the stick neutral?
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
 
         // Up-B diagonally toward the stage
@@ -4418,8 +4394,7 @@ static void ftCo_800A949C(Fighter* fp, bool unused)
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
     } else {
         // Wait a frame with the stick neutral?
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
 
         // Up-B straight up
@@ -4538,11 +4513,6 @@ static inline bool ftCo_IsNearlyZero(float x)
     return false;
 }
 
-static inline float ftCo_800A9904_inline0(Fighter* fp)
-{
-    return fp->co_attrs.terminal_vel;
-}
-
 #define ftCo_800A9904_sqrtf_store(dst, x, store)                              \
     do {                                                                      \
         if (x > 0.0f) {                                                       \
@@ -4617,7 +4587,7 @@ void ftCo_800A9904(Fighter* fp)
                 fp->cur_pos.y +
                 (fp->pos_delta.y * terminal_time -
                  0.5 * (*grav_p * sqrt_terminal) -
-                 ((x_time - terminal_time) * ftCo_800A9904_inline0(fp)));
+                 ((x_time - terminal_time) * ftCo_GetTerminalVelocity(fp)));
         }
         {
             int stick = 4.7000003F * (data->level + 1) + 80.0f;
@@ -4627,19 +4597,16 @@ void ftCo_800A9904(Fighter* fp)
                 ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
             }
         }
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuFinishWithNeutralY(fp);
     } else if (mpCheckCeiling(fp->cur_pos.x, fp->cur_pos.y, data->x54.x,
                               data->x54.y, &ceiling.pos, &ceiling.line_id,
                               &ceiling.flags, &ceiling.normal, -1, -1))
     {
         ftCo_800B46B8(fp, CpuCmd_LstickXTowardDestination, 0x81);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuFinishWithNeutralY(fp);
     } else {
         ftCo_800B46B8(fp, CpuCmd_LstickXTowardDestination, 0x7F);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuFinishWithNeutralY(fp);
     }
 }
 
@@ -4717,9 +4684,7 @@ void ftCo_800A9CB4(Fighter* fp)
     PAD_STACK(0x18);
 
     if (ftCo_800A1CA8(fp)) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuFinishWithNeutralStick(fp);
         return;
     }
     if (ftCo_800A3234(fp)) {
@@ -4746,26 +4711,22 @@ void ftCo_800A9CB4(Fighter* fp)
         }
         if ((var_r0_2 = ftCo_800A9CB4_inline0(fp))) {
             if (var_r0_2 == 1) {
-                ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+                ftCo_CpuSetNeutralStick(fp);
                 ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
                 ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x7F);
                 ftCo_800B463C(fp, CpuCmd_PressR);
                 ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
                 ftCo_800B463C(fp, CpuCmd_ReleaseR);
-                ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-                ftCo_800B463C(fp, CpuCmd_Done);
+                ftCo_CpuFinishWithNeutralY(fp);
             } else {
-                ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+                ftCo_CpuSetNeutralStick(fp);
                 ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
                 ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0x50);
                 ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x7F);
                 ftCo_800B463C(fp, CpuCmd_PressR);
                 ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
                 ftCo_800B463C(fp, CpuCmd_ReleaseR);
-                ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-                ftCo_800B463C(fp, CpuCmd_Done);
+                ftCo_CpuFinishWithNeutralY(fp);
             }
             return;
         }
@@ -4776,8 +4737,7 @@ void ftCo_800A9CB4(Fighter* fp)
     }
     if (data->xFA_b6) {
         ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0x81);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuFinishWithNeutralY(fp);
         return;
     }
     dx = data->x54.x - fp->cur_pos.x;
@@ -4825,8 +4785,7 @@ void ftCo_800A9CB4(Fighter* fp)
             ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
         }
     }
-    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-    ftCo_800B463C(fp, CpuCmd_Done);
+    ftCo_CpuFinishWithNeutralY(fp);
 }
 
 #undef ftCo_800A9CB4_sqrtf_store
@@ -4966,8 +4925,7 @@ void ftCo_800AA42C(Fighter* fp)
         facing_dest = false;
     }
     if (!facing_dest) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0xB0);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
@@ -5011,8 +4969,7 @@ void ftCo_800AA42C(Fighter* fp)
         tmp = ftCo_800AA42C_inline0(clamp, dist, data->x38, data->x3C);
         ftCo_800B4778(fp, CpuCmd_LstickXTowardDestinationClamped, stick, tmp);
     } else {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
     }
     ftCo_800B463C(fp, CpuCmd_Done);
 }
@@ -5132,8 +5089,7 @@ void ftCo_800AACD0(Fighter* fp)
         if ((data->x54.x < sp24.x || data->x54.x > sp18.x) &&
             !ftCo_800A2BD4(fp))
         {
-            ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-            ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+            ftCo_CpuSetNeutralStick(fp);
             ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
             ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0xB0);
             ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
@@ -5246,8 +5202,7 @@ bool ftCo_800AAF48(Fighter* fp)
 
 static inline void ftCo_800AD54C_inline0(Fighter* fp)
 {
-    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+    ftCo_CpuSetNeutralStick(fp);
     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
     ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0xB0);
     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
@@ -5369,8 +5324,7 @@ void ftCo_800AB224(Fighter* fp)
             }
             if (var_r0_6 != 0) {
                 if (ftCo_800A28D0(fp, 1.0F)) {
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+                    ftCo_CpuSetNeutralStick(fp);
                     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
                     ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0xB0);
                     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
@@ -5446,11 +5400,6 @@ static inline void ftCo_800ABBA8_blk155144r(Fighter* fp, Fighter** target)
     PAD_STACK(0x28);
 
     *target = data->x44;
-}
-
-static inline f32 ftCo_800ABBA8_inline0(Fighter* fp)
-{
-    return fp->co_attrs.terminal_vel;
 }
 
 void ftCo_800ABBA8(Fighter* fp)
@@ -5592,14 +5541,12 @@ void ftCo_800ABBA8(Fighter* fp)
                     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
                     ftCo_800B463C(fp, CpuCmd_PressR);
                     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+                    ftCo_CpuSetNeutralStick(fp);
                     ftCo_800B463C(fp, CpuCmd_ReleaseR);
                     ftCo_800B46B8(fp, CpuCmd_WaitFor, 0x32);
                     ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x81);
                     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-                    ftCo_800B463C(fp, CpuCmd_Done);
+                    ftCo_CpuFinishWithNeutralY(fp);
                     return;
                 }
             }
@@ -5640,15 +5587,14 @@ void ftCo_800ABBA8(Fighter* fp)
         tmp = sqrtf(vf5);
         land_y =
             fp->cur_pos.y + (fp->pos_delta.y * vf5 - 0.5 * (*grav_ptr * tmp) -
-                             (vf0 - vf5) * ftCo_800ABBA8_inline0(fp));
+                             (vf0 - vf5) * ftCo_GetTerminalVelocity(fp));
     }
     if (vf0 < 0.0 || land_y < data->x54.y) {
         ftCo_800B46B8(fp, CpuCmd_LstickXTowardDestination, 0x7F);
     } else {
         ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
     }
-    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-    ftCo_800B463C(fp, CpuCmd_Done);
+    ftCo_CpuFinishWithNeutralY(fp);
 }
 
 static inline bool inlineG0(Fighter* fp)
@@ -5783,8 +5729,7 @@ void ftCo_800AC5A0(Fighter* fp)
         ftCo_800B46B8(fp, CpuCmd_SetLstickX, stick_y);
         ftCo_800B46B8(fp, CpuCmd_SetLstickY, stick_x);
     } else {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
     }
     if (data->xFA_b1) {
         ftCo_800B463C(fp, CpuCmd_PressR);
@@ -5809,9 +5754,7 @@ void ftCo_800AC7D4(Fighter* fp)
         return;
     }
     if (var_r0 == 1) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuFinishWithNeutralStick(fp);
         return;
     }
     temp_r0_2 = data->xC;
@@ -5819,8 +5762,7 @@ void ftCo_800AC7D4(Fighter* fp)
         ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
         ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x7F);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuFinishWithNeutralY(fp);
         return;
     }
     temp_r3 = ftCo_800A4BEC(fp);
@@ -5828,8 +5770,7 @@ void ftCo_800AC7D4(Fighter* fp)
         ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
         ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x7F);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuFinishWithNeutralY(fp);
     } else if (ftCo_800A1AB4(fp, temp_r3) < 15.0) {
         if (HSD_Randf() < 0.1F * data->level) {
             ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
@@ -5858,8 +5799,7 @@ void ftCo_800AC7D4(Fighter* fp)
         ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
         ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x7F);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuFinishWithNeutralY(fp);
     }
 }
 
@@ -5875,9 +5815,7 @@ void ftCo_800ACB44(Fighter* fp)
 
     var_r0 = ftCo_800A3200(fp);
     if (var_r0 == 1) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuFinishWithNeutralStick(fp);
         return;
     }
     if (var_r0 == 0) {
@@ -5931,8 +5869,7 @@ void ftCo_800ACD5C(Fighter* fp)
         }
     }
     if (data->x88 > 0 && gm_GetCurrentGameMode() != GM_TRAINING) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         ftCo_800B463C(fp, CpuCmd_PressUp);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
@@ -5958,8 +5895,7 @@ void ftCo_800ACD5C(Fighter* fp)
         return;
     }
     if (!ftCo_800A2C08(fp)) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0xB0);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
@@ -5970,15 +5906,12 @@ void ftCo_800ACD5C(Fighter* fp)
         return;
     }
     if (data->level < 5) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuFinishWithNeutralStick(fp);
         return;
     }
     if (fp->kind == FTKIND_DONKEY) {
         if (fp->motion_id != ftDk_MS_SpecialNLoop && fp->fv.dk.x222C == 0) {
-            ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-            ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+            ftCo_CpuSetNeutralStick(fp);
             ftCo_800B463C(fp, CpuCmd_PressB);
             ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
             ftCo_800B463C(fp, CpuCmd_ReleaseB);
@@ -5987,8 +5920,7 @@ void ftCo_800ACD5C(Fighter* fp)
         }
     } else if (fp->kind == FTKIND_SAMUS) {
         if (fp->motion_id != ftSs_MS_SpecialNHold && fp->fv.ss.x2230 == 0) {
-            ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-            ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+            ftCo_CpuSetNeutralStick(fp);
             ftCo_800B463C(fp, CpuCmd_PressB);
             ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
             ftCo_800B463C(fp, CpuCmd_ReleaseB);
@@ -6012,8 +5944,7 @@ void ftCo_800ACD5C(Fighter* fp)
         } else if (fp->motion_id != ftMt_MS_SpecialNLoop &&
                    fp->fv.mt.x2234_shadowBallCharge == 0)
         {
-            ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-            ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+            ftCo_CpuSetNeutralStick(fp);
             ftCo_800B463C(fp, CpuCmd_PressB);
             ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
             ftCo_800B463C(fp, CpuCmd_ReleaseB);
@@ -6024,8 +5955,7 @@ void ftCo_800ACD5C(Fighter* fp)
         if (fp->fv.kb.hat.kind == FTKIND_DONKEY) {
             if (fp->motion_id != ftKb_MS_DkSpecialNLoop && fp->fv.kb.xBC == 0)
             {
-                ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+                ftCo_CpuSetNeutralStick(fp);
                 ftCo_800B463C(fp, CpuCmd_PressB);
                 ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
                 ftCo_800B463C(fp, CpuCmd_ReleaseB);
@@ -6035,8 +5965,7 @@ void ftCo_800ACD5C(Fighter* fp)
         } else if (fp->fv.kb.hat.kind == FTKIND_SAMUS) {
             if (fp->motion_id != ftKb_MS_SsSpecialNHold && fp->fv.kb.xA8 == 0)
             {
-                ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+                ftCo_CpuSetNeutralStick(fp);
                 ftCo_800B463C(fp, CpuCmd_PressB);
                 ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
                 ftCo_800B463C(fp, CpuCmd_ReleaseB);
@@ -6057,8 +5986,7 @@ void ftCo_800ACD5C(Fighter* fp)
             } else if (fp->motion_id != ftKb_MS_MtSpecialNLoop &&
                        fp->fv.kb.x9C == 0)
             {
-                ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+                ftCo_CpuSetNeutralStick(fp);
                 ftCo_800B463C(fp, CpuCmd_PressB);
                 ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
                 ftCo_800B463C(fp, CpuCmd_ReleaseB);
@@ -6067,9 +5995,7 @@ void ftCo_800ACD5C(Fighter* fp)
             }
         }
     }
-    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-    ftCo_800B463C(fp, CpuCmd_Done);
+    ftCo_CpuFinishWithNeutralStick(fp);
 }
 
 void ftCo_800AD42C(Fighter* fp)
@@ -6079,12 +6005,9 @@ void ftCo_800AD42C(Fighter* fp)
         data->x18 = data->x1C;
         ftCo_800B463C(fp, CpuCmd_Done);
     } else if (fp->ground_or_air == GA_Air) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuFinishWithNeutralStick(fp);
     } else {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B463C(fp, CpuCmd_ReleaseY);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         ftCo_800B463C(fp, CpuCmd_PressY);
@@ -6105,8 +6028,7 @@ void ftCo_800AD54C(Fighter* fp)
     ftCo_800AA320(fp, &stick, &clamp);
     if (fp->ground_or_air == GA_Air) {
         ftCo_800B4778(fp, CpuCmd_LstickForwardClamped, stick, clamp);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuFinishWithNeutralY(fp);
     } else if (ftCo_800A28D0(fp, 1.0F)) {
         ftCo_800AD54C_inline0(fp);
     } else if (inlineC0(fp)) {
@@ -8527,8 +8449,7 @@ void ftCo_800B2790(Fighter* fp)
                     data->x18 = data->x1C;
                     ftCo_800B463C(fp, CpuCmd_Done);
                 } else {
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+                    ftCo_CpuSetNeutralStick(fp);
                     ftCo_800B463C(fp, CpuCmd_ReleaseA);
                     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
                     ftCo_800B463C(fp, CpuCmd_PressA);
@@ -8560,9 +8481,7 @@ void ftCo_800B2790(Fighter* fp)
                     data->x18 = data->x1C;
                     ftCo_800B463C(fp, CpuCmd_Done);
                 } else {
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-                    ftCo_800B463C(fp, CpuCmd_Done);
+                    ftCo_CpuFinishWithNeutralStick(fp);
                 }
                 break;
             case 18:

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -753,11 +753,6 @@ bool ftCo_800A1C44(Fighter* fp)
     return false;
 }
 
-static inline bool ftCo_800A1C44_dontinline(Fighter* fp)
-{
-    return ftCo_800A1C44(fp);
-}
-
 bool ftCo_800A1CA8(Fighter* fp)
 {
     return fp->x2168 ? true : false;
@@ -8418,9 +8413,7 @@ void ftCo_800B21C8(Fighter* fp)
     Fighter* target;
     Fighter* attack_target;
     s32 do_act;
-    f32 dx;
-    f32 dy;
-    PAD_STACK(0x14);
+    PAD_STACK(0xC);
 
     cmd = ftCo_800A229C(fp, &sp20);
     if (cmd != 0) {
@@ -8445,24 +8438,7 @@ void ftCo_800B21C8(Fighter* fp)
     data->xF9_b1 = false;
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
     fp->x1A88.x50 = ftCo_800A648C(fp);
-    if (ftCo_800A1C44_dontinline(fp)) {
-        data->xF8_b6 = false;
-    } else {
-        target = data->x44;
-        if (target != NULL && fp->ground_or_air == GA_Ground) {
-            dy = fp->cur_pos.y - target->cur_pos.y;
-            dx = fp->cur_pos.x;
-            dx = dx - target->cur_pos.x;
-            if (sqrtf__Ff(dx * dx + dy * dy) < Fighter_804D64FC->x20[fp->kind])
-            {
-                data->xF8_b6 = true;
-            } else {
-                data->xF8_b6 = false;
-            }
-        } else {
-            data->xF8_b6 = false;
-        }
-    }
+    ftCo_CpuUpdateTargetDistance(fp);
 
     data2 = &fp->x1A88;
     if (data2->x18 != data2->x20 && data2->x18 != data2->x1C) {

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -6460,15 +6460,29 @@ static bool ftCo_800ADE48(Fighter* fp)
     }
     return true;
 }
+
+static inline void ftCo_CpuUpdateItemTargets(Fighter* fp)
+{
+    struct Fighter_x1A88_t* data;
+
+    data = &fp->x1A88;
+    if (fp->item_gobj != NULL && !ftCo_800A5908(GET_ITEM(fp->item_gobj))) {
+        data->x4C = NULL;
+    } else {
+        if (fp->x2168 != 0) {
+            data->x4C = NULL;
+        } else {
+            data->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
+        }
+    }
+    fp->x1A88.x50 = ftCo_800A648C(fp);
+}
+
 void ftCo_800AE7AC(Fighter* fp, Vec3* arg1, int arg2)
 {
     struct Fighter_x1A88_t* data0 = &fp->x1A88;
-    struct Fighter_x1A88_t* data;
     struct Fighter_x1A88_t* data2;
     struct Fighter_x1A88_t* data3;
-    Item_GObj* item_gobj;
-    ItemKind kind;
-    s32 is_food;
     s32 do_act;
     u8 _[8];
     Vec3 dir;
@@ -6480,7 +6494,7 @@ void ftCo_800AE7AC(Fighter* fp, Vec3* arg1, int arg2)
     f32 sum_y;
     f32 cy;
     f32 dy;
-    PAD_STACK(8);
+    PAD_STACK(4);
 
     data0->xF8_b0 = true;
     data0->xF9_b3 = false;
@@ -6497,33 +6511,7 @@ void ftCo_800AE7AC(Fighter* fp, Vec3* arg1, int arg2)
         data0->xF9_b6 = true;
     }
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    data = &fp->x1A88;
-    item_gobj = fp->item_gobj;
-    if (item_gobj != NULL) {
-        kind = GET_ITEM(item_gobj)->kind;
-        if (kind == It_Kind_Heart) {
-            is_food = 1;
-        } else if (kind == It_Kind_Tomato) {
-            is_food = 1;
-        } else if (kind == It_Kind_Foods) {
-            is_food = 1;
-        } else {
-            is_food = 0;
-        }
-        if (is_food == 0) {
-            data->x4C = NULL;
-        } else {
-            goto block_13;
-        }
-    } else {
-    block_13:
-        if (fp->x2168 != 0) {
-            data->x4C = NULL;
-        } else {
-            data->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
-        }
-    }
-    fp->x1A88.x50 = ftCo_800A648C(fp);
+    ftCo_CpuUpdateItemTargets(fp);
     data2 = &fp->x1A88;
     if (data2->x18 != data2->x20 && data2->x18 != data2->x1C) {
         data2->x60 = 0;
@@ -6578,13 +6566,11 @@ void ftCo_800AEA8C(Fighter* fp)
     int line_id;
     Vec3 floor_normal;
     Vec3 floor_pos;
-    Item_GObj* item_gobj;
-    ItemKind kind;
     s32 is_food;
     s32 do_floor;
     s32 found;
 
-    PAD_STACK(0xC);
+    PAD_STACK(8);
 
     data->xF8_b0 = false;
     data->xF9_b2 = (is_food = 1);
@@ -6595,32 +6581,7 @@ void ftCo_800AEA8C(Fighter* fp)
     data->xF9_b7 = true;
     data->xF9_b1 = false;
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    item_gobj = fp->item_gobj;
-    if (item_gobj != NULL) {
-        kind = GET_ITEM(item_gobj)->kind;
-        if (kind == It_Kind_Heart) {
-            is_food = 1;
-        } else if (kind == It_Kind_Tomato) {
-            is_food = 1;
-        } else if (kind == It_Kind_Foods) {
-            is_food = 1;
-        } else {
-            is_food = 0;
-        }
-        if (is_food == 0) {
-            data->x4C = NULL;
-        } else {
-            goto block_10;
-        }
-    } else {
-    block_10:
-        if (fp->x2168 != 0) {
-            data->x4C = NULL;
-        } else {
-            data->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
-        }
-    }
-    fp->x1A88.x50 = ftCo_800A648C(fp);
+    ftCo_CpuUpdateItemTargets(fp);
     data2 = &fp->x1A88;
     if (data2->x18 != data2->x20 && data2->x18 != data2->x1C) {
         data2->x60 = 0;
@@ -6725,9 +6686,7 @@ void ftCo_800AECF0(Fighter* fp)
     Fighter* target;
     s32 do_act;
     s32 is_food;
-    Item_GObj* item_gobj;
-    ItemKind kind;
-    PAD_STACK(0x18);
+    PAD_STACK(0x14);
 
     cmd = ftCo_800A229C(fp, &sp28);
     if (cmd != 0) {
@@ -6751,32 +6710,7 @@ void ftCo_800AECF0(Fighter* fp)
     data->xF9_b7 = true;
     data->xF9_b1 = false;
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    item_gobj = fp->item_gobj;
-    if (item_gobj != NULL) {
-        kind = GET_ITEM(item_gobj)->kind;
-        if (kind == It_Kind_Heart) {
-            is_food = 1;
-        } else if (kind == It_Kind_Tomato) {
-            is_food = 1;
-        } else if (kind == It_Kind_Foods) {
-            is_food = 1;
-        } else {
-            is_food = 0;
-        }
-        if (is_food == 0) {
-            data->x4C = NULL;
-        } else {
-            goto block_22;
-        }
-    } else {
-    block_22:
-        if (fp->x2168 != 0) {
-            data->x4C = NULL;
-        } else {
-            data->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
-        }
-    }
-    (fp->x1A88).x50 = ftCo_800A648C(fp);
+    ftCo_CpuUpdateItemTargets(fp);
     data2 = &fp->x1A88;
     if ((data2->x18 != data2->x20) && (data2->x18 != (data2->x1C))) {
         data2->x60 = 0;
@@ -7154,22 +7088,6 @@ void ftCo_800AF78C(Fighter* fp)
     ftCo_800ADE48(fp);
 }
 
-static inline void ftCo_800AFC40_inline0(Fighter* fp)
-{
-    struct Fighter_x1A88_t* data;
-
-    data = &fp->x1A88;
-    if (fp->item_gobj != NULL && !ftCo_800A5908(GET_ITEM(fp->item_gobj))) {
-        data->x4C = NULL;
-    } else {
-        if (fp->x2168 != 0) {
-            data->x4C = NULL;
-        } else {
-            data->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
-        }
-    }
-    fp->x1A88.x50 = ftCo_800A648C(fp);
-}
 void ftCo_800AFC40(Fighter* fp)
 {
     struct Fighter_x1A88_t* temp_r31;
@@ -7201,7 +7119,7 @@ void ftCo_800AFC40(Fighter* fp)
     temp_r31->xF9_b7 = false;
     temp_r31->xF9_b1 = false;
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    ftCo_800AFC40_inline0(fp);
+    ftCo_CpuUpdateItemTargets(fp);
     temp_r4 = &fp->x1A88;
     if (ftCo_CpuDataShouldAct(temp_r4)) {
         temp_r3_3 = ftCo_800A50D4(fp);
@@ -7260,16 +7178,7 @@ void ftCo_800AFE3C(Fighter* fp, int arg1)
     temp_r31->xF9_b7 = true;
     temp_r31->xF9_b1 = false;
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    if (fp->item_gobj != NULL && !ftCo_800A5908(GET_ITEM(fp->item_gobj))) {
-        temp_r31->x4C = NULL;
-    } else {
-        if (fp->x2168 != 0) {
-            temp_r31->x4C = NULL;
-        } else {
-            temp_r31->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
-        }
-    }
-    fp->x1A88.x50 = ftCo_800A648C(fp);
+    ftCo_CpuUpdateItemTargets(fp);
     if (ftCo_CpuShouldAct(fp)) {
         ftCo_CpuActOnPlayer(fp, temp_r31, arg1);
     }
@@ -7495,14 +7404,7 @@ void ftCo_800B0760(Fighter* fp)
 
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
 
-    if (fp->item_gobj != NULL && !ftCo_800A5908(GET_ITEM(fp->item_gobj))) {
-        data->x4C = NULL;
-    } else if (fp->x2168 != 0) {
-        data->x4C = NULL;
-    } else {
-        data->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
-    }
-    fp->x1A88.x50 = ftCo_800A648C(fp);
+    ftCo_CpuUpdateItemTargets(fp);
     inlineI3(fp, data);
     ftCo_800ADE48(fp);
 }
@@ -7842,16 +7744,7 @@ void ftCo_800B126C(Fighter* fp)
     PAD_STACK(0x10);
 
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    if (fp->item_gobj != NULL && !ftCo_800A5908(GET_ITEM(fp->item_gobj))) {
-        data->x4C = NULL;
-    } else {
-        if (fp->x2168 != 0) {
-            data->x4C = NULL;
-        } else {
-            data->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
-        }
-    }
-    fp->x1A88.x50 = ftCo_800A648C(fp);
+    ftCo_CpuUpdateItemTargets(fp);
 
     if (ftCo_CpuShouldAct(fp)) {
         if (data->x4C != NULL && fp->item_gobj == NULL) {
@@ -7870,10 +7763,8 @@ void ftCo_800B1478(Fighter* fp)
     Fighter* target;
     Fighter* attack_target;
     s32 is_food;
-    Item_GObj* item_gobj;
-    ItemKind kind;
 
-    PAD_STACK(0x20);
+    PAD_STACK(0x18);
 
     data = &fp->x1A88;
     target = ftCo_800A5CE0(fp);
@@ -7897,32 +7788,7 @@ void ftCo_800B1478(Fighter* fp)
     data->xF9_b1 = false;
 
     *target_slot = ftCo_800A4BEC(fp);
-    item_gobj = fp->item_gobj;
-    if (item_gobj != NULL) {
-        kind = GET_ITEM(item_gobj)->kind;
-        if (kind == It_Kind_Heart) {
-            is_food = true;
-        } else if (kind == It_Kind_Tomato) {
-            is_food = true;
-        } else if (kind == It_Kind_Foods) {
-            is_food = true;
-        } else {
-            is_food = false;
-        }
-        if (is_food == false) {
-            data->x4C = NULL;
-        } else {
-            goto maybe_find_item;
-        }
-    } else {
-    maybe_find_item:
-        if (fp->x2168 != 0) {
-            data->x4C = NULL;
-        } else {
-            data->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
-        }
-    }
-    fp->x1A88.x50 = ftCo_800A648C(fp);
+    ftCo_CpuUpdateItemTargets(fp);
 
     ftCo_CpuUpdateTargetDistance(fp);
 
@@ -7950,9 +7816,7 @@ void ftCo_800B17D0(Fighter* fp)
     Fighter* attack_target;
     s32 do_act;
     s32 is_food;
-    Item_GObj* item_gobj;
-    ItemKind kind;
-    PAD_STACK(0x18);
+    PAD_STACK(0x14);
 
     cmd = ftCo_800A229C(fp, &sp28);
     if (cmd != 0) {
@@ -7977,32 +7841,7 @@ void ftCo_800B17D0(Fighter* fp)
     data->x2C = is_food;
     data->xF9_b1 = false;
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    item_gobj = fp->item_gobj;
-    if (item_gobj != NULL) {
-        kind = GET_ITEM(item_gobj)->kind;
-        if (kind == It_Kind_Heart) {
-            is_food = 1;
-        } else if (kind == It_Kind_Tomato) {
-            is_food = 1;
-        } else if (kind == It_Kind_Foods) {
-            is_food = 1;
-        } else {
-            is_food = 0;
-        }
-        if (is_food == 0) {
-            data->x4C = NULL;
-        } else {
-            goto block_22;
-        }
-    } else {
-    block_22:
-        if (fp->x2168 != 0) {
-            data->x4C = NULL;
-        } else {
-            data->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
-        }
-    }
-    fp->x1A88.x50 = ftCo_800A648C(fp);
+    ftCo_CpuUpdateItemTargets(fp);
     data2 = &fp->x1A88;
     if (data2->x18 != data2->x20 && data2->x18 != data2->x1C) {
         data2->x60 = 0;
@@ -8037,9 +7876,7 @@ void ftCo_800B1AB8(Fighter* fp)
     Fighter* attack_target;
     s32 do_act;
     s32 is_food;
-    Item_GObj* item_gobj;
-    ItemKind kind;
-    PAD_STACK(0x18);
+    PAD_STACK(0x14);
 
     cmd = ftCo_800A229C(fp, &sp28);
     if (cmd != 0) {
@@ -8064,32 +7901,7 @@ void ftCo_800B1AB8(Fighter* fp)
     data->x2C = is_food;
     data->xF9_b1 = false;
     fp->x1A88.x44 = ftCo_800A4BEC(fp);
-    item_gobj = fp->item_gobj;
-    if (item_gobj != NULL) {
-        kind = GET_ITEM(item_gobj)->kind;
-        if (kind == It_Kind_Heart) {
-            is_food = 1;
-        } else if (kind == It_Kind_Tomato) {
-            is_food = 1;
-        } else if (kind == It_Kind_Foods) {
-            is_food = 1;
-        } else {
-            is_food = 0;
-        }
-        if (is_food == 0) {
-            data->x4C = NULL;
-        } else {
-            goto block_22;
-        }
-    } else {
-    block_22:
-        if (fp->x2168 != 0) {
-            data->x4C = NULL;
-        } else {
-            data->x4C = ftCo_800A5F4C(fp, It_Kind_L_Gun_Ray);
-        }
-    }
-    fp->x1A88.x50 = ftCo_800A648C(fp);
+    ftCo_CpuUpdateItemTargets(fp);
     data2 = &fp->x1A88;
     if (data2->x18 != data2->x20 && data2->x18 != data2->x1C) {
         data2->x60 = 0;

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -103,6 +103,14 @@ static inline void ftCo_CpuFinishWithNeutralStick(Fighter* fp)
     ftCo_800B463C(fp, CpuCmd_Done);
 }
 
+static inline void ftCo_CpuHoldUpForOneFrame(Fighter* fp)
+{
+    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x7F);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_CpuFinishWithNeutralY(fp);
+}
+
 static inline void ftCo_CpuTapA(Fighter* fp)
 {
     ftCo_800B463C(fp, CpuCmd_PressA);
@@ -115,6 +123,13 @@ static inline void ftCo_CpuTapB(Fighter* fp)
     ftCo_800B463C(fp, CpuCmd_PressB);
     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
     ftCo_800B463C(fp, CpuCmd_ReleaseB);
+}
+
+static inline void ftCo_CpuStartCharging(Fighter* fp)
+{
+    ftCo_CpuSetNeutralStick(fp);
+    ftCo_CpuTapB(fp);
+    ftCo_800B463C(fp, CpuCmd_Done);
 }
 
 static inline void ftCo_CpuTapR(Fighter* fp)
@@ -5642,18 +5657,12 @@ void ftCo_800AC7D4(Fighter* fp)
     }
     temp_r0_2 = data->xC;
     if ((temp_r0_2 == 0xF) || (temp_r0_2 == 0)) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x7F);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_CpuFinishWithNeutralY(fp);
+        ftCo_CpuHoldUpForOneFrame(fp);
         return;
     }
     temp_r3 = ftCo_800A4BEC(fp);
     if (temp_r3 == NULL) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x7F);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_CpuFinishWithNeutralY(fp);
+        ftCo_CpuHoldUpForOneFrame(fp);
     } else if (ftCo_800A1AB4(fp, temp_r3) < 15.0) {
         if (HSD_Randf() < 0.1F * data->level) {
             ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
@@ -5677,10 +5686,7 @@ void ftCo_800AC7D4(Fighter* fp)
             ftCo_800B463C(fp, CpuCmd_Done);
         }
     } else {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x7F);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_CpuFinishWithNeutralY(fp);
+        ftCo_CpuHoldUpForOneFrame(fp);
     }
 }
 
@@ -5781,16 +5787,12 @@ void ftCo_800ACD5C(Fighter* fp)
     }
     if (fp->kind == FTKIND_DONKEY) {
         if (fp->motion_id != ftDk_MS_SpecialNLoop && fp->fv.dk.x222C == 0) {
-            ftCo_CpuSetNeutralStick(fp);
-            ftCo_CpuTapB(fp);
-            ftCo_800B463C(fp, CpuCmd_Done);
+            ftCo_CpuStartCharging(fp);
             return;
         }
     } else if (fp->kind == FTKIND_SAMUS) {
         if (fp->motion_id != ftSs_MS_SpecialNHold && fp->fv.ss.x2230 == 0) {
-            ftCo_CpuSetNeutralStick(fp);
-            ftCo_CpuTapB(fp);
-            ftCo_800B463C(fp, CpuCmd_Done);
+            ftCo_CpuStartCharging(fp);
             return;
         }
     } else if (fp->kind == FTKIND_MEWTWO) {
@@ -5808,26 +5810,20 @@ void ftCo_800ACD5C(Fighter* fp)
         } else if (fp->motion_id != ftMt_MS_SpecialNLoop &&
                    fp->fv.mt.x2234_shadowBallCharge == 0)
         {
-            ftCo_CpuSetNeutralStick(fp);
-            ftCo_CpuTapB(fp);
-            ftCo_800B463C(fp, CpuCmd_Done);
+            ftCo_CpuStartCharging(fp);
             return;
         }
     } else if (fp->kind == FTKIND_KIRBY) {
         if (fp->fv.kb.hat.kind == FTKIND_DONKEY) {
             if (fp->motion_id != ftKb_MS_DkSpecialNLoop && fp->fv.kb.xBC == 0)
             {
-                ftCo_CpuSetNeutralStick(fp);
-                ftCo_CpuTapB(fp);
-                ftCo_800B463C(fp, CpuCmd_Done);
+                ftCo_CpuStartCharging(fp);
                 return;
             }
         } else if (fp->fv.kb.hat.kind == FTKIND_SAMUS) {
             if (fp->motion_id != ftKb_MS_SsSpecialNHold && fp->fv.kb.xA8 == 0)
             {
-                ftCo_CpuSetNeutralStick(fp);
-                ftCo_CpuTapB(fp);
-                ftCo_800B463C(fp, CpuCmd_Done);
+                ftCo_CpuStartCharging(fp);
                 return;
             }
         } else if (fp->fv.kb.hat.kind == FTKIND_MEWTWO) {
@@ -5842,9 +5838,7 @@ void ftCo_800ACD5C(Fighter* fp)
             } else if (fp->motion_id != ftKb_MS_MtSpecialNLoop &&
                        fp->fv.kb.x9C == 0)
             {
-                ftCo_CpuSetNeutralStick(fp);
-                ftCo_CpuTapB(fp);
-                ftCo_800B463C(fp, CpuCmd_Done);
+                ftCo_CpuStartCharging(fp);
                 return;
             }
         }

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -4685,18 +4685,14 @@ void ftCo_800A9CB4(Fighter* fp)
                 ftCo_CpuSetNeutralStick(fp);
                 ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
                 ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x7F);
-                ftCo_800B463C(fp, CpuCmd_PressR);
-                ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                ftCo_800B463C(fp, CpuCmd_ReleaseR);
+                ftCo_CpuTapR(fp);
                 ftCo_CpuFinishWithNeutralY(fp);
             } else {
                 ftCo_CpuSetNeutralStick(fp);
                 ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
                 ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0x50);
                 ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x7F);
-                ftCo_800B463C(fp, CpuCmd_PressR);
-                ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                ftCo_800B463C(fp, CpuCmd_ReleaseR);
+                ftCo_CpuTapR(fp);
                 ftCo_CpuFinishWithNeutralY(fp);
             }
             return;
@@ -4827,6 +4823,18 @@ static inline bool isInTeeter(Fighter* fp)
     return false;
 }
 
+static inline void ftCo_CpuTurnAround(Fighter* fp)
+{
+    ftCo_CpuSetNeutralStick(fp);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0xB0);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 10);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
+    ftCo_800B463C(fp, CpuCmd_Done);
+}
+
 static inline int ftCo_800AA42C_inline0(float clamp, float dist, float near,
                                         float far)
 {
@@ -4887,14 +4895,7 @@ void ftCo_800AA42C(Fighter* fp)
         facing_dest = false;
     }
     if (!facing_dest) {
-        ftCo_CpuSetNeutralStick(fp);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0xB0);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 0xA);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuTurnAround(fp);
         return;
     }
     {
@@ -5051,14 +5052,7 @@ void ftCo_800AACD0(Fighter* fp)
         if ((data->x54.x < sp24.x || data->x54.x > sp18.x) &&
             !ftCo_800A2BD4(fp))
         {
-            ftCo_CpuSetNeutralStick(fp);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0xB0);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 0xA);
-            ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-            ftCo_800B463C(fp, CpuCmd_Done);
+            ftCo_CpuTurnAround(fp);
             return;
         }
     }
@@ -5162,18 +5156,6 @@ bool ftCo_800AAF48(Fighter* fp)
     return false;
 }
 
-static inline void ftCo_800AD54C_inline0(Fighter* fp)
-{
-    ftCo_CpuSetNeutralStick(fp);
-    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-    ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0xB0);
-    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-    ftCo_800B46B8(fp, CpuCmd_WaitFor, 10);
-    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-    ftCo_800B463C(fp, CpuCmd_Done);
-}
-
 void ftCo_800AB224(Fighter* fp)
 {
     struct Fighter_x1A88_t* temp_r31;
@@ -5202,7 +5184,7 @@ void ftCo_800AB224(Fighter* fp)
     temp_r31 = &fp->x1A88;
     if (temp_r31->xFA_b6) {
         if (fp->facing_dir > 0.0) {
-            ftCo_800AD54C_inline0(fp);
+            ftCo_CpuTurnAround(fp);
             return;
         }
         if (!ftCo_800A28D0(fp, 1.0F)) {
@@ -5286,14 +5268,7 @@ void ftCo_800AB224(Fighter* fp)
             }
             if (var_r0_6 != 0) {
                 if (ftCo_800A28D0(fp, 1.0F)) {
-                    ftCo_CpuSetNeutralStick(fp);
-                    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                    ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0xB0);
-                    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-                    ftCo_800B46B8(fp, CpuCmd_WaitFor, 0xA);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                    ftCo_800B463C(fp, CpuCmd_Done);
+                    ftCo_CpuTurnAround(fp);
                 } else if (ftCo_800AAF48(fp) != 0) {
                     ftCo_800A0148(fp);
                 } else {
@@ -5303,7 +5278,7 @@ void ftCo_800AB224(Fighter* fp)
                 ftCo_800A0148(fp);
             } else if (!ftCo_800A2BD4(fp)) {
                 if (var_f31 < 1.3089969288557768) {
-                    ftCo_800AD54C_inline0(fp);
+                    ftCo_CpuTurnAround(fp);
                 } else {
                     ftCo_800AABC8_dontinline(fp);
                 }
@@ -5312,7 +5287,7 @@ void ftCo_800AB224(Fighter* fp)
             }
         } else if (var_f31 > -0.7853981573134661) {
             if (!ftCo_800A2BD4(fp)) {
-                ftCo_800AD54C_inline0(fp);
+                ftCo_CpuTurnAround(fp);
             } else {
                 ftCo_800AA844(fp);
             }
@@ -5847,14 +5822,7 @@ void ftCo_800ACD5C(Fighter* fp)
         return;
     }
     if (!ftCo_800A2C08(fp)) {
-        ftCo_CpuSetNeutralStick(fp);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0xB0);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-        ftCo_800B46B8(fp, CpuCmd_WaitFor, 0xA);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B463C(fp, CpuCmd_Done);
+        ftCo_CpuTurnAround(fp);
         return;
     }
     if (data->level < 5) {
@@ -5966,12 +5934,12 @@ void ftCo_800AD54C(Fighter* fp)
         ftCo_800B4778(fp, CpuCmd_LstickForwardClamped, stick, clamp);
         ftCo_CpuFinishWithNeutralY(fp);
     } else if (ftCo_800A28D0(fp, 1.0F)) {
-        ftCo_800AD54C_inline0(fp);
+        ftCo_CpuTurnAround(fp);
     } else if (inlineC0(fp)) {
         if (HSD_Randf() < 0.5f) {
             ftCo_800A0384(fp);
         } else {
-            ftCo_800AD54C_inline0(fp);
+            ftCo_CpuTurnAround(fp);
         }
     } else if (mpIsland_8005AB54(fp->coll_data.floor.index) != NULL) {
         ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
@@ -6013,7 +5981,7 @@ void ftCo_800AD7FC(Fighter* fp)
     item = GET_ITEM(fp->item_gobj);
     if (enemy != NULL && data->xC == 0x1D) {
         if (!ftCo_800A2C08(fp)) {
-            ftCo_800AD54C_inline0(fp);
+            ftCo_CpuTurnAround(fp);
         } else {
             angle = lb_8000D008(enemy->cur_pos.y - fp->cur_pos.y,
                                 ABS(enemy->cur_pos.x - fp->cur_pos.x));

--- a/src/melee/ft/ftcpuattack.c
+++ b/src/melee/ft/ftcpuattack.c
@@ -2908,6 +2908,18 @@ bool ftCo_800BB104(Fighter* fp, Fighter* arg1, Vec3* arg2, f32 arg3)
     return false;
 }
 
+static inline void ftCo_CpuPredictHitboxPosition(HitCapsule* hit, int frames,
+                                                 Vec3* predicted)
+{
+    f32 dx = hit->x4C.x - hit->x58.x;
+    f32 dy = hit->x4C.y - hit->x58.y;
+    f32 dz = hit->x4C.z - hit->x58.z;
+
+    predicted->x = dx * frames + hit->x4C.x;
+    predicted->y = dy * frames + hit->x4C.y;
+    predicted->z = dz * frames + hit->x4C.z;
+}
+
 int ftCo_800BB220(Fighter* fp, Item* ip, Vec3* arg2, f32 arg3)
 {
     UNUSED u8 padD8[8];
@@ -2963,19 +2975,13 @@ int ftCo_800BB220(Fighter* fp, Item* ip, Vec3* arg2, f32 arg3)
             Vec3 spAC;
             UNUSED u8 padA0[0xC];
             Vec3 sp94;
-            f32 dx, dy, dz;
             for (i = 0; i < 4; i++) {
                 state = ip->x5D4_hitboxes[i].hit.state;
                 hit = &ip->x5D4_hitboxes[i].hit;
                 if (state != HitCapsule_Disabled &&
                     state != HitCapsule_Enabled && !hit->x43_b2 &&
                     hit->element != 0xB && !lbColl_8000ACFC(fp, hit) &&
-                    (dx = hit->x4C.x - hit->x58.x,
-                     dy = hit->x4C.y - hit->x58.y,
-                     dz = hit->x4C.z - hit->x58.z,
-                     sp94.x = dx * count + hit->x4C.x,
-                     sp94.y = dy * count + hit->x4C.y,
-                     sp94.z = dz * count + hit->x4C.z,
+                    (ftCo_CpuPredictHitboxPosition(hit, count, &sp94),
                      lbColl_80006094(&hit->x4C, &sp94, arg2, &dst, &spAC,
                                      &spB8, hit->scale, arg3)))
                 {
@@ -2988,23 +2994,18 @@ int ftCo_800BB220(Fighter* fp, Item* ip, Vec3* arg2, f32 arg3)
                 }
             }
         } else {
+            UNUSED u8 pad88[4];
             Vec3 sp84;
             Vec3 sp78;
             UNUSED u8 pad6C[0xC];
             Vec3 sp60;
-            f32 dx, dy, dz;
             for (i = 0; i < 4; i++) {
                 state = ip->x5D4_hitboxes[i].hit.state;
                 hit = &ip->x5D4_hitboxes[i].hit;
                 if (state != HitCapsule_Disabled &&
                     state != HitCapsule_Enabled && !hit->x43_b2 &&
                     hit->element != 0xB && !lbColl_8000ACFC(fp, hit) &&
-                    (dx = hit->x4C.x - hit->x58.x,
-                     dy = hit->x4C.y - hit->x58.y,
-                     dz = hit->x4C.z - hit->x58.z,
-                     sp60.x = dx * count + hit->x4C.x,
-                     sp60.y = dy * count + hit->x4C.y,
-                     sp60.z = dz * count + hit->x4C.z,
+                    (ftCo_CpuPredictHitboxPosition(hit, count, &sp60),
                      lbColl_80006094(&hit->x4C, &sp60, arg2, &dst, &sp78,
                                      &sp84, hit->scale, arg3)))
                 {
@@ -3021,23 +3022,18 @@ int ftCo_800BB220(Fighter* fp, Item* ip, Vec3* arg2, f32 arg3)
             }
         }
     } else {
+        UNUSED u8 pad58[4];
         Vec3 sp50;
         Vec3 sp44;
         UNUSED u8 pad38[0xC];
         Vec3 sp2C;
-        UNUSED u8 pad24[8];
-        f32 dx, dy, dz;
         for (i = 0; i < 4; i++) {
             state = ip->x5D4_hitboxes[i].hit.state;
             hit = &ip->x5D4_hitboxes[i].hit;
             if (state != HitCapsule_Disabled && state != HitCapsule_Enabled &&
                 !hit->x43_b2 && hit->element != 0xB &&
                 !lbColl_8000ACFC(fp, hit) &&
-                (dx = hit->x4C.x - hit->x58.x, dy = hit->x4C.y - hit->x58.y,
-                 dz = hit->x4C.z - hit->x58.z,
-                 sp2C.x = dx * count + hit->x4C.x,
-                 sp2C.y = dy * count + hit->x4C.y,
-                 sp2C.z = dz * count + hit->x4C.z,
+                (ftCo_CpuPredictHitboxPosition(hit, count, &sp2C),
                  lbColl_80006094(&hit->x4C, &sp2C, arg2, &dst, &sp44, &sp50,
                                  hit->scale, arg3)))
             {

--- a/src/melee/ft/ftcpuattack.c
+++ b/src/melee/ft/ftcpuattack.c
@@ -156,6 +156,15 @@ static inline int ftCo_CpuSelectAttack(Fighter* fp,
     return entry->cmd;
 }
 
+static inline void ftCo_CpuClearTargetAndFinish(Fighter* fp)
+{
+    struct Fighter_x1A88_t* cpu = &fp->x1A88;
+
+    cpu->x44 = NULL;
+    cpu->x18 = cpu->x1C;
+    ftCo_800A0C8C(fp);
+}
+
 int ftCo_800B4AB0(Fighter* fp, Fighter* target, void* arg2)
 {
     ftCo_AttackEntry sp3C[32];
@@ -884,9 +893,7 @@ void ftCo_800B658C(Fighter* fp)
     Fighter* temp_r0 = fp->x1A88.x44;
 
     if (temp_r0 == NULL) {
-        temp_r31->x44 = NULL;
-        temp_r31->x18 = temp_r31->x1C;
-        ftCo_800A0C8C(fp);
+        ftCo_CpuClearTargetAndFinish(fp);
         return;
     }
 
@@ -947,9 +954,7 @@ void ftCo_800B658C(Fighter* fp)
             return;
         }
         if (!ftCo_800B8A9C(fp)) {
-            fp->x1A88.x44 = NULL;
-            fp->x1A88.x18 = fp->x1A88.x1C;
-            ftCo_800A0C8C(fp);
+            ftCo_CpuClearTargetAndFinish(fp);
             return;
         }
     }
@@ -1019,9 +1024,7 @@ void ftCo_800B683C(Fighter* fp)
     Vec3 sp24;
 
     if (fp->victim_gobj == NULL) {
-        temp_r31->x44 = 0;
-        temp_r31->x18 = temp_r31->x1C;
-        ftCo_800A0C8C(fp);
+        ftCo_CpuClearTargetAndFinish(fp);
         return;
     }
     var_r30 = false;
@@ -2167,9 +2170,7 @@ void ftCo_800B9020(Fighter* fp)
     PAD_STACK(8);
 
     if (fp->x1A88.x44 == NULL) {
-        temp_r31->x44 = 0;
-        temp_r31->x18 = temp_r31->x1C;
-        ftCo_800A0C8C(fp);
+        ftCo_CpuClearTargetAndFinish(fp);
         return;
     }
 
@@ -2218,14 +2219,10 @@ void ftCo_800B9020(Fighter* fp)
             temp_r31->xA4 = 0;
             temp_r31->x90++;
         } else {
-            fp->x1A88.x44 = NULL;
-            fp->x1A88.x18 = fp->x1A88.x1C;
-            ftCo_800A0C8C(fp);
+            ftCo_CpuClearTargetAndFinish(fp);
         }
     } else {
-        fp->x1A88.x44 = NULL;
-        fp->x1A88.x18 = fp->x1A88.x1C;
-        ftCo_800A0C8C(fp);
+        ftCo_CpuClearTargetAndFinish(fp);
     }
 }
 
@@ -2235,15 +2232,11 @@ void ftCo_800B920C(Fighter* fp)
     PAD_STACK(0x10);
 
     if (temp_r3 == NULL) {
-        fp->x1A88.x44 = NULL;
-        fp->x1A88.x18 = fp->x1A88.x1C;
-        ftCo_800A0C8C(fp);
+        ftCo_CpuClearTargetAndFinish(fp);
     } else if (ABS(temp_r3->cur_pos.y - fp->cur_pos.y) < 25.0) {
         ftCo_800B463C(fp, CpuCmd_ReleaseB);
         ftCo_800B463C(fp, CpuCmd_Done);
-        fp->x1A88.x44 = NULL;
-        fp->x1A88.x18 = fp->x1A88.x1C;
-        ftCo_800A0C8C(fp);
+        ftCo_CpuClearTargetAndFinish(fp);
     } else {
         ftCo_800B46B8(fp, CpuCmd_LstickTowardFighter, 0x7F);
         ftCo_800B463C(fp, CpuCmd_Done);
@@ -2254,9 +2247,7 @@ void ftCo_800B92D4(Fighter* fp)
 {
     PAD_STACK(4 * 4);
     if (fp->x1A88.x44 == NULL) {
-        fp->x1A88.x44 = NULL;
-        fp->x1A88.x18 = fp->x1A88.x1C;
-        ftCo_800A0C8C(fp);
+        ftCo_CpuClearTargetAndFinish(fp);
     } else {
         ftCo_800B46B8(fp, 0x94, 0x7F);
         ftCo_800B463C(fp, 0x7F);
@@ -2315,9 +2306,7 @@ void ftCo_800B9504(Fighter* fp)
 
     temp_r3_2 = ftCo_800A4E8C(fp, &sp14);
     if (temp_r3_2 == NULL) {
-        fp->x1A88.x44 = NULL;
-        fp->x1A88.x18 = fp->x1A88.x1C;
-        ftCo_800A0C8C(fp);
+        ftCo_CpuClearTargetAndFinish(fp);
     } else {
         var_f1 = ABS(temp_r3_2->cur_pos.x - fp->cur_pos.x);
         var_f2 = ABS(sp14.x - fp->cur_pos.x);

--- a/src/melee/ft/ftcpuattack.c
+++ b/src/melee/ft/ftcpuattack.c
@@ -145,6 +145,17 @@ static inline f32 get_scale(Fighter* fp)
     return fp->x34_scale.y;
 }
 
+static inline int ftCo_CpuSelectAttack(Fighter* fp,
+                                       struct Fighter_x1A88_t* cpu,
+                                       const ftCo_AttackEntry* entry)
+{
+    cpu->x6C.x = fp->x34_scale.y * entry->x08;
+    cpu->x6C.y = fp->x34_scale.y * entry->x10;
+    cpu->x74.x = fp->x34_scale.y * entry->x0C;
+    cpu->x74.y = fp->x34_scale.y * entry->x14;
+    return entry->cmd;
+}
+
 int ftCo_800B4AB0(Fighter* fp, Fighter* target, void* arg2)
 {
     ftCo_AttackEntry sp3C[32];
@@ -341,11 +352,7 @@ int ftCo_800B4AB0(Fighter* fp, Fighter* target, void* arg2)
     for (i = 0, sel = sp3C; i < count; i++, sel++) {
         acc += sel->weight;
         if (acc * inv >= r) {
-            cpu->x6C.x = fp->x34_scale.y * sp3C[i].x08;
-            cpu->x6C.y = fp->x34_scale.y * sp3C[i].x10;
-            cpu->x74.x = fp->x34_scale.y * sp3C[i].x0C;
-            cpu->x74.y = fp->x34_scale.y * sp3C[i].x14;
-            return sp3C[i].cmd;
+            return ftCo_CpuSelectAttack(fp, cpu, &sp3C[i]);
         }
     }
     HSD_ASSERT(0xFA, NULL);
@@ -547,11 +554,7 @@ int ftCo_800B52AC(Fighter* fp, Fighter* target, void* arg2, f32 reach)
     for (i = 0, sel = sp40; i < count; i++, sel++) {
         acc += sel->weight;
         if (acc * inv >= r) {
-            cpu->x6C.x = fp->x34_scale.y * sp40[i].x08;
-            cpu->x6C.y = fp->x34_scale.y * sp40[i].x10;
-            cpu->x74.x = fp->x34_scale.y * sp40[i].x0C;
-            cpu->x74.y = fp->x34_scale.y * sp40[i].x14;
-            return sp40[i].cmd;
+            return ftCo_CpuSelectAttack(fp, cpu, &sp40[i]);
         }
     }
     HSD_ASSERT(0x1C5, NULL);

--- a/src/melee/ft/ftcpuattack.c
+++ b/src/melee/ft/ftcpuattack.c
@@ -867,6 +867,14 @@ void ftCo_800B63D8(Fighter* fp)
     }
 }
 
+static inline void ftCo_CpuTapRAndWaitFiveFrames(Fighter* fp)
+{
+    ftCo_800B463C(fp, CpuCmd_PressR);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B463C(fp, CpuCmd_ReleaseR);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 5);
+}
+
 void ftCo_800B658C(Fighter* fp)
 {
     struct Fighter_x1A88_t* temp_r31 = &fp->x1A88;
@@ -910,17 +918,11 @@ void ftCo_800B658C(Fighter* fp)
         }
     } else if (fp->kind == FTKIND_SAMUS) {
         if (fp->motion_id == ftSs_MS_SpecialNHold) {
-            ftCo_800B463C(fp, CpuCmd_PressR);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_ReleaseR);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 5);
+            ftCo_CpuTapRAndWaitFiveFrames(fp);
         }
     } else if (fp->kind == FTKIND_DONKEY) {
         if (fp->motion_id == ftDk_MS_SpecialNLoop) {
-            ftCo_800B463C(fp, CpuCmd_PressR);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_ReleaseR);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 5);
+            ftCo_CpuTapRAndWaitFiveFrames(fp);
         }
     } else if (fp->kind == FTKIND_ZELDA) {
         if (fp->motion_id >= ftZd_MS_SpecialSLoop &&
@@ -2754,7 +2756,7 @@ static inline void inline2(Fighter* fp, Fighter* temp_r4_2)
     }
 }
 
-static inline bool escape(ftCommon_MotionState id)
+static inline bool ftCo_CpuIsRollOrAirDodge(ftCommon_MotionState id)
 {
     if (id == ftCo_MS_EscapeF || id == ftCo_MS_EscapeB ||
         id == ftCo_MS_EscapeAir)
@@ -2764,12 +2766,38 @@ static inline bool escape(ftCommon_MotionState id)
     return false;
 }
 
-static inline bool escapen(ftCommon_MotionState id)
+static inline bool ftCo_CpuIsSpotDodge(ftCommon_MotionState id)
 {
     if (id == ftCo_MS_EscapeN) {
         return true;
     }
     return false;
+}
+
+static inline void ftCo_CpuFireBlaster(Fighter* fp)
+{
+    int delay = 9 - fp->x1A88.level;
+
+    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickY, -0x50);
+    ftCo_800B463C(fp, CpuCmd_PressB);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+    if (delay != 0) {
+        ftCo_800B46B8(fp, CpuCmd_WaitFor,
+                      delay * ((int) (4.0f * HSD_Randf()) + 4));
+    }
+    ftCo_800B463C(fp, CpuCmd_Done);
+}
+
+static inline void ftCo_CpuRetapR(Fighter* fp)
+{
+    ftCo_800B463C(fp, CpuCmd_ReleaseR);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B463C(fp, CpuCmd_PressR);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B463C(fp, CpuCmd_ReleaseR);
+    ftCo_800B463C(fp, CpuCmd_Done);
 }
 
 void ftCo_800BA9A0(Fighter* fp)
@@ -2778,8 +2806,6 @@ void ftCo_800BA9A0(Fighter* fp)
     f32 temp_f2;
     f32 var_f1;
     s32 temp_r30;
-    s32 temp_r30_2;
-    s32 temp_r30_4;
     s32 temp_r30_5;
     s32 temp_r3;
     struct Fighter_x1A88_t* temp_r5;
@@ -2787,7 +2813,7 @@ void ftCo_800BA9A0(Fighter* fp)
 
     temp_r5 = &fp->x1A88;
     temp_r3 = fp->motion_id;
-    if (escape(temp_r3) || escapen(temp_r3)) {
+    if (ftCo_CpuIsRollOrAirDodge(temp_r3) || ftCo_CpuIsSpotDodge(temp_r3)) {
         ftCo_800A0C8C(fp);
         return;
     }
@@ -2807,35 +2833,14 @@ void ftCo_800BA9A0(Fighter* fp)
     if (fp->ground_or_air == GA_Air) {
         if (fp->kind == FTKIND_FOX || fp->kind == FTKIND_FALCO) {
             if (temp_r4 == 2) {
-                temp_r30_2 = 9 - fp->x1A88.level;
-                ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                ftCo_800B46B8(fp, CpuCmd_SetLstickY, -0x50);
-                ftCo_800B463C(fp, CpuCmd_PressB);
-                ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-                if (temp_r30_2 != 0) {
-                    ftCo_800B46B8(fp, CpuCmd_WaitFor,
-                                  temp_r30_2 *
-                                      ((int) (4.0f * HSD_Randf()) + 4));
-                }
-                ftCo_800B463C(fp, CpuCmd_Done);
+                ftCo_CpuFireBlaster(fp);
             } else {
-                ftCo_800B463C(fp, CpuCmd_ReleaseR);
-                ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                ftCo_800B463C(fp, CpuCmd_PressR);
-                ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                ftCo_800B463C(fp, CpuCmd_ReleaseR);
-                ftCo_800B463C(fp, CpuCmd_Done);
+                ftCo_CpuRetapR(fp);
             }
         } else if (temp_r4 == 3) {
             ftCo_800BA080_dontinline(fp);
         } else {
-            ftCo_800B463C(fp, CpuCmd_ReleaseR);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_PressR);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B463C(fp, CpuCmd_ReleaseR);
-            ftCo_800B463C(fp, CpuCmd_Done);
+            ftCo_CpuRetapR(fp);
         }
     } else if (temp_r4 == 2) {
         temp_r30_3 = temp_r5->xF4;
@@ -2848,18 +2853,7 @@ void ftCo_800BA9A0(Fighter* fp)
         } else {
             if (fp->kind == FTKIND_FOX || fp->kind == FTKIND_FALCO) {
                 if (HSD_Randf() > 0.5) {
-                    temp_r30_4 = 9 - fp->x1A88.level;
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickY, -0x50);
-                    ftCo_800B463C(fp, CpuCmd_PressB);
-                    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-                    if (temp_r30_4 != 0) {
-                        ftCo_800B46B8(fp, CpuCmd_WaitFor,
-                                      temp_r30_4 *
-                                          ((int) (4.0f * HSD_Randf()) + 4));
-                    }
-                    ftCo_800B463C(fp, CpuCmd_Done);
+                    ftCo_CpuFireBlaster(fp);
                 } else {
                     ftCo_800B9F90(fp);
                 }

--- a/src/melee/ft/ftcpuattack.c
+++ b/src/melee/ft/ftcpuattack.c
@@ -953,6 +953,40 @@ void ftCo_800B658C(Fighter* fp)
     temp_r31->xA4 = 0;
 }
 
+static inline void ftCo_CpuSetNeutralStick(Fighter* fp)
+{
+    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+}
+
+static inline void ftCo_CpuFlickLstickX(Fighter* fp, s8 half, s8 full)
+{
+    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickX, half);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickX, full);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
+    ftCo_800B463C(fp, CpuCmd_Done);
+}
+
+static inline void ftCo_CpuPressAWithLstickX(Fighter* fp, s8 stick_x)
+{
+    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickX, stick_x);
+    ftCo_800B463C(fp, CpuCmd_PressA);
+    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
+    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+    ftCo_800B463C(fp, CpuCmd_ReleaseA);
+    ftCo_800B463C(fp, CpuCmd_Done);
+}
+
 void ftCo_800B683C(Fighter* fp)
 {
     u8 _[0xC];
@@ -1003,34 +1037,14 @@ void ftCo_800B683C(Fighter* fp)
                 ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0x7F);
                 ftCo_800B463C(fp, CpuCmd_Done);
             } else {
-                ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-                ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-                ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0x7F);
-                ftCo_800B463C(fp, CpuCmd_PressA);
-                ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-                ftCo_800B463C(fp, CpuCmd_ReleaseA);
-                ftCo_800B463C(fp, CpuCmd_Done);
+                ftCo_CpuPressAWithLstickX(fp, 0x7F);
             }
         } else if (var_f1 > 10.0) {
             ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
             ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0x81);
             ftCo_800B463C(fp, CpuCmd_Done);
         } else {
-            ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-            ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-            ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0x81);
-            ftCo_800B463C(fp, CpuCmd_PressA);
-            ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-            ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-            ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-            ftCo_800B463C(fp, CpuCmd_ReleaseA);
-            ftCo_800B463C(fp, CpuCmd_Done);
+            ftCo_CpuPressAWithLstickX(fp, 0x81);
         }
         return;
     } else if ((fp->kind == FTKIND_KOOPA || fp->kind == FTKIND_GKOOPS) &&
@@ -1054,8 +1068,7 @@ void ftCo_800B683C(Fighter* fp)
             ftCo_800B463C(fp, CpuCmd_ReleaseA);
             ftCo_800B463C(fp, CpuCmd_Done);
         } else {
-            ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-            ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+            ftCo_CpuSetNeutralStick(fp);
             ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
             ftCo_800B46B8(fp, CpuCmd_SetLstickY, -0x7F);
             ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
@@ -1114,35 +1127,18 @@ void ftCo_800B683C(Fighter* fp)
             var_f1_2 = ABS(fp->cur_pos.x - sp24.x);
             if (var_f2_2 > var_f1_2) {
                 if (var_f1_2 < 30.0) {
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-                    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickX, -0x50);
-                    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickX, -0x7F);
-                    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                    ftCo_800B463C(fp, CpuCmd_Done);
+                    ftCo_CpuFlickLstickX(fp, -0x50, -0x7F);
                     return;
                 }
             } else {
                 if (var_f2_2 < 30.0) {
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
-                    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0x50);
-                    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0x7F);
-                    ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-                    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                    ftCo_800B463C(fp, CpuCmd_Done);
+                    ftCo_CpuFlickLstickX(fp, 0x50, 0x7F);
                     return;
                 }
             }
         }
         temp_f31 = HSD_Randf();
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         if (temp_f31 < 0.25) {
             ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0x50);
@@ -1162,8 +1158,7 @@ void ftCo_800B683C(Fighter* fp)
             ftCo_800B46B8(fp, CpuCmd_LstickXForward, 0x81);
         }
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B463C(fp, CpuCmd_Done);
     } else {
         ftCo_800A0C8C(fp);
@@ -2206,8 +2201,7 @@ void ftCo_800B9020(Fighter* fp)
     }
 
     if (ftCo_800B630C(fp)) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800A0C8C(fp);
         temp_r31->xA4 = 0;
     } else if (temp_r31->xA4 != 0) {
@@ -2324,16 +2318,14 @@ void ftCo_800B9504(Fighter* fp)
         var_f2 = ABS(sp14.x - fp->cur_pos.x);
         if (var_f2 > var_f1) {
             ftCo_800B463C(fp, CpuCmd_ReleaseB);
-            ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-            ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+            ftCo_CpuSetNeutralStick(fp);
             ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         } else {
             if (ABS(sp14.x - temp_r3_2->cur_pos.x) < 15.0 &&
                 ABS(15.0 + temp_r3_2->cur_pos.y - sp14.y) < 15.0)
             {
                 ftCo_800B463C(fp, CpuCmd_ReleaseB);
-                ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-                ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+                ftCo_CpuSetNeutralStick(fp);
                 ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
             } else {
                 if (15.0f + temp_r3_2->cur_pos.y > sp14.y) {
@@ -2609,8 +2601,7 @@ void ftCo_800B9F90(Fighter* fp)
 
     if (fp->motion_id == ftCo_MS_Guard) {
         temp_r31 = 9 - cpu->level;
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B463C(fp, CpuCmd_PressR);
         if (temp_r31 != 0) {
             ftCo_800B46B8(fp, CpuCmd_WaitFor,
@@ -2618,8 +2609,7 @@ void ftCo_800B9F90(Fighter* fp)
         }
         ftCo_800B463C(fp, CpuCmd_Done);
     } else {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B463C(fp, CpuCmd_PressR);
         ftCo_800B463C(fp, CpuCmd_Done);
     }
@@ -2628,12 +2618,10 @@ void ftCo_800B9F90(Fighter* fp)
 void ftCo_800BA080(Fighter* fp)
 {
     if (fp->motion_id >= 0x16F && fp->motion_id <= 0x178) {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B463C(fp, CpuCmd_Done);
     } else {
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B463C(fp, CpuCmd_ReleaseB);
         ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
         ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
@@ -2650,8 +2638,7 @@ static inline void ftCo_800BA080_dontinline(Fighter* fp)
 
 void ftCo_800BA160(Fighter* fp)
 {
-    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+    ftCo_CpuSetNeutralStick(fp);
     ftCo_800B463C(fp, CpuCmd_ReleaseR);
     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
     ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0x7F);
@@ -2665,8 +2652,7 @@ void ftCo_800BA160(Fighter* fp)
 
 void ftCo_800BA224(Fighter* fp)
 {
-    ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-    ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+    ftCo_CpuSetNeutralStick(fp);
     ftCo_800B463C(fp, CpuCmd_ReleaseR);
     ftCo_800B46B8(fp, CpuCmd_WaitFor, 1);
     ftCo_800B46B8(fp, CpuCmd_SetLstickX, -0x7F);
@@ -2812,8 +2798,7 @@ void ftCo_800BA9A0(Fighter* fp)
     temp_r4 = temp_r5->xF8_b12;
     if (temp_r4 == 0) {
         temp_r5->x18 = temp_r5->x1C;
-        ftCo_800B46B8(fp, CpuCmd_SetLstickX, 0);
-        ftCo_800B46B8(fp, CpuCmd_SetLstickY, 0);
+        ftCo_CpuSetNeutralStick(fp);
         ftCo_800B463C(fp, CpuCmd_ReleaseR);
         ftCo_800B463C(fp, CpuCmd_ReleaseB);
         ftCo_800A0C8C(fp);

--- a/src/melee/ft/ftcpuattack.c
+++ b/src/melee/ft/ftcpuattack.c
@@ -1367,6 +1367,40 @@ int ftCo_800B7638(Fighter* fp)
     return 0;
 }
 
+static inline bool ftCo_CpuCanUseRangedAttack(Fighter* fp, Fighter* target,
+                                              ftCo_CollData* coll, f32 range)
+{
+    f32 x;
+    f32 y;
+
+    if (target != NULL &&
+        mpCheckAll(&coll->p, &coll->line, &coll->flags, &coll->n, -1, -1,
+                   fp->cur_pos.x, fp->cur_pos.y, target->cur_pos.x,
+                   target->cur_pos.y))
+    {
+        return true;
+    }
+    if (fp->facing_dir > 0.0) {
+        y = fp->cur_pos.y;
+        x = range;
+        x = fp->cur_pos.x + x;
+        if (ftCo_800A0FB0(&coll->p, &coll->line, &coll->flags, &coll->n, -1,
+                          -1, -1, x, 5.0 + y, x, y - 1000.0, 0.0f) == 0)
+        {
+            return true;
+        }
+    } else {
+        y = fp->cur_pos.y;
+        x = fp->cur_pos.x - range;
+        if (ftCo_800A0FB0(&coll->p, &coll->line, &coll->flags, &coll->n, -1,
+                          -1, -1, x, 5.0 + y, x, y - 1000.0, 0.0f) == 0)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 void ftCo_800B77E8(Fighter* fp)
 {
     u8 operand_pad[0x28];
@@ -1399,38 +1433,7 @@ void ftCo_800B77E8(Fighter* fp)
     switch (fp->kind) {
     case FTKIND_MARIO:
         target = fp->x1A88.x44;
-        if (target != NULL && mpCheckAll(&c1.p, &c1.line, &c1.flags, &c1.n, -1,
-                                         -1, fp->cur_pos.x, fp->cur_pos.y,
-                                         target->cur_pos.x, target->cur_pos.y))
-        {
-            can_attack = 1;
-        } else {
-            do {
-                if (fp->facing_dir > 0.0) {
-                    y = fp->cur_pos.y;
-                    x = 22.0f;
-                    x = fp->cur_pos.x + x;
-                    if (ftCo_800A0FB0(&c1.p, &c1.line, &c1.flags, &c1.n, -1,
-                                      -1, -1, x, 5.0 + y, x, y - 1000.0,
-                                      0.0f) == 0)
-                    {
-                        can_attack = 1;
-                        break;
-                    }
-                } else {
-                    y = fp->cur_pos.y;
-                    x = fp->cur_pos.x - 22.0f;
-                    if (ftCo_800A0FB0(&c1.p, &c1.line, &c1.flags, &c1.n, -1,
-                                      -1, -1, x, 5.0 + y, x, y - 1000.0,
-                                      0.0f) == 0)
-                    {
-                        can_attack = 1;
-                        break;
-                    }
-                }
-                can_attack = 0;
-            } while (0);
-        }
+        can_attack = ftCo_CpuCanUseRangedAttack(fp, target, &c1, 22.0f);
         if (can_attack != 0) {
             struct Fighter_x1A88_t* tmp = &fp->x1A88;
             if (fp->x1A88.xEC < 8U) {
@@ -1443,38 +1446,7 @@ void ftCo_800B77E8(Fighter* fp)
     case FTKIND_FOX:
     case FTKIND_FALCO:
         target = fp->x1A88.x44;
-        if (target != NULL && mpCheckAll(&c2.p, &c2.line, &c2.flags, &c2.n, -1,
-                                         -1, fp->cur_pos.x, fp->cur_pos.y,
-                                         target->cur_pos.x, target->cur_pos.y))
-        {
-            can_attack = 1;
-        } else {
-            do {
-                if (fp->facing_dir > 0.0) {
-                    y = fp->cur_pos.y;
-                    x = 62.0f;
-                    x = fp->cur_pos.x + x;
-                    if (ftCo_800A0FB0(&c2.p, &c2.line, &c2.flags, &c2.n, -1,
-                                      -1, -1, x, 5.0 + y, x, y - 1000.0,
-                                      0.0f) == 0)
-                    {
-                        can_attack = 1;
-                        break;
-                    }
-                } else {
-                    y = fp->cur_pos.y;
-                    x = fp->cur_pos.x - 62.0f;
-                    if (ftCo_800A0FB0(&c2.p, &c2.line, &c2.flags, &c2.n, -1,
-                                      -1, -1, x, 5.0 + y, x, y - 1000.0,
-                                      0.0f) == 0)
-                    {
-                        can_attack = 1;
-                        break;
-                    }
-                }
-                can_attack = 0;
-            } while (0);
-        }
+        can_attack = ftCo_CpuCanUseRangedAttack(fp, target, &c2, 62.0f);
         if (can_attack != 0) {
             struct Fighter_x1A88_t* tmp = &fp->x1A88;
             if (fp->x1A88.xEC < 8U) {
@@ -1487,38 +1459,7 @@ void ftCo_800B77E8(Fighter* fp)
     case FTKIND_CAPTAIN:
     case FTKIND_GANON:
         target = *(target_pp = &fp->x1A88.x44);
-        if (target != NULL && mpCheckAll(&c3.p, &c3.line, &c3.flags, &c3.n, -1,
-                                         -1, fp->cur_pos.x, fp->cur_pos.y,
-                                         target->cur_pos.x, target->cur_pos.y))
-        {
-            can_attack = 1;
-        } else {
-            do {
-                if (fp->facing_dir > 0.0) {
-                    y = fp->cur_pos.y;
-                    x = 102.0f;
-                    x = fp->cur_pos.x + x;
-                    if (ftCo_800A0FB0(&c3.p, &c3.line, &c3.flags, &c3.n, -1,
-                                      -1, -1, x, 5.0 + y, x, y - 1000.0,
-                                      0.0f) == 0)
-                    {
-                        can_attack = 1;
-                        break;
-                    }
-                } else {
-                    y = fp->cur_pos.y;
-                    x = fp->cur_pos.x - 102.0f;
-                    if (ftCo_800A0FB0(&c3.p, &c3.line, &c3.flags, &c3.n, -1,
-                                      -1, -1, x, 5.0 + y, x, y - 1000.0,
-                                      0.0f) == 0)
-                    {
-                        can_attack = 1;
-                        break;
-                    }
-                }
-                can_attack = 0;
-            } while (0);
-        }
+        can_attack = ftCo_CpuCanUseRangedAttack(fp, target, &c3, 102.0f);
         if (can_attack != 0) {
             struct Fighter_x1A88_t* tmp = &fp->x1A88;
             if (fp->x1A88.xEC < 8U) {
@@ -1527,38 +1468,7 @@ void ftCo_800B77E8(Fighter* fp)
             }
         }
         target = *target_pp;
-        if (target != NULL && mpCheckAll(&c4.p, &c4.line, &c4.flags, &c4.n, -1,
-                                         -1, fp->cur_pos.x, fp->cur_pos.y,
-                                         target->cur_pos.x, target->cur_pos.y))
-        {
-            can_attack = 1;
-        } else {
-            do {
-                if (fp->facing_dir > 0.0) {
-                    y = fp->cur_pos.y;
-                    x = 58.0f;
-                    x = fp->cur_pos.x + x;
-                    if (ftCo_800A0FB0(&c4.p, &c4.line, &c4.flags, &c4.n, -1,
-                                      -1, -1, x, 5.0 + y, x, y - 1000.0,
-                                      0.0f) == 0)
-                    {
-                        can_attack = 1;
-                        break;
-                    }
-                } else {
-                    y = fp->cur_pos.y;
-                    x = fp->cur_pos.x - 58.0f;
-                    if (ftCo_800A0FB0(&c4.p, &c4.line, &c4.flags, &c4.n, -1,
-                                      -1, -1, x, 5.0 + y, x, y - 1000.0,
-                                      0.0f) == 0)
-                    {
-                        can_attack = 1;
-                        break;
-                    }
-                }
-                can_attack = 0;
-            } while (0);
-        }
+        can_attack = ftCo_CpuCanUseRangedAttack(fp, target, &c4, 58.0f);
         if (can_attack != 0) {
             struct Fighter_x1A88_t* tmp = &fp->x1A88;
             u8* xec;
@@ -1586,38 +1496,7 @@ void ftCo_800B77E8(Fighter* fp)
     case FTKIND_PIKACHU:
     case FTKIND_PICHU:
         target = fp->x1A88.x44;
-        if (target != NULL && mpCheckAll(&c5.p, &c5.line, &c5.flags, &c5.n, -1,
-                                         -1, fp->cur_pos.x, fp->cur_pos.y,
-                                         target->cur_pos.x, target->cur_pos.y))
-        {
-            can_attack = 1;
-        } else {
-            do {
-                if (fp->facing_dir > 0.0) {
-                    y = fp->cur_pos.y;
-                    x = 57.0f;
-                    x = fp->cur_pos.x + x;
-                    if (ftCo_800A0FB0(&c5.p, &c5.line, &c5.flags, &c5.n, -1,
-                                      -1, -1, x, 5.0 + y, x, y - 1000.0,
-                                      0.0f) == 0)
-                    {
-                        can_attack = 1;
-                        break;
-                    }
-                } else {
-                    y = fp->cur_pos.y;
-                    x = fp->cur_pos.x - 57.0f;
-                    if (ftCo_800A0FB0(&c5.p, &c5.line, &c5.flags, &c5.n, -1,
-                                      -1, -1, x, 5.0 + y, x, y - 1000.0,
-                                      0.0f) == 0)
-                    {
-                        can_attack = 1;
-                        break;
-                    }
-                }
-                can_attack = 0;
-            } while (0);
-        }
+        can_attack = ftCo_CpuCanUseRangedAttack(fp, target, &c5, 57.0f);
         if (can_attack != 0) {
             struct Fighter_x1A88_t* tmp = &fp->x1A88;
             if (fp->x1A88.xEC < 8U) {
@@ -1630,39 +1509,7 @@ void ftCo_800B77E8(Fighter* fp)
     case FTKIND_KOOPA:
         if (fp->ground_or_air == GA_Ground) {
             target = fp->x1A88.x44;
-            if (target != NULL &&
-                mpCheckAll(&c6.p, &c6.line, &c6.flags, &c6.n, -1, -1,
-                           fp->cur_pos.x, fp->cur_pos.y, target->cur_pos.x,
-                           target->cur_pos.y))
-            {
-                can_attack = 1;
-            } else {
-                do {
-                    if (fp->facing_dir > 0.0) {
-                        y = fp->cur_pos.y;
-                        x = 27.0f;
-                        x = fp->cur_pos.x + x;
-                        if (ftCo_800A0FB0(&c6.p, &c6.line, &c6.flags, &c6.n,
-                                          -1, -1, -1, x, 5.0 + y, x,
-                                          y - 1000.0, 0.0f) == 0)
-                        {
-                            can_attack = 1;
-                            break;
-                        }
-                    } else {
-                        y = fp->cur_pos.y;
-                        x = fp->cur_pos.x - 27.0f;
-                        if (ftCo_800A0FB0(&c6.p, &c6.line, &c6.flags, &c6.n,
-                                          -1, -1, -1, x, 5.0 + y, x,
-                                          y - 1000.0, 0.0f) == 0)
-                        {
-                            can_attack = 1;
-                            break;
-                        }
-                    }
-                    can_attack = 0;
-                } while (0);
-            }
+            can_attack = ftCo_CpuCanUseRangedAttack(fp, target, &c6, 27.0f);
             if (can_attack != 0) {
                 struct Fighter_x1A88_t* tmp = &fp->x1A88;
                 if (fp->x1A88.xEC < 8U) {
@@ -1683,39 +1530,7 @@ void ftCo_800B77E8(Fighter* fp)
     case FTKIND_GKOOPS:
         if (fp->ground_or_air == GA_Ground) {
             target = fp->x1A88.x44;
-            if (target != NULL &&
-                mpCheckAll(&c7.p, &c7.line, &c7.flags, &c7.n, -1, -1,
-                           fp->cur_pos.x, fp->cur_pos.y, target->cur_pos.x,
-                           target->cur_pos.y))
-            {
-                can_attack = 1;
-            } else {
-                do {
-                    if (fp->facing_dir > 0.0) {
-                        y = fp->cur_pos.y;
-                        x = 53.0f;
-                        x = fp->cur_pos.x + x;
-                        if (ftCo_800A0FB0(&c7.p, &c7.line, &c7.flags, &c7.n,
-                                          -1, -1, -1, x, 5.0 + y, x,
-                                          y - 1000.0, 0.0f) == 0)
-                        {
-                            can_attack = 1;
-                            break;
-                        }
-                    } else {
-                        y = fp->cur_pos.y;
-                        x = fp->cur_pos.x - 53.0f;
-                        if (ftCo_800A0FB0(&c7.p, &c7.line, &c7.flags, &c7.n,
-                                          -1, -1, -1, x, 5.0 + y, x,
-                                          y - 1000.0, 0.0f) == 0)
-                        {
-                            can_attack = 1;
-                            break;
-                        }
-                    }
-                    can_attack = 0;
-                } while (0);
-            }
+            can_attack = ftCo_CpuCanUseRangedAttack(fp, target, &c7, 53.0f);
             if (can_attack != 0) {
                 struct Fighter_x1A88_t* tmp = &fp->x1A88;
                 if (fp->x1A88.xEC < 8U) {
@@ -1736,39 +1551,7 @@ void ftCo_800B77E8(Fighter* fp)
     case FTKIND_YOSHI:
         if (fp->ground_or_air == GA_Ground) {
             target = fp->x1A88.x44;
-            if (target != NULL &&
-                mpCheckAll(&c8.p, &c8.line, &c8.flags, &c8.n, -1, -1,
-                           fp->cur_pos.x, fp->cur_pos.y, target->cur_pos.x,
-                           target->cur_pos.y))
-            {
-                can_attack = 1;
-            } else {
-                do {
-                    if (fp->facing_dir > 0.0) {
-                        y = fp->cur_pos.y;
-                        x = 16.0f;
-                        x = fp->cur_pos.x + x;
-                        if (ftCo_800A0FB0(&c8.p, &c8.line, &c8.flags, &c8.n,
-                                          -1, -1, -1, x, 5.0 + y, x,
-                                          y - 1000.0, 0.0f) == 0)
-                        {
-                            can_attack = 1;
-                            break;
-                        }
-                    } else {
-                        y = fp->cur_pos.y;
-                        x = fp->cur_pos.x - 16.0f;
-                        if (ftCo_800A0FB0(&c8.p, &c8.line, &c8.flags, &c8.n,
-                                          -1, -1, -1, x, 5.0 + y, x,
-                                          y - 1000.0, 0.0f) == 0)
-                        {
-                            can_attack = 1;
-                            break;
-                        }
-                    }
-                    can_attack = 0;
-                } while (0);
-            }
+            can_attack = ftCo_CpuCanUseRangedAttack(fp, target, &c8, 16.0f);
             if (can_attack != 0) {
                 struct Fighter_x1A88_t* tmp = &fp->x1A88;
                 if (fp->x1A88.xEC < 8U) {
@@ -1788,38 +1571,7 @@ void ftCo_800B77E8(Fighter* fp)
         break;
     case FTKIND_LUIGI:
         target = fp->x1A88.x44;
-        if (target != NULL && mpCheckAll(&c9.p, &c9.line, &c9.flags, &c9.n, -1,
-                                         -1, fp->cur_pos.x, fp->cur_pos.y,
-                                         target->cur_pos.x, target->cur_pos.y))
-        {
-            can_attack = 1;
-        } else {
-            do {
-                if (fp->facing_dir > 0.0) {
-                    y = fp->cur_pos.y;
-                    x = 60.0f;
-                    x = fp->cur_pos.x + x;
-                    if (ftCo_800A0FB0(&c9.p, &c9.line, &c9.flags, &c9.n, -1,
-                                      -1, -1, x, 5.0 + y, x, y - 1000.0,
-                                      0.0f) == 0)
-                    {
-                        can_attack = 1;
-                        break;
-                    }
-                } else {
-                    y = fp->cur_pos.y;
-                    x = fp->cur_pos.x - 60.0f;
-                    if (ftCo_800A0FB0(&c9.p, &c9.line, &c9.flags, &c9.n, -1,
-                                      -1, -1, x, 5.0 + y, x, y - 1000.0,
-                                      0.0f) == 0)
-                    {
-                        can_attack = 1;
-                        break;
-                    }
-                }
-                can_attack = 0;
-            } while (0);
-        }
+        can_attack = ftCo_CpuCanUseRangedAttack(fp, target, &c9, 60.0f);
         if (can_attack != 0) {
             struct Fighter_x1A88_t* tmp = &fp->x1A88;
             if (fp->x1A88.xEC < 8U) {
@@ -1830,6 +1582,7 @@ void ftCo_800B77E8(Fighter* fp)
         }
         break;
     case FTKIND_PEACH:
+        /// @todo Sharing this last case shifts every collision stack slot.
         target = fp->x1A88.x44;
         if (target != NULL && mpCheckAll(&c10.p, &c10.line, &c10.flags, &c10.n,
                                          -1, -1, fp->cur_pos.x, fp->cur_pos.y,


### PR DESCRIPTION
Removing some of the dontinline helpers is a good signal that some of the new code structure is perhaps more faithful to the original. There are lots of other refactors in various other areas too.