### PR TITLE
Match fn_80392A3C (hsd_3915)

### DIFF
--- a/src/sysdolphin/baselib/hsd_3915.c
+++ b/src/sysdolphin/baselib/hsd_3915.c
@@ -934,8 +934,6 @@ static s32 lbl_804D609C = 0x00FFFFFF;
 static s32 lbl_804D60A0 = 0x8080FF;
 static s32 lbl_804D60A4 = (s32) 0xC0C000FF;
 
-// @TODO: Currently 89.63% match - needs register allocation and expression
-// fixes
 static inline PerfDispItem* get_perf_disp_item(s32 count)
 {
     return &hsd_804CE3F8[count];
@@ -954,8 +952,9 @@ void* fn_80392A3C(void)
     numFrames = lbl_804D6088;
     if (0 != numFrames) {
         u8* counts = &hsd_804CE3F8[0].content.bytes[0];
-        u8* colors_base = &hsd_804CE3F8[0].content.bytes[4];
-        u8* colors = colors_base;
+        u8* colors = &hsd_804CE3F8[0].content.bytes[4];
+        // Self-assign forces colors into r5 and green's stack slot to 0x8.
+        colors = colors;
         hsd_804CE3F8[0].type = 1;
         *(s32*) counts = 1;
         bar_count = count;


### PR DESCRIPTION
## Summary

Matches `fn_80392A3C` (perf-display bar / gradient setup in `hsd_3915`) at 100% code match.

### What matched

- `fn_80392A3C` (size 0x290 / 656)

### Why this is correct

MWCC was emitting a different register / stack layout for the color pointer and the `volatile s32 green` local. Collapsing the temporary `colors_base` into a single `colors` pointer and self-assigning it (`colors = colors;`) forces:

1. `colors` into **r5** (matching target)
2. `green`'s stack slot to **0x8** (matching target)

No control-flow or semantic change: the same byte/count arrays are written, and the same green color value is stored and later reused for the gradient entry.

### How verified

```text
export WINEPREFIX="$HOME/.wine-melee-hsd3915" WINEDEBUG=-all
ninja build/GALE01/src/sysdolphin/baselib/hsd_3915.o
build/tools/objdiff-cli diff \
  -1 build/GALE01/obj/sysdolphin/baselib/hsd_3915.o \
  -2 build/GALE01/src/sysdolphin/baselib/hsd_3915.o \
  -c functionRelocDiffs=data_value \
  -o - --format json \
  fn_80392A3C
```

Result: `fn_80392A3C` reports `match_percent` 100.0 (size 656). Without `functionRelocDiffs=data_value`, SDA/local label names make objdiff report ~99.79 while the instruction stream and reloc data values match.

TU remains NonMatching (not flipped). Independent of #2956 / #2957 / #2959 / #2960 / #2961 (branched from current `upstream/master` @ `607b232ac`).

### Notes

- Legal US 1.02 `main.dol` is not included in this PR.
- No global field renames, no data-section matching, no Matching flag changes.
- Touch: `src/sysdolphin/baselib/hsd_3915.c` only.

> AI assistance was used for the colors self-assign regalloc pattern and objdiff verification. No new globals or field names were introduced.