### PR TITLE
Match fn_8001FEC4

### DIFF
--- a/src/melee/lb/lbbgflash.c
+++ b/src/melee/lb/lbbgflash.c
@@ -254,10 +254,11 @@ void fn_8001FEC4(HSD_GObj* gobj, s32 code)
             s32 y2;
 
             for (y2 = *(pY = &data->x38); y2 <= 0x1E0; y2 += data->x32) {
+                s32 right;
+                u8 strip_h;
+                s32 x34;
+
                 if (y2 == *pY) {
-                    s32 right;
-                    u8 strip_h;
-                    s32 x34;
                     s32 neg_y;
                     s32 xr;
                     s32 neg_yh;
@@ -280,9 +281,9 @@ void fn_8001FEC4(HSD_GObj* gobj, s32 code)
                     GXColor4u8(0, 0, 0, 0xFF);
                 } else {
                     s32 neg_y;
-                    u8 strip_h = data->x32;
                     s32 neg_yh;
 
+                    strip_h = data->x32;
                     GXBegin(GX_QUADS, GX_VTXFMT0, 4);
                     neg_y = -y2;
                     neg_yh = -(y2 + strip_h);
@@ -295,6 +296,8 @@ void fn_8001FEC4(HSD_GObj* gobj, s32 code)
                     GXPosition2f32(0.0f, (f32) neg_yh);
                     GXColor4u8(0, 0, 0, 0xFF);
                 }
+                /* Keep strip_h live across both arms (required for match). */
+                (void) strip_h;
             }
         }
         break;


### PR DESCRIPTION
## Summary

Matches `fn_8001FEC4` (background flash GX draw) at 100% code match.

### What matched

- `fn_8001FEC4`

### Why this is correct

The remaining miss was register coloring in the mode-0 strip loop. Hoisting `right`, `strip_h`, and `x34` to for-loop scope (assigning `strip_h` in both arms) and keeping `strip_h` live with `(void) strip_h` forces the same callee-saved coloring as target. (Load-bearing: removing the keep-alive drops match to ~99.52%.) Draw path and constants are unchanged.

Verified under `functionRelocDiffs=data_value` so residual sdata2 label names do not mask a false match.

### How verified

```text
ninja build/GALE01/src/melee/lb/lbbgflash.o
build/tools/objdiff-cli diff \
  -1 build/GALE01/obj/melee/lb/lbbgflash.o \
  -2 build/GALE01/src/melee/lb/lbbgflash.o \
  -c functionRelocDiffs=data_value \
  fn_8001FEC4
```

Result: `match_percent` 100.0 under `functionRelocDiffs=data_value`.

TU remains NonMatching. Single-file, independent of other open PRs.

### Notes

- Legal US 1.02 `main.dol` is not included.
- No global field renames, no data-section matching, no Matching flag change.
- Touch: `src/melee/lb/lbbgflash.c` only.

> AI assistance was used for the loop-scope hoist / keep-alive regalloc pattern and objdiff verification. No new globals or field names were introduced.
