### PR TITLE
Match ftCo_800B4AB0

### DIFF
--- a/src/melee/ft/ftcpuattack.c
+++ b/src/melee/ft/ftcpuattack.c
@@ -140,6 +140,22 @@ typedef struct ftCo_CollData {
 } ftCo_CollData;
 
 /// @todo Fake helper forcing a fresh load of the scale field.
+
+/// MSL sqrtf expansion writing through a caller-provided stack slot so each
+/// call site owns a distinct 4-byte temp (retail 0x28..0x34 below sp3C).
+static inline float sqrtf_store(float x, volatile float* y)
+{
+    if (x > 0.0f) {
+        double guess = __frsqrte((double) x);
+        guess = 0.5 * guess * (3.0 - guess * guess * x);
+        guess = 0.5 * guess * (3.0 - guess * guess * x);
+        guess = 0.5 * guess * (3.0 - guess * guess * x);
+        *y = (float) (x * guess);
+        return *(volatile float*) y;
+    }
+    return x;
+}
+
 static inline f32 get_scale(Fighter* fp)
 {
     return fp->x34_scale.y;
@@ -168,9 +184,9 @@ static inline void ftCo_CpuClearTargetAndFinish(Fighter* fp)
 int ftCo_800B4AB0(Fighter* fp, Fighter* target, void* arg2)
 {
     ftCo_AttackEntry sp3C[32];
-    u8 operand_pad[8];
+    float sqrt_tmp[4]; /* pins sqrtf volatile slots at 0x28..0x34 */
     ftCo_AttackEntry* list = arg2;
-    ftCo_AttackEntry* sel;
+    ftCo_AttackEntry* sel; /* layout/reg pressure; unused */
     struct Fighter_x1A88_t* cpu = &fp->x1A88;
     s32 count;
     s32 i;
@@ -186,7 +202,7 @@ int ftCo_800B4AB0(Fighter* fp, Fighter* target, void* arg2)
     f32 relPredY;
     f32 v;
     f32 sq;
-    f32 scale;
+    f32 scale; /* layout; unused */
     f32 upper;
     f32 lower;
     f32 fpX;
@@ -270,11 +286,11 @@ int ftCo_800B4AB0(Fighter* fp, Fighter* target, void* arg2)
             if (v <= 0.0f) {
                 fpPredY = fpVy * t + fpY;
             } else if (t < v) {
-                sq = sqrtf(t);
+                sq = sqrtf_store(t, &sqrt_tmp[2]);
                 fpPredY = (f32) ((f64) fpY + ((f64) (fpVy * t) -
                                               0.5 * (f64) (fpGrav * sq)));
             } else {
-                sq = sqrtf(v);
+                sq = sqrtf_store(v, &sqrt_tmp[1]);
                 fpPredY =
                     (f32) ((f64) fpY +
                            ((f64) (fpTermNeg * (t - v)) +
@@ -297,12 +313,12 @@ int ftCo_800B4AB0(Fighter* fp, Fighter* target, void* arg2)
             if (v <= 0.0f) {
                 relPredY = (tgtVy * t + tgtY) - fpPredY;
             } else if (t < v) {
-                sq = sqrtf(t);
+                sq = sqrtf_store(t, &sqrt_tmp[0]);
                 relPredY = (f32) (((f64) (tgtVy * t + tgtY) -
                                    0.5 * (f64) (tgtGrav * sq)) -
                                   (f64) fpPredY);
             } else {
-                sq = sqrtf(v);
+                sq = sqrtf_store(v, sqrt_tmp - 1);
                 relPredY = (f32) (((f64) (tgtTermNeg * (t - v)) +
                                    ((f64) (tgtVy * t + tgtY) -
                                     0.5 * (f64) (tgtGrav * sq))) -
@@ -320,9 +336,12 @@ int ftCo_800B4AB0(Fighter* fp, Fighter* target, void* arg2)
         }
         dirx *= halfRange;
         diry *= halfRange;
-        scale = get_scale(fp);
-        upper = list->x14 * scale * halfRange;
-        lower = list->x10 * scale * halfRange;
+        {
+            f32 u = list->x14 * fp->x34_scale.y;
+            upper = u * halfRange;
+        }
+        lower = list->x10 * fp->x34_scale.y;
+        lower *= halfRange;
         if (upper > relPredY && lower < relPredY + x568 &&
             dirx < relx + rangeF && diry > relx - rangeB)
         {
@@ -358,8 +377,8 @@ int ftCo_800B4AB0(Fighter* fp, Fighter* target, void* arg2)
     }
     inv = 1.0 / sum;
     acc = 0.0f;
-    for (i = 0, sel = sp3C; i < count; i++, sel++) {
-        acc += sel->weight;
+    for (i = 0; i < count; i++) {
+        acc += sp3C[i].weight;
         if (acc * inv >= r) {
             return ftCo_CpuSelectAttack(fp, cpu, &sp3C[i]);
         }


### PR DESCRIPTION
## Summary

Matches `ftCo_800B4AB0` (CPU attack selection) at 100% code match.

### What matched

- `ftCo_800B4AB0`

### Why this is correct

1. Pin MSL `sqrtf` expansion stack temps via `sqrtf_store` + `sqrt_tmp[4]` so each call site owns the retail 4-byte slots.
2. Array-only weight selection for induction coloring.
3. Stage upper/lower multiplies for FPR order.

No new globals. Semantics unchanged.

### How verified

```text
ninja build/GALE01/src/melee/ft/ftcpuattack.o
build/tools/objdiff-cli diff \
  -1 build/GALE01/obj/melee/ft/ftcpuattack.o \
  -2 build/GALE01/src/melee/ft/ftcpuattack.o \
  -c functionRelocDiffs=none \
  ftCo_800B4AB0
```

Result: `match_percent` 100.0 (instruction stream). Under `functionRelocDiffs=data_value` one SDA21 symbol-name display differs (`ftCo_804D3B70` vs local `@479`) with identical `li r5,0` encoding.

TU remains NonMatching. Single-file, independent of other open PRs.

### Notes

- Legal US 1.02 `main.dol` is not included.
- No global field renames, no data-section matching, no Matching flag change.
- Touch: `src/melee/ft/ftcpuattack.c` only.

> AI assistance was used for the sqrtf stack-slot pins, weight-selection regalloc, and objdiff verification. No new globals or field names were introduced.
