### PR TITLE
Match ftCo_800A2C80

### DIFF
--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -1304,6 +1304,17 @@ bool ftCo_800A2C08(Fighter* fp)
     }
 }
 
+static inline s32 ftCo_800A2C80_inline0(Fighter* fp)
+{
+    int floor_id = fp->coll_data.floor.index;
+    if (grBigBlue_801EF844(floor_id) || grInishie1_801FCAAC(floor_id) ||
+        grCorneria_801E2D90(floor_id) || grVenom_80206D10(floor_id))
+    {
+        return 1;
+    }
+    return 0;
+}
+
 s32 ftCo_800A2C80(Fighter* fp)
 {
     s32 result;
@@ -1333,13 +1344,7 @@ s32 ftCo_800A2C80(Fighter* fp)
         return 0;
     }
     if (fp->ground_or_air == GA_Ground) {
-        int floor_id = fp->coll_data.floor.index;
-        if (grBigBlue_801EF844(floor_id) || grInishie1_801FCAAC(floor_id) ||
-            grCorneria_801E2D90(floor_id) || grVenom_80206D10(floor_id))
-        {
-            return 1;
-        }
-        return 0;
+        return ftCo_800A2C80_inline0(fp);
     }
     if (fp->motion_id == 0xF4) {
         return 0;


### PR DESCRIPTION
## Summary

Matches `ftCo_800A2C80` in `src/melee/ft/chara/ftCommon/ftCo_0A01.c` by moving the GA_Ground floor-id checks into a static inline that takes `Fighter* fp` and loads `floor.index` inside the inline.

### What matched

- `ftCo_800A2C80` (0x800A2C80)

### Why this is correct

With the checks inlined in the outer function, MWCC kept `floor_id` in r31 (reused with `fp`). Target keeps `floor_id` in r28. Taking `Fighter* fp` and loading `fp->coll_data.floor.index` inside a static inline restores that allocation for the GA_Ground early-out path:

```c
static inline s32 ftCo_800A2C80_inline0(Fighter* fp)
{
    int floor_id = fp->coll_data.floor.index;
    if (grBigBlue_801EF844(floor_id) || grInishie1_801FCAAC(floor_id) ||
        grCorneria_801E2D90(floor_id) || grVenom_80206D10(floor_id))
    {
        return 1;
    }
    return 0;
}
// call: if (fp->ground_or_air == GA_Ground) return ftCo_800A2C80_inline0(fp);
```

### How verified

```text
export WINEPREFIX="/tmp/melee-wine-800A2C80" WINEDEBUG=-all
ninja build/GALE01/src/melee/ft/chara/ftCommon/ftCo_0A01.o
build/tools/objdiff-cli diff \
  -u main/melee/ft/chara/ftCommon/ftCo_0A01 \
  -p . -o /tmp/objdiff_ftCo_800A2C80.json --format json \
  ftCo_800A2C80
# plus raw .text byte compare of the symbol
```

Result: function size 0x4B4 (1204), raw instruction bytes match target exactly (perfect byte match). Objdiff may still report ~99.88 when counting cross-object reloc symbol indices; the instruction stream itself matches.

TU remains NonMatching (not flipped).

### Notes

- Independent of #2956 and #2957. Branched from latest `master` only.
- Legal US 1.02 `main.dol` is not included in this PR.
- No global field renames, no data-section matching, no Matching flag changes.
- Only `src/melee/ft/chara/ftCommon/ftCo_0A01.c` is touched.

> AI assistance was used for the r28 vs r31 register diagnosis, the static-inline floor-id helper, and objdiff/byte verification. No new global names were introduced.