### PR TITLE
Match fn_80252548 (mninfo)

### DIFF
--- a/src/melee/mn/mninfo.c
+++ b/src/melee/mn/mninfo.c
@@ -425,7 +425,6 @@ static inline void fn_80252548_inline(MnInfoData* data, HSD_GObj* gobj)
 {
     HSD_GObjProc* proc;
     HSD_JObj* jobj;
-    u8* trophy;
     s32 i;
     PAD_STACK(16);
     if (mn_804A04F0.cur_menu != MENU_KIND_DATA_SPECIAL) {
@@ -457,16 +456,14 @@ static inline void fn_80252548_inline(MnInfoData* data, HSD_GObj* gobj)
             data->anim_timer--;
             return;
         }
-        trophy = mnInfo_804A0968;
         for (i = 0; i < 4; i++) {
-            if (mnInfo_80251A08(*trophy) != 0) {
-                u32 id = *trophy;
+            if (mnInfo_80251A08(mnInfo_804A0968[i]) != 0) {
+                u32 id = mnInfo_804A0968[i];
 
                 mnInfo_80251D58((mnInfo_GObj*) gobj, i, id,
                                 *gmMainLib_8015D804(id));
                 mnInfo_80251F04((mnInfo_GObj*) gobj, i, id);
             }
-            trophy++;
         }
         jobj = HSD_JObjLoadJoint(mnInfo_804A0958.joint);
         HSD_GObjObject_80390A70(gobj, HSD_GObj_804D7849, jobj);
@@ -482,7 +479,6 @@ static inline void fn_80252548_inline(MnInfoData* data, HSD_GObj* gobj)
     }
 }
 
-/// @todo Two callee-saved registers are swapped.
 void fn_80252548(HSD_GObj* gobj)
 {
     MnInfoData* data = GET_MNINFO(gobj);


### PR DESCRIPTION
## Summary

Matches `fn_80252548` (data special menu setup proc) at 100% code match.

### What matched

- `fn_80252548` (via existing `fn_80252548_inline`)

### Why this is correct

The remaining miss was callee-saved register coloring on the initial trophy loop. Replacing the walking `u8* trophy` cursor with direct `mnInfo_804A0968[i]` indexing matches target register use without changing control flow or call order.

Also drops the stale swapped-regs `@todo`.

### How verified

```text
ninja build/GALE01/src/melee/mn/mninfo.o
build/tools/objdiff-cli diff \
  -1 build/GALE01/obj/melee/mn/mninfo.o \
  -2 build/GALE01/src/melee/mn/mninfo.o \
  -c functionRelocDiffs=data_value \
  fn_80252548
```

Result: `match_percent` 100.0 under `functionRelocDiffs=data_value`.

TU remains NonMatching. Single-file, independent of other open PRs.

### Notes

- Legal US 1.02 `main.dol` is not included.
- No global field renames, no data-section matching, no Matching flag change.
- Touch: `src/melee/mn/mninfo.c` only.

> AI assistance was used for the array-index regalloc rewrite and objdiff verification. No new globals or field names were introduced.