### PR TITLE
Match ftCo_CaptureWaitHi_Coll and ftCo_CaptureWaitLw_Coll

### DIFF
--- a/src/melee/ft/chara/ftCommon/ftCo_Attack100.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Attack100.c
@@ -2773,7 +2773,10 @@ void ftCo_CaptureWaitHi_Phys(Fighter_GObj* gobj)
 
 void ftCo_CaptureWaitHi_Coll(Fighter_GObj* gobj)
 {
-    ftCo_CapturePulledHi_Coll(gobj);
+    Fighter* fp = GET_FIGHTER(gobj);
+    if (!fp->x2226_b2) {
+        ft_80083C00(gobj, fn_800DBAC4);
+    }
 }
 
 void fn_800DBAC4(Fighter_GObj* gobj)
@@ -2890,7 +2893,10 @@ void ftCo_CaptureWaitLw_Phys(Fighter_GObj* gobj)
 
 void ftCo_CaptureWaitLw_Coll(Fighter_GObj* gobj)
 {
-    ftCo_CapturePulledLw_Coll(gobj);
+    Fighter* fp = GET_FIGHTER(gobj);
+    if (!fp->x2226_b2) {
+        ft_8008403C(gobj, fn_800DBED4);
+    }
 }
 
 static inline void fn_800DBED4_inline(Fighter_GObj* gobj)

--- a/src/melee/ft/chara/ftCommon/ftCo_Attack100.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Attack100.c
@@ -3029,6 +3029,7 @@ void ftCo_CaptureDamageHi_Phys(Fighter_GObj* gobj)
 }
 #pragma pop
 
+/// @todo Fix duplicate ::ft_80083C00 usages
 void ftCo_CaptureDamageHi_Coll(Fighter_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);


### PR DESCRIPTION
## Summary

Replaces incorrect `ftCo_CapturePulledHi/Lw_Coll` stubs in the CaptureWait coll handlers with the real collision bodies used by sibling capture states in the same TU.

### What matched

- `ftCo_CaptureWaitHi_Coll` (0x800DBA8C)
- `ftCo_CaptureWaitLw_Coll` (0x800DBE9C)

### Why this is correct

Both wait colls follow the established capture-coll pattern elsewhere in `ftCo_Attack100.c`:

1. Load the fighter.
2. Skip if `x2226_b2` is set.
3. Call `ft_80083C00` (hi) / `ft_8008403C` (lw) with the wait-specific landing callbacks (`fn_800DBAC4` / `fn_800DBED4`).

The previous implementations simply called the CapturePulled colls, which do not match the target code.

### How verified

```text
export WINEPREFIX="$HOME/.wine-melee-pr" WINEDEBUG=-all
ninja build/GALE01/src/melee/ft/chara/ftCommon/ftCo_Attack100.o
build/tools/objdiff-cli diff \
  -1 build/GALE01/obj/melee/ft/chara/ftCommon/ftCo_Attack100.o \
  -2 build/GALE01/src/melee/ft/chara/ftCommon/ftCo_Attack100.o \
  -o - --format json
```

Result: both functions report `match_percent` 100.0 (size 0x38 each).

TU remains NonMatching (not flipped).

### Notes

- Legal US 1.02 `main.dol` is not included in this PR.
- No global field renames, no data-section matching, no Matching flag changes.

> AI assistance was used for review, patch extraction, and objdiff verification. The coll bodies match the existing human-written sibling pattern in this file.