### PR TITLE
Match gm_80166378

### DIFF
--- a/src/melee/gm/gm_1601.c
+++ b/src/melee/gm/gm_1601.c
@@ -3101,7 +3101,8 @@ void gm_80166378(lbl_8046B6A0_24C_t* arg0_raw)
             sp48_y = (a = 0.031f) * ((f32) cnt * fn_8016B5B0());
             fn_80166A8C((Vec3*) &sp48_y, (Vec3*) &sp48_x);
             arg0->player_standings[i].xE = *(u16*) &sp48_x;
-            arg0->player_standings[i].x34 = (s8) ((b = 100.0f) * pl_80040948(i));
+            arg0->player_standings[i].x34 =
+                (s8) ((b = 100.0f) * pl_80040948(i));
             arg0->player_standings[i].x38 = pl_80040900(i);
             arg0->player_standings[i].x3C = pl_80040924(i);
             arg0->player_standings[i].x40 = pl_80040B3C(i);
@@ -3126,9 +3127,9 @@ void gm_80166378(lbl_8046B6A0_24C_t* arg0_raw)
             arg0->player_standings[i].x8C = pl_80040AF0(i);
             arg0->player_standings[i].x90 = pl_8003E39C(i);
             arg0->player_standings[i].x94 =
-                (u32) ((void)(c = 60.0f), (c * ((d = 10.0f) * pl_80040D44(i))));
-            arg0->player_standings[i].x98 =
-                (u32) (c * (d * pl_80040D68(i)));
+                (u32) ((void) (c = 60.0f),
+                       (c * ((d = 10.0f) * pl_80040D44(i))));
+            arg0->player_standings[i].x98 = (u32) (c * (d * pl_80040D68(i)));
             arg0->player_standings[i].x9C = (u32) pl_80040CFC(i) / 60U;
             arg0->player_standings[i].xA0 = (u32) pl_80040D20(i) / 60U;
             arg0->player_standings[i].xA4 = pl_80040DB8(i);

--- a/src/melee/gm/gm_1601.c
+++ b/src/melee/gm/gm_1601.c
@@ -3066,6 +3066,7 @@ void gm_80166378(lbl_8046B6A0_24C_t* arg0_raw)
     f32 sp48_x;
     s32 j;
     u32 cnt;
+    f32 d, c, b, a;
 
     PAD_STACK(60);
 
@@ -3097,10 +3098,10 @@ void gm_80166378(lbl_8046B6A0_24C_t* arg0_raw)
             arg0->player_standings[i].x3_7 = Player_GetMoreFlagsBit2(i);
             arg0->player_standings[i].x9 = (s8) Player_GetRemainingHP(i);
             cnt = Player_GetJoystickCountByIndex(i, 0);
-            sp48_y = 0.031f * ((f32) cnt * fn_8016B5B0());
+            sp48_y = (a = 0.031f) * ((f32) cnt * fn_8016B5B0());
             fn_80166A8C((Vec3*) &sp48_y, (Vec3*) &sp48_x);
             arg0->player_standings[i].xE = *(u16*) &sp48_x;
-            arg0->player_standings[i].x34 = (s8) (100.0f * pl_80040948(i));
+            arg0->player_standings[i].x34 = (s8) ((b = 100.0f) * pl_80040948(i));
             arg0->player_standings[i].x38 = pl_80040900(i);
             arg0->player_standings[i].x3C = pl_80040924(i);
             arg0->player_standings[i].x40 = pl_80040B3C(i);
@@ -3125,9 +3126,9 @@ void gm_80166378(lbl_8046B6A0_24C_t* arg0_raw)
             arg0->player_standings[i].x8C = pl_80040AF0(i);
             arg0->player_standings[i].x90 = pl_8003E39C(i);
             arg0->player_standings[i].x94 =
-                (u32) (60.0f * (10.0f * pl_80040D44(i)));
+                (u32) ((void)(c = 60.0f), (c * ((d = 10.0f) * pl_80040D44(i))));
             arg0->player_standings[i].x98 =
-                (u32) (60.0f * (10.0f * pl_80040D68(i)));
+                (u32) (c * (d * pl_80040D68(i)));
             arg0->player_standings[i].x9C = (u32) pl_80040CFC(i) / 60U;
             arg0->player_standings[i].xA0 = (u32) pl_80040D20(i) / 60U;
             arg0->player_standings[i].xA4 = pl_80040DB8(i);


### PR DESCRIPTION
## Summary

Matches `gm_80166378` (match end / player standings fill) at 100%.

### What matched

- `gm_80166378` (size 0x714 / 1812)

### Why this is correct

MWCC was not coloring the loop-invariant float constants the same way as the target. The fix:

1. Declares locals in reverse register order: `f32 d, c, b, a` so assignment coloring lands on `f27`..`f30` (with the existing stack bias on `f31`).
2. Materializes each constant via assign-exprs (`a = 0.031f`, `b = 100.0f`, `c = 60.0f`, `d = 10.0f`) and reuses `c`/`d` for the second scale so both multiplies share the same FPRs as the original.

Semantics are unchanged; this is pure FPR allocation control.

### How verified

```text
export WINEPREFIX="$HOME/.wine-melee-pr" WINEDEBUG=-all
ninja build/GALE01/src/melee/gm/gm_1601.o
build/tools/objdiff-cli diff \
  -1 build/GALE01/obj/melee/gm/gm_1601.o \
  -2 build/GALE01/src/melee/gm/gm_1601.o \
  -o - --format json
```

Result: `gm_80166378` reports `match_percent` 100.0 (size 1812).

TU remains NonMatching (not flipped). Independent of #2956 / #2957 / #2959 (branched from current `upstream/master` @ `607b232ac`).

### Notes

- Legal US 1.02 `main.dol` is not included in this PR.
- No global field renames, no data-section matching, no Matching flag changes.
- Touch: `src/melee/gm/gm_1601.c` only.

> AI assistance was used for FPR coloring exploration, patch application, and objdiff verification. No new globals or field names were introduced.