### PR TITLE
Match HSD_SisLib_803A8134

### DIFF
--- a/src/sysdolphin/baselib/sislib.c
+++ b/src/sysdolphin/baselib/sislib.c
@@ -1232,8 +1232,6 @@ void HSD_SisLib_803A8134(void* cursor, HSD_Text* text, f32* out_width,
     u32 pop_result;
     TextKerning* kern_data_2;
     u8 opcode;
-    u8 kern_left;
-    u8 kern_right;
     TextKerning* kern_data;
     saved_scale_x = text->x80.x;
     saved_scale_y = text->x80.y;
@@ -1255,6 +1253,11 @@ loop_3:
             cursor = (u8*) (pop_result + 4);
             goto block_33;
         }
+        break;
+    case 1:
+    case 2:
+    case 3:
+    case 7:
         break;
     case 9:
         HSD_SisLib_803A7684(text, (u8*) cursor, 0x85U);
@@ -1311,23 +1314,22 @@ loop_3:
             if (kern_enabled != 0) {
                 glyph_code = *(u16*) cursor;
                 if (glyph_code < 0x4000U) {
-                    kern_data = (TextKerning*) (default_kerning +
-                                                (((glyph_code - 0x2000) * 2) &
-                                                 0x1FFFE));
-                    kern_right = kern_data->right;
-                    kern_left = kern_data->left;
-                    kern_width = kern_right - 2;
-                    kern_width = kern_left + kern_width;
+                    kern_width =
+                        (s32) (default_kerning +
+                               (((glyph_code - 0x2000) * 2) & 0x1FFFE));
+                    kern_data = (TextKerning*) kern_width;
+                    kern_width = kern_data->right - 2;
+                    kern_data = (TextKerning*) (u32) kern_data->left;
+                    kern_width = (s32) kern_data + kern_width;
                     *out_width =
                         -((text->x80.x * (f32) kern_width) - *out_width);
                 } else {
                     kern_data_2 =
                         (TextKerning*) &glyph_tex
                             ->data[((glyph_code - 0x4000) * 2) & 0x1FFFE];
-                    kern_right = kern_data_2->right;
-                    kern_left = kern_data_2->left;
-                    kern_width = kern_right - 2;
-                    kern_width = kern_left + kern_width;
+                    kern_width = kern_data_2->right - 2;
+                    kern_data_2 = (TextKerning*) (u32) kern_data_2->left;
+                    kern_width = (s32) kern_data_2 + kern_width;
                     *out_width =
                         -((text->x80.x * (f32) kern_width) - *out_width);
                 }


### PR DESCRIPTION
## Summary

Matches `HSD_SisLib_803A8134` (SIS text measure / width-height walk) at 100% code match.

### What matched

- `HSD_SisLib_803A8134` (size 0x388 / 904)

### Why this is correct

Two small control-flow / regalloc fixes:

1. **Cases 1/2/3/7 break the measure loop.** Target treats these opcodes as line terminators (same as case 0's fail path). Without explicit cases they fell into `default` and were treated as glyph data (`continue` via `block_33`), which is wrong and also mismatches the jump table layout.
2. **Kern path uses an s32 cast stash for left/right.** Target reuses the same GPR for the kerning pointer and the width accumulation (`right - 2`, then add `left` via pointer-as-s32). The previous `u8 kern_left` / `u8 kern_right` locals forced extra registers and different instruction order.

Semantics of the measure walk are unchanged for the intentional terminator opcodes; glyph kerning math is identical (`left + right - 2` scaled by `x80.x`).

### How verified

```text
export WINEPREFIX="$HOME/.wine-melee-pr" WINEDEBUG=-all
ninja build/GALE01/src/sysdolphin/baselib/sislib.o
build/tools/objdiff-cli diff \
  -1 build/GALE01/obj/sysdolphin/baselib/sislib.o \
  -2 build/GALE01/src/sysdolphin/baselib/sislib.o \
  -c functionRelocDiffs=data_value \
  -o - --format json \
  HSD_SisLib_803A8134
```

Result: `HSD_SisLib_803A8134` reports `match_percent` 100.0 (size 904). Without `functionRelocDiffs=data_value`, SDA/local label names (`@190@sda21` vs `HSD_SisLib_804DEAE0@sda21`) make objdiff report ~99.8 while the instruction stream and reloc data values match.

TU remains NonMatching (not flipped). Independent of #2956 / #2957 / #2959 / #2960 (branched from current `upstream/master` @ `607b232ac`).

### Notes

- Legal US 1.02 `main.dol` is not included in this PR.
- No global field renames, no data-section matching, no Matching flag changes.
- Touch: `src/sysdolphin/baselib/sislib.c` only.

> AI assistance was used for the terminator-case diagnosis, the s32 kern stash regalloc pattern, and objdiff verification. No new globals or field names were introduced.