### PR TITLE
Match grBigBlue_801ED694

### DIFF
--- a/src/melee/gr/grbigblue.c
+++ b/src/melee/gr/grbigblue.c
@@ -3626,6 +3626,7 @@ typedef union grBigBlue_CarPhysics {
 void grBigBlue_801ED694(Ground_GObj* gobj, s32 lane)
 {
     grBigBlue_CarPhysics* gp = gobj->user_data;
+    Point3d sp_vec;
     s32 offset;
     HSD_JObj* jobj;
     u8* lane_flags;
@@ -3636,7 +3637,6 @@ void grBigBlue_801ED694(Ground_GObj* gobj, s32 lane)
     f32 f31_rot;
     f32 heading_osc;
     f32 heading_val;
-    Point3d sp_vec;
 
     /* Check and handle lane status */
     {


### PR DESCRIPTION
## Summary

Matches `grBigBlue_801ED694` at 100% code match.

### What matched

- `grBigBlue_801ED694`

### Why this is correct

The only remaining diffs were stack offsets for the collision normal vector (`sp_vec` at `0x18` vs target `0x1c`). Declaring `Point3d sp_vec` first among locals causes MWCC to pack it at the retail slot. No control-flow or semantics change.

### How verified

```text
ninja build/GALE01/src/melee/gr/grbigblue.o
build/tools/objdiff-cli diff \
  -1 build/GALE01/obj/melee/gr/grbigblue.o \
  -2 build/GALE01/src/melee/gr/grbigblue.o \
  -c functionRelocDiffs=data_value \
  grBigBlue_801ED694
```

Result: `match_percent` 100.0 under `functionRelocDiffs=data_value`.

TU remains NonMatching. Single-file, independent of other open PRs.

### Notes

- Legal US 1.02 `main.dol` is not included.
- No global field renames, no data-section matching, no Matching flag change.
- Touch: `src/melee/gr/grbigblue.c` only.

> AI assistance was used for the stack-local ordering diagnosis and objdiff verification. No new globals or field names were introduced.
