### PR TITLE
Match fn_802B805C (itsamusgrapple)

### DIFF
--- a/src/melee/it/items/itsamusgrapple.c
+++ b/src/melee/it/items/itsamusgrapple.c
@@ -588,7 +588,6 @@ void itSamusgrapple_UnkMotion0_Phys(Item_GObj* gobj)
 void fn_802B805C(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
-    Fighter_GObj* owner;
     itSamusGrappleAttributes* attrs;
     ItemLink* link;
     Fighter* fp;
@@ -599,9 +598,8 @@ void fn_802B805C(Item_GObj* gobj)
     Mtx m;
     PAD_STACK(28);
 
-    owner = ip->owner;
     attrs = ip->xC4_article_data->x4_specialAttributes;
-    fp = owner->user_data;
+    fp = ip->owner->user_data;
     samus_grapple_state_sync(fp);
 
     link = ip->xDD4_itemVar.samusgrapple.x0;


### PR DESCRIPTION
## Summary

Matches `fn_802B805C` in `src/melee/it/items/itsamusgrapple.c` by shrinking the stack frame to the target size.

### What matched

- `fn_802B805C` (0x802B805C)

### Why this is correct

An extra live `Fighter_GObj* owner` local forced a larger frame (0xa8 vs target 0xa0). Dropping that local and reading through `ip->owner` / `ip->owner->user_data` matches sibling style in this file and restores the expected frame. `PAD_STACK(28)` and `u8 _padA[4]` are unchanged.

### How verified

```text
export WINEPREFIX="$HOME/.wine-melee-pr2" WINEDEBUG=-all
ninja build/GALE01/src/melee/it/items/itsamusgrapple.o
build/tools/objdiff-cli diff \
  -1 build/GALE01/obj/melee/it/items/itsamusgrapple.o \
  -2 build/GALE01/src/melee/it/items/itsamusgrapple.o \
  -o - --format json
```

Result: `fn_802B805C` reports `match_percent` 100.0 (size 788).

TU remains NonMatching (not flipped).

### Notes

- Independent of #2956 (CaptureWait). Branched from latest `master` only.
- Legal US 1.02 `main.dol` is not included in this PR.
- No global field renames, no data-section matching, no Matching flag changes.
- Only `src/melee/it/items/itsamusgrapple.c` is touched.

> AI assistance was used for the stack-frame diagnosis, the owner-local removal, and objdiff verification. No new global names were introduced.