### PR TITLE
Match grShrineRoute_8020AF38

### DIFF
--- a/src/melee/gr/grshrineroute.c
+++ b/src/melee/gr/grshrineroute.c
@@ -1262,11 +1262,16 @@ s32 grShrineRoute_8020AE08(HSD_GObj* gobj, HSD_GObj* player_gobj, s32* out)
     return 0;
 }
 
+static inline Ground* getGp(HSD_GObj* gobj)
+{
+    return GET_GROUND(gobj);
+}
+
 void grShrineRoute_8020AF38(HSD_GObj* gobj, s32 arg1)
 {
-    Ground* gp = GET_GROUND(gobj);
-    HSD_GObj** symbolp;
     s32 ix = arg1 - 0xBD;
+    Ground* gp = getGp(gobj);
+    HSD_GObj** symbolp;
     HSD_JObj* jobj;
     HSD_GObj* pgobj;
 


### PR DESCRIPTION
## Summary

Matches `grShrineRoute_8020AF38` in `src/melee/gr/grshrineroute.c` at 100%.

### What matched

- `grShrineRoute_8020AF38` (size 0xE8 / 232)

### Why this is correct

The `GET_GROUND(gobj)` load needs to happen after `ix` is computed, but writing it
that way directly leaves `gp` in the wrong register. Wrapping the load in a local
static inline defers it to the right point while keeping the source readable, and
moving the `ix` initialiser above it gives the retail ordering.

### How verified

```text
python3 configure.py && ninja
python3 configure.py progress
```

Against current `master` this unit goes from 19432 to 19433 matched functions and
3268496 to 3268728 matched code bytes (+232, the exact size of this function).
`report.json` reports `grShrineRoute_8020AF38` at 100.0.

### Notes

- Touches `src/melee/gr/grshrineroute.c` only; no header, struct or global changes.
- No data-section matching; the TU stays `NonMatching`.
- `clang-format` clean.
- Branched directly off `master` with no merge commits, per the note on #2965.

> AI assistance was used for the register-ordering experiments and objdiff verification. No new globals or field names were introduced.
