### PR TITLE
Share item to parent attachment code

### DIFF
--- a/src/melee/it/items/inlines.h
+++ b/src/melee/it/items/inlines.h
@@ -73,13 +73,20 @@ static inline void Item_InitSpawn(SpawnItem* spawn, HSD_GObj* parent,
     spawn->x40 = 0;
 }
 
+static inline Item_GObj*
+Item_AttachToParent(Item_GObj* item_gobj, HSD_GObj* parent, Fighter_Part part)
+{
+    Item_8026AB54(item_gobj, parent, part);
+    db_80225DD8(item_gobj, parent);
+    return item_gobj;
+}
+
 static inline void Item_AttachGameWatchArticle(HSD_GObj* parent,
                                                Fighter_Part part,
                                                Item_GObj* item_gobj,
                                                void** attributes)
 {
-    Item_8026AB54(item_gobj, parent, part);
-    db_80225DD8(item_gobj, parent);
+    Item_AttachToParent(item_gobj, parent, part);
     it_8027CE64(item_gobj, parent, attributes[0]);
 }
 

--- a/src/melee/it/items/inlines.h
+++ b/src/melee/it/items/inlines.h
@@ -1,6 +1,7 @@
 #ifndef MELEE_IT_ITEMS_INLINES_H
 #define MELEE_IT_ITEMS_INLINES_H
 
+#include "db/db.h"
 #include "ef/eflib.h"
 #include "it/inlines.h"
 #include "it/it_26B1.h"
@@ -9,6 +10,7 @@
 #include "it/item.h"
 #include "it/items/itlinkhookshot.h"
 #include "it/itmaplib.h"
+#include "it/itzako.h"
 #include "it/types.h"
 #include "lb/lbrefract.h"
 #include "lb/lbvector.h"
@@ -69,6 +71,16 @@ static inline void Item_InitSpawn(SpawnItem* spawn, HSD_GObj* parent,
     spawn->x4_parent_gobj2 = spawn->x0_parent_gobj;
     spawn->x44_flag.b0 = true;
     spawn->x40 = 0;
+}
+
+static inline void Item_AttachGameWatchArticle(HSD_GObj* parent,
+                                               Fighter_Part part,
+                                               Item_GObj* item_gobj,
+                                               void** attributes)
+{
+    Item_8026AB54(item_gobj, parent, part);
+    db_80225DD8(item_gobj, parent);
+    it_8027CE64(item_gobj, parent, attributes[0]);
 }
 
 static inline void Item_EnterAirStateWithHitlag(Item_GObj* gobj, enum_t msid)

--- a/src/melee/it/items/itgamewatchbreath.c
+++ b/src/melee/it/items/itgamewatchbreath.c
@@ -28,14 +28,11 @@ HSD_GObj* it_802C720C(HSD_GObj* parent, Vec3* pos, Fighter_Part part,
 
     spawn.kind = It_Kind_GameWatch_Breath;
     Item_InitSpawn(&spawn, parent, pos, dir);
-
     result = Item_80268B18(&spawn);
     if (result != NULL) {
         Item* item = GET_ITEM(result);
         void** attr = item->xC4_article_data->x4_specialAttributes;
-        Item_8026AB54(result, parent, part);
-        db_80225DD8(result, parent);
-        it_8027CE64(result, parent, attr[0]);
+        Item_AttachGameWatchArticle(parent, part, result, attr);
         return result;
     }
     return NULL;

--- a/src/melee/it/items/itgamewatchfire.c
+++ b/src/melee/it/items/itgamewatchfire.c
@@ -27,14 +27,11 @@ HSD_GObj* itGamewatchFire_Spawn(HSD_GObj* parent, Vec3* pos, Fighter_Part part,
 
     spawn.kind = It_Kind_GameWatch_Fire;
     Item_InitSpawn(&spawn, parent, pos, dir);
-
     result = Item_80268B18(&spawn);
     if (result != NULL) {
         Item* item = GET_ITEM(result);
         void** attr = item->xC4_article_data->x4_specialAttributes;
-        Item_8026AB54(result, parent, part);
-        db_80225DD8(result, parent);
-        it_8027CE64(result, parent, attr[0]);
+        Item_AttachGameWatchArticle(parent, part, result, attr);
         return result;
     }
     return NULL;

--- a/src/melee/it/items/itgamewatchgreenhouse.c
+++ b/src/melee/it/items/itgamewatchgreenhouse.c
@@ -35,14 +35,11 @@ HSD_GObj* itGamewatchGreenhouse_Spawn(HSD_GObj* parent, Vec3* pos,
 
     spawn.kind = It_Kind_GameWatch_Greenhouse;
     Item_InitSpawn(&spawn, parent, pos, dir);
-
     result = Item_80268B18(&spawn);
     if (result != NULL) {
         Item* item = GET_ITEM(result);
         void** attr = item->xC4_article_data->x4_specialAttributes;
-        Item_8026AB54(result, parent, part);
-        db_80225DD8(result, parent);
-        it_8027CE64(result, parent, attr[0]);
+        Item_AttachGameWatchArticle(parent, part, result, attr);
         return result;
     }
     return NULL;

--- a/src/melee/it/items/itgamewatchmanhole.c
+++ b/src/melee/it/items/itgamewatchmanhole.c
@@ -22,18 +22,17 @@ ItemStateTable it_803F78D8[] = { { 0, itGamewatchmanhole_UnkMotion0_Anim, 0,
 HSD_GObj* it_802C65E4(Item_GObj* gobj, Vec* vec, enum Fighter_Part arg2,
                       float arg3)
 {
-    HSD_GObj* n;
-    SpawnItem si;
-    PAD_STACK(4);
-    si.kind = It_Kind_GameWatch_Manhole;
-    Item_InitSpawn(&si, gobj, vec, arg3);
-    n = Item_80268B18(&si);
-    if (n != NULL) {
-        void** x = GET_ITEM(n)->xC4_article_data->x4_specialAttributes;
-        Item_8026AB54(n, gobj, arg2);
-        db_80225DD8(n, gobj);
-        it_8027CE64(n, gobj, *x);
-        return n;
+    SpawnItem spawn;
+    Item_GObj* result;
+
+    spawn.kind = It_Kind_GameWatch_Manhole;
+    Item_InitSpawn(&spawn, gobj, vec, arg3);
+    result = Item_80268B18(&spawn);
+    if (result != NULL) {
+        Item* item = GET_ITEM(result);
+        void** attr = item->xC4_article_data->x4_specialAttributes;
+        Item_AttachGameWatchArticle(gobj, arg2, result, attr);
+        return result;
     }
     return NULL;
 }

--- a/src/melee/it/items/itgamewatchpanic.c
+++ b/src/melee/it/items/itgamewatchpanic.c
@@ -19,20 +19,17 @@ ItemStateTable it_803F79A0[] = {
 
 HSD_GObj* it_802C7D60(Item_GObj* parent, Vec3* pos, Fighter_Part arg2, f32 dir)
 {
-    SpawnItem spawn_item;
-    HSD_GObj* gobj;
-    void** attr;
+    SpawnItem spawn;
+    Item_GObj* result;
 
-    spawn_item.kind = It_Kind_GameWatch_Panic;
-    Item_InitSpawn(&spawn_item, parent, pos, dir);
-    gobj = Item_80268B18(&spawn_item);
-    if (gobj != NULL) {
-        Item* ip = GET_ITEM(gobj);
-        attr = ip->xC4_article_data->x4_specialAttributes;
-        Item_8026AB54(gobj, parent, arg2);
-        db_80225DD8(gobj, parent);
-        it_8027CE64(gobj, parent, *attr);
-        return gobj;
+    spawn.kind = It_Kind_GameWatch_Panic;
+    Item_InitSpawn(&spawn, parent, pos, dir);
+    result = Item_80268B18(&spawn);
+    if (result != NULL) {
+        Item* item = GET_ITEM(result);
+        void** attr = item->xC4_article_data->x4_specialAttributes;
+        Item_AttachGameWatchArticle(parent, arg2, result, attr);
+        return result;
     }
     return NULL;
 }

--- a/src/melee/it/items/itgamewatchparachute.c
+++ b/src/melee/it/items/itgamewatchparachute.c
@@ -30,20 +30,17 @@ ItemStateTable it_803F78F8[] = {
 HSD_GObj* it_802C6C38(Item_GObj* parent, Vec3* pos, enum_t part,
                       float facing_dir)
 {
-    Item_GObj* gobj;
     SpawnItem spawn;
-    PAD_STACK(4);
+    Item_GObj* result;
 
-    spawn.kind = 0x75;
+    spawn.kind = It_Kind_GameWatch_Parachute;
     Item_InitSpawn(&spawn, parent, pos, facing_dir);
-    gobj = Item_80268B18(&spawn);
-    if (gobj != NULL) {
-        itGamewatchparachuteAttributes* attrs =
-            GET_ITEM(gobj)->xC4_article_data->x4_specialAttributes;
-        Item_8026AB54(gobj, parent, part);
-        db_80225DD8(gobj, parent);
-        it_8027CE64(gobj, parent, attrs->x0);
-        return gobj;
+    result = Item_80268B18(&spawn);
+    if (result != NULL) {
+        Item* item = GET_ITEM(result);
+        void** attr = item->xC4_article_data->x4_specialAttributes;
+        Item_AttachGameWatchArticle(parent, part, result, attr);
+        return result;
     }
     return NULL;
 }

--- a/src/melee/it/items/itgamewatchturtle.c
+++ b/src/melee/it/items/itgamewatchturtle.c
@@ -30,20 +30,17 @@ ItemStateTable it_803F7918[] = {
 
 Item_GObj* it_802C6F40(HSD_GObj* parent, Vec3* pos, Fighter_Part arg2, f32 dir)
 {
-    SpawnItem spawn_item;
-    HSD_GObj* item_gobj;
-    void** temp_r30;
+    SpawnItem spawn;
+    Item_GObj* result;
 
-    spawn_item.kind = It_Kind_GameWatch_Turtle;
-    Item_InitSpawn(&spawn_item, parent, pos, dir);
-    item_gobj = Item_80268B18(&spawn_item);
-    if (item_gobj != NULL) {
-        Item* it = GET_ITEM(item_gobj);
-        temp_r30 = it->xC4_article_data->x4_specialAttributes;
-        Item_8026AB54(item_gobj, parent, arg2);
-        db_80225DD8(item_gobj, parent);
-        it_8027CE64(item_gobj, parent, *temp_r30);
-        return item_gobj;
+    spawn.kind = It_Kind_GameWatch_Turtle;
+    Item_InitSpawn(&spawn, parent, pos, dir);
+    result = Item_80268B18(&spawn);
+    if (result != NULL) {
+        Item* item = GET_ITEM(result);
+        void** attr = item->xC4_article_data->x4_specialAttributes;
+        Item_AttachGameWatchArticle(parent, arg2, result, attr);
+        return result;
     }
     return NULL;
 }

--- a/src/melee/it/items/itkirbygamewatchchefpan.c
+++ b/src/melee/it/items/itkirbygamewatchchefpan.c
@@ -28,9 +28,7 @@ Item_GObj* it_802C74D8(HSD_GObj* parent, Vec3* pos, Fighter_Part part,
     if (result != NULL) {
         Item* item = GET_ITEM(result);
         void** attr = item->xC4_article_data->x4_specialAttributes;
-        Item_8026AB54(result, parent, part);
-        db_80225DD8(result, parent);
-        it_8027CE64(result, parent, attr[0]);
+        Item_AttachGameWatchArticle(parent, part, result, attr);
         return result;
     }
     return NULL;

--- a/src/melee/it/items/itlinkarrow.c
+++ b/src/melee/it/items/itlinkarrow.c
@@ -212,6 +212,8 @@ HSD_GObj* it_802A83E0(f32 facing_dir, Fighter_GObj* arg1, Vec3* arg2,
         item->xDD4_itemVar.linkarrow.xE4 = -1;
         item->xDD4_itemVar.linkarrow.xEC = 0.0f;
         item->xDD4_itemVar.linkarrow.xE8 = 0.0f;
+        /// @todo Use Item_AttachToParent when it inlines here without growing
+        /// the stack frame.
         Item_8026AB54(gobj, arg1, arg3);
         db_80225DD8(gobj, (Fighter_GObj*) arg1);
     }

--- a/src/melee/it/items/itmariocape.c
+++ b/src/melee/it/items/itmariocape.c
@@ -27,9 +27,7 @@ Item_GObj* it_802B2560(Fighter_GObj* parent_gobj, float facing_dir, Vec3* pos,
 
     gobj = Item_80268B18(&spawn);
     if (gobj != NULL) {
-        Item_8026AB54(gobj, parent_gobj, part);
-        db_80225DD8(gobj, parent_gobj);
-        return gobj;
+        return Item_AttachToParent(gobj, parent_gobj, part);
     }
     return NULL;
 }

--- a/src/melee/it/items/itpeachparasol.c
+++ b/src/melee/it/items/itpeachparasol.c
@@ -46,9 +46,7 @@ Item_GObj* it_802BDA64(HSD_GObj* parent, Vec3* pos, Fighter_Part arg2, f32 dir)
     Item_InitSpawn(&spawn, parent, pos, dir);
     item_gobj = Item_80268B18(&spawn);
     if (item_gobj != NULL) {
-        Item_8026AB54(item_gobj, parent, arg2);
-        db_80225DD8(item_gobj, parent);
-        return item_gobj;
+        return Item_AttachToParent(item_gobj, parent, arg2);
     }
     return NULL;
 }

--- a/src/melee/it/items/itpeachtoad.c
+++ b/src/melee/it/items/itpeachtoad.c
@@ -64,9 +64,7 @@ Item_GObj* it_802BDE18(Item_GObj* item_gobj, Vec3* pos, Fighter_Part part,
 
     spawn_gobj = Item_80268B18(&spawn);
     if (spawn_gobj != NULL) {
-        Item_8026AB54(spawn_gobj, item_gobj, part);
-        db_80225DD8(spawn_gobj, item_gobj);
-        return spawn_gobj;
+        return Item_AttachToParent(spawn_gobj, item_gobj, part);
     }
     return NULL;
 }


### PR DESCRIPTION
From Codex
> Route eight article spawners through a common attach, debug, and effect helper while retaining caller-owned locals required for exact register allocation. All affected functions remain 100% matches.