### PR TITLE
Fix MSL header inclusions

### DIFF
--- a/src/MSL/math_ppc.c
+++ b/src/MSL/math_ppc.c
@@ -1,1 +1,0 @@
-#include "math_ppc.h"

--- a/src/MSL/math_ppc.h
+++ b/src/MSL/math_ppc.h
@@ -1,5 +1,5 @@
 #ifndef _MATH_PPC_H_
-#define _MATH_PPC_H_
+#define _MATH_PPC_H_ // IWYU pragma: always_keep
 
 #ifdef __MWERKS__
 #pragma push

--- a/src/MSL/trigf.c
+++ b/src/MSL/trigf.c
@@ -1,3 +1,5 @@
+#include "trigf.h"
+
 #include "math.h"
 
 #define __epsilon 3.45266983e-4f

--- a/src/MSL/trigf.h
+++ b/src/MSL/trigf.h
@@ -1,7 +1,5 @@
 #ifndef MSL_TRIGF_H
-#define MSL_TRIGF_H
-
-#include <platform.h>
+#define MSL_TRIGF_H // IWYU pragma: always_keep
 
 float acosf(float);
 float asinf(float);

--- a/src/melee/cm/camera.c
+++ b/src/melee/cm/camera.c
@@ -35,7 +35,7 @@
 #include "pl/player.h"
 
 #include <math.h>
-#include <math_ppc.h> // IWYU pragma: keep
+#include <math_ppc.h>
 #include <baselib/controller.h>
 #include <baselib/gobjgxlink.h>
 #include <baselib/gobjobject.h>

--- a/src/melee/db/dbcamera.c
+++ b/src/melee/db/dbcamera.c
@@ -10,8 +10,7 @@
 #include "lb/lbvector.h"
 
 #include <math.h>
-#include <trigf.h> // IWYU pragma: keep
-
+#include <trigf.h>
 /* 4A03C0 */ static char db_CameraInfoDisplay_buf[0xC0];
 
 /// @todo does the padding mean this should be in another file before this one?

--- a/src/melee/ef/eflib.c
+++ b/src/melee/ef/eflib.c
@@ -32,8 +32,7 @@
 #include "MSL/math.h"
 
 #include <runtime.h>
-#include <trigf.h> // IWYU pragma: keep
-
+#include <trigf.h>
 // externs
 extern u32* ptclref_804D0E5C[65];
 extern EF_DAT_Entry efAsync_DatEntries[51];

--- a/src/melee/ft/chara/ftCommon/ftCo_09F7.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_09F7.c
@@ -10,7 +10,7 @@
 #include "ft/types.h"
 
 #include <math.h>
-#include <trigf.h> // IWYU pragma: keep
+#include <trigf.h>
 #include <baselib/gobj.h>
 #include <melee/ft/ftcmdscript.h>
 

--- a/src/melee/ft/chara/ftCommon/ftCo_0C35.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0C35.c
@@ -12,9 +12,9 @@
 
 #include <common_structs.h>
 #include <math.h>
+#include <trigf.h>
 #include <dolphin/mtx.h>
 #include <baselib/jobj.h>
-#include <MSL/trigf.h>
 
 static void inlineA0(Fighter_GObj* gobj)
 {

--- a/src/melee/ft/chara/ftCommon/ftCo_Damage.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Damage.c
@@ -57,11 +57,11 @@
 #include <common_structs.h>
 #include <math.h>
 #include <math_ppc.h>
+#include <trigf.h>
 #include <dolphin/mtx.h>
 #include <baselib/mtx.h>
 #include <baselib/random.h>
 #include <MetroTRK/intrinsics.h>
-#include <MSL/trigf.h>
 
 int ftCo_803C5520[2][12] = {
     { 81, 78, 75, 82, 79, 76, 83, 80, 77, 89, 88, 87 },

--- a/src/melee/ft/chara/ftCommon/ftCo_Guard.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Guard.c
@@ -38,7 +38,7 @@
 
 #include <common_structs.h>
 #include <math.h>
-#include <math_ppc.h> // IWYU pragma: keep
+#include <math_ppc.h>
 #include <baselib/gobj.h>
 #include <baselib/jobj.h>
 

--- a/src/melee/ft/chara/ftCommon/ftCo_ItemThrow.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_ItemThrow.c
@@ -34,7 +34,7 @@
 
 #include <common_structs.h>
 #include <math.h>
-#include <MSL/trigf.h>
+#include <trigf.h>
 
 /* 094D70 */ bool ftCo_800951D0(Fighter_GObj* gobj);
 /* 094E7C */ static bool ftCo_800952DC(Fighter_GObj* gobj);

--- a/src/melee/ft/chara/ftMewtwo/ftMt_SpecialHi.c
+++ b/src/melee/ft/chara/ftMewtwo/ftMt_SpecialHi.c
@@ -26,11 +26,10 @@
 #include "lb/lbvector.h"
 
 #include <common_structs.h>
-#include <trigf.h> // IWYU pragma: keep
+#include <math_ppc.h>
+#include <trigf.h>
 #include <dolphin/mtx.h>
 #include <MSL/math.h>
-#include <MSL/math_ppc.h> // IWYU pragma: keep
-
 /// Create Teleport Start GFX
 void ftMt_SpecialHi_CreateGFX(HSD_GObj* gobj)
 {

--- a/src/melee/ft/chara/ftMewtwo/ftMt_SpecialN.c
+++ b/src/melee/ft/chara/ftMewtwo/ftMt_SpecialN.c
@@ -32,7 +32,7 @@
 #include "lb/lb_00B0.h"
 
 #include <common_structs.h>
-#include <trigf.h> // IWYU pragma: keep
+#include <trigf.h>
 #include <dolphin/mtx.h>
 
 /// SpecialN/SpecialAirN

--- a/src/melee/ft/chara/ftNess/ftNs_SpecialS.c
+++ b/src/melee/ft/chara/ftNess/ftNs_SpecialS.c
@@ -15,8 +15,8 @@
 #include "lb/lb_00B0.h"
 
 #include <common_structs.h>
+#include <trigf.h>
 #include <dolphin/mtx.h>
-#include <MSL/trigf.h>
 
 /// https://decomp.me/scratch/apf7Y
 void ftNs_SpecialS_ItemPKFireSpawn(

--- a/src/melee/ft/chara/ftPikachu/ftPk_SpecialHi.c
+++ b/src/melee/ft/chara/ftPikachu/ftPk_SpecialHi.c
@@ -28,8 +28,8 @@
 #include "lb/lbvector.h"
 
 #include <math.h>
-#include <math_ppc.h> // IWYU pragma: keep
-#include <trigf.h>    // IWYU pragma: keep
+#include <math_ppc.h>
+#include <trigf.h>
 #include <dolphin/mtx.h>
 #include <baselib/jobj.h>
 #include <baselib/random.h>

--- a/src/melee/ft/chara/ftPurin/ftPr_SpecialN.c
+++ b/src/melee/ft/chara/ftPurin/ftPr_SpecialN.c
@@ -24,10 +24,10 @@
 #include "ft/types.h"
 #include "ftPurin/ftPr_Init.h"
 #include "ftPurin/types.h"
-#include "MSL/trigf.h"
 
 #include <common_structs.h>
 #include <math.h>
+#include <trigf.h>
 #include <baselib/archive.h>
 #include <baselib/gobj.h>
 #include <baselib/jobj.h>

--- a/src/melee/ft/chara/ftSeak/ftSk_SpecialHi.c
+++ b/src/melee/ft/chara/ftSeak/ftSk_SpecialHi.c
@@ -28,7 +28,7 @@
 #include "lb/lbvector.h"
 
 #include <math.h>
-#include <trigf.h> // IWYU pragma: keep
+#include <trigf.h>
 #include <baselib/gobj.h>
 
 static MotionFlags const ftSk_MF_SpecialHi_Coll =

--- a/src/melee/ft/chara/ftYoshi/ftYs_SpecialS.c
+++ b/src/melee/ft/chara/ftYoshi/ftYs_SpecialS.c
@@ -37,8 +37,8 @@
 
 #include "lb/lb_00B0.h"
 #include "mp/mplib.h"
-#include "MSL/trigf.h"
 
+#include <trigf.h>
 #include <dolphin/mtx.h>
 #include <baselib/gobj.h>
 

--- a/src/melee/ft/chara/ftZelda/ftZd_SpecialHi.c
+++ b/src/melee/ft/chara/ftZelda/ftZd_SpecialHi.c
@@ -25,7 +25,7 @@
 
 #include <common_structs.h>
 #include <math.h>
-#include <trigf.h> // IWYU pragma: keep
+#include <trigf.h>
 #include <dolphin/mtx.h>
 #include <MetroTRK/intrinsics.h>
 

--- a/src/melee/ft/fighter.c
+++ b/src/melee/ft/fighter.c
@@ -86,6 +86,8 @@
 #include "sfx/crowdsfx.h"
 
 #include <common_structs.h>
+#include <math_ppc.h>
+#include <trigf.h>
 #include <dolphin/gx.h>
 #include <dolphin/mtx.h>
 #include <dolphin/os/OSError.h>
@@ -101,8 +103,6 @@
 #include <baselib/mtx.h>
 #include <baselib/random.h>
 #include <MSL/math.h>
-#include <MSL/math_ppc.h>
-#include <MSL/trigf.h>
 
 extern struct UnkCostumeList CostumeListsForeachCharacter[FTKIND_MAX];
 

--- a/src/melee/ft/ft_0892.c
+++ b/src/melee/ft/ft_0892.c
@@ -7,10 +7,10 @@
 #include "pl/plattack.h"
 #include "pl/pltrick.h"
 
+#include <math_ppc.h>
+#include <trigf.h>
 #include <baselib/gobj.h>
 #include <baselib/jobj.h>
-#include <MSL/math_ppc.h>
-#include <MSL/trigf.h>
 
 void lbBgFlash_80020E38(HSD_JObj*, Vec3*, f32, f32, f32);
 void lbBgFlash_80021410(IKState*);

--- a/src/melee/ft/ft_0899.c
+++ b/src/melee/ft/ft_0899.c
@@ -11,10 +11,10 @@
 #include "lb/lbvector.h"
 #include "mp/mplib.h"
 
+#include <math_ppc.h>
+#include <trigf.h>
 #include <baselib/gobj.h>
 #include <baselib/jobj.h>
-#include <MSL/math_ppc.h>
-#include <MSL/trigf.h>
 
 /* 08998C */ static bool fn_8008998C(Fighter* fp, IKState* ik, Vec3* normal);
 

--- a/src/melee/ft/ft_08A1.c
+++ b/src/melee/ft/ft_08A1.c
@@ -15,10 +15,10 @@
 #include "it/it_26B1.h"
 #include "it/items/itpeachparasol.h"
 
+#include <math_ppc.h>
+#include <trigf.h>
 #include <baselib/gobj.h>
 #include <baselib/jobj.h>
-#include <MSL/math_ppc.h>
-#include <MSL/trigf.h>
 
 bool ft_8008A1FC(Fighter_GObj* gobj)
 {

--- a/src/melee/ft/ftafterimage.c
+++ b/src/melee/ft/ftafterimage.c
@@ -7,7 +7,7 @@
 
 #include "baselib/debug.h"
 
-#include <math_ppc.h> // IWYU pragma: keep
+#include <math_ppc.h>
 #include <dolphin/gx.h>
 #include <dolphin/mtx.h>
 #include <baselib/cobj.h>

--- a/src/melee/ft/ftcoll.c
+++ b/src/melee/ft/ftcoll.c
@@ -44,11 +44,11 @@
 
 #include <common_structs.h>
 #include <math.h>
+#include <trigf.h>
 #include <dolphin/mtx.h>
 #include <baselib/debug.h>
 #include <baselib/gobj.h>
 #include <baselib/random.h>
-#include <MSL/trigf.h>
 #include <Runtime/runtime.h>
 
 /// @todo .sdata2 order hack

--- a/src/melee/ft/ftcpuattack.c
+++ b/src/melee/ft/ftcpuattack.c
@@ -13,7 +13,7 @@
 #include <melee/ft/chara/ftZelda/forward.h>
 
 #include <math.h>
-#include <math_ppc.h> // IWYU pragma: keep
+#include <math_ppc.h>
 #include <sysdolphin/baselib/gobj.h>
 #include <melee/ft/chara/ftCommon/ftCo_09F7.h>
 #include <melee/ft/chara/ftCommon/ftCo_0A01.h>

--- a/src/melee/gm/gmstaffroll.c
+++ b/src/melee/gm/gmstaffroll.c
@@ -19,7 +19,7 @@
 #include "sc/types.h"
 #include "ty/toy.h"
 
-#include <math_ppc.h> // IWYU pragma: keep
+#include <math_ppc.h>
 #include <baselib/particle.h>
 #include <sysdolphin/baselib/cobj.h>
 #include <sysdolphin/baselib/controller.h>

--- a/src/melee/gr/grbigblue.c
+++ b/src/melee/gr/grbigblue.c
@@ -27,8 +27,8 @@
 #include "mp/mplib.h"
 
 #include <math.h>
-#include <math_ppc.h> // IWYU pragma: keep
-#include <trigf.h>    // IWYU pragma: keep
+#include <math_ppc.h>
+#include <trigf.h>
 #include <baselib/gobjgxlink.h>
 #include <baselib/gobjproc.h>
 #include <baselib/jobj.h>

--- a/src/melee/gr/grbigblueroute.c
+++ b/src/melee/gr/grbigblueroute.c
@@ -21,7 +21,7 @@
 #include "lb/lbspdisplay.h"
 #include "lb/lbvector.h"
 
-#include <trigf.h> // IWYU pragma: keep
+#include <trigf.h>
 #include <dolphin/os.h>
 #include <baselib/gobj.h>
 #include <baselib/gobjgxlink.h>

--- a/src/melee/gr/grcastle.c
+++ b/src/melee/gr/grcastle.c
@@ -24,7 +24,7 @@
 #include "lb/types.h"
 #include "mp/mplib.h"
 
-#include <trigf.h> // IWYU pragma: keep
+#include <trigf.h>
 #include <dolphin/mtx.h>
 #include <baselib/archive.h>
 #include <baselib/gobj.h>

--- a/src/melee/gr/grfourside.c
+++ b/src/melee/gr/grfourside.c
@@ -21,6 +21,7 @@
 #include "lb/lbspdisplay.h"
 #include "mp/mplib.h"
 
+#include <trigf.h>
 #include <dolphin/mtx.h>
 #include <baselib/gobj.h>
 #include <baselib/gobjgxlink.h>
@@ -29,7 +30,6 @@
 #include <baselib/gobjuserdata.h>
 #include <baselib/jobj.h>
 #include <baselib/random.h>
-#include <MSL/trigf.h>
 
 static struct {
     /* 00 */ int heli_wait;

--- a/src/melee/gr/grkinokoroute.c
+++ b/src/melee/gr/grkinokoroute.c
@@ -20,9 +20,9 @@
 #include "lb/lbspdisplay.h"
 #include "lb/lbvector.h"
 #include "mp/mplib.h"
-#include "MSL/math_ppc.h"
 
 #include <math.h>
+#include <math_ppc.h>
 #include <baselib/debug.h>
 #include <baselib/gobj.h>
 #include <baselib/gobjgxlink.h>

--- a/src/melee/gr/grkongo.c
+++ b/src/melee/gr/grkongo.c
@@ -27,8 +27,8 @@
 
 #include "mp/mplib.h"
 #include "MSL/math.h"
-#include "MSL/math_ppc.h" // IWYU pragma: keep
 
+#include <math_ppc.h>
 #include <baselib/gobj.h>
 #include <baselib/gobjgxlink.h>
 #include <baselib/gobjproc.h>

--- a/src/melee/gr/grmutecity.c
+++ b/src/melee/gr/grmutecity.c
@@ -25,9 +25,10 @@
 #include "lb/lbvector.h"
 #include "mp/mplib.h"
 #include "MSL/math.h"
-#include "MSL/trigf.h"
 #include "sysdolphin/baselib/spline.h"
 
+#include <math_ppc.h>
+#include <trigf.h>
 #include <baselib/debug.h>
 #include <baselib/gobj.h>
 #include <baselib/gobjgxlink.h>
@@ -35,7 +36,6 @@
 #include <baselib/lobj.h>
 #include <baselib/psappsrt.h>
 #include <baselib/psstructs.h>
-#include <MSL/math_ppc.h>
 
 const Vec3 grMc_803B81B8 = { 0.0f, 0.0f, 0.0f };
 

--- a/src/melee/gr/grrcruise.c
+++ b/src/melee/gr/grrcruise.c
@@ -29,6 +29,8 @@
 #include "sysdolphin/baselib/memory.h"
 
 #include <math.h>
+#include <math_ppc.h>
+#include <trigf.h>
 #include <baselib/archive.h>
 #include <baselib/dobj.h>
 #include <baselib/gobj.h>
@@ -36,8 +38,6 @@
 #include <baselib/gobjproc.h>
 #include <baselib/jobj.h>
 #include <baselib/random.h>
-#include <MSL/math_ppc.h>
-#include <MSL/trigf.h>
 
 static void sdata2_order(void)
 {

--- a/src/melee/gr/grshrineroute.c
+++ b/src/melee/gr/grshrineroute.c
@@ -26,14 +26,14 @@
 #include "mp/mplib.h"
 #include "pl/player.h"
 
+#include <math_ppc.h>
+#include <trigf.h>
 #include <baselib/debug.h>
 #include <baselib/gobj.h>
 #include <baselib/gobjgxlink.h>
 #include <baselib/gobjproc.h>
 #include <baselib/lobj.h>
 #include <baselib/random.h>
-#include <MSL/math_ppc.h>
-#include <MSL/trigf.h>
 
 s16 grSh_Route_803E58E0[8] = {
     0x33, 0x4F, 0x65, 0x66, 0x73, 0x74, 0x83, 0x00

--- a/src/melee/gr/grzebes.c
+++ b/src/melee/gr/grzebes.c
@@ -19,7 +19,7 @@
 #include "lb/lbspdisplay.h"
 #include "mp/mplib.h"
 
-#include <math_ppc.h> // IWYU pragma: keep
+#include <math_ppc.h>
 #include <dolphin/os.h>
 #include <baselib/gobjgxlink.h>
 #include <baselib/gobjproc.h>

--- a/src/melee/it/items/itdrmariopill.c
+++ b/src/melee/it/items/itdrmariopill.c
@@ -1,6 +1,5 @@
 #include "itdrmariopill.h"
 
-#include "math_ppc.h"
 #include "placeholder.h"
 #include "platform.h"
 
@@ -32,6 +31,7 @@
 #include "it/itmaplib.h"
 
 #include <math.h>
+#include <math_ppc.h>
 
 #define GET_ATTRS(ip)                                                         \
     ((itDrMarioPillAttributes*) ip->xC4_article_data->x4_specialAttributes)

--- a/src/melee/it/items/ithassam.c
+++ b/src/melee/it/items/ithassam.c
@@ -21,9 +21,9 @@
 #include "it/types.h"
 #include "lb/lbvector.h"
 
+#include <trigf.h>
 #include <baselib/gobj.h>
 #include <baselib/jobj.h>
-#include <MSL/trigf.h>
 
 /* 2CDC5C */ static void itHassam_802CDC5C(Item_GObj* gobj);
 /* 2CDC80 */ static void itHassam_802CDC80(Item_GObj* gobj);

--- a/src/melee/it/items/ithinoarashi.c
+++ b/src/melee/it/items/ithinoarashi.c
@@ -18,7 +18,7 @@
 #include "lb/lbvector.h"
 
 #include <math.h>
-#include <MSL/trigf.h>
+#include <trigf.h>
 
 /* 2D60C8 */ static bool itHinoarashi_UnkMotion2_Anim(Item_GObj* gobj);
 

--- a/src/melee/it/items/itkirbycutterbeam.c
+++ b/src/melee/it/items/itkirbycutterbeam.c
@@ -11,7 +11,7 @@
 #include "lb/lbvector.h"
 
 #include <math.h>
-#include <MSL/trigf.h>
+#include <trigf.h>
 
 ItemStateTable it_803F6798[] = {
     NULL,

--- a/src/melee/it/items/itkoopaflame.c
+++ b/src/melee/it/items/itkoopaflame.c
@@ -10,6 +10,7 @@
 #include <melee/it/forward.h>
 #include <melee/lb/forward.h>
 
+#include <trigf.h>
 #include <sysdolphin/baselib/random.h>
 #include <melee/db/db.h>
 #include <melee/ef/eflib.h>
@@ -23,7 +24,6 @@
 #include <melee/it/item.h>
 #include <melee/lb/lbvector.h>
 #include <MSL/math.h>
-#include <MSL/trigf.h>
 
 #define itkpf_Floor 1
 #define itkpf_Ceiling 2

--- a/src/melee/it/items/itleadead.c
+++ b/src/melee/it/items/itleadead.c
@@ -21,9 +21,9 @@
 #include "mp/mplib.h"
 #include "sysdolphin/baselib/random.h"
 
+#include <trigf.h>
 #include <baselib/jobj.h>
 #include <MSL/math.h>
-#include <MSL/trigf.h>
 
 ItemStateTable it_803F8EB0[] = {
     {

--- a/src/melee/it/items/itlinkboomerang.c
+++ b/src/melee/it/items/itlinkboomerang.c
@@ -18,7 +18,7 @@
 #include "lb/lbvector.h"
 
 #include <math_ppc.h>
-#include <MSL/trigf.h>
+#include <trigf.h>
 
 #define HYPOT(x, y) sqrtf((x) * (x) + (y) * (y))
 #define VEC_XY_LENGTH(v) HYPOT((v)->x, (v)->y)

--- a/src/melee/it/items/itlinkhookshot.c
+++ b/src/melee/it/items/itlinkhookshot.c
@@ -29,7 +29,7 @@
 #include "sysdolphin/baselib/gobjplink.h"
 #include "sysdolphin/baselib/jobj.h"
 
-#include <MSL/math_ppc.h>
+#include <math_ppc.h>
 
 /* 2A5770 */ static void it_802A5770_inline(ItemLink* link_1,
                                             itLinkHookshotAttributes* arg2,

--- a/src/melee/it/items/itmasterhandlaser.c
+++ b/src/melee/it/items/itmasterhandlaser.c
@@ -1,7 +1,5 @@
 #include "itmasterhandlaser.h"
 
-#include "math_ppc.h"
-
 #include <placeholder.h>
 #include <platform.h>
 
@@ -27,6 +25,7 @@
 #include "mp/mplib.h"
 
 #include <math.h>
+#include <math_ppc.h>
 #include <baselib/gobj.h>
 
 ItemStateTable it_803F9378[] = {

--- a/src/melee/it/items/itmewtwoshadowball.c
+++ b/src/melee/it/items/itmewtwoshadowball.c
@@ -14,9 +14,9 @@
 #include "lb/lb_00B0.h"
 #include "lb/lbvector.h"
 
+#include <trigf.h>
 #include <baselib/mtx.h>
 #include <baselib/random.h>
-#include <MSL/trigf.h>
 
 /* 2C5B18 */ static void it_802C5B18(Item_GObj*, Item_GObj*);
 

--- a/src/melee/it/items/itnesspkflash.c
+++ b/src/melee/it/items/itnesspkflash.c
@@ -16,9 +16,9 @@
 #include "it/it_2725.h"
 #include "it/item.h"
 #include "it/items/itnesspkflashexplode.h"
-#include "MSL/trigf.h"
 
 #include <math.h>
+#include <trigf.h>
 #include <baselib/jobj.h>
 
 /* 2AB29C */ static bool itNesspkflash_UnkMotion1_Coll(Item_GObj* gobj);

--- a/src/melee/it/items/itnesspkthundertrail.c
+++ b/src/melee/it/items/itnesspkthundertrail.c
@@ -12,9 +12,9 @@
 #include "it/it_2725.h"
 #include "it/item.h"
 #include "it/items/itnesspkthunderball.h"
-#include "MSL/trigf.h"
 
 #include <math.h>
+#include <trigf.h>
 #include <baselib/jobj.h>
 
 ItemStateTable it_803F6C08[] = {

--- a/src/melee/it/items/itpikachutjoltair.c
+++ b/src/melee/it/items/itpikachutjoltair.c
@@ -17,9 +17,9 @@
 #include "it/items/itpikachutjoltground.h"
 #include "lb/lb_00B0.h"
 
+#include <trigf.h>
 #include <baselib/jobj.h>
 #include <MSL/math.h>
-#include <MSL/trigf.h>
 
 /* 2B45E8 */ static bool itPikachutjoltair_UnkMotion0_Coll(Item_GObj* gobj);
 

--- a/src/melee/it/items/itsamusbomb.c
+++ b/src/melee/it/items/itsamusbomb.c
@@ -1,7 +1,6 @@
 #include "itsamusbomb.h"
 
 #include "math.h"
-#include "math_ppc.h"
 
 #include <placeholder.h>
 #include <platform.h>
@@ -19,6 +18,7 @@
 #include "lb/lb_00B0.h"
 #include "lb/lbvector.h"
 
+#include <math_ppc.h>
 #include <baselib/mtx.h>
 
 ItemStateTable it_803F7220[] = {

--- a/src/melee/it/items/itseakneedlethrown.c
+++ b/src/melee/it/items/itseakneedlethrown.c
@@ -17,10 +17,10 @@
 #include "mp/mpcoll.h"
 #include "mp/mplib.h"
 
+#include <trigf.h>
 #include <baselib/jobj.h>
 #include <baselib/random.h>
 #include <MSL/math.h>
-#include <MSL/trigf.h>
 
 ItemStateTable it_803F6F50[] = {
     { 0, itSeakneedlethrown_UnkMotion0_Anim,

--- a/src/melee/it/items/itsscopebeam.c
+++ b/src/melee/it/items/itsscopebeam.c
@@ -9,8 +9,8 @@
 #include "lb/lbvector.h"
 #include "MSL/math.h"
 
+#include <trigf.h>
 #include <baselib/random.h>
-#include <MSL/trigf.h>
 
 ItemStateTable it_803F6568[] = {
     { 0, itSscopebeam_UnkMotion9_Anim, itSscopebeam_UnkMotion9_Phys,

--- a/src/melee/it/items/itstarrodstar.c
+++ b/src/melee/it/items/itstarrodstar.c
@@ -18,7 +18,7 @@
 
 #include "lb/forward.h"
 
-#include <MSL/trigf.h>
+#include <trigf.h>
 
 ItemStateTable it_803F6530[] = { { 0, itStarrodstar_UnkMotion0_Anim,
                                    itStarrodstar_UnkMotion0_Phys,

--- a/src/melee/it/items/itunknown.c
+++ b/src/melee/it/items/itunknown.c
@@ -13,9 +13,9 @@
 #include "it/itmaplib.h"
 #include "lb/lbvector.h"
 
+#include <trigf.h>
 #include <baselib/random.h>
 #include <MSL/math.h>
-#include <MSL/trigf.h>
 
 ItemStateTable it_803F7D60[] = {
     { 0, itUnknown_UnkMotion0_Anim, itUnknown_UnkMotion0_Phys,

--- a/src/melee/lb/lbbgflash.c
+++ b/src/melee/lb/lbbgflash.c
@@ -42,6 +42,7 @@ typedef struct BgFlashData {
 
 extern BgFlashData lbl_80433658;
 
+#include <trigf.h>
 #include <dolphin/gx.h>
 #include <baselib/cobj.h>
 #include <baselib/gobj.h>
@@ -59,7 +60,6 @@ extern BgFlashData lbl_80433658;
 #include <melee/lb/lbspdisplay.h>
 #include <melee/lb/lbvector.h>
 #include <MSL/math.h>
-#include <MSL/trigf.h>
 
 /* 021C18 */ static void fn_80021C18(HSD_GObj* gobj, CommandInfo* cmd,
                                      int arg2);

--- a/src/melee/lb/lbcollision.c
+++ b/src/melee/lb/lbcollision.c
@@ -14,6 +14,7 @@
 #include "lb/types.h"
 
 #include <math.h>
+#include <math_ppc.h>
 #include <dolphin/gx.h>
 #include <dolphin/mtx.h>
 #include <baselib/cobj.h>
@@ -22,7 +23,6 @@
 #include <baselib/state.h>
 #include <baselib/tev.h>
 #include <MetroTRK/intrinsics.h>
-#include <MSL/math_ppc.h>
 
 /* 006E58 */ static bool
 lbColl_80006E58(Vec3* hit_start, Vec3* hit_end, Vec3* hurt_start,

--- a/src/melee/lb/lbshadow.c
+++ b/src/melee/lb/lbshadow.c
@@ -1,5 +1,6 @@
 #include "lbshadow.h"
 
+#include <math_ppc.h>
 #include <dolphin/gx/GXVert.h>
 #include <sysdolphin/baselib/debug.h>
 #include <sysdolphin/baselib/gobj.h>
@@ -20,7 +21,6 @@
 #include <melee/gr/ground.h>
 #include <melee/lb/lbvector.h>
 #include <melee/lb/types.h>
-#include <MSL/math_ppc.h>
 
 void lbShadow_8000E9F0(Vec3* p, HSD_Spline* spline, f32 u)
 {

--- a/src/melee/lb/lbspdisplay.c
+++ b/src/melee/lb/lbspdisplay.c
@@ -1,7 +1,6 @@
 #include "lbspdisplay.static.h"
 
 #include "math.h"
-#include "math_ppc.h"
 #include "stdarg.h"
 #include "stddef.h"
 
@@ -29,6 +28,8 @@
 #include "lb/lbvector.h"
 #include "lb/types.h"
 
+#include <math_ppc.h>
+#include <trigf.h>
 #include <baselib/cobj.h>
 #include <baselib/dobj.h>
 #include <baselib/gobj.h>
@@ -43,8 +44,6 @@
 #include <baselib/tev.h>
 #include <melee/mp/mplib.h>
 #include <melee/sc/types.h>
-#include <MSL/trigf.h> // IWYU pragma: keep
-
 typedef bool (*lb_803BA248_fn)(ColorOverlay*);
 
 struct lb_Collider {

--- a/src/melee/lb/lbtrigf.c
+++ b/src/melee/lb/lbtrigf.c
@@ -1,5 +1,5 @@
 #include <math.h>
-#include <trigf.h> // IWYU pragma: keep
+#include <trigf.h>
 #include <MetroTRK/intrinsics.h>
 
 /* 022DF8 */ static float lb_sqrtf(float x);

--- a/src/melee/mn/mncharsel.c
+++ b/src/melee/mn/mncharsel.c
@@ -7,6 +7,7 @@
 #include "baselib/forward.h"
 #include "ft/forward.h"
 
+#include <trigf.h>
 #include <sysdolphin/baselib/aobj.h>
 #include <sysdolphin/baselib/cobj.h>
 #include <sysdolphin/baselib/controller.h>
@@ -41,7 +42,6 @@
 #include <melee/mn/mnmainrule.h>
 #include <melee/mn/mnname.h>
 #include <melee/mn/mnnamenew.h>
-#include <MSL/trigf.h>
 
 typedef struct CSSAllData {
     u8 gnw_name[0x1C];

--- a/src/melee/mp/mpcoll.c
+++ b/src/melee/mp/mpcoll.c
@@ -22,10 +22,10 @@
 #include "mp/mplib.h"
 
 #include <string.h>
+#include <trigf.h>
 #include <dolphin/os/OSError.h>
 #include <baselib/debug.h>
 #include <baselib/gobj.h>
-#include <MSL/trigf.h>
 
 struct mpColl_80458810_t {
     /*  +0 */ int right[9];

--- a/src/melee/ty/toy.c
+++ b/src/melee/ty/toy.c
@@ -2,7 +2,6 @@
 
 #include "m2c_macros.h"
 #include "math.h"
-#include "math_ppc.h" // IWYU pragma: keep
 #include "placeholder.h"
 #include "platform.h"
 #include "stddef.h"
@@ -10,7 +9,6 @@
 
 #include "toy.static.h"
 
-#include "trigf.h" // IWYU pragma: keep
 #include "tylist.h"
 #include "types.h"
 
@@ -36,11 +34,12 @@
 #include "mn/mnmain.h"
 #include "mn/mnsoundtest.h"
 #include "MSL/math.h"
-#include "MSL/math_ppc.h"
 #include "sc/types.h"
 #include "ty/toy.h"
 #include "ty/types.h"
 
+#include <math_ppc.h>
+#include <trigf.h>
 #include <dolphin/gx.h>
 #include <dolphin/mtx.h>
 #include <dolphin/os.h>

--- a/src/melee/ty/tydisplay.c
+++ b/src/melee/ty/tydisplay.c
@@ -1,12 +1,10 @@
 #include "tydisplay.h"
 
 #include "math.h"
-#include "math_ppc.h" // IWYU pragma: keep
 #include "placeholder.h"
 #include "platform.h"
 #include "stddef.h"
 #include "toy.h"
-#include "trigf.h" // IWYU pragma: keep
 
 #include <placeholder.h>
 #include <platform.h>
@@ -46,10 +44,12 @@
 #include "melee/if/textlib.h"
 #include "mn/mnmain.h"
 #include "MSL/math.h"
-#include "MSL/math_ppc.h"
 #include "sc/types.h"
 #include "ty/toy.h"
 #include "ty/types.h"
+
+#include <math_ppc.h>
+#include <trigf.h>
 
 /* 31830C */ static void _tyDisplay_8031830C(TySortElem*, s32, s32);
 /* 318714 */ static void _tyDisplay_80318714(TySortElem*, s32, s32);

--- a/src/melee/ty/tyfigupon.c
+++ b/src/melee/ty/tyfigupon.c
@@ -1,12 +1,10 @@
 #include "tyfigupon.h"
 
 #include "math.h"
-#include "math_ppc.h" // IWYU pragma: keep
 #include "placeholder.h"
 #include "platform.h"
 #include "stddef.h"
 #include "toy.h"
-#include "trigf.h" // IWYU pragma: keep
 
 #include <placeholder.h>
 #include <platform.h>
@@ -45,11 +43,13 @@
 #include "lb/lbvector.h"
 #include "mn/mnmain.h"
 #include "MSL/math.h"
-#include "MSL/math_ppc.h"
 #include "sc/types.h"
 #include "ty/inlines.h"
 #include "ty/toy.h"
 #include "ty/types.h"
+
+#include <math_ppc.h>
+#include <trigf.h>
 
 /* 314AA8 */ static void _tyFigupon_80314AA8(HSD_JObj*, char*, char*, char*);
 /* 314B54 */ static s32 _tyFigupon_80314B54(void);

--- a/src/melee/ty/tylist.c
+++ b/src/melee/ty/tylist.c
@@ -14,8 +14,8 @@
 #include "ty/toy.h"
 #include "ty/types.h"
 
-#include <math_ppc.h> // IWYU pragma: keep
-#include <trigf.h>    // IWYU pragma: keep
+#include <math_ppc.h>
+#include <trigf.h>
 #include <dolphin/mtx.h>
 #include <dolphin/os.h>
 #include <baselib/archive.h>

--- a/src/sysdolphin/baselib/bytecode.c
+++ b/src/sysdolphin/baselib/bytecode.c
@@ -8,11 +8,11 @@
 #include "baselib/random.h"
 #include "baselib/util.h"
 
+#include <math_ppc.h>
+#include <trigf.h>
 #include <dolphin/os.h>
 #include <melee/lb/lb_00CE.h>
 #include <MSL/math.h>
-#include <MSL/math_ppc.h>
-#include <MSL/trigf.h>
 
 typedef union {
     void* p;

--- a/src/sysdolphin/baselib/cobj.c
+++ b/src/sysdolphin/baselib/cobj.c
@@ -13,13 +13,13 @@
 #include <placeholder.h>
 
 #include <math.h>
+#include <math_ppc.h>
+#include <trigf.h>
 #include <dolphin/gx.h>
 #include <dolphin/gx/GXTransform.h>
 #include <dolphin/mtx.h>
 #include <dolphin/vi.h>
 #include <MetroTRK/intrinsics.h>
-#include <MSL/math_ppc.h>
-#include <MSL/trigf.h>
 
 static HSD_ClassInfo* default_class;
 static HSD_CObj* current;

--- a/src/sysdolphin/baselib/controller.c
+++ b/src/sysdolphin/baselib/controller.c
@@ -5,10 +5,10 @@
 #include "baselib/rumble.h"
 #include "baselib/util.h"
 
+#include <math_ppc.h>
+#include <trigf.h>
 #include <dolphin/os/OSInterrupt.h>
 #include <dolphin/pad.h>
-#include <MSL/math_ppc.h>
-#include <MSL/trigf.h>
 
 HSD_PadStatus default_status_data = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 };

--- a/src/sysdolphin/baselib/displayfunc.c
+++ b/src/sysdolphin/baselib/displayfunc.c
@@ -11,9 +11,9 @@
 #include "baselib/tev.h"
 #include "baselib/util.h"
 
+#include <math_ppc.h>
 #include <dolphin/gx.h>
 #include <dolphin/mtx.h>
-#include <MSL/math_ppc.h>
 #include <Runtime/__mem.h>
 
 #define FLT_EPSILON 1.00000001335e-10F

--- a/src/sysdolphin/baselib/hsd_3915.c
+++ b/src/sysdolphin/baselib/hsd_3915.c
@@ -3,6 +3,8 @@
 #include "hsd_3915.static.h"
 
 #include <math.h>
+#include <math_ppc.h>
+#include <trigf.h>
 #include <dolphin/gx.h>
 #include <dolphin/gx/GXGeometry.h>
 #include <dolphin/mcc.h>
@@ -23,8 +25,6 @@
 #include <baselib/state.h>
 #include <baselib/video.h>
 #include <MetroTRK/ppc_reg.h>
-#include <MSL/math_ppc.h>
-#include <MSL/trigf.h>
 
 /* 4CF810 */ extern struct ParticleScreenState hsd_804CF810;
 

--- a/src/sysdolphin/baselib/jobj.c
+++ b/src/sysdolphin/baselib/jobj.c
@@ -16,10 +16,10 @@
 
 #include <__mem.h>
 #include <math.h>
+#include <math_ppc.h>
 #include <trigf.h>
 #include <dolphin/mtx.h>
 #include <dolphin/os.h>
-#include <MSL/math_ppc.h>
 
 void JObjInfoInit(void);
 HSD_JObjInfo hsdJObj = { JObjInfoInit };

--- a/src/sysdolphin/baselib/mtx.c
+++ b/src/sysdolphin/baselib/mtx.c
@@ -3,8 +3,8 @@
 #include "debug.h"
 #include "math.h"
 
-#include <MSL/math_ppc.h>
-#include <MSL/trigf.h>
+#include <math_ppc.h>
+#include <trigf.h>
 
 #define EPSILON 0.0000000001f
 #define FLOAT_MIN 1.1754943E-38f

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -22,6 +22,8 @@ typedef struct {
 #include "particle.static.h"
 
 #include <math.h>
+#include <math_ppc.h>
+#include <trigf.h>
 #include <dolphin/gx.h>
 #include <dolphin/gx/GXGeometry.h>
 #include <dolphin/mcc.h>
@@ -42,8 +44,6 @@ typedef struct {
 #include <baselib/state.h>
 #include <baselib/video.h>
 #include <MetroTRK/ppc_reg.h>
-#include <MSL/math_ppc.h>
-#include <MSL/trigf.h>
 
 static HSD_JObj* hsd_804D08E8[8];
 static void* hsd_804D0908[0x144 / 4];

--- a/src/sysdolphin/baselib/quatlib.c
+++ b/src/sysdolphin/baselib/quatlib.c
@@ -2,8 +2,8 @@
 
 #include <placeholder.h>
 
+#include <trigf.h>
 #include <MSL/math.h>
-#include <MSL/trigf.h>
 
 inline float sqrtf(float x)
 {

--- a/src/sysdolphin/baselib/robj.c
+++ b/src/sysdolphin/baselib/robj.c
@@ -19,7 +19,6 @@
 #include <math_ppc.h>
 #include <dolphin/mtx.h>
 #include <dolphin/os.h>
-#include <MSL/math_ppc.h>
 
 HSD_ObjAllocData robj_alloc_data;   // robj_alloc_data
 HSD_ObjAllocData rvalue_alloc_data; // rvalue_alloc_data

--- a/src/sysdolphin/baselib/shadow.c
+++ b/src/sysdolphin/baselib/shadow.c
@@ -18,9 +18,9 @@
 
 #include <__mem.h>
 #include <math.h>
+#include <trigf.h>
 #include <dolphin/gx.h>
 #include <dolphin/mtx.h>
-#include <MSL/trigf.h>
 
 HSD_ObjAllocData shadow_alloc_data;
 

--- a/src/sysdolphin/baselib/util.h
+++ b/src/sysdolphin/baselib/util.h
@@ -3,10 +3,10 @@
 
 #include <platform.h>
 
+#include <trigf.h>
 #include <dolphin/gx.h>
 #include <dolphin/mtx.h>
 #include <sysdolphin/baselib/mtx.h>
-#include <MSL/trigf.h>
 
 /// functions
 void HSD_MulColor(GXColor* arg0, GXColor* arg1, GXColor* dest);


### PR DESCRIPTION
* Ignore IWYU warnings caused by hardcoded stdlib paths
* Use angle brackets everywhere
* Eschew `MSL/` prefix
* Delete nonexistent `math_ppc.c`