### PR TITLE
Match the three Icicle Mountain joint collision callbacks

### DIFF
--- a/src/melee/gr/gricemt.c
+++ b/src/melee/gr/gricemt.c
@@ -804,10 +804,9 @@ void grIceMt_801F7F70(Ground_GObj* arg0)
     grIceMt_801F8CDC(arg0, (s16*) &sp14, 2, &gp->u.icemt2.xF8[0]);
     grIceMt_801F91EC(arg0, (s16*) ((u8*) gp + 0x100),
                      grIceMt_801FA500(arg0, jobj), -1, 0x25, 0x109, 0x27E,
-                     (mpLib_JointCollisionCallback) fn_801F9338);
+                     fn_801F9338);
     grIceMt_801F91EC(arg0, &gp->u.icemt.x108[3], grIceMt_801FA500(arg0, jobj2),
-                     -1, 0x26, 0x109, 0x27E,
-                     (mpLib_JointCollisionCallback) fn_801F9448);
+                     -1, 38, 265, 638, fn_801F9448);
 }
 
 bool grIceMt_801F8154(Ground_GObj* param1)
@@ -927,8 +926,7 @@ void grIceMt_801F83EC(Ground_GObj* arg0)
     grIceMt_801F8CDC(arg0, (s16*) &sp14, 4, &gp->u.icemt2.xF8[0]);
     r = grIceMt_801FA500(arg0, jobj3);
     grIceMt_801F91EC(arg0, gp->u.icemt.x108, grIceMt_801FA500(arg0, jobj2), r,
-                     0x75, 0x109, 0x27E,
-                     (mpLib_JointCollisionCallback) fn_801F9558);
+                     117, 265, 638, fn_801F9558);
 }
 
 bool grIceMt_801F85BC(Ground_GObj* param1)
@@ -1329,72 +1327,81 @@ void grIceMt_801F929C(HSD_GObj* arg0, void* arg1)
 }
 
 /// @copydoc mpLib_JointCollisionCallback
-void fn_801F9338(Ground* gp, int joint_id, CollData* coll, int coll_x50,
+void fn_801F9338(void* user_data, int joint_id, CollData* coll, int coll_x50,
                  mpLib_GroundEnum ground_kind, float delta_y)
 {
-    HSD_GObj* gobj;
-    s16* s = gp->u.icemt.x100;
-    PAD_STACK(8);
-    if ((s32) coll->x34_flags.b1234 == 1 && s[0] == 0) {
-        gobj = Ground_801C2BA4(2);
-        s[0] = 1;
-        s[1] = 0;
-        grAnime_801C7A04(gobj, s[2], 7, 1.0f);
-        grAnime_801C7B24(gobj, s[2], 7, 0.0f);
-        grAnime_801C78FC(gobj, s[2], 7);
-        if (s[3] != -1) {
-            grAnime_801C7A04(gobj, s[3], 7, 1.0f);
-            grAnime_801C7B24(gobj, s[3], 7, 0.0f);
-            grAnime_801C78FC(gobj, s[3], 7);
+    {
+        HSD_GObj* gobj;
+        Ground* gp = user_data;
+        s16* s = gp->u.icemt.x100;
+        if ((s32) coll->x34_flags.b1234 == 1 && s[0] == 0) {
+            gobj = Ground_801C2BA4(2);
+            s[0] = 1;
+            s[1] = 0;
+            grAnime_801C7A04(gobj, s[2], 7, 1.0f);
+            grAnime_801C7B24(gobj, s[2], 7, 0.0f);
+            grAnime_801C78FC(gobj, s[2], 7);
+            if (s[3] != -1) {
+                grAnime_801C7A04(gobj, s[3], 7, 1.0f);
+                grAnime_801C7B24(gobj, s[3], 7, 0.0f);
+                grAnime_801C78FC(gobj, s[3], 7);
+            }
         }
     }
-    grIceMt_801FA7F0(gp, joint_id, coll, coll_x50, ground_kind, delta_y);
+    grIceMt_801FA7F0(user_data, joint_id, coll, coll_x50, ground_kind,
+                     delta_y);
 }
 
 /// @copydoc mpLib_JointCollisionCallback
-void fn_801F9448(Ground* gp, int joint_id, CollData* coll, int coll_x50,
+void fn_801F9448(void* user_data, int joint_id, CollData* coll, int coll_x50,
                  mpLib_GroundEnum ground_kind, float delta_y)
 {
-    HSD_GObj* gobj;
-    s16* s = &gp->u.icemt.x108[3];
-    PAD_STACK(8);
-    if ((s32) coll->x34_flags.b1234 == 1 && s[0] == 0) {
-        gobj = Ground_801C2BA4(2);
-        s[0] = 1;
-        s[1] = 0;
-        grAnime_801C7A04(gobj, s[2], 7, 1.0f);
-        grAnime_801C7B24(gobj, s[2], 7, 0.0f);
-        grAnime_801C78FC(gobj, s[2], 7);
-        if (s[3] != -1) {
-            grAnime_801C7A04(gobj, s[3], 7, 1.0f);
-            grAnime_801C7B24(gobj, s[3], 7, 0.0f);
-            grAnime_801C78FC(gobj, s[3], 7);
+    {
+        HSD_GObj* gobj;
+        Ground* gp = user_data;
+        s16* s = &gp->u.icemt.x108[3];
+        if ((s32) coll->x34_flags.b1234 == 1 && s[0] == 0) {
+            gobj = Ground_801C2BA4(2);
+            s[0] = 1;
+            s[1] = 0;
+            grAnime_801C7A04(gobj, s[2], 7, 1.0f);
+            grAnime_801C7B24(gobj, s[2], 7, 0.0f);
+            grAnime_801C78FC(gobj, s[2], 7);
+            if (s[3] != -1) {
+                grAnime_801C7A04(gobj, s[3], 7, 1.0f);
+                grAnime_801C7B24(gobj, s[3], 7, 0.0f);
+                grAnime_801C78FC(gobj, s[3], 7);
+            }
         }
     }
-    grIceMt_801FA7F0(gp, joint_id, coll, coll_x50, ground_kind, delta_y);
+    grIceMt_801FA7F0(user_data, joint_id, coll, coll_x50, ground_kind,
+                     delta_y);
 }
 
 /// @copydoc mpLib_JointCollisionCallback
-void fn_801F9558(Ground* gp, int joint_id, CollData* coll, int coll_x50,
+void fn_801F9558(void* user_data, int joint_id, CollData* coll, int coll_x50,
                  mpLib_GroundEnum ground_kind, float delta_y)
 {
-    HSD_GObj* gobj;
-    s16* s = gp->u.icemt.x108;
-    PAD_STACK(8);
-    if ((s32) coll->x34_flags.b1234 == 1 && s[0] == 0) {
-        gobj = Ground_801C2BA4(4);
-        s[0] = 1;
-        s[1] = 0;
-        grAnime_801C7A04(gobj, s[2], 7, 1.0f);
-        grAnime_801C7B24(gobj, s[2], 7, 0.0f);
-        grAnime_801C78FC(gobj, s[2], 7);
-        if (s[3] != -1) {
-            grAnime_801C7A04(gobj, s[3], 7, 1.0f);
-            grAnime_801C7B24(gobj, s[3], 7, 0.0f);
-            grAnime_801C78FC(gobj, s[3], 7);
+    {
+        HSD_GObj* gobj;
+        Ground* gp = user_data;
+        s16* s = gp->u.icemt.x108;
+        if ((s32) coll->x34_flags.b1234 == 1 && s[0] == 0) {
+            gobj = Ground_801C2BA4(4);
+            s[0] = 1;
+            s[1] = 0;
+            grAnime_801C7A04(gobj, s[2], 7, 1.0f);
+            grAnime_801C7B24(gobj, s[2], 7, 0.0f);
+            grAnime_801C78FC(gobj, s[2], 7);
+            if (s[3] != -1) {
+                grAnime_801C7A04(gobj, s[3], 7, 1.0f);
+                grAnime_801C7B24(gobj, s[3], 7, 0.0f);
+                grAnime_801C78FC(gobj, s[3], 7);
+            }
         }
     }
-    grIceMt_801FA7F0(gp, joint_id, coll, coll_x50, ground_kind, delta_y);
+    grIceMt_801FA7F0(user_data, joint_id, coll, coll_x50, ground_kind,
+                     delta_y);
 }
 
 void grIceMt_801F9668(float arg8)

--- a/src/melee/gr/gricemt.c
+++ b/src/melee/gr/gricemt.c
@@ -804,9 +804,10 @@ void grIceMt_801F7F70(Ground_GObj* arg0)
     grIceMt_801F8CDC(arg0, (s16*) &sp14, 2, &gp->u.icemt2.xF8[0]);
     grIceMt_801F91EC(arg0, (s16*) ((u8*) gp + 0x100),
                      grIceMt_801FA500(arg0, jobj), -1, 0x25, 0x109, 0x27E,
-                     fn_801F9338);
+                     (mpLib_JointCollisionCallback) fn_801F9338);
     grIceMt_801F91EC(arg0, &gp->u.icemt.x108[3], grIceMt_801FA500(arg0, jobj2),
-                     -1, 0x26, 0x109, 0x27E, fn_801F9448);
+                     -1, 0x26, 0x109, 0x27E,
+                     (mpLib_JointCollisionCallback) fn_801F9448);
 }
 
 bool grIceMt_801F8154(Ground_GObj* param1)
@@ -926,7 +927,8 @@ void grIceMt_801F83EC(Ground_GObj* arg0)
     grIceMt_801F8CDC(arg0, (s16*) &sp14, 4, &gp->u.icemt2.xF8[0]);
     r = grIceMt_801FA500(arg0, jobj3);
     grIceMt_801F91EC(arg0, gp->u.icemt.x108, grIceMt_801FA500(arg0, jobj2), r,
-                     0x75, 0x109, 0x27E, fn_801F9558);
+                     0x75, 0x109, 0x27E,
+                     (mpLib_JointCollisionCallback) fn_801F9558);
 }
 
 bool grIceMt_801F85BC(Ground_GObj* param1)
@@ -1327,10 +1329,9 @@ void grIceMt_801F929C(HSD_GObj* arg0, void* arg1)
 }
 
 /// @copydoc mpLib_JointCollisionCallback
-void fn_801F9338(void* user_data, int joint_id, CollData* coll, int coll_x50,
+void fn_801F9338(Ground* gp, int joint_id, CollData* coll, int coll_x50,
                  mpLib_GroundEnum ground_kind, float delta_y)
 {
-    Ground* gp = user_data;
     HSD_GObj* gobj;
     s16* s = gp->u.icemt.x100;
     PAD_STACK(8);
@@ -1351,10 +1352,9 @@ void fn_801F9338(void* user_data, int joint_id, CollData* coll, int coll_x50,
 }
 
 /// @copydoc mpLib_JointCollisionCallback
-void fn_801F9448(void* user_data, int joint_id, CollData* coll, int coll_x50,
+void fn_801F9448(Ground* gp, int joint_id, CollData* coll, int coll_x50,
                  mpLib_GroundEnum ground_kind, float delta_y)
 {
-    Ground* gp = user_data;
     HSD_GObj* gobj;
     s16* s = &gp->u.icemt.x108[3];
     PAD_STACK(8);
@@ -1375,10 +1375,9 @@ void fn_801F9448(void* user_data, int joint_id, CollData* coll, int coll_x50,
 }
 
 /// @copydoc mpLib_JointCollisionCallback
-void fn_801F9558(void* user_data, int joint_id, CollData* coll, int coll_x50,
+void fn_801F9558(Ground* gp, int joint_id, CollData* coll, int coll_x50,
                  mpLib_GroundEnum ground_kind, float delta_y)
 {
-    Ground* gp = user_data;
     HSD_GObj* gobj;
     s16* s = gp->u.icemt.x108;
     PAD_STACK(8);

--- a/src/melee/gr/gricemt.static.h
+++ b/src/melee/gr/gricemt.static.h
@@ -33,16 +33,16 @@
 #include <baselib/gobj.h>
 #include <baselib/jobj.h>
 
-/* 1F9338 */ static void fn_801F9338(void* user_data, int joint_id,
-                                     CollData* coll, int coll_x50,
+/* 1F9338 */ static void fn_801F9338(Ground* gp, int joint_id, CollData* coll,
+                                     int coll_x50,
                                      mpLib_GroundEnum ground_kind,
                                      float delta_y);
-/* 1F9448 */ static void fn_801F9448(void* user_data, int joint_id,
-                                     CollData* coll, int coll_x50,
+/* 1F9448 */ static void fn_801F9448(Ground* gp, int joint_id, CollData* coll,
+                                     int coll_x50,
                                      mpLib_GroundEnum ground_kind,
                                      float delta_y);
-/* 1F9558 */ static void fn_801F9558(void* user_data, int joint_id,
-                                     CollData* coll, int coll_x50,
+/* 1F9558 */ static void fn_801F9558(Ground* gp, int joint_id, CollData* coll,
+                                     int coll_x50,
                                      mpLib_GroundEnum ground_kind,
                                      float delta_y);
 /* 1F8C64 */ static void fn_801F8C64(Item_GObj* gobj, Ground* u1, Vec3* u2,

--- a/src/melee/gr/gricemt.static.h
+++ b/src/melee/gr/gricemt.static.h
@@ -33,16 +33,16 @@
 #include <baselib/gobj.h>
 #include <baselib/jobj.h>
 
-/* 1F9338 */ static void fn_801F9338(Ground* gp, int joint_id, CollData* coll,
-                                     int coll_x50,
+/* 1F9338 */ static void fn_801F9338(void* user_data, int joint_id,
+                                     CollData* coll, int coll_x50,
                                      mpLib_GroundEnum ground_kind,
                                      float delta_y);
-/* 1F9448 */ static void fn_801F9448(Ground* gp, int joint_id, CollData* coll,
-                                     int coll_x50,
+/* 1F9448 */ static void fn_801F9448(void* user_data, int joint_id,
+                                     CollData* coll, int coll_x50,
                                      mpLib_GroundEnum ground_kind,
                                      float delta_y);
-/* 1F9558 */ static void fn_801F9558(Ground* gp, int joint_id, CollData* coll,
-                                     int coll_x50,
+/* 1F9558 */ static void fn_801F9558(void* user_data, int joint_id,
+                                     CollData* coll, int coll_x50,
                                      mpLib_GroundEnum ground_kind,
                                      float delta_y);
 /* 1F8C64 */ static void fn_801F8C64(Item_GObj* gobj, Ground* u1, Vec3* u2,


### PR DESCRIPTION
Only 1 more function (nearly matched) in this TU to link it.

From Claude:
> fn_801F9338, fn_801F9448 and fn_801F9558 each aliased the void* callback argument into a local Ground*.  That copy is ranked with the user declarations, so it took the highest callee-saved register instead of being homed with the other parameters, rotating every register in the function.  Casting user_data at its two use sites lets MWCC home the argument alongside the rest and all three match.