### PR TITLE
Reuse menu sfx inlines

### DIFF
--- a/src/melee/gm/gm_1832.c
+++ b/src/melee/gm/gm_1832.c
@@ -6,6 +6,7 @@
 
 #include "dolphin/pad.h"
 #include "gm/gm_1B14.h"
+#include "mn/inlines.h"
 #include "pl/pl_040D.h"
 
 #include <math_ppc.h>
@@ -1675,7 +1676,7 @@ void fn_80187CF4(HSD_GObj* gobj)
         break;
     case 2:
         if (gm_GetButtonsTriggered(data->x38) & PAD_BUTTON_START) {
-            lbAudioAx_80024030(1);
+            sfxForward();
             data->x36.active = 1;
             data->x37.state2 = 3;
             anim_state = data->x37.state2;
@@ -2398,7 +2399,7 @@ void fn_801891F4(void)
         sub->x01 = 1;
 
         if (buttons & 0x1000000000ULL) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             if ((u8) sub->x00 != 0) {
                 sub->x00--;
                 if (sub->x00 == 5) {
@@ -2410,7 +2411,7 @@ void fn_801891F4(void)
         }
 
         if (buttons & 0x2000000000ULL) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             if ((u8) sub->x00 < 8) {
                 sub->x00++;
                 if (sub->x00 == 5) {
@@ -2424,7 +2425,7 @@ void fn_801891F4(void)
         switch (sub->x00) {
         case 0:
             if (buttons & 0x4000000000ULL) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 if ((u32) sub->menu_values[sub->x00] != 0) {
                     sub->menu_values[sub->x00]--;
                     return;
@@ -2433,7 +2434,7 @@ void fn_801891F4(void)
                 return;
             }
             if (buttons & 0x8000000000ULL) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 if ((u32) sub->menu_values[sub->x00] < 5) {
                     sub->menu_values[sub->x00]++;
                     return;
@@ -2444,14 +2445,14 @@ void fn_801891F4(void)
             break;
         case 1:
             if (buttons & 0x4000000000ULL) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 if ((u32) sub->menu_values[sub->x00] != 0) {
                     sub->menu_values[sub->x00]--;
                 } else {
                     sub->menu_values[sub->x00] = 0x1D;
                 }
             } else if (buttons & 0x8000000000ULL) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 if ((u32) sub->menu_values[sub->x00] < 0x1D) {
                     sub->menu_values[sub->x00]++;
                 } else {
@@ -2473,7 +2474,7 @@ void fn_801891F4(void)
             break;
         case 2:
             if (buttons & 0x4000000000ULL) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 if ((u32) sub->menu_values[sub->x00] != 0) {
                     sub->menu_values[sub->x00]--;
                     return;
@@ -2482,7 +2483,7 @@ void fn_801891F4(void)
                 return;
             }
             if (buttons & 0x8000000000ULL) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 if ((u32) sub->menu_values[sub->x00] < 2) {
                     sub->menu_values[sub->x00]++;
                     return;
@@ -2493,7 +2494,7 @@ void fn_801891F4(void)
             break;
         case 3:
             if (buttons & 0x4000000000ULL) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 if ((u32) sub->menu_values[sub->x00] != 0) {
                     sub->menu_values[sub->x00]--;
                     return;
@@ -2502,7 +2503,7 @@ void fn_801891F4(void)
                 return;
             }
             if (buttons & 0x8000000000ULL) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 if ((u32) sub->menu_values[sub->x00] < 5) {
                     sub->menu_values[sub->x00]++;
                     return;
@@ -2513,7 +2514,7 @@ void fn_801891F4(void)
             break;
         case 4:
             if (buttons & 0x4000000000ULL) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 if ((u32) sub->menu_values[sub->x00] != 0) {
                     sub->menu_values[sub->x00]--;
                     if ((u32) sub->menu_values[sub->x00] == 0) {
@@ -2525,7 +2526,7 @@ void fn_801891F4(void)
                     return;
                 }
             } else if (buttons & 0x8000000000ULL) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 if ((u32) sub->menu_values[sub->x00] < 0x3E7) {
                     sub->menu_values[sub->x00]++;
                     if ((u32) sub->menu_values[sub->x00] == 0x3E7) {
@@ -2540,19 +2541,19 @@ void fn_801891F4(void)
             break;
         case 5:
             if (buttons & 0x4000000000ULL) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 sub->menu_values[sub->x00] = 0;
                 return;
             }
             if (buttons & 0x8000000000ULL) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 sub->menu_values[sub->x00] = 1;
                 return;
             }
             break;
         case 6:
             if (buttons & 0x4000000000ULL) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 if ((u32) sub->menu_values[sub->x00] != 0) {
                     sub->menu_values[sub->x00]--;
                 } else {
@@ -2574,7 +2575,7 @@ void fn_801891F4(void)
                     return;
                 }
             } else if (buttons & 0x8000000000ULL) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 if ((u32) sub->menu_values[sub->x00] < 2) {
                     sub->menu_values[sub->x00]++;
                 } else {
@@ -2599,7 +2600,7 @@ void fn_801891F4(void)
             break;
         case 7:
             if (buttons & 0x100ULL) {
-                lbAudioAx_80024030(1);
+                sfxForward();
                 fn_80188644();
                 return;
             }
@@ -2620,7 +2621,7 @@ void fn_801891F4(void)
 
             speeds = *(ClassicProcArray*) lbl_803B7C68;
 
-            lbAudioAx_80024030(0);
+            sfxBack();
             sub->anim_frames[22] = 0x14;
             lb_80019880(__cvt_dbl_usll(
                 (f64) (0.016666668f / ((f32*) speeds.v)[sub->menu_values[0]] *

--- a/src/melee/gm/gm_19EF.c
+++ b/src/melee/gm/gm_19EF.c
@@ -8,6 +8,7 @@
 
 #include "dolphin/pad.h"
 #include "it/inlines.h"
+#include "mn/inlines.h"
 
 #include <sysdolphin/baselib/archive.h>
 #include <sysdolphin/baselib/cobj.h>
@@ -226,7 +227,7 @@ static void fn_8019F2D4(u32 arg0)
             if ((u8) lbl_80479A98.x14 != 0) {
                 if ((u16) lbl_80479A98.x1E >= (u16) lbl_80479A98.x1C) {
                     lbl_80479A98.x0 = 8;
-                    lbAudioAx_80024030(1);
+                    sfxForward();
                     lbl_80479A98.x60 = 1;
                     lbl_80479A98.x22 =
                         lbl_80479A98.x22 - (lbl_80479A98.x1C * 0xA);
@@ -239,7 +240,7 @@ static void fn_8019F2D4(u32 arg0)
                 return;
             }
             lbl_80479A98.x0 = 8;
-            lbAudioAx_80024030(1);
+            sfxForward();
             lbAudioAx_80023F28(0x20);
             lbAudioAx_800237A8(0x9C43, 0x7F, 0x40);
             lbl_804D66C8.x4 = 0x6E;
@@ -247,11 +248,11 @@ static void fn_8019F2D4(u32 arg0)
             return;
         }
         if ((arg0 & 0x40000) && ((u8) lbl_80479A98.x14 == 0)) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             lbl_80479A98.x14 = 1;
         }
         if ((arg0 & 0x80000) && ((u8) lbl_80479A98.x14 == 1)) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             lbl_80479A98.x14 = 0;
             return;
         }

--- a/src/melee/gm/gm_1A33.c
+++ b/src/melee/gm/gm_1A33.c
@@ -8,6 +8,7 @@
 #include <melee/gm/types.h>
 #include <melee/lb/lbaudio_ax.h>
 #include <melee/lb/lbsnap.h>
+#include <melee/mn/inlines.h>
 #include <melee/mn/mnmain.h>
 
 static f32 gmCamera_803DA758[12] = {
@@ -74,20 +75,20 @@ void gmCamera_801A34FC_OnFrame(void)
         }
         gmCamera_801A33BC();
     } else if (mn_8022F218() != 0) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_8022F268();
         *gmCamera_VsCameraTextLayout.x0 = 2;
         gm_801A4B60();
     } else if (button = gm_GetButtonsTriggered(PAD_ALL_CONTROLLERS),
                button & (HSD_PAD_START | HSD_PAD_A))
     {
-        lbAudioAx_80024030(1);
+        sfxForward();
         *gmCamera_VsCameraTextLayout.x0 = 0;
         gm_801A4B60();
     } else if (button = gm_GetButtonsTriggered(PAD_ALL_CONTROLLERS),
                button & PAD_BUTTON_B)
     {
-        lbAudioAx_80024030(0);
+        sfxBack();
         *gmCamera_VsCameraTextLayout.x0 = 1;
         gm_801A4B60();
     }

--- a/src/melee/gm/gm_1A9B.c
+++ b/src/melee/gm/gm_1A9B.c
@@ -24,6 +24,7 @@
 #include "lb/lbaudio_ax.h"
 #include "lb/lbbgflash.h"
 #include "lb/lbmthp.h"
+#include "mn/inlines.h"
 
 #include <baselib/gobj.h>
 #include <baselib/gobjgxlink.h>
@@ -172,7 +173,7 @@ void gm_801A9D0C_OnFrame(void)
             lbBgFlash_8002063C(0x3C);
             gmRegend_ExitTimer = 0x3C;
             lbAudioAx_80023694();
-            lbAudioAx_80024030(1);
+            sfxForward();
         }
     }
 }

--- a/src/melee/gm/gm_1AED.c
+++ b/src/melee/gm/gm_1AED.c
@@ -10,6 +10,7 @@
 #include <melee/lb/lbcardgame.h>
 #include <melee/lb/lbcardnew.h>
 #include <melee/lb/lblanguage.h>
+#include <melee/mn/inlines.h>
 
 static u8 gm_804D6870;
 static u16 gm_804D6872;
@@ -86,14 +87,14 @@ int gm_801AF0D4(void)
     if (gm_801AEDC8() & 0x40001 ? 1 : 0) {
         if (gm_80480DA8.unk1C != 0) {
             if (gm_80480DA8.unk10 != 0) {
-                lbAudioAx_80024030(2);
+                sfxMove();
             }
             gm_80480DA8.unk1C = 0;
         }
     } else if ((gm_801AEDC8() & 0x80002 ? 1 : 0)) {
         if (gm_80480DA8.unk1C < 1) {
             if (gm_80480DA8.unk10 != 0) {
-                lbAudioAx_80024030(2);
+                sfxMove();
             }
             gm_80480DA8.unk1C = 1;
         }
@@ -119,7 +120,7 @@ static inline u8 set_gm_804D6870_inline(void)
 static inline bool gm_801AEDC8_flag_check(void)
 {
     if (gm_801AEDC8() & 0x1100) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         return true;
     }
     return false;

--- a/src/melee/gm/gm_1B03.c
+++ b/src/melee/gm/gm_1B03.c
@@ -6,6 +6,9 @@
 #include "if/soundtest.h"
 
 #include "mn/forward.h"
+
+#include "mn/inlines.h"
+
 #include <melee/pl/forward.h>
 
 #include <sysdolphin/baselib/controller.h>
@@ -530,7 +533,7 @@ void gm_801B09C0(GameScene* arg0)
 int fn_801B09F8(int arg0)
 {
     if (arg0 == 0) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         gm_ChangeGameModeAfterCurrentScene(GM_TITLE);
         gm_801A4B60();
     }
@@ -551,7 +554,7 @@ void gm_801B0A34(GameScene* arg0)
 int fn_801B0A8C(int arg0)
 {
     if (arg0 == 0) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         gm_SetPendingSceneIndex(0);
         gm_801A4B60();
     }

--- a/src/melee/gm/gm_1B14.c
+++ b/src/melee/gm/gm_1B14.c
@@ -22,6 +22,7 @@
 #include "melee/lb/lbtime.h"
 #include "melee/lb/types.h"
 #include "melee/mn/types.h"
+#include "mn/inlines.h"
 
 #include <sysdolphin/baselib/controller.h>
 #include <sysdolphin/baselib/memory.h>
@@ -704,7 +705,7 @@ void gm_801B2204(GameScene* arg0)
     if (!gm_80173754(0x1C, gm_804D68C0)) {
         gm_SetPendingSceneIndex(0);
     }
-    lbAudioAx_80024030(1);
+    sfxForward();
 }
 
 void gm_801B2298_OnInit(void)

--- a/src/melee/gm/gmcamera.c
+++ b/src/melee/gm/gmcamera.c
@@ -28,6 +28,7 @@
 #include "lb/lbcardnew.h"
 #include "lb/lbsnap.h"
 #include "lb/lbspdisplay.h"
+#include "mn/inlines.h"
 #include "mn/mnmain.h"
 #include "sc/types.h"
 
@@ -375,7 +376,7 @@ void gmCamera_801A2AAC(void)
     if ((lbSnap_8001D338(0) != 0) || (lbSnap_8001D338(1) != 0)) {
         gmCamera_801A3048(2);
     } else if (HSD_PadCopyStatus[3].trigger & 0x100) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         switch (gmCamera_VsCamUiState.x44) {
         case 0:
         case 1:
@@ -397,7 +398,7 @@ void gmCamera_801A2AAC(void)
             break;
         }
     } else if (HSD_PadCopyStatus[3].trigger & 0x200) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         gmCamera_801A3048(0);
     }
 }
@@ -405,7 +406,7 @@ void gmCamera_801A2AAC(void)
 void gmCamera_801A2BB0(void)
 {
     if (HSD_PadCopyStatus[3].trigger & 0x200) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         gmCamera_801A3048(0);
     }
 }
@@ -460,7 +461,7 @@ static inline void gmCamera_801A2D44_update_selection(HSD_JObj** jobj_b,
 
     if (HSD_PadCopyStatus[3].trigger & 0x40001) {
         if (*(px18 = &gcus->x18) != 0) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             *px18 = 0;
             lb_80011E24(gcus->x8, &(*jobj), 0xC, -1);
             if (*px18 != 0) {
@@ -474,7 +475,7 @@ static inline void gmCamera_801A2D44_update_selection(HSD_JObj** jobj_b,
     }
     if (HSD_PadCopyStatus[3].trigger & 0x80002) {
         if (*(px18 = &gcus->x18) != 1) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             *px18 = 1;
             lb_80011E24(gcus->x8, &(*jobj_b), 0xC, -1);
             if (*px18 != 0) {
@@ -500,16 +501,16 @@ void gmCamera_801A2D44(void)
     }
     if (HSD_PadCopyStatus[3].trigger & 0x1100) {
         if (gcus->x18 == 0) {
-            lbAudioAx_80024030(1);
+            sfxForward();
             gmCamera_801A3048(7);
             return;
         }
-        lbAudioAx_80024030(0);
+        sfxBack();
         gmCamera_801A3048(0);
         return;
     }
     if (HSD_PadCopyStatus[3].trigger & 0x200) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         gmCamera_801A3048(0);
         return;
     }

--- a/src/melee/gm/gmhowto.c
+++ b/src/melee/gm/gmhowto.c
@@ -11,6 +11,7 @@
 #include <melee/gm/gmmain_lib.h>
 #include <melee/lb/lbaudio_ax.h>
 #include <melee/lb/lbmthp.h>
+#include <melee/mn/inlines.h>
 
 static u32 gm_803DD2C0[] = {
     1,  19, 856, 1,  1,   85, 279, 1,  1,   59,  17,  1,  1,     59, 19,
@@ -73,7 +74,7 @@ void gm_801ACD8C_OnFrame(void)
         if (gm_GetButtonsTriggered(PAD_ALL_CONTROLLERS) &
             (HSD_PAD_START | HSD_PAD_A))
         {
-            lbAudioAx_80024030(1);
+            sfxForward();
             gm_SetPendingGameMode(GM_TITLE);
             gm_SetNewGameModePending();
         } else if (gmMainLib_8015DB00() != 5) {

--- a/src/melee/gm/gmomake15.c
+++ b/src/melee/gm/gmomake15.c
@@ -11,6 +11,7 @@
 #include <melee/gm/gmmain_lib.h>
 #include <melee/lb/lbaudio_ax.h>
 #include <melee/lb/lbmthp.h>
+#include <melee/mn/inlines.h>
 
 static HSD_GObj* gm_804D6858;
 
@@ -64,7 +65,7 @@ void gm_801ACF8C_OnFrame(void)
             var_r31)
         {
             if (var_r31 == 0) {
-                lbAudioAx_80024030(1);
+                sfxForward();
             }
             gm_SetPendingGameMode(GM_TITLE);
             gm_SetNewGameModePending();

--- a/src/melee/gm/gmopening.c
+++ b/src/melee/gm/gmopening.c
@@ -16,6 +16,7 @@
 #include <melee/lb/lbaudio_ax.h>
 #include <melee/lb/lblanguage.h>
 #include <melee/lb/lbmthp.h>
+#include <melee/mn/inlines.h>
 #include <melee/mn/types.h>
 
 /* 3B7D68 */ static const Vec3 gm_803B7D68 = { 0.0f, 0.0f, 1.0f };
@@ -262,7 +263,7 @@ void gm_801AA28C_OnFrame(void)
         if (gm_GetButtonsTriggered(PAD_ALL_CONTROLLERS) & HSD_PAD_START) {
             gmMainLib_8015F500();
             lbAudioAx_800236DC();
-            lbAudioAx_80024030(1);
+            sfxForward();
             gm_801A4B60();
             gm_80173EEC();
             gm_80172898(0x100);
@@ -278,7 +279,7 @@ void gm_801AA28C_OnFrame(void)
             gmMainLib_8015F500();
             lbAudioAx_800236DC();
             lbAudioAx_80023694();
-            lbAudioAx_80024030(1);
+            sfxForward();
             gm_801A4B60();
             gm_SetPendingGameMode(GM_TITLE);
             gm_SetNewGameModePending();

--- a/src/melee/gm/gmprogressive.c
+++ b/src/melee/gm/gmprogressive.c
@@ -17,6 +17,7 @@
 #include <melee/lb/lbarchive.h>
 #include <melee/lb/lbaudio_ax.h>
 #include <melee/lb/lblanguage.h>
+#include <melee/mn/inlines.h>
 #include <melee/sc/types.h>
 
 static struct {
@@ -138,14 +139,14 @@ void gm_801AD620_OnFrame(void)
         if ((gm_GetButtonsTriggered(PAD_ALL_CONTROLLERS) & PAD_ANY_LEFT) &&
             gm_80480D70.x10 == 2 && gm_80480D70.x14 == 0)
         {
-            lbAudioAx_80024030(2);
+            sfxMove();
             gm_80480D70.x10 = 1;
             gm_801AD254(gm_80480D70.x10);
         }
         if ((gm_GetButtonsTriggered(PAD_ALL_CONTROLLERS) & PAD_ANY_RIGHT) &&
             gm_80480D70.x10 == 1 && gm_80480D70.x14 == 0)
         {
-            lbAudioAx_80024030(2);
+            sfxMove();
             gm_80480D70.x10 = 2;
             gm_801AD254(gm_80480D70.x10);
         }
@@ -153,12 +154,12 @@ void gm_801AD620_OnFrame(void)
             gm_80480D70.x14 == 0)
         {
             if (gm_80480D70.x10 == 1) {
-                lbAudioAx_80024030(1);
+                sfxForward();
                 gm_80480D70.x10 = 3;
                 gm_80480D70.x8->hidden = 1;
                 HSD_JObjSetFlagsAll(gm_80480D70.x4, JOBJ_HIDDEN);
             } else if (gm_80480D70.x10 == 2) {
-                lbAudioAx_80024030(1);
+                sfxForward();
                 gm_80480D70.x14 = 2;
                 gm_801AD254(5);
                 OSSetProgressiveMode(0);

--- a/src/melee/gm/gmregclear.c
+++ b/src/melee/gm/gmregclear.c
@@ -8,6 +8,8 @@
 
 #include "gm/forward.h"
 
+#include "mn/inlines.h"
+
 #include <math_ppc.h>
 #include <dolphin/gx.h>
 #include <sysdolphin/baselib/aobj.h>
@@ -2489,7 +2491,7 @@ void fn_8017FF1C(HSD_GObj* gobj)
             {
                 state->xFC = state->x104;
                 state->x116 = 1;
-                lbAudioAx_80024030(1);
+                sfxForward();
                 break;
             }
         }
@@ -4046,7 +4048,7 @@ void fn_80182F40(HSD_GObj* unused)
     {
         lbAudioAx_80024C84();
         lbAudioAx_80023694();
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_801A4B60();
         gm_SetPendingGameMode(GM_TITLE);
         gm_SetNewGameModePending();

--- a/src/melee/gm/gmregtyfall.c
+++ b/src/melee/gm/gmregtyfall.c
@@ -18,6 +18,7 @@
 #include "lb/lbarchive.h"
 #include "lb/lbaudio_ax.h"
 #include "lb/lbspdisplay.h"
+#include "mn/inlines.h"
 #include "mn/mnmain.h"
 #include "mp/mpcoll.h"
 #include "pl/player.h"
@@ -547,7 +548,7 @@ void gm_801A79D4_OnFrame(void)
         gm_804D6740--;
     } else if (gm_GetButtonsTriggered(gm_801BF010()) & PAD_BUTTON_START) {
         lbAudioAx_80023694();
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_801A4B60();
     }
 }

--- a/src/melee/gm/gmresult.c
+++ b/src/melee/gm/gmresult.c
@@ -43,6 +43,7 @@ extern HSD_Archive* lbl_804D65B8;
 #include "lb/lblanguage.h"
 #include "lb/lbspdisplay.h"
 #include "lb/lbvector.h"
+#include "mn/inlines.h"
 #include "mn/mnmain.h"
 #include "pl/player.h"
 #include "sc/types.h"
@@ -88,17 +89,17 @@ s32 fn_80174284(u8 slot)
 
 void fn_80174338(void)
 {
-    lbAudioAx_80024030(1);
+    sfxForward();
 }
 
 void fn_8017435C(void)
 {
-    lbAudioAx_80024030(0);
+    sfxBack();
 }
 
 void fn_80174380(void)
 {
-    lbAudioAx_80024030(2);
+    sfxMove();
 }
 
 bool gm_801743A4(u8 outcome)

--- a/src/melee/gm/gmtitle.c
+++ b/src/melee/gm/gmtitle.c
@@ -21,6 +21,7 @@
 #include <melee/lb/lbmthp.h>
 #include <melee/lb/lbspdisplay.h>
 #include <melee/lb/lbtime.h>
+#include <melee/mn/inlines.h>
 #include <melee/mn/mnmain.h>
 #include <melee/sc/types.h>
 
@@ -278,24 +279,24 @@ void gmTitle_801A1C18_OnFrame(void)
         lbAudioAx_8002702C(0xC, 0);
         lbAudioAx_80027168();
         lbAudioAx_80027648();
-        lbAudioAx_80024030(1);
+        sfxForward();
         gmMainLib_8015ECBC();
         tmp = gm_GetCurrentSceneExitData();
         *tmp = input;
         gm_801A4B60();
     } else if (DbLevel >= 3) {
         if (input & HSD_PAD_Y) {
-            lbAudioAx_80024030(1);
+            sfxForward();
             tmp = gm_GetCurrentSceneExitData();
             *tmp = input;
             gm_801A4B60();
         } else if (input & HSD_PAD_A) {
-            lbAudioAx_80024030(1);
+            sfxForward();
             tmp = gm_GetCurrentSceneExitData();
             *tmp = input;
             gm_801A4B60();
         } else if (input & HSD_PAD_X) {
-            lbAudioAx_80024030(1);
+            sfxForward();
             tmp = gm_GetCurrentSceneExitData();
             *tmp = input;
             gm_801A4B60();

--- a/src/melee/gm/gmtou_0.c
+++ b/src/melee/gm/gmtou_0.c
@@ -17,6 +17,7 @@
 
 #include "lb/lbarchive.h"
 #include "lb/lbaudio_ax.h"
+#include "mn/inlines.h"
 #include "mn/mnmain.h"
 #include "mn/mnmainrule.h"
 #include "mn/mnname.h"
@@ -1543,7 +1544,7 @@ static inline void tmSettings_StepDown(s32* menu, TmSettingTable* table,
     s32* ptr;
     s32 val;
 
-    lbAudioAx_80024030(2);
+    sfxMove();
     state->x7 = 5;
     idx = menu[0];
     ptr = menu + idx;
@@ -1563,7 +1564,7 @@ static inline void tmSettings_StepUp(s32* menu, TmSettingTable* table,
     s32* ptr;
     s32 val;
 
-    lbAudioAx_80024030(2);
+    sfxMove();
     state->x8 = 5;
     idx = menu[0];
     ptr = menu + idx;
@@ -1607,7 +1608,7 @@ void fn_801937C4(s32* arg0, u32 arg1, u32 arg2)
         u8* tp;
         s32* dp;
 
-        lbAudioAx_80024030(1);
+        sfxForward();
         idx = arg0[0];
         global = &gm_804771C4;
         arg0[0] = idx + 1;
@@ -1630,7 +1631,7 @@ void fn_801937C4(s32* arg0, u32 arg1, u32 arg2)
             }
         }
     } else if (arg2 & 0x200) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         gm_ChangeGameModeAfterCurrentScene(GM_MENU);
         gm_801A4B60();
     }
@@ -1678,7 +1679,7 @@ void fn_80193B58(s32* arg0, u32 arg1, u32 arg2)
             ptr = arg0 + idx;
             if (*++ptr > (s32) (entry = table->min)[idx][!!*mt]) {
                 *ptr = *ptr - 1;
-                lbAudioAx_80024030(2);
+                sfxMove();
                 state->x7 = 5;
             } else {
                 s32 max = (s32) table->max[idx][!!*mt];
@@ -1690,7 +1691,7 @@ void fn_80193B58(s32* arg0, u32 arg1, u32 arg2)
                 idx = arg0[0];
                 val = arg0[idx + 1];
                 if (val != (s32) entry[idx][!!*mt]) {
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     state->x7 = 5;
                 }
             }
@@ -1704,14 +1705,14 @@ void fn_80193B58(s32* arg0, u32 arg1, u32 arg2)
             if (*++ptr < (s32) (entry = table->max)[idx][!!*mt]) {
                 if (*ptr + 1 <= clamp_val) {
                     *ptr = *ptr + 1;
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     state->x8 = 5;
                 } else {
                     *ptr = (s32) table->min[idx][!!*mt];
                     idx = arg0[0];
                     val = arg0[idx + 1];
                     if (val != clamp_val) {
-                        lbAudioAx_80024030(2);
+                        sfxMove();
                         state->x8 = 5;
                     }
                 }
@@ -1720,7 +1721,7 @@ void fn_80193B58(s32* arg0, u32 arg1, u32 arg2)
                 idx = arg0[0];
                 val = arg0[idx + 1];
                 if (val != (s32) entry[idx][!!*mt]) {
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     state->x8 = 5;
                 }
             }
@@ -1742,7 +1743,7 @@ void fn_80193B58(s32* arg0, u32 arg1, u32 arg2)
     }
 
     if (arg2 & 0x100) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         arg0[0] = arg0[0] + 1;
         if (*mt == 0) {
             u8 x30 = ((TmData*) arg0)->x30;
@@ -1760,7 +1761,7 @@ void fn_80193B58(s32* arg0, u32 arg1, u32 arg2)
             fn_80190520(lbl_804DA6E0, lbl_804DA6E4, 0.0F);
         }
     } else if (arg2 & 0x200) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         arg0[0] = arg0[0] - 1;
     }
 
@@ -1805,7 +1806,7 @@ void fn_80193FCC(s32* arg0, u32 arg1, u32 arg2)
             ptr = arg0 + idx;
             if (*++ptr > (s32) (entry = table->min)[idx][!!*mt]) {
                 *ptr = *ptr - 1;
-                lbAudioAx_80024030(2);
+                sfxMove();
                 state->x7 = 5;
             } else {
                 s32 max_plus1 = (s32) table->max[idx][!!*mt] + 1;
@@ -1817,7 +1818,7 @@ void fn_80193FCC(s32* arg0, u32 arg1, u32 arg2)
                 idx = arg0[0];
                 val = arg0[idx + 1];
                 if (val != (s32) entry[idx][!!*mt]) {
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     state->x7 = 5;
                 }
             }
@@ -1859,7 +1860,7 @@ void fn_80193FCC(s32* arg0, u32 arg1, u32 arg2)
             if (*++ptr < (s32) (entry = table->max)[idx][!!*mt] + 1) {
                 if (*ptr + 1 <= clamp_val && *ptr + 1 < arg0[2]) {
                     *ptr = *ptr + 1;
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     state->x8 = 5;
                     goto after_right;
                 }
@@ -1867,7 +1868,7 @@ void fn_80193FCC(s32* arg0, u32 arg1, u32 arg2)
                 idx = arg0[0];
                 val = arg0[idx + 1];
                 if (val != clamp_val) {
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     state->x8 = 5;
                 }
             } else {
@@ -1875,12 +1876,12 @@ void fn_80193FCC(s32* arg0, u32 arg1, u32 arg2)
                 idx = arg0[0];
                 val = arg0[idx + 1];
                 if (val != (s32) entry[idx][!!*mt] + 1) {
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     state->x8 = 5;
                 }
             }
         } else {
-            lbAudioAx_80024030(2);
+            sfxMove();
             state->x8 = 5;
             idx = arg0[0];
             ptr = arg0 + idx;
@@ -1966,10 +1967,10 @@ post_clamp:
     }
 
     if (arg2 & 0x100) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         arg0[0] = arg0[0] + 1;
     } else if (arg2 & 0x200) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         arg0[0] = arg0[0] - 1;
         if (*mt == 0) {
             fn_8018EC7C();
@@ -2069,7 +2070,7 @@ end:
     }
 
     if (val != arg0[4]) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         if (changed == 0) {
             lbl_804799B8.x7 = 5;
         } else {
@@ -2083,10 +2084,10 @@ end:
     }
 
     if (arg2 & 0x100) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         arg0[0] = arg0[0] + 1;
     } else if (arg2 & 0x200) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         arg0[0] = arg0[0] - 1;
     }
 
@@ -2118,14 +2119,14 @@ void fn_801949B4(s32* arg0, u32 arg1, u32 arg2)
     }
 
     if (arg2 & 0x100) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         if (gm_804771C4.match_type == 0) {
             *arg0 = *arg0 + 1;
         } else {
             *arg0 = 6;
         }
     } else if (arg2 & 0x200) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         *arg0 = *arg0 - 1;
     }
 
@@ -2163,10 +2164,10 @@ void fn_80194BC4(s32* arg0, u32 arg1, u32 arg2)
     }
 
     if (arg2 & 0x100) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         *arg0 = *arg0 + 1;
     } else if (arg2 & 0x200) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         *arg0 = *arg0 - 1;
     }
 
@@ -2186,11 +2187,11 @@ void fn_80194D84(s32* state, u32 buttons, u32 trigger)
 
     if (buttons & 0x40001) {
         if (*state > 6) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             *state -= 1;
         }
     } else if ((buttons & 0x80002) && (*state < 8)) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         *state += 1;
     }
 
@@ -2199,7 +2200,7 @@ void fn_80194D84(s32* state, u32 buttons, u32 trigger)
     }
 
     if (trigger & 0x1100) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         fn_8018EC7C();
         cur_state = *state;
         if (cur_state == 6) {
@@ -2220,7 +2221,7 @@ void fn_80194D84(s32* state, u32 buttons, u32 trigger)
             *state = 0;
         }
     } else if (trigger & 0x200) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         if (gm_804771C4.match_type == 0) {
             *state = 5;
         } else {
@@ -2269,7 +2270,7 @@ void fn_80194F30(s32* state_ptr, u32 buttons, u32 trigger)
     s32 idx;
 
     if (trigger & 0x1000) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         lbl_804D6654 = *state_ptr;
         *state_ptr = 0x11;
         return;
@@ -2278,11 +2279,11 @@ void fn_80194F30(s32* state_ptr, u32 buttons, u32 trigger)
     if (buttons & 0x40001) {
         switch (*state_ptr) {
         case 12:
-            lbAudioAx_80024030(2);
+            sfxMove();
             *state_ptr = 0xA;
             break;
         case 16:
-            lbAudioAx_80024030(2);
+            sfxMove();
             *state_ptr = 0xC;
             state->x1 = 0;
             break;
@@ -2292,12 +2293,12 @@ void fn_80194F30(s32* state_ptr, u32 buttons, u32 trigger)
         case 11:
             break;
         case 10:
-            lbAudioAx_80024030(2);
+            sfxMove();
             *state_ptr = 0xC;
             break;
         case 12:
             if (state->x0 != 0) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 *state_ptr = 0x10;
             }
             break;
@@ -2306,12 +2307,12 @@ void fn_80194F30(s32* state_ptr, u32 buttons, u32 trigger)
         if (*state_ptr != 0x10 || state->x1 == 0) {
             u8* pos_ptr;
             if (*(pos_ptr = &state->x2) != 0) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 *pos_ptr -= 1;
                 fn_80190ABC(5);
             } else {
                 if (*(pos_ptr = &state->x3) != 0) {
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     *pos_ptr -= 1;
                     state->x4 -= 1;
                     fn_80190ABC(5);
@@ -2323,7 +2324,7 @@ void fn_80194F30(s32* state_ptr, u32 buttons, u32 trigger)
             u8* scroll_ptr;
             idx = *(scroll_ptr = &state->x2) + *(pos_ptr = &state->x3);
             if (tm->x37[idx].x2 > 1) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 idx = *scroll_ptr + *pos_ptr;
                 tm->x37[idx].x2 -= 1;
             }
@@ -2335,13 +2336,13 @@ void fn_80194F30(s32* state_ptr, u32 buttons, u32 trigger)
             u8 pos = *(scroll_ptr = &state->x2);
             if (pos < 0xB) {
                 if (pos + state->x3 < tm->x2E - 1) {
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     *scroll_ptr += 1;
                     fn_80190ABC(5);
                 }
             } else {
                 if (pos + *(pos_ptr = &state->x3) < tm->x2E - 1) {
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     *pos_ptr += 1;
                     state->x4 += 1;
                     fn_80190ABC(5);
@@ -2353,7 +2354,7 @@ void fn_80194F30(s32* state_ptr, u32 buttons, u32 trigger)
             u8* scroll_ptr;
             idx = *(scroll_ptr = &state->x2) + *(pos_ptr = &state->x3);
             if (tm->x37[idx].x2 < 9) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 idx = *scroll_ptr + *pos_ptr;
                 tm->x37[idx].x2 += 1;
             }
@@ -2364,7 +2365,7 @@ void fn_80194F30(s32* state_ptr, u32 buttons, u32 trigger)
         switch (*state_ptr) {
         case 12:
         case 10:
-            lbAudioAx_80024030(1);
+            sfxForward();
             idx = state->x2 + state->x3;
             tm->x37[idx].x4 = tm->x37[idx].x3;
             idx = state->x2 + state->x3;
@@ -2379,7 +2380,7 @@ void fn_80194F30(s32* state_ptr, u32 buttons, u32 trigger)
             if (state->x0 != 1) {
                 u8* flag_ptr;
                 if (*(flag_ptr = &state->x1) != 1) {
-                    lbAudioAx_80024030(1);
+                    sfxForward();
                 }
                 *flag_ptr = 1;
                 return;
@@ -2388,7 +2389,7 @@ void fn_80194F30(s32* state_ptr, u32 buttons, u32 trigger)
         }
     } else if (trigger & 0x200) {
         u8* flag_ptr;
-        lbAudioAx_80024030(0);
+        sfxBack();
         if (*state_ptr != 0x10 || *(flag_ptr = &state->x1) == 0) {
             *state_ptr = 6;
             state->xE = 0;
@@ -2432,7 +2433,7 @@ void fn_801953C8(s32* state_ptr, u32 buttons, u32 trigger)
     cur_pos = fn_8018F310(fn_8018F6FC(tm->x37[idx].x3));
 
     if (trigger & 0x1000) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         idx = lbl_804799B8.x2 + lbl_804799B8.x3;
         tm->x37[idx].x3 = tm->x37[idx].x4;
         idx = lbl_804799B8.x2 + lbl_804799B8.x3;
@@ -2461,7 +2462,7 @@ void fn_801953C8(s32* state_ptr, u32 buttons, u32 trigger)
                 occupied = 0;
             }
             if (occupied != 0) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 idx = lbl_804799B8.x2 + lbl_804799B8.x3;
                 tm->x37[idx].x7 = 0;
                 idx = lbl_804799B8.x2 + lbl_804799B8.x3;
@@ -2489,7 +2490,7 @@ void fn_801953C8(s32* state_ptr, u32 buttons, u32 trigger)
                 occupied = 0;
             }
             if (occupied != 0) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 idx = lbl_804799B8.x2 + lbl_804799B8.x3;
                 tm->x37[idx].x7 = 0;
                 idx = lbl_804799B8.x2 + lbl_804799B8.x3;
@@ -2518,7 +2519,7 @@ void fn_801953C8(s32* state_ptr, u32 buttons, u32 trigger)
                 occupied = 0;
             }
             if (occupied != 0) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 idx = lbl_804799B8.x2 + lbl_804799B8.x3;
                 tm->x37[idx].x7 = 0;
                 idx = lbl_804799B8.x2 + lbl_804799B8.x3;
@@ -2546,7 +2547,7 @@ void fn_801953C8(s32* state_ptr, u32 buttons, u32 trigger)
                 occupied = 0;
             }
             if (occupied != 0) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 idx = lbl_804799B8.x2 + lbl_804799B8.x3;
                 tm->x37[idx].x7 = 0;
                 idx = lbl_804799B8.x2 + lbl_804799B8.x3;
@@ -2568,7 +2569,7 @@ void fn_801953C8(s32* state_ptr, u32 buttons, u32 trigger)
                 lbAudioAx_80024030(3);
                 return;
             }
-            lbAudioAx_80024030(1);
+            sfxForward();
             idx = lbl_804799B8.x2 + lbl_804799B8.x3;
             tm->x37[idx].x5 = 1;
             *state_ptr -= 1;
@@ -2579,14 +2580,14 @@ void fn_801953C8(s32* state_ptr, u32 buttons, u32 trigger)
             lbAudioAx_80024030(3);
             return;
         }
-        lbAudioAx_80024030(1);
+        sfxForward();
         *state_ptr -= 1;
         idx = fn_801953C8_GetPlayerIndex();
         if (tm->x37[idx].x5 != 0) {
             tm->x37[idx].x5 = 0;
         }
     } else if (trigger & 0x200) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         idx = lbl_804799B8.x2 + lbl_804799B8.x3;
         tm->x37[idx].x3 = tm->x37[idx].x4;
         idx = lbl_804799B8.x2 + lbl_804799B8.x3;
@@ -2600,14 +2601,14 @@ void fn_801953C8(s32* state_ptr, u32 buttons, u32 trigger)
                 tm->x37[lbl_804799B8.x2 + lbl_804799B8.x3].x3)) -
                 1)
         {
-            lbAudioAx_80024030(2);
+            sfxMove();
             idx = lbl_804799B8.x2 + lbl_804799B8.x3;
             tm->x37[idx].x7++;
         }
     } else if (trigger & 0x800) {
         idx = lbl_804799B8.x2 + lbl_804799B8.x3;
         if (tm->x37[idx].x7 != 0) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             idx = lbl_804799B8.x2 + lbl_804799B8.x3;
             tm->x37[idx].x7--;
         }
@@ -2633,16 +2634,16 @@ void fn_80195AF0(s32* state_ptr, u32 buttons, u32 trigger)
 
     if (buttons & 0x40001) {
         if (*state_ptr == 0xE) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             *state_ptr = 0xD;
         }
     } else if ((buttons & 0x80002) && (*state_ptr == 0xD)) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         *state_ptr = 0xE;
     }
 
     if (trigger & 0x100) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         tm_alt = (TmData_80194F30*) state_ptr;
         idx = *(x2 = &menu->x2) + *(x3 = &menu->x3);
         tm_alt->x37[idx].xB = tm_alt->x37[idx].x9;
@@ -2669,7 +2670,7 @@ void fn_80195AF0(s32* state_ptr, u32 buttons, u32 trigger)
             return;
         }
     } else if (trigger & 0x200) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         tm_alt = (TmData_80194F30*) state_ptr;
         idx = menu->x2 + menu->x3;
         tm_alt->x37[idx].x9 = tm_alt->x37[idx].xB;
@@ -2712,7 +2713,7 @@ void fn_80195CCC(s32* arg, u32 buttons, u32 trigger)
     u8* x6_tmp;
 
     if (buttons & 0x40001) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         if ((*(ptr = menu + 5) % 4) != 0) {
             *ptr -= 1;
             slot = lbl_804799B8.x2 + lbl_804799B8.x3;
@@ -2723,7 +2724,7 @@ void fn_80195CCC(s32* arg, u32 buttons, u32 trigger)
     } else if (buttons & 0x80002) {
         u8* right_x5;
 
-        lbAudioAx_80024030(2);
+        sfxMove();
         if (((s32) (*(right_x5 = menu + 5) % 4) < 3) &&
             ((s32) (*right_x5 + (i = (*(x6_tmp = menu + 6) * 4) + 1)) <
              GetNameCount()))
@@ -2735,7 +2736,7 @@ void fn_80195CCC(s32* arg, u32 buttons, u32 trigger)
             fn_80190ABC(4);
         }
     } else if (buttons & 0x10008) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         if (((s32) lbl_804799B8.x5 / 4) != 0) {
             lbl_804799B8.x5 -= 4;
             slot = lbl_804799B8.x2 + lbl_804799B8.x3;
@@ -2750,7 +2751,7 @@ void fn_80195CCC(s32* arg, u32 buttons, u32 trigger)
             fn_80190ABC(4);
         }
     } else if (buttons & 0x20004) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         if ((s32) ((s32) * (ptr = menu + 5) / 4) < 8) {
             if ((s32) (*ptr + (i = (*(x6_tmp = menu + 6) * 4) + 4)) <
                 GetNameCount())
@@ -2789,7 +2790,7 @@ void fn_80195CCC(s32* arg, u32 buttons, u32 trigger)
             unique =
                 fn_80195CCC_IsUniqueEntry(tm, (s32) count, slot, selected);
             if (unique != 0) {
-                lbAudioAx_80024030(1);
+                sfxForward();
                 slot = *x2_ptr + *menu;
                 tm_alt->x37[slot].x9 = *x5 + (*x6_ptr * 4);
                 fn_80190ABC(5);
@@ -2803,7 +2804,7 @@ void fn_80195CCC(s32* arg, u32 buttons, u32 trigger)
     }
 
     if (trigger & 0x200) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         slot = menu[2] + menu[3];
         tm_alt->x37[slot].x9 = tm_alt->x37[slot].xB;
         fn_80190ABC(5);
@@ -2824,12 +2825,12 @@ void fn_8019610C(s32* state, u32 buttons, u32 trigger)
 
     if (buttons & 0x10008) {
         if (*state == 0x12) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             *state = 0x11;
         }
     } else if ((buttons & 0x20004) != 0) {
         if (*state == 0x11) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             *state = 0x12;
         }
     }
@@ -2864,11 +2865,11 @@ void fn_8019610C(s32* state, u32 buttons, u32 trigger)
             }
             gm_801A4B60();
         } else {
-            lbAudioAx_80024030(0);
+            sfxBack();
             *state = lbl_804D6654;
         }
     } else if ((trigger & 0x200) != 0) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         *state = lbl_804D6654;
     }
 }
@@ -2886,7 +2887,7 @@ void gm_8019628C_OnFrame(void)
     r29 = fn_8018F640(4);
 
     if (mn_8022F218() != 0) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         HSD_SisLib_803A5E70();
         mn_8022F138(1, 8);
         mn_8022F138(0x19, 0x1C);

--- a/src/melee/gm/gmtou_1.c
+++ b/src/melee/gm/gmtou_1.c
@@ -21,6 +21,7 @@
 #include "lb/lbaudio_ax.h"
 #include "lb/lbdvd.h"
 #include "lb/types.h"
+#include "mn/inlines.h"
 #include "mn/mnmain.h"
 #include "sc/types.h"
 
@@ -1864,7 +1865,7 @@ void fn_8019A86C(TmData* tm, u32 arg1, u32 arg2)
     if (tm->cur_option == 0x1D) {
         lbl_804799D8.x0 += 1;
         if ((arg2 & 0x600) || (lbl_804799D8.x0 >= 0x12CU)) {
-            lbAudioAx_80024030(0);
+            sfxBack();
             fn_8018EC48();
             tm->x2D = 0;
             tm->cur_option = 0x1F;
@@ -1874,7 +1875,7 @@ void fn_8019A86C(TmData* tm, u32 arg1, u32 arg2)
             s32 stype;
             s32 cond;
 
-            lbAudioAx_80024030(1);
+            sfxForward();
             t = gm_GetTournamentData();
             t->x2D = 1;
             stype = t->stage_selection_type;
@@ -1934,7 +1935,7 @@ void fn_8019A86C(TmData* tm, u32 arg1, u32 arg2)
                 cond3 = 0;
             }
             if (cond3 != 0 && pad_err != 0) {
-                lbAudioAx_80024030(0);
+                sfxBack();
                 HSD_SisLib_803A5E70();
                 mn_8022F138(0x19, 0x1C);
                 mn_8022F138(0x12, 0x15);
@@ -2031,7 +2032,7 @@ void fn_8019A86C(TmData* tm, u32 arg1, u32 arg2)
                     u32 buttons = fn_8018F640(i);
 
                     if (buttons & (PAD_BUTTON_A | PAD_BUTTON_START)) {
-                        lbAudioAx_80024030(1);
+                        sfxForward();
                         if (lbl_804799D8.x44[i] == 7) {
                             lbl_804799D8.x44[i] = 6;
                         } else if (lbl_804799D8.x44[i] == 8) {
@@ -2066,7 +2067,7 @@ void fn_8019A86C(TmData* tm, u32 arg1, u32 arg2)
                         }
                     } else if (buttons & PAD_BUTTON_X) {
                         if (lbl_804799D8.x44[i] != 6) {
-                            lbAudioAx_80024030(0);
+                            sfxBack();
                             lbl_804799D8.x44[i] = 6;
                         } else {
                             u8 pstate2 = lbl_804799D8.x2A[i].state;
@@ -2081,11 +2082,11 @@ void fn_8019A86C(TmData* tm, u32 arg1, u32 arg2)
                                     }
                                 }
                                 if (count5 < (s32) (tm->x30 - 1)) {
-                                    lbAudioAx_80024030(0);
+                                    sfxBack();
                                     lbl_804799D8.x44[i] = 7;
                                 }
                             } else if (pstate2 == 2) {
-                                lbAudioAx_80024030(0);
+                                sfxBack();
                                 lbl_804799D8.x2A[i].state = 3;
                                 lbl_804799D8.x2A[i].done = 0;
                             }
@@ -2094,14 +2095,14 @@ void fn_8019A86C(TmData* tm, u32 arg1, u32 arg2)
                                (buttons & PAD_BUTTON_UP))
                     {
                         if (lbl_804799D8.x44[i] == 8) {
-                            lbAudioAx_80024030(2);
+                            sfxMove();
                             lbl_804799D8.x44[i] = 7;
                         }
                     } else if (((buttons & PAD_STICK_DOWN) ||
                                 (buttons & PAD_BUTTON_DOWN)) &&
                                lbl_804799D8.x44[i] == 7)
                     {
-                        lbAudioAx_80024030(2);
+                        sfxMove();
                         lbl_804799D8.x44[i] = 8;
                     }
                 }

--- a/src/melee/gm/gmtou_2.c
+++ b/src/melee/gm/gmtou_2.c
@@ -20,6 +20,7 @@
 #include "lb/lbaudio_ax.h"
 #include "lb/lbdvd.h"
 #include "lb/types.h"
+#include "mn/inlines.h"
 #include "mn/mnmain.h"
 
 #include "pl/forward.h"
@@ -801,7 +802,7 @@ void gm_8019DF8C_OnFrame(void)
     fn_8018F640(4);
 
     if (mn_8022F218() != 0) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_8022F268();
         gm_801A4B60();
         gm_ChangeGameModeAfterCurrentScene(GM_MENU);
@@ -836,7 +837,7 @@ void gm_8019DF8C_OnFrame(void)
                 if (fn_8018F6A8(i) & 0x200) {
                     lbl_80479A58.x18[i] = (u8) (lbl_80479A58.x18[i] + 1);
                     if ((u8) lbl_80479A58.x18[i] > 0x5AU) {
-                        lbAudioAx_80024030(1);
+                        sfxForward();
                         gm_SetPendingSceneIndex(0U);
                         gm_801A4B60();
                         return;
@@ -856,7 +857,7 @@ void gm_8019DF8C_OnFrame(void)
 
                     if (pressed & 0x40001) {
                         u8 chr;
-                        lbAudioAx_80024030(2);
+                        sfxMove();
 
                         j = get_match_player_index(i);
                         tmd->x37[j].x5 = 0;
@@ -882,7 +883,7 @@ void gm_8019DF8C_OnFrame(void)
 
                     } else if (pressed & 0x80002) {
                         u8 chr;
-                        lbAudioAx_80024030(2);
+                        sfxMove();
 
                         j = get_match_player_index(i);
                         tmd->x37[j].x5 = 0;
@@ -912,7 +913,7 @@ void gm_8019DF8C_OnFrame(void)
                 if (buttons & 0x1100) {
                     if ((u8) lbl_80479A58.x1D[i].x0 != 2) {
                         u16 char_id;
-                        lbAudioAx_80024030(1);
+                        sfxForward();
                         lbl_80479A58.x1D[i].x0 = 1;
                         char_id = tmd->x4B8[i].x6;
                         if (char_id <= 0x78U) {
@@ -923,7 +924,7 @@ void gm_8019DF8C_OnFrame(void)
                     }
                 } else if (buttons & 0x200) {
                     if ((u8) lbl_80479A58.x1D[i].x0 == 2) {
-                        lbAudioAx_80024030(0);
+                        sfxBack();
                         lbl_80479A58.x1D[i].x0 = 3;
                     }
                 } else {

--- a/src/melee/if/soundtest.c
+++ b/src/melee/if/soundtest.c
@@ -14,6 +14,7 @@
 #include "lb/lbcardnew.h"
 #include "lb/lblanguage.h"
 #include "lb/lbsnap.h"
+#include "mn/inlines.h"
 #include "ty/toy.h"
 #include "ty/tylist.h"
 
@@ -366,7 +367,7 @@ bool un_802FFC6C(bool update_scene)
 {
     if (update_scene == true) {
         lbAudioAx_80023694();
-        lbAudioAx_80024030(0);
+        sfxBack();
         lbAudioAx_800236DC();
         lbAudioAx_800245D4(0x7F);
         lbAudioAx_800245F4(0x7F);
@@ -398,7 +399,7 @@ void un_802FFD94(int arg0, void* arg1, void* arg2)
     struct un_80304138_objalloc_t* d;
     if (arg0 == 1) {
         d = un_80302DF0();
-        lbAudioAx_80024030(1);
+        sfxForward();
         un_80304210(d, arg1, 0, -60, 0);
         un_80302DF8(un_80302DF0(), arg2);
     }
@@ -408,11 +409,11 @@ int fn_802FFE0C(int arg0)
 {
     switch (arg0) {
     case 0:
-        lbAudioAx_80024030(0);
+        sfxBack();
         un_80304334(un_80302DF0());
         break;
     case 6:
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_SetPendingSceneIndex(4);
         gm_801A4B60();
         break;
@@ -424,7 +425,7 @@ bool fn_802FFE6C(bool update_scene)
 {
     bool res = update_scene;
     if (update_scene == false) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         un_80304334(un_80302DF0());
         res = false;
     }
@@ -435,7 +436,7 @@ bool fn_802FFE6C(bool update_scene)
 bool un_802FFEA4(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_SetPendingSceneIndex(0x4);
         gm_801A4B60();
     }
@@ -542,7 +543,7 @@ void un_802FFF2C(StartMeleeData* arg0)
 bool un_803001DC(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_SetPendingSceneIndex(0x1);
         gm_801A4B60();
     }
@@ -559,7 +560,7 @@ int un_80300218(void)
 int un_80300248(int arg0)
 {
     if (un_803FA258.x4[0] && arg0 == 1) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gmMainLib_8015FB68();
     }
     return 0;
@@ -569,7 +570,7 @@ int un_80300290(int arg0)
 {
     if (arg0 == 1) {
         struct un_80304138_objalloc_t* x = un_80302DF0();
-        lbAudioAx_80024030(1);
+        sfxForward();
         un_80304210(x, &un_803FA658, 0, -60, 0);
         un_80302DF8(un_80302DF0(), fn_802FFE6C);
     }
@@ -579,7 +580,7 @@ int un_80300290(int arg0)
 bool un_803002FC(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_SetPendingSceneIndex(0x2);
         gm_801A4B60();
     }
@@ -639,7 +640,7 @@ s32 un_80300410(s32 arg0)
 {
     if (arg0 == 1) {
         u8* dst;
-        lbAudioAx_80024030(1);
+        sfxForward();
         dst = gmMainLib_8045A6C0;
         dst += un_803FA128.x220;
         dst[0x1868] = un_803FA128.x224;
@@ -807,7 +808,7 @@ int un_80300934(int arg0)
 bool un_80300968(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_ChangeGameModeAfterCurrentScene(GM_HANYU_CSS);
         gm_801A4B60();
     }
@@ -818,7 +819,7 @@ bool un_80300968(bool update_scene)
 bool un_803009A4(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_ChangeGameModeAfterCurrentScene(GM_HANYU_SSS);
         gm_801A4B60();
     }
@@ -865,7 +866,7 @@ int un_80300A88(void)
 bool un_80300AB8(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_SetPendingSceneIndex(0x4);
         gm_801A4B60();
     }
@@ -877,7 +878,7 @@ bool un_80300AF4(int arg0)
 {
     if (arg0 == 1) {
         struct un_803FA258_t* data;
-        lbAudioAx_80024030(1);
+        sfxForward();
         data = &un_803FA258;
         data->x4[1] = 0x3F;
         data->x4[3] = 0xE;
@@ -894,7 +895,7 @@ bool un_80300B58(int arg0)
 {
     if (arg0 == 1) {
         struct un_803FA258_t* data;
-        lbAudioAx_80024030(1);
+        sfxForward();
         {
             struct un_803FA258_t* data = &un_803FA258;
             data->x4[1] = 0x3B;
@@ -965,11 +966,11 @@ void fn_80300CC8(int arg0)
 
     switch (arg0) {
     case 0:
-        lbAudioAx_80024030(0);
+        sfxBack();
         un_80304334(un_80302DF0());
         break;
     case 6:
-        lbAudioAx_80024030(1);
+        sfxForward();
         r29 = gmMainLib_GetTimeMatchTotal();
         r30 = gmMainLib_GetStockMatchTotal();
         r31 = gmMainLib_GetCoinMatchTotal();
@@ -1008,11 +1009,11 @@ void fn_80300DE0(int arg0)
     ptr = gmMainLib_8015D06C(un_804D6DC8);
     switch (arg0) {
     case 0:
-        lbAudioAx_80024030(0);
+        sfxBack();
         un_80304334(un_80302DF0());
         break;
     case 6:
-        lbAudioAx_80024030(1);
+        sfxForward();
         *ptr = (u32) (un_804DDC48 * un_804D6DD0);
         gm_ChangeGameModeAfterCurrentScene(GM_MENU);
         gm_801A4B60();
@@ -1036,11 +1037,11 @@ void fn_80300ED0(int arg0)
 {
     switch (arg0) {
     case 0:
-        lbAudioAx_80024030(0);
+        sfxBack();
         un_80304334(un_80302DF0());
         break;
     case 6:
-        lbAudioAx_80024030(1);
+        sfxForward();
         gmMainLib_8015D4E8(un_804D6DC8, un_804D6DCC);
         gm_ChangeGameModeAfterCurrentScene(GM_MENU);
         gm_801A4B60();
@@ -1066,7 +1067,7 @@ s32 un_80300F98(s32 arg0)
 
     if (arg0 == 1) {
         temp_r31 = gmMainLib_GetKOTotal();
-        lbAudioAx_80024030(1);
+        sfxForward();
         *temp_r31 = un_804D6DF4;
         gm_ChangeGameModeAfterCurrentScene(GM_MENU);
         gm_801A4B60();
@@ -1077,7 +1078,7 @@ s32 un_80300F98(s32 arg0)
 bool un_80300FEC(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_SetPendingSceneIndex(0x4);
         gm_801A4B60();
     }
@@ -1090,7 +1091,7 @@ int un_80301028(int arg0)
     if (arg0 == 1) {
         struct gmm_x0_528_t* ptr = gmMainLib_8015CDD4();
         ptr->x5 = un_804D5908 - 1;
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_ChangeGameModeAfterCurrentScene(GM_ADVENTURE);
         gm_801A4B60();
     }
@@ -1102,7 +1103,7 @@ int un_80301074(int arg0)
     if (arg0 == 1) {
         struct gmm_x0_528_t* ptr = gmMainLib_8015CDC8();
         ptr->x5 = un_804D590C - 1;
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_ChangeGameModeAfterCurrentScene(GM_CLASSIC);
         gm_801A4B60();
     }
@@ -1114,7 +1115,7 @@ int un_803010C0(int arg0)
     if (arg0 == 1) {
         struct gmm_x0_528_t* ptr = gmMainLib_8015CDE0();
         ptr->x5 = un_804D5910 - 1;
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_ChangeGameModeAfterCurrentScene(GM_ALLSTAR);
         gm_801A4B60();
     }
@@ -1125,11 +1126,11 @@ int fn_8030110C(int arg0)
 {
     switch (arg0) {
     case 0:
-        lbAudioAx_80024030(0);
+        sfxBack();
         un_80304334(un_80302DF0());
         break;
     case 6:
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_801BEFA4(un_804D6DF8);
         gm_801BEFC0(un_804D6DFC);
         {
@@ -1161,11 +1162,11 @@ void fn_803011EC(int arg0)
 {
     switch (arg0) {
     case 0:
-        lbAudioAx_80024030(0);
+        sfxBack();
         un_80304334(un_80302DF0());
         break;
     case 6:
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_801BEFA4(un_804D6DF8);
         gm_801BEFC0(un_804D6DFC);
         {
@@ -1205,7 +1206,7 @@ int un_803012D4(int arg0)
 bool un_80301328(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_801BF708(0x0);
         gm_ChangeGameModeAfterCurrentScene(GM_OPENING_MV);
         gm_801A4B60();
@@ -1217,7 +1218,7 @@ bool un_80301328(bool update_scene)
 bool un_8030136C(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_801BF708(0x5);
         gm_ChangeGameModeAfterCurrentScene(GM_OPENING_MV);
         gm_801A4B60();
@@ -1229,7 +1230,7 @@ bool un_8030136C(bool update_scene)
 bool un_803013B0(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_ChangeGameModeAfterCurrentScene(GM_DEBUG_CUTSCENE);
         gm_801A4B60();
     }
@@ -1254,7 +1255,7 @@ int un_80301420(int arg0)
 bool un_80301454(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_ChangeGameModeAfterCurrentScene(GM_BOOT);
         gm_801A4B60();
     }
@@ -1265,7 +1266,7 @@ bool un_80301454(bool update_scene)
 bool un_80301490(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_SetPendingSceneIndex(0xD);
         gm_801A4B60();
     }
@@ -1276,7 +1277,7 @@ bool un_80301490(bool update_scene)
 bool un_803014CC(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_SetPendingSceneIndex(0x7);
         gm_801A4B60();
     }
@@ -1287,7 +1288,7 @@ bool un_803014CC(bool update_scene)
 bool un_80301508(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_SetPendingSceneIndex(0x3);
         gm_801A4B60();
     }
@@ -1298,7 +1299,7 @@ bool un_80301508(bool update_scene)
 bool un_80301544(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_SetPendingSceneIndex(0x9);
         gm_801A4B60();
     }
@@ -1309,7 +1310,7 @@ bool un_80301544(bool update_scene)
 bool un_80301580(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_SetPendingSceneIndex(0xC);
         gm_801A4B60();
     }
@@ -1320,7 +1321,7 @@ bool un_80301580(bool update_scene)
 bool un_803015BC(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_ChangeGameModeAfterCurrentScene(GM_PROGRESSIVE_SCAN);
         gm_801A4B60();
     }
@@ -1331,7 +1332,7 @@ bool un_803015BC(bool update_scene)
 bool un_803015F8(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_SetPendingSceneIndex(0xA);
         gm_801A4B60();
     }
@@ -1537,11 +1538,11 @@ int un_80301B48(int arg0)
 {
     switch (arg0) {
     case 0:
-        lbAudioAx_80024030(0);
+        sfxBack();
         un_80304334(un_80302DF0());
         break;
     case 6:
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_SetPendingSceneIndex(6);
         gm_801A4B60();
         break;
@@ -1589,11 +1590,11 @@ int un_80301C80(int arg0)
 {
     switch (arg0) {
     case 0:
-        lbAudioAx_80024030(0);
+        sfxBack();
         un_80304334(un_80302DF0());
         break;
     case 6:
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_SetPendingSceneIndex(0xB);
         gm_801A4B60();
         break;
@@ -1605,7 +1606,7 @@ void un_80301CE0(int arg0)
 {
     switch (arg0) {
     case 6:
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_SetPendingSceneIndex(0xB);
         gm_801A4B60();
         break;
@@ -1618,7 +1619,7 @@ void un_80301CE0(int arg0)
 bool un_80301D40(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_ChangeGameModeAfterCurrentScene(GM_FIXED_CAMERA_VS);
         gm_801A4B60();
     }
@@ -1629,7 +1630,7 @@ bool un_80301D40(bool update_scene)
 int un_80301D7C(int arg0)
 {
     if (arg0 == 1) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_801BEB74(un_803FA258.x188 - 1);
         gm_ChangeGameModeAfterCurrentScene(GM_EVENT);
         gm_801A4B60();
@@ -1640,7 +1641,7 @@ int un_80301D7C(int arg0)
 bool un_80301DCC(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_SetPendingSceneIndex(0x4);
         gm_801A4B60();
     }
@@ -1651,7 +1652,7 @@ bool un_80301DCC(bool update_scene)
 bool un_80301E08(bool update_scene)
 {
     if (update_scene == true) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_SetPendingSceneIndex(0xE);
         gm_801A4B60();
     }

--- a/src/melee/if/textlib.c
+++ b/src/melee/if/textlib.c
@@ -8,6 +8,7 @@
 #include "if/types.h"
 #include "lb/lb_00B0.h"
 #include "lb/lbaudio_ax.h"
+#include "mn/inlines.h"
 #include "ty/toy.h"
 
 #include <printf.h>
@@ -498,7 +499,7 @@ bool un_80303444(struct un_80304138_objalloc_t* arg0)
             *q += 1;
             ret = true;
             arg0->x1 = arg0->x1 | 1;
-            lbAudioAx_80024030(2);
+            sfxMove();
         }
         break;
     }
@@ -508,7 +509,7 @@ bool un_80303444(struct un_80304138_objalloc_t* arg0)
             ret = true;
             *q += arg0->x8[arg0->x0].x1C;
             arg0->x1 = arg0->x1 | 1;
-            lbAudioAx_80024030(2);
+            sfxMove();
         }
         break;
     }
@@ -522,7 +523,7 @@ bool un_80303444(struct un_80304138_objalloc_t* arg0)
         }
         ret = true;
         arg0->x1 = arg0->x1 | 1;
-        lbAudioAx_80024030(2);
+        sfxMove();
         break;
     }
     case 6: {
@@ -535,7 +536,7 @@ bool un_80303444(struct un_80304138_objalloc_t* arg0)
         }
         ret = true;
         arg0->x1 = arg0->x1 | 1;
-        lbAudioAx_80024030(2);
+        sfxMove();
         break;
     }
     case 4:
@@ -549,7 +550,7 @@ bool un_80303444(struct un_80304138_objalloc_t* arg0)
         }
         ret = true;
         arg0->x1 = arg0->x1 | 1;
-        lbAudioAx_80024030(2);
+        sfxMove();
         break;
     }
     case 8: {
@@ -558,7 +559,7 @@ bool un_80303444(struct un_80304138_objalloc_t* arg0)
             *q += arg0->x8[arg0->x0].x1C;
             ret = true;
             arg0->x1 = arg0->x1 | 1;
-            lbAudioAx_80024030(2);
+            sfxMove();
         }
         break;
     }
@@ -577,7 +578,7 @@ bool un_80303720(struct un_80304138_objalloc_t* arg0)
             *q -= 1;
             ret = true;
             arg0->x1 = arg0->x1 | 1;
-            lbAudioAx_80024030(2);
+            sfxMove();
         }
         break;
     }
@@ -587,7 +588,7 @@ bool un_80303720(struct un_80304138_objalloc_t* arg0)
             ret = true;
             *q -= x8[arg0->x0].x1C;
             arg0->x1 = arg0->x1 | 1;
-            lbAudioAx_80024030(2);
+            sfxMove();
         }
         break;
     }
@@ -601,7 +602,7 @@ bool un_80303720(struct un_80304138_objalloc_t* arg0)
         }
         ret = true;
         arg0->x1 = arg0->x1 | 1;
-        lbAudioAx_80024030(2);
+        sfxMove();
         break;
     }
     case 6: {
@@ -614,7 +615,7 @@ bool un_80303720(struct un_80304138_objalloc_t* arg0)
         }
         ret = true;
         arg0->x1 = arg0->x1 | 1;
-        lbAudioAx_80024030(2);
+        sfxMove();
         break;
     }
     case 4:
@@ -624,7 +625,7 @@ bool un_80303720(struct un_80304138_objalloc_t* arg0)
         *q = *q - idk;
         ret = true;
         arg0->x1 = arg0->x1 | 1;
-        lbAudioAx_80024030(2);
+        sfxMove();
         break;
     }
     case 8: {
@@ -633,7 +634,7 @@ bool un_80303720(struct un_80304138_objalloc_t* arg0)
             *q -= x8[arg0->x0].x1C;
             ret = true;
             arg0->x1 = arg0->x1 | 1;
-            lbAudioAx_80024030(2);
+            sfxMove();
         }
         break;
     }
@@ -709,7 +710,7 @@ void un_80303AC4(struct un_80304138_objalloc_t* arg0)
         if (i != -1) {
             arg0->x0 = i;
             arg0->x1 = arg0->x1 | 1;
-            lbAudioAx_80024030(2);
+            sfxMove();
         }
     } else if (buttons & (0x20000000 | HSD_PAD_X)) { // down
         u8 j = arg0->x0;
@@ -726,7 +727,7 @@ void un_80303AC4(struct un_80304138_objalloc_t* arg0)
         if (i != -1) {
             arg0->x0 = i;
             arg0->x1 = arg0->x1 | 1;
-            lbAudioAx_80024030(2);
+            sfxMove();
         }
     } else if (buttons & (0x80000000 | HSD_PAD_R)) { // right
         if (un_80303444(arg0)) {

--- a/src/melee/mn/mncharsel.c
+++ b/src/melee/mn/mncharsel.c
@@ -1,5 +1,7 @@
 #include "mncharsel.h"
 
+#include "inlines.h"
+
 #include "mncharsel.static.h"
 
 #include "types.h"
@@ -774,7 +776,7 @@ void mnCharSel_8025DB34(u8 arg0)
                 }
             }
             if ((u8) mnCharSel_804D6CF6 != 3 && (u8) mnCharSel_804D6CF6 != 4) {
-                lbAudioAx_80024030(2);
+                sfxMove();
             }
         }
     }
@@ -1871,7 +1873,7 @@ void mnCharSel_CostumeChange(int door, u32 input)
     }
     if (prev_costume != mnCharSel_803F0DFC.doors[door].costume) {
         mnCharSel_8025DB34(door);
-        lbAudioAx_80024030(2);
+        sfxMove();
     }
 }
 
@@ -2507,7 +2509,7 @@ void mnCharSel_CursorThink(HSD_GObj* gobj)
                                     mnCharSel_804D6CB0->data.data
                                         .players[(s8) (u8) mnCharSel_804D6CF0]
                                         .stocks = (s8) data2.stocks;
-                                    lbAudioAx_80024030(2);
+                                    sfxMove();
                                 } else {
                                     goto block_231;
                                 }
@@ -2538,7 +2540,7 @@ void mnCharSel_CursorThink(HSD_GObj* gobj)
                                     mnCharSel_804D6CB0->data.data
                                         .players[(s8) (u8) mnCharSel_804D6CF0]
                                         .stocks = (s8) data2.stocks;
-                                    lbAudioAx_80024030(2);
+                                    sfxMove();
                                 } else {
                                     goto block_231;
                                 }
@@ -2571,7 +2573,7 @@ void mnCharSel_CursorThink(HSD_GObj* gobj)
                                                 s8) (u8) mnCharSel_804D6CF0]
                                             .cpu_level =
                                             mnCharSel_803F0DFC.xcd;
-                                        lbAudioAx_80024030(2);
+                                        sfxMove();
                                     } else {
                                         goto block_298;
                                     }
@@ -2590,7 +2592,7 @@ void mnCharSel_CursorThink(HSD_GObj* gobj)
                                                 s8) (u8) mnCharSel_804D6CF0]
                                             .cpu_level =
                                             mnCharSel_803F0DFC.xcd;
-                                        lbAudioAx_80024030(2);
+                                        sfxMove();
                                     } else {
                                         goto block_298;
                                     }
@@ -2637,7 +2639,7 @@ void mnCharSel_CursorThink(HSD_GObj* gobj)
                     if ((s32) mtype < 0xB && (s32) mtype >= 0) {
                         cursor->x8 = 1;
                         if (trigger & 0x100) {
-                            lbAudioAx_80024030(2);
+                            sfxMove();
                             mnCharSel_804D6CB0->data.data.rules.is_teams =
                                 (mnCharSel_804D6CB0->data.data.rules.is_teams +
                                  1) &
@@ -2820,7 +2822,7 @@ void mnCharSel_CursorThink(HSD_GObj* gobj)
                                                     }
                                                     mnCharSel_8025DB34(
                                                         (u8) di);
-                                                    lbAudioAx_80024030(2);
+                                                    sfxMove();
                                                     goto block_348;
                                                 }
                                             }
@@ -2849,7 +2851,7 @@ void mnCharSel_CursorThink(HSD_GObj* gobj)
                                                             .team = dp->team;
                                                         mnCharSel_8025DB34(
                                                             (u8) di);
-                                                        lbAudioAx_80024030(2);
+                                                        sfxMove();
                                                     }
                                                 }
                                             }
@@ -3142,7 +3144,7 @@ void mnCharSel_CursorThink(HSD_GObj* gobj)
                                         .players[cursor->x4]
                                         .slot_type = 0;
                                     mnCharSel_8025DB34(cursor->x4);
-                                    lbAudioAx_80024030(2);
+                                    sfxMove();
                                 }
 
                                 {
@@ -3760,7 +3762,7 @@ void fn_802633B0(HSD_GObj* gobj)
                         AOBJ_ARG_AF, 0.0f);
         tag->state = 2;
         tag->timer = 0;
-        lbAudioAx_80024030(2);
+        sfxMove();
         return;
 
     case 2: {
@@ -3952,7 +3954,7 @@ void fn_802633B0(HSD_GObj* gobj)
                 mnCharSel_804D6CB0->data.data.players[port].xA = 0x78;
                 tag->use_tag = 0;
                 tag->state = 4;
-                lbAudioAx_80024030(2);
+                sfxMove();
                 goto block_116;
             }
 
@@ -4028,7 +4030,7 @@ void fn_802633B0(HSD_GObj* gobj)
                             row - 1;
                         tag->use_tag = 1;
                         tag->state = 4;
-                        lbAudioAx_80024030(2);
+                        sfxMove();
                     }
                 }
             }
@@ -4037,7 +4039,7 @@ void fn_802633B0(HSD_GObj* gobj)
     block_116:
         if (trigger & 0x200) {
             tag->state = 4;
-            lbAudioAx_80024030(0);
+            sfxBack();
             return;
         }
         break;
@@ -5165,7 +5167,7 @@ void mnCharSel_802669F4_OnFrame(void)
         lbDvd_80018254();
     }
     if (mn_8022F218() != 0) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         lb_800145F4();
         mn_8022F138(1, 8);
         HSD_SisLib_803A5E70();
@@ -5191,26 +5193,26 @@ void mnCharSel_802669F4_OnFrame(void)
             if ((u8) mnCharSel_804D6CF5 == 4) {
                 lbAudioAx_8002411C(0x147);
             }
-            lbAudioAx_80024030(1);
+            sfxForward();
         }
         break;
     case 2:
         gm_801A4B60();
-        lbAudioAx_80024030(0);
+        sfxBack();
         break;
     case 3:
         mn_8022F138(1, 8);
         HSD_SisLib_803A5E70();
         mn_80231804(mnCharSel_804D6CD4, 1);
         mnCharSel_804D6CF6 = 5;
-        lbAudioAx_80024030(1);
+        sfxForward();
         break;
     case 4:
         mn_8022F138(1, 8);
         HSD_SisLib_803A5E70();
         mnNameNew_EnterFromMnCharSel(mnCharSel_804D6CD4, mnCharSel_804D6CF9);
         mnCharSel_804D6CF6 = 5;
-        lbAudioAx_80024030(1);
+        sfxForward();
         break;
     }
 }

--- a/src/melee/mn/mndatadel.c
+++ b/src/melee/mn/mndatadel.c
@@ -421,7 +421,7 @@ void fn_8024F318(HSD_GObj* gobj)
                 lbAudioAx_800237A8(0xBD, 0x7F, 0x40);
                 return;
             }
-            lbAudioAx_80024030(0);
+            sfxBack();
             user_data->x1 = 0U;
             user_data->x2 = 0U;
             proc = HSD_GObj_SetupProc(temp_gobj, fn_8024F840, 0U);
@@ -517,7 +517,7 @@ void fn_8024F318(HSD_GObj* gobj)
             }
             lbAudioAx_800237A8(0xBE, 0x7F, 0x40);
         } else {
-            lbAudioAx_80024030(0);
+            sfxBack();
         }
         user_data->x1 = 0U;
         HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
@@ -526,7 +526,7 @@ void fn_8024F318(HSD_GObj* gobj)
         return;
     }
     if (buttons & 0x20) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804D6BC8.cooldown = 5;
         user_data->x1 = 0U;
         HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
@@ -535,7 +535,7 @@ void fn_8024F318(HSD_GObj* gobj)
         return;
     }
     if ((buttons & 8) || (buttons & 4)) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         if (user_data->x2 != 0) {
             user_data->x2 = 0U;
             return;
@@ -554,7 +554,7 @@ static inline void fn_8024F840_inline(u64 buttons,
     struct MnDataDelGObjUserData* temp_user_data;
 
     if (buttons & 2) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         temp_user_data = mnDataDel_804D6C68->user_data;
         joint = (HSD_JObj*) mn_80231634(
             (struct mn_80231634_t*)
@@ -625,7 +625,7 @@ void fn_8024F840(HSD_GObj* gobj)
     buttons = Menu_GetAllInputs();
     zero = 0;
     if (buttons & 0x20) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = zero;
         mn_80229894(4, 5U, 3);
         return;
@@ -642,7 +642,7 @@ void fn_8024F840(HSD_GObj* gobj)
         return;
     }
     if (buttons & 1) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         temp_user_data = mnDataDel_804D6C68->user_data;
         joint = (HSD_JObj*) mn_80231634(
             (struct mn_80231634_t*)

--- a/src/melee/mn/mndiagram.c
+++ b/src/melee/mn/mndiagram.c
@@ -878,7 +878,7 @@ void mnDiagram_PopupInputProc(HSD_GObj* gobj)
     Diagram* data = mnDiagram_804D6C10->user_data;
     u64 input = Menu_GetAllInputs();
     if ((u32) input & 0x20) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
         proc = HSD_GObj_SetupProc(
             gobj, (void (*)(HSD_GObj*)) mnDiagram_InputProc, 0);
@@ -1314,7 +1314,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
         return;
     }
     if (input & 0x20) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = count2;
         {
             Diagram* d = mnDiagram_804D6C10->user_data;
@@ -1328,7 +1328,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
         return;
     }
     if (input & 0xC0) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         {
             Diagram* d = mnDiagram_804D6C10->user_data;
             gmMainLib_GetGameRules()->xE = (u8) (d->fighter_cursor_pos >> 8);
@@ -1350,7 +1350,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
             lbAudioAx_80024030(3);
             return;
         }
-        lbAudioAx_80024030(1);
+        sfxForward();
         data->is_name_mode = (data->is_name_mode == 0) ? (1) : (count2);
         if (data->is_name_mode != 0) {
             count = GetNameCount();
@@ -1398,7 +1398,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
         if (input & 1) {
             col = (u8) mn_804A04F0.hovered_selection;
             if ((col > 0) && (count > (col - 1))) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 mn_804A04F0.hovered_selection =
                     (mn_804A04F0.hovered_selection & 0xFF00) |
                     ((col - 1) & 0xFF);
@@ -1408,7 +1408,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
                 cur = (u8) data->name_cursor_pos;
                 found = (u8) mnDiagram_FindPrevName(cur);
                 if (cur != found) {
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     data->name_cursor_pos =
                         (data->name_cursor_pos & 0xFF00) | found;
                     mnDiagram_RefreshGrid(mnDiagram_804D6C10,
@@ -1419,7 +1419,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
         } else if (input & 2) {
             col = (u8) mn_804A04F0.hovered_selection;
             if ((col < 9) && (count > (col + 1))) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 mn_804A04F0.hovered_selection =
                     (mn_804A04F0.hovered_selection & 0xFF00) |
                     ((col + 1) & 0xFF);
@@ -1453,7 +1453,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
                         goto dn_n_inner;
                     }
                     if (col_result3 != 0x78) {
-                        lbAudioAx_80024030(2);
+                        sfxMove();
                         data->name_cursor_pos =
                             (data->name_cursor_pos & 0xFF00) | found;
                         mnDiagram_RefreshGrid(mnDiagram_804D6C10,
@@ -1465,7 +1465,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
         } else if (input & 4) {
             row3 = mn_804A04F0.hovered_selection >> 8;
             if ((0 < row3) && (count > (row3 - 1))) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 mn_804A04F0.hovered_selection =
                     ((u8) mn_804A04F0.hovered_selection) | ((row3 - 1) << 8);
                 return;
@@ -1474,7 +1474,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
                 cur = data->name_cursor_pos >> 8;
                 found = (u8) mnDiagram_FindPrevNameWrap(cur);
                 if (cur != found) {
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     data->name_cursor_pos =
                         ((u8) data->name_cursor_pos) | (found << 8);
                     mnDiagram_RefreshGrid(mnDiagram_804D6C10,
@@ -1485,7 +1485,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
         } else if (input & 8) {
             row4 = mn_804A04F0.hovered_selection >> 8;
             if ((row4 < 6) && (count > (row4 + 1))) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 mn_804A04F0.hovered_selection =
                     ((u8) mn_804A04F0.hovered_selection) | ((row4 + 1) << 8);
                 return;
@@ -1518,7 +1518,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
                         goto rt_n_inner;
                     }
                     if (row_result3 != 0x78) {
-                        lbAudioAx_80024030(2);
+                        sfxMove();
                         data->name_cursor_pos =
                             ((u8) data->name_cursor_pos) | (found << 8);
                         mnDiagram_RefreshGrid(mnDiagram_804D6C10,
@@ -1539,7 +1539,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
         if (input & 1) {
             col = (u8) mn_804A04F0.hovered_selection;
             if ((col > new_var) && (count2 > (col - 1))) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 mn_804A04F0.hovered_selection =
                     (mn_804A04F0.hovered_selection & 0xFF00) |
                     ((col - 1) & 0xFF);
@@ -1549,7 +1549,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
                 cur = (u8) data->fighter_cursor_pos;
                 found = (u8) mnDiagram_FindPrevFighter(sorted, cur);
                 if (cur != found) {
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     data->fighter_cursor_pos =
                         (data->fighter_cursor_pos & 0xFF00) | found;
                     mnDiagram_RefreshGrid(mnDiagram_804D6C10,
@@ -1560,7 +1560,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
         } else if (input & 2) {
             col = (u8) mn_804A04F0.hovered_selection;
             if ((col < 9) && (count2 > (col + 1))) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 mn_804A04F0.hovered_selection =
                     (mn_804A04F0.hovered_selection & 0xFF00) |
                     ((col + 1) & 0xFF);
@@ -1595,7 +1595,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
                 }
 
                 if (col_result4 != 0x19) {
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     data->fighter_cursor_pos =
                         (data->fighter_cursor_pos & 0xFF00) | found;
                     mnDiagram_RefreshGrid(mnDiagram_804D6C10,
@@ -1606,7 +1606,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
         } else if (input & 4) {
             row5 = mn_804A04F0.hovered_selection >> 8;
             if ((row5 > new_var) && (count2 > (row5 - 1))) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 mn_804A04F0.hovered_selection =
                     ((u8) mn_804A04F0.hovered_selection) | ((row5 - 1) << 8);
                 return;
@@ -1615,7 +1615,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
                 cur = data->fighter_cursor_pos >> 8;
                 found = (u8) mnDiagram_FindPrevFighterWrap(sorted, cur);
                 if (cur != found) {
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     data->fighter_cursor_pos =
                         ((u8) data->fighter_cursor_pos) | (found << 8);
                     mnDiagram_RefreshGrid(mnDiagram_804D6C10,
@@ -1626,7 +1626,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
         } else if (input & 8) {
             row6 = mn_804A04F0.hovered_selection >> 8;
             if ((row6 < 6) && (count2 > (row6 + 1))) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 mn_804A04F0.hovered_selection =
                     ((u8) mn_804A04F0.hovered_selection) | ((row6 + 1) << 8);
                 return;
@@ -1659,7 +1659,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
                 }
 
                 if (row_result4 != 0x19) {
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     data->fighter_cursor_pos =
                         ((u8) data->fighter_cursor_pos) | (found << 8);
                     mnDiagram_RefreshGrid(mnDiagram_804D6C10,

--- a/src/melee/mn/mndiagram2.c
+++ b/src/melee/mn/mndiagram2.c
@@ -6,6 +6,7 @@
 
 #include "baselib/forward.h"
 
+#include "mn/inlines.h"
 #include "mn/types.h"
 
 #include <stdbool.h>
@@ -294,7 +295,7 @@ void mnDiagram2_HandleInput(HSD_GObj* gobj)
     result = mn_804A04F0.buttons = mn_80229624(4);
 
     if (result & 0x20) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = 0;
         data2 = (d2 = mnDiagram2_804D6C18)->user_data;
         x46 = data2->selected_fighter_idx;
@@ -308,7 +309,7 @@ void mnDiagram2_HandleInput(HSD_GObj* gobj)
     }
 
     if (result & 0xC0) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         data2 = mnDiagram2_804D6C18->user_data;
         x46 = data2->selected_fighter_idx;
         gmMainLib_GetGameRules()->x12 = x46;
@@ -331,7 +332,7 @@ void mnDiagram2_HandleInput(HSD_GObj* gobj)
             lbAudioAx_80024030(3);
             return;
         }
-        lbAudioAx_80024030(1);
+        sfxForward();
         var_r28 = 0;
         if (data->is_name_mode == 0) {
             var_r28 = 1;
@@ -371,13 +372,13 @@ void mnDiagram2_HandleInput(HSD_GObj* gobj)
         GetNameCount();
         if (result & 1) {
             if (data->scroll_offset != 0) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 data->scroll_offset = data->scroll_offset - 1;
                 mnDiagram2_RefreshStatRows();
             }
         } else if (result & 2) {
             if ((s32) (data->scroll_offset + 10) < 0x18) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 data->scroll_offset = data->scroll_offset + 1;
                 mnDiagram2_RefreshStatRows();
             }
@@ -385,7 +386,7 @@ void mnDiagram2_HandleInput(HSD_GObj* gobj)
             var_r28 =
                 (u8) mnDiagram_GetPrevNameIndex_s(data->selected_name_idx);
             if ((s32) data->selected_name_idx != var_r28) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 data->selected_name_idx = var_r28;
                 mnDiagram2_RefreshStatRows();
                 mnDiagram2_UpdateHeader(mnDiagram2_804D6C18,
@@ -396,7 +397,7 @@ void mnDiagram2_HandleInput(HSD_GObj* gobj)
             var_r28 =
                 (u8) mnDiagram_GetNextNameIndex_s(data->selected_name_idx);
             if ((s32) data->selected_name_idx != var_r28) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 data->selected_name_idx = var_r28;
                 mnDiagram2_RefreshStatRows();
                 mnDiagram2_UpdateHeader(mnDiagram2_804D6C18,
@@ -408,13 +409,13 @@ void mnDiagram2_HandleInput(HSD_GObj* gobj)
         mnDiagram_CountUnlockedFighters();
         if (result & 1) {
             if (data->scroll_offset != 0) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 data->scroll_offset = data->scroll_offset - 1;
                 mnDiagram2_RefreshStatRows();
             }
         } else if (result & 2) {
             if ((s32) (data->scroll_offset + 10) < 0x15) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 data->scroll_offset = data->scroll_offset + 1;
                 mnDiagram2_RefreshStatRows();
             }
@@ -422,7 +423,7 @@ void mnDiagram2_HandleInput(HSD_GObj* gobj)
             var_r28 = (u8) mnDiagram_GetPrevFighterIndex_s(
                 data->selected_fighter_idx);
             if ((s32) data->selected_fighter_idx != var_r28) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 data->selected_fighter_idx = var_r28;
                 mnDiagram2_RefreshStatRows();
                 mnDiagram2_UpdateHeader(mnDiagram2_804D6C18,
@@ -433,7 +434,7 @@ void mnDiagram2_HandleInput(HSD_GObj* gobj)
             var_r28 = (u8) mnDiagram_GetNextFighterIndex_s(
                 data->selected_fighter_idx);
             if ((s32) data->selected_fighter_idx != var_r28) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 data->selected_fighter_idx = var_r28;
                 mnDiagram2_RefreshStatRows();
                 mnDiagram2_UpdateHeader(mnDiagram2_804D6C18,

--- a/src/melee/mn/mndiagram3.c
+++ b/src/melee/mn/mndiagram3.c
@@ -598,7 +598,7 @@ void mnDiagram3_HandleInput(HSD_GObj* gobj)
     PAD_STACK(72);
 
     if ((u32) input & 0x20) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         i = mn_804A04F0.entering_menu = 0;
         gmMainLib_GetGameRules()->xD =
             ((Diagram3*) mnDiagram3_804D6C20->user_data)->is_name_mode;
@@ -621,7 +621,7 @@ void mnDiagram3_HandleInput(HSD_GObj* gobj)
         return;
     }
     if (input & 0xC0) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gmMainLib_GetGameRules()->xD =
             ((Diagram3*) mnDiagram3_804D6C20->user_data)->is_name_mode;
         mnDiagram2_ClearDetailView(mnDiagram3_804D6C20);
@@ -651,7 +651,7 @@ void mnDiagram3_HandleInput(HSD_GObj* gobj)
             lbAudioAx_80024030(3);
             return;
         }
-        lbAudioAx_80024030(1);
+        sfxForward();
         data->is_name_mode = (data->is_name_mode == 0) ? 1 : 0;
         if ((data->is_name_mode == 0) &&
             ((s32) (data->scroll_offset + 0xA) >= 0x15))
@@ -716,7 +716,7 @@ void mnDiagram3_HandleInput(HSD_GObj* gobj)
             Diagram3* cur;
             u8 n;
             f32 spacing;
-            lbAudioAx_80024030(2);
+            sfxMove();
             data->cursor_row = data->cursor_row - 1;
             cur = mnDiagram3_804D6C20->user_data;
             popup = data->popup_gobj->hsd_obj;
@@ -742,7 +742,7 @@ void mnDiagram3_HandleInput(HSD_GObj* gobj)
             u8 base_idx_u8;
             u8 i_u8;
             f32 spacing;
-            lbAudioAx_80024030(2);
+            sfxMove();
             data->scroll_offset = data->scroll_offset - 1;
             data = mnDiagram3_804D6C20->user_data;
             {
@@ -796,7 +796,7 @@ void mnDiagram3_HandleInput(HSD_GObj* gobj)
             Diagram3* cur;
             u8 n;
             f32 spacing;
-            lbAudioAx_80024030(2);
+            sfxMove();
             data->cursor_row = data->cursor_row + 1;
             cur = mnDiagram3_804D6C20->user_data;
             popup = data->popup_gobj->hsd_obj;
@@ -822,7 +822,7 @@ void mnDiagram3_HandleInput(HSD_GObj* gobj)
             u8 base_idx_u8;
             u8 i_u8;
             f32 spacing;
-            lbAudioAx_80024030(2);
+            sfxMove();
             data->scroll_offset = data->scroll_offset + 1;
             data = mnDiagram3_804D6C20->user_data;
             {

--- a/src/melee/mn/mnevent.c
+++ b/src/melee/mn/mnevent.c
@@ -449,7 +449,7 @@ void fn_8024D864(HSD_GObj* gobj)
     inputs = mn_804A04F0.buttons = mn_80229624(4);
 
     if (inputs & MenuInput_Back) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = 0;
         mn_80229894(1, 1, 3);
         return;
@@ -466,7 +466,7 @@ void fn_8024D864(HSD_GObj* gobj)
 
     data = mnEvent_804D6C60->user_data;
     if (inputs & MenuInput_Confirm) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         gm_801BEB74(data->first_event + data->page);
         gm_801677E8(mn_802295AC());
         mn_80229860(0x2B);
@@ -478,7 +478,7 @@ void fn_8024D864(HSD_GObj* gobj)
         if (data->first_event + 9 < max_events ||
             data->first_event != max_events)
         {
-            lbAudioAx_80024030(2);
+            sfxMove();
             if (data->first_event + 9 < max_events) {
                 data->first_event += 9;
             } else {
@@ -502,7 +502,7 @@ void fn_8024D864(HSD_GObj* gobj)
         }
     } else if (inputs & MenuInput_YButton) {
         if (data->first_event - 9 >= 0 || data->first_event != 0) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             if (data->first_event - 9 >= 0) {
                 data->first_event -= 9;
             } else {
@@ -526,7 +526,7 @@ void fn_8024D864(HSD_GObj* gobj)
     } else if (inputs & MenuInput_Up) {
         page = data->page;
         if (page != 0) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             data->page -= 1;
             lb_80011E24(mnEvent_804D6C60->hsd_obj, &jobj_0A, 0xA, -1);
             lb_80011E24(mnEvent_804D6C60->hsd_obj, &jobj_0C, 0xC, -1);
@@ -548,7 +548,7 @@ void fn_8024D864(HSD_GObj* gobj)
             return;
         }
         if (data->first_event != 0) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             data->first_event -= 1;
             first_event = data->first_event;
             for (i = 0; i < 9; i++) {
@@ -569,7 +569,7 @@ void fn_8024D864(HSD_GObj* gobj)
     } else if (inputs & MenuInput_Down) {
         page = data->page;
         if (page < 8) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             data->page += 1;
             lb_80011E24(mnEvent_804D6C60->hsd_obj, &jobj_0A, 0xA, -1);
             lb_80011E24(mnEvent_804D6C60->hsd_obj, &jobj_0C, 0xC, -1);
@@ -591,7 +591,7 @@ void fn_8024D864(HSD_GObj* gobj)
             return;
         }
         if (data->first_event < mnEvent_8024CE74()) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             data->first_event += 1;
             first_event = data->first_event;
             for (i = 0; i < 9; i++) {

--- a/src/melee/mn/mngallery.c
+++ b/src/melee/mn/mngallery.c
@@ -210,7 +210,7 @@ static void mnGallery_80258DBC(HSD_GObj* gobj,
     pressed = buttons & 0x1300;
     if (pressed != 0 || data->unk1 > 0x32 || skip != 0) {
         if (pressed != 0) {
-            lbAudioAx_80024030(0);
+            sfxBack();
         }
         data->state = 1;
         mn_8022BD8C();

--- a/src/melee/mn/mninfo.c
+++ b/src/melee/mn/mninfo.c
@@ -254,7 +254,7 @@ void fn_80251FE4(void)
     }
     buttons = mn_804A04F0.buttons = mn_80229624(4);
     if (buttons & MenuInput_Back) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = 0;
         mn_80229894(5, 4, 3);
         return;
@@ -262,7 +262,7 @@ void fn_80251FE4(void)
     if (buttons & MenuInput_Up) {
         if (data->scroll_idx != 0) {
             data->scroll_idx -= 1;
-            lbAudioAx_80024030(2);
+            sfxMove();
             j = 0;
             data2 = mnInfo_804D6C78->user_data;
             data3 = data2;
@@ -297,7 +297,7 @@ void fn_80251FE4(void)
             }
         }
         if ((data->scroll_idx + 4) < count) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             data->scroll_idx += 1;
             j = 0;
             data2 = mnInfo_804D6C78->user_data;

--- a/src/melee/mn/mninfobonus.c
+++ b/src/melee/mn/mninfobonus.c
@@ -206,14 +206,14 @@ void fn_80252C50(HSD_GObj* gobj)
     }
     if (((u64) temp_r3 & 1) != 0) {
         if (o->x0 > 0) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             --o->x0;
             mnInfoBonus_802529B4();
         }
     } else if (((u64) temp_r3 & 2) != 0 &&
                mnInfoBonus_802528F8_wrapper() /* @todo don't inline! */ > 5)
     {
-        lbAudioAx_80024030(2);
+        sfxMove();
         ++o->x0;
         mnInfoBonus_802529B4();
     }

--- a/src/melee/mn/mnlanguage.c
+++ b/src/melee/mn/mnlanguage.c
@@ -52,7 +52,7 @@ void mnLanguage_8024BFE0(HSD_GObj* arg0_unused)
     }
     temp_r3 = Menu_GetAllInputs();
     if (temp_r3 & 0x20) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = 0;
         mn_80229894(4, 4, 3);
         return;
@@ -70,7 +70,7 @@ void mnLanguage_8024BFE0(HSD_GObj* arg0_unused)
         }
     } else if (temp_r31->x2 != 0) {
         if (temp_r3 & 4) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             temp_r31->x0 = temp_r31->x0 == 0 ? 1 : 0;
             lang = temp_r31->x0;
             lb_80011E24(mnLanguage_804D6C50->hsd_obj, &sp2C, 1, -1);
@@ -78,7 +78,7 @@ void mnLanguage_8024BFE0(HSD_GObj* arg0_unused)
             mn_8022F3D8(sp2C, -1, JOBJ_MASK);
             HSD_JObjAnimAll(sp2C);
         } else if (temp_r3 & 8) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             temp_r31->x0 = temp_r31->x0 == 0 ? 1 : 0;
             lang = temp_r31->x0;
             lb_80011E24(GET_JOBJ(mnLanguage_804D6C50), &sp24, 1, -1);

--- a/src/melee/mn/mnmain.c
+++ b/src/melee/mn/mnmain.c
@@ -1894,68 +1894,68 @@ void mn_8022C4F4(HSD_GObj* gp)
         mn_804A04F0.entering_menu = 1;
         switch (mn_804A04F0.hovered_selection) {
         case SEL_SPECIAL_VS_CAMERA:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_CAMERA_MODE;
             gm_801A4B60();
             break;
         case SEL_SPECIAL_VS_STAMINA:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_STAMINA_VS;
             gm_801A4B60();
             break;
         case SEL_SPECIAL_VS_SUDDEN_DEATH:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_SUPER_SUDDEN_DEATH_VS;
             gm_801A4B60();
             break;
         case SEL_SPECIAL_VS_GIANT:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_GIANT_VS;
             gm_801A4B60();
             break;
         case SEL_SPECIAL_VS_TINY:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_TINY_VS;
             gm_801A4B60();
             break;
         case SEL_SPECIAL_VS_INVISIBLE:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_INVISIBLE_VS;
             gm_801A4B60();
             break;
         case SEL_SPECIAL_VS_FIXED_CAMERA:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_FIXED_CAMERA_VS;
             gm_801A4B60();
             break;
         case SEL_SPECIAL_VS_SINGLE_BUTTON:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_SINGLE_BUTTON_VS;
             gm_801A4B60();
             break;
         case SEL_SPECIAL_VS_LIGHTNING:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_LIGHTNING_VS;
             gm_801A4B60();
             break;
         case SEL_SPECIAL_VS_SLOMO:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_SLOMO_VS;
             gm_801A4B60();
             break;
         }
     } else if (buttons & MenuInput_Back) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = 0;
         mn_804D6BC8.cooldown = 5;
         mn_804A04F0.prev_menu = mn_804A04F0.cur_menu;
@@ -1969,10 +1969,10 @@ void mn_8022C4F4(HSD_GObj* gp)
             temp_r3_2->flags_3 = HSD_GObj_804D783C;
         }
     } else if (buttons & MenuInput_Up) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         x2_dec(selection_count);
     } else if (buttons & MenuInput_Down) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         x2_inc(selection_count);
     }
 }
@@ -2007,27 +2007,27 @@ void mn_8022C7CC(HSD_GObj* gp)
         mn_804A04F0.entering_menu = 1;
         switch (mn_804A04F0.hovered_selection) {
         case SEL_STADIUM_TARGET:
-            lbAudioAx_80024030(1);
+            sfxForward();
             gm_801677E8(mn_8022C7CC_inline());
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_TARGET_TEST;
             gm_801A4B60();
             return;
         case SEL_STADIUM_HOMERUN:
-            lbAudioAx_80024030(1);
+            sfxForward();
             gm_801677E8(mn_8022C7CC_inline());
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_HOME_RUN_CONTEST;
             gm_801A4B60();
             return;
         case SEL_STADIUM_MULTIMAN:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mnHyaku_8024CD64(0);
             HSD_GObjPLink_80390228(gp);
             return;
         }
     } else if (buttons & MenuInput_Back) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = 0;
         mn_804D6BC8.cooldown = 5;
         mn_804A04F0.prev_menu = mn_804A04F0.cur_menu;
@@ -2041,10 +2041,10 @@ void mn_8022C7CC(HSD_GObj* gp)
             think->flags_3 = HSD_GObj_804D783C;
         }
     } else if (buttons & MenuInput_Up) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         x2_dec(selection_count);
     } else if (buttons & MenuInput_Down) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         x2_inc(selection_count);
     }
 }
@@ -2064,23 +2064,23 @@ void mn_8022CA54(HSD_GObj* gp)
         mn_804A04F0.entering_menu = 1;
         switch ((RecordsMenuSelection) mn_804A04F0.hovered_selection) {
         case SEL_RECORDS_VS:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mnDiagram_Init(1, 1);
             HSD_GObjPLink_80390228(gp);
             return;
         case SEL_RECORDS_BONUS:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mnInfoBonus_80252F8C();
             HSD_GObjPLink_80390228(gp);
             return;
         case SEL_RECORDS_MISC:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mnCount_Create();
             HSD_GObjPLink_80390228(gp);
             return;
         }
     } else if (buttons & MenuInput_Back) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = 0;
         mn_804D6BC8.cooldown = 5;
         mn_804A04F0.prev_menu = mn_804A04F0.cur_menu;
@@ -2093,7 +2093,7 @@ void mn_8022CA54(HSD_GObj* gp)
             think->flags_3 = HSD_GObj_804D783C;
         }
     } else if (buttons & MenuInput_Up) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         if ((RecordsMenuSelection) mn_804A04F0.hovered_selection ==
             SEL_RECORDS_VS)
         {
@@ -2103,7 +2103,7 @@ void mn_8022CA54(HSD_GObj* gp)
             mn_804A04F0.hovered_selection--;
         }
     } else if (buttons & MenuInput_Down) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         if ((RecordsMenuSelection) mn_804A04F0.hovered_selection ==
             SEL_RECORDS_MISC)
         {
@@ -2133,26 +2133,26 @@ void mn_8022CC28(HSD_GObj* gp)
         switch ((RegMatchMenuSelection)
                     mn_804A04F0.hovered_selection) { /* irregular */
         case SEL_REG_CLASSIC:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_CLASSIC;
             gm_801A4B60();
             return;
         case SEL_REG_ADVENTURE:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_ADVENTURE;
             gm_801A4B60();
             return;
         case SEL_REG_ALLSTAR:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_ALLSTAR;
             gm_801A4B60();
             return;
         }
     } else if (buttons & MenuInput_Back) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = 0;
         mn_804D6BC8.cooldown = 5;
         mn_804A04F0.prev_menu = mn_804A04F0.cur_menu;
@@ -2165,7 +2165,7 @@ void mn_8022CC28(HSD_GObj* gp)
             think->flags_3 = HSD_GObj_804D783C;
         }
     } else if (buttons & MenuInput_Up) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         do {
             if (mn_804A04F0.hovered_selection !=
                 (RegMatchMenuSelection) SEL_REG_CLASSIC)
@@ -2177,7 +2177,7 @@ void mn_8022CC28(HSD_GObj* gp)
             }
         } while (mn_80229938(6, (s32) mn_804A04F0.hovered_selection) == 0);
     } else if (buttons & MenuInput_Down) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         do {
             if ((RegMatchMenuSelection) mn_804A04F0.hovered_selection ==
                 SEL_REG_ALLSTAR)
@@ -2209,12 +2209,12 @@ void mn_8022CE6C(HSD_GObj* gp)
         switch ((DataMenuSelection)
                     mn_804A04F0.hovered_selection) { /* irregular */
         case SEL_DATA_SNAP:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mnSnap_80257F24();
             HSD_GObjPLink_80390228(gp);
             break;
         case SEL_DATA_ARCHIVES:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mnGallery_80259868();
             HSD_GObjPLink_80390228(gp);
             break;
@@ -2225,7 +2225,7 @@ void mn_8022CE6C(HSD_GObj* gp)
             HSD_GObjPLink_80390228(gp);
             break;
         case SEL_DATA_RECORDS:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mn_804D6BC8.cooldown = 5;
             mn_804A04F0.prev_menu = mn_804A04F0.cur_menu;
             mn_804A04F0.cur_menu = MENU_KIND_RECORDS;
@@ -2239,13 +2239,13 @@ void mn_8022CE6C(HSD_GObj* gp)
             }
             break;
         case SEL_DATA_SPECIAL:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mnInfo_80252758();
             HSD_GObjPLink_80390228(gp);
             break;
         }
     } else if (buttons & MenuInput_Back) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = 0;
         mn_804D6BC8.cooldown = 5;
         mn_804A04F0.prev_menu = mn_804A04F0.cur_menu;
@@ -2259,7 +2259,7 @@ void mn_8022CE6C(HSD_GObj* gp)
             think2->flags_3 = HSD_GObj_804D783C;
         }
     } else if (buttons & MenuInput_Up) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         do {
             if (mn_804A04F0.hovered_selection !=
                 (DataMenuSelection) SEL_DATA_SNAP)
@@ -2271,7 +2271,7 @@ void mn_8022CE6C(HSD_GObj* gp)
             }
         } while (mn_80229938(5, (s32) mn_804A04F0.hovered_selection) == 0);
     } else if (buttons & MenuInput_Down) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         do {
             if ((DataMenuSelection) mn_804A04F0.hovered_selection ==
                 SEL_DATA_SPECIAL)
@@ -2303,33 +2303,33 @@ void mn_8022D104(HSD_GObj* gp)
         mn_804A04F0.entering_menu = 1;
         switch (mn_804A04F0.hovered_selection) {
         case SEL_SETTINGS_RUMBLE:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mnVibration_Init(1);
             HSD_GObjPLink_80390228(gp);
             break;
         case SEL_SETTINGS_SOUND:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mnSound_8024A09C(1);
             HSD_GObjPLink_80390228(gp);
             break;
         case SEL_SETTINGS_DISPLAY:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mnDeflicker_8024A6C4(1);
             HSD_GObjPLink_80390228(gp);
             break;
         case SEL_SETTINGS_LANG:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mnLanguage_8024C5C0((HSD_GObj*) 1);
             HSD_GObjPLink_80390228(gp);
             break;
         case SEL_SETTINGS_ERASE:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mnDataDel_80250170();
             HSD_GObjPLink_80390228(gp);
             break;
         }
     } else if (buttons & MenuInput_Back) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = 0;
         mn_804D6BC8.cooldown = 5;
         mn_804A04F0.prev_menu = mn_804A04F0.cur_menu;
@@ -2343,7 +2343,7 @@ void mn_8022D104(HSD_GObj* gp)
             temp_r3_2->flags_3 = HSD_GObj_804D783C;
         }
     } else if (buttons & MenuInput_Up) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         do {
             if (mn_804A04F0.hovered_selection !=
                 (SettingsMenuSelection) SEL_SETTINGS_RUMBLE)
@@ -2354,7 +2354,7 @@ void mn_8022D104(HSD_GObj* gp)
             }
         } while (mn_80229938(4, mn_804A04F0.hovered_selection) == 0);
     } else if (buttons & 2) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         do {
             if (mn_804A04F0.hovered_selection == (u8) selection_count - 1) {
                 mn_804A04F0.hovered_selection = SEL_SETTINGS_RUMBLE;
@@ -2383,26 +2383,26 @@ void mn_8022D34C(HSD_GObj* gp)
         gm_801677E8(mn_8022C7CC_inline());
         switch (mn_804A04F0.hovered_selection) {
         case SEL_TOY_GALLERY:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_TOY_GALLERY;
             gm_801A4B60();
             return;
         case SEL_TOY_LOTTERY:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_TOY_LOTTERY;
             gm_801A4B60();
             return;
         case SEL_TOY_COLLECTION:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_TOY_COLLECTION;
             gm_801A4B60();
             return;
         }
     } else if (buttons & MenuInput_Back) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = 0;
         mn_804D6BC8.cooldown = 5;
         mn_804A04F0.prev_menu = mn_804A04F0.cur_menu;
@@ -2415,7 +2415,7 @@ void mn_8022D34C(HSD_GObj* gp)
             think->flags_3 = HSD_GObj_804D783C;
         }
     } else if (buttons & MenuInput_Up) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         do {
             if (mn_804A04F0.hovered_selection !=
                 (TrophyMenuSelection) SEL_TOY_GALLERY)
@@ -2427,7 +2427,7 @@ void mn_8022D34C(HSD_GObj* gp)
             }
         } while (mn_80229938(3, mn_804A04F0.hovered_selection) == 0);
     } else if (buttons & MenuInput_Down) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         do {
             if ((TrophyMenuSelection) mn_804A04F0.hovered_selection ==
                 SEL_TOY_COLLECTION)
@@ -2459,19 +2459,19 @@ void mn_8022D594(HSD_GObj* gp)
         mn_804A04F0.entering_menu = 1;
         switch (mn_804A04F0.hovered_selection) {
         case SEL_VS_MELEE:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_VS;
             gm_801A4B60();
             break;
         case SEL_VS_TOURNAMENT:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_TOURNAMENT;
             gm_801A4B60();
             break;
         case SEL_VS_SPECIAL:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mn_804D6BC8.cooldown = 5;
             mn_804A04F0.prev_menu = mn_804A04F0.cur_menu;
             mn_804A04F0.cur_menu = MENU_KIND_SPECIAL;
@@ -2486,18 +2486,18 @@ void mn_8022D594(HSD_GObj* gp)
             }
             break;
         case SEL_VS_RULES:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mn_80231714();
             HSD_GObjPLink_80390228(gp);
             break;
         case SEL_VS_NAME:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mnName_8023AC40();
             HSD_GObjPLink_80390228(gp);
             break;
         }
     } else if (buttons & MenuInput_Back) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = 0;
         mn_804D6BC8.cooldown = 5;
         mn_804A04F0.prev_menu = mn_804A04F0.cur_menu;
@@ -2511,14 +2511,14 @@ void mn_8022D594(HSD_GObj* gp)
             think2->flags_3 = HSD_GObj_804D783C;
         }
     } else if (buttons & MenuInput_Up) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         if ((VsMenuSelection) mn_804A04F0.hovered_selection == SEL_VS_MELEE) {
             mn_804A04F0.hovered_selection = SEL_VS_NAME;
         } else {
             mn_804A04F0.hovered_selection--;
         }
     } else if (buttons & MenuInput_Down) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         if ((VsMenuSelection) mn_804A04F0.hovered_selection == SEL_VS_NAME) {
             mn_804A04F0.hovered_selection = SEL_VS_MELEE;
         } else {
@@ -2548,7 +2548,7 @@ void mn_8022D7F4(HSD_GObj* gp)
         gm_801677E8(mn_8022C7CC_inline());
         switch (mn_804A04F0.hovered_selection) {
         case SEL_1P_REG:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mn_804D6BC8.cooldown = 5;
             mn_804A04F0.prev_menu = mn_804A04F0.cur_menu;
             mn_804A04F0.cur_menu = MENU_KIND_REG;
@@ -2563,7 +2563,7 @@ void mn_8022D7F4(HSD_GObj* gp)
             }
             break;
         case SEL_1P_STADIUM:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mn_804D6BC8.cooldown = 5;
             mn_804A04F0.prev_menu = mn_804A04F0.cur_menu;
             mn_804A04F0.cur_menu = MENU_KIND_STADIUM;
@@ -2578,19 +2578,19 @@ void mn_8022D7F4(HSD_GObj* gp)
             }
             break;
         case SEL_1P_EVENT:
-            lbAudioAx_80024030(1);
+            sfxForward();
             mnEvent_8024E838(0, 1);
             HSD_GObjPLink_80390228(gp);
             break;
         case SEL_1P_TRAINING:
-            lbAudioAx_80024030(1);
+            sfxForward();
             data = gm_GetCurrentSceneExitData();
             data->pending_mode = GM_TRAINING;
             gm_801A4B60();
             break;
         }
     } else if (buttons & MenuInput_Back) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = 0;
         mn_804D6BC8.cooldown = 5;
         mn_804A04F0.prev_menu = mn_804A04F0.cur_menu;
@@ -2604,7 +2604,7 @@ void mn_8022D7F4(HSD_GObj* gp)
             temp_r3_4->flags_3 = HSD_GObj_804D783C;
         }
     } else if (buttons & MenuInput_Up) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         do {
             if (mn_804A04F0.hovered_selection !=
                 (OnePlayerMenuSelection) SEL_1P_REG)
@@ -2615,7 +2615,7 @@ void mn_8022D7F4(HSD_GObj* gp)
             }
         } while (mn_80229938(1, mn_804A04F0.hovered_selection) == 0);
     } else if (buttons & MenuInput_Down) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         do {
             if (mn_804A04F0.hovered_selection == (u8) selection_count - 1) {
                 mn_804A04F0.hovered_selection =
@@ -2648,7 +2648,7 @@ void mn_8022DB10(HSD_GObj* gp)
     if (buttons & MenuInput_Confirm) {
         mn_804D6BC8.cooldown = 5;
         mf->entering_menu = 1;
-        lbAudioAx_80024030(1);
+        sfxForward();
         prev_menu_ptr = &mf->prev_menu;
         selection_ptr = &mf->hovered_selection;
         *prev_menu_ptr = mf->cur_menu;
@@ -2687,17 +2687,17 @@ void mn_8022DB10(HSD_GObj* gp)
             temp_r3_2->flags_3 = HSD_GObj_804D783C;
         }
     } else if (buttons & MenuInput_Back) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mf->entering_menu = 0;
         mn_804D6BC8.cooldown = 5;
         data = gm_GetCurrentSceneExitData();
         data->pending_mode = GM_TITLE;
         gm_801A4B60();
     } else if (buttons & MenuInput_Up) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         decrement_selection(selection_count, MENU_KIND_MAIN);
     } else if (buttons & MenuInput_Down) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         increment_selection(selection_count, MENU_KIND_MAIN);
     }
 }
@@ -2707,7 +2707,7 @@ void mn_8022DD38_OnFrame(void)
     MenuExitData* data;
     if (mn_8022F218() && mn_804A04F0.cur_menu != MENU_KIND_MAIN) {
         lbAudioAx_80023694();
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_8022F268();
         gm_801603B0();
         lb_8001B760(0xB);

--- a/src/melee/mn/mnmainrule.c
+++ b/src/melee/mn/mnmainrule.c
@@ -1,5 +1,6 @@
 #include "mnmainrule.h"
 
+#include "inlines.h"
 #include "mnmain.h"
 
 #include "baselib/gobjgxlink.h"
@@ -202,7 +203,7 @@ void fn_8022F538(HSD_GObj* arg0)
         if (mn_804A04F0.hovered_selection == 5 ||
             mn_804A04F0.hovered_selection == 6)
         {
-            lbAudioAx_80024030(1);
+            sfxForward();
             mn_804A04F0.entering_menu = 1;
             mn_804D6BC8.cooldown = 5;
             switch (mn_804A04F0.hovered_selection) {
@@ -226,7 +227,7 @@ void fn_8022F538(HSD_GObj* arg0)
             return;
         }
     } else if ((buttons & 0x100) != 0) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         switch ((s32) gm_GetCurrentGameMode()) {
         case GM_MENU:
             data = mn_804D6BD0->user_data;
@@ -265,7 +266,7 @@ void fn_8022F538(HSD_GObj* arg0)
         }
     }
     if ((buttons & 0x20) != 0) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = 0;
         data = mn_804D6BD0->user_data;
         rules = gmMainLib_GetGameRules();
@@ -291,7 +292,7 @@ void fn_8022F538(HSD_GObj* arg0)
         return;
     }
     if ((buttons & 1) != 0) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         do {
             if ((s32) mn_804A04F0.hovered_selection == 0) {
                 mn_804A04F0.hovered_selection = 6;
@@ -314,7 +315,7 @@ void fn_8022F538(HSD_GObj* arg0)
         return;
     }
     if ((buttons & 2) != 0) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         do {
             if ((s32) mn_804A04F0.hovered_selection == 6) {
                 mn_804A04F0.hovered_selection = 0;
@@ -349,7 +350,7 @@ void fn_8022F538(HSD_GObj* arg0)
         limits = mn_803EC7DC[mn_804A04F0.hovered_selection];
     }
     if ((buttons & 4) != 0) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         if (mn_804A04F0.confirmed_selection > limits[0]) {
             mn_804A04F0.confirmed_selection--;
             if (mn_804A04F0.confirmed_selection == limits[0] &&
@@ -378,7 +379,7 @@ void fn_8022F538(HSD_GObj* arg0)
         return;
     }
     if ((buttons & 8) != 0) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         if (mn_804A04F0.confirmed_selection < limits[1]) {
             mn_804A04F0.confirmed_selection++;
             if (mn_804A04F0.confirmed_selection == limits[1] &&

--- a/src/melee/mn/mnname.c
+++ b/src/melee/mn/mnname.c
@@ -1,5 +1,6 @@
 #include "mnname.h"
 
+#include "inlines.h"
 #include "mnmain.h"
 #include "mnmainrule.h"
 
@@ -386,7 +387,7 @@ u8 mnName_80237D94(s32 arg0, u8 arg1)
         if (arg0 & 8) {
             if ((s32) (arg1 / 6) == 3) {
                 if (mnName_GetColumnCount() > 4) {
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     if ((s32) (mnName_GetColumnCount() - 1) >
                         (s32) gobj->gx_link)
                     {
@@ -403,7 +404,7 @@ u8 mnName_80237D94(s32 arg0, u8 arg1)
         if (arg0 & 4) {
             if ((arg1 / 6) == 0) {
                 if (mnName_GetColumnCount() > 4) {
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     if (gobj->gx_link != 0) {
                         gobj->gx_link = gobj->gx_link - 1;
                     } else {
@@ -451,7 +452,7 @@ void mnName_ConfirmNameDeleteInput(HSD_GObj* arg0)
     PAD_STACK(0x18);
     if (buttons & 0x10) {
         if ((u8) flow->confirmed_selection == 0) {
-            lbAudioAx_80024030(0);
+            sfxBack();
             mn_804D6BC8.cooldown = 5;
             flow->x10 = 0;
             return;
@@ -469,7 +470,7 @@ void mnName_ConfirmNameDeleteInput(HSD_GObj* arg0)
             }
             idx = (sel % 6) + (col * 6);
             nameIdx = mnName_NameDisplayOrder[idx];
-            lbAudioAx_80024030(1);
+            sfxForward();
             {
                 u8 term = mnName_StringTerminator;
                 nameIdxInt = (u8) nameIdx;
@@ -493,13 +494,13 @@ void mnName_ConfirmNameDeleteInput(HSD_GObj* arg0)
         return;
     }
     if (buttons & 0x20) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804D6BC8.cooldown = 5;
         flow->x10 = 0;
         return;
     }
     if ((buttons & 8) || (buttons & 4)) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         if ((u8) mn_804A04F0.confirmed_selection == 0) {
             mn_804A04F0.confirmed_selection = 1;
             return;
@@ -553,7 +554,7 @@ void mnName_MainInput(HSD_GObj* arg0)
     mn_804A04F0.buttons = buttons;
 
     if (buttons & 0x20) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804D6BC8.cooldown = 5;
         if ((u16) mn_804A04F0.hovered_selection < 0x18U) {
             mn_804A04F0.hovered_selection = 0x1A;
@@ -572,7 +573,7 @@ void mnName_MainInput(HSD_GObj* arg0)
             isFull = GetNameCount_noinline() < 0x78 ? 0 : 1;
             if (isFull == 0) {
                 u8 count;
-                lbAudioAx_80024030(1);
+                sfxForward();
                 mnName_80239878(1U, (HSD_GObj*) gobj2);
                 mnName_80238A04((HSD_GObj*) gobj2, 0x18U, 1U);
                 HSD_SisLib_803A5CC4(gobj2->text2);
@@ -584,7 +585,7 @@ void mnName_MainInput(HSD_GObj* arg0)
             return;
         case 25:
             if (mnName_GetPageCount() != 0) {
-                lbAudioAx_80024030(1);
+                sfxForward();
                 isFull = 0;
                 if ((u8) gobj2->gobj.p_priority == 0) {
                     isFull = 1;
@@ -599,7 +600,7 @@ void mnName_MainInput(HSD_GObj* arg0)
             return;
         case 26:
             if (mnName_GetPageCount() != 0) {
-                lbAudioAx_80024030(1);
+                sfxForward();
                 mn_804A04F0.hovered_selection = 0;
                 mnName_80238A04((HSD_GObj*) gobj2, 0x1AU, 1U);
                 return;
@@ -618,7 +619,7 @@ void mnName_MainInput(HSD_GObj* arg0)
                     isValid = 1;
                 }
                 if (isValid != 0) {
-                    lbAudioAx_80024030(1);
+                    sfxForward();
                     mn_804A04F0.x10 = 2;
                     mn_804A04F0.confirmed_selection = 0;
                     mnName_8023A290();
@@ -633,7 +634,7 @@ void mnName_MainInput(HSD_GObj* arg0)
         u32 isL = buttons & 0x40;
         if (isL != 0 || (buttons & 0x80)) {
             if (mnName_GetColumnCount() > 4) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 if (isL != 0) {
                     u8 scroll = gobj2->gobj.gx_link;
                     if (scroll != 0) {
@@ -658,7 +659,7 @@ void mnName_MainInput(HSD_GObj* arg0)
             mn_804A04F0.hovered_selection =
                 (u16) mnName_80237D94((s32) buttons, prev);
             if ((s32) prev != (s32) mn_804A04F0.hovered_selection) {
-                lbAudioAx_80024030(2);
+                sfxMove();
             }
         }
     }

--- a/src/melee/mn/mnnamenew.c
+++ b/src/melee/mn/mnnamenew.c
@@ -13,6 +13,7 @@
 #include "lb/lbcardgame.h"
 #include "lb/lblanguage.h"
 #include "lb/lbspdisplay.h"
+#include "mn/inlines.h"
 #include "mn/mncharsel.h"
 #include "mn/mnmain.h"
 #include "mn/mnname.h"
@@ -936,7 +937,7 @@ void mnNameNew_GlyphVariantInput(void)
         AddCharacterToName(&mnNameNew_CurrentNameText[data->cursor_pos * 3],
                            mn_804A04F0.hovered_selection,
                            mn_804A04F0.confirmed_selection, data->mode);
-        lbAudioAx_80024030(1);
+        sfxForward();
         cur_pos = data->cursor_pos;
         old_hover = mn_804A04F0.hovered_selection;
         count = (s32) old_hover;
@@ -1003,7 +1004,7 @@ void mnNameNew_GlyphVariantInput(void)
             }
         }
         if (old_sel != (u8) mn_804A04F0.confirmed_selection) {
-            lbAudioAx_80024030(2);
+            sfxMove();
         }
     }
 }

--- a/src/melee/mn/mnruleplus.c
+++ b/src/melee/mn/mnruleplus.c
@@ -19,6 +19,7 @@
 
 #include "mn/forward.h"
 
+#include "mn/inlines.h"
 #include "mn/mnmain.h"
 #include "mn/mnmainrule.h"
 #include "mn/mnstagesw.h"
@@ -195,7 +196,7 @@ void fn_8023201C(HSD_GObj* gobj)
     if (buttons & 0x200) {
         /// A button: confirm stage select (option 5 only)
         if ((u16) mn_804A04F0.hovered_selection == 5) {
-            lbAudioAx_80024030(1);
+            sfxForward();
             mn_804A04F0.entering_menu = 1;
             mnRulePlus_SaveRules();
             mn_804D6BC8.cooldown = 5;
@@ -204,7 +205,7 @@ void fn_8023201C(HSD_GObj* gobj)
         }
     } else if (buttons & 0x100) {
         /// Start button: accept all rules and proceed
-        lbAudioAx_80024030(1);
+        sfxForward();
         switch (gm_GetCurrentGameMode()) {
         case GM_MENU:
             mnRulePlus_SaveRules();
@@ -216,7 +217,7 @@ void fn_8023201C(HSD_GObj* gobj)
         return;
     } else if (buttons & 0x20) {
         /// B button: cancel and go back
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = 0;
         mnRulePlus_SaveRules();
         mn_804D6BC8.cooldown = 5;
@@ -225,7 +226,7 @@ void fn_8023201C(HSD_GObj* gobj)
         return;
     } else if (buttons & 1) {
         /// D-Pad Up: move selection up (with wrap)
-        lbAudioAx_80024030(2);
+        sfxMove();
         do {
             if ((s32) mn_804A04F0.hovered_selection == 0) {
                 mn_804A04F0.hovered_selection = 5;
@@ -239,7 +240,7 @@ void fn_8023201C(HSD_GObj* gobj)
         return;
     } else if (buttons & 2) {
         /// D-Pad Down: move selection down (with wrap)
-        lbAudioAx_80024030(2);
+        sfxMove();
         do {
             if ((s32) mn_804A04F0.hovered_selection == 5) {
                 mn_804A04F0.hovered_selection = 0;
@@ -255,7 +256,7 @@ void fn_8023201C(HSD_GObj* gobj)
         /// D-Pad Left/Right: adjust value for non-stage options
         u8* bounds = mn_803ED2E8.stat[mn_804A04F0.hovered_selection];
         if (buttons & 4) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             if ((u8) mn_804A04F0.confirmed_selection > (u8) bounds[0]) {
                 mn_804A04F0.confirmed_selection -= 1;
                 return;
@@ -264,7 +265,7 @@ void fn_8023201C(HSD_GObj* gobj)
             return;
         }
         if (buttons & 8) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             if ((u8) mn_804A04F0.confirmed_selection < (u8) bounds[1]) {
                 mn_804A04F0.confirmed_selection += 1;
                 return;

--- a/src/melee/mn/mnsnap.c
+++ b/src/melee/mn/mnsnap.c
@@ -516,7 +516,7 @@ s32 mnSnap_80253BE0(u64 buttons, s32* cursor, s32 count)
         return 0;
     }
 
-    lbAudioAx_80024030(2);
+    sfxMove();
     if ((next / 4) == (cur / 4)) {
         return 1;
     }
@@ -814,7 +814,7 @@ s32 mnSnap_8025441C(u64 buttons)
     if (mnSnap_804A0A10.dlg_type != 0 && (buttons & 0x8) &&
         mnSnap_804A0A10.btn_idx == 0)
     {
-        lbAudioAx_80024030(2);
+        sfxMove();
         HSD_JObjReqAnimAll(mnSnap_804A0A10.left_btn, 0.0F);
         mnSnap_804A0A10.btn_idx = 1;
         HSD_JObjAnimAll(mnSnap_804A0A10.left_btn);
@@ -825,7 +825,7 @@ s32 mnSnap_8025441C(u64 buttons)
     if (mnSnap_804A0A10.dlg_type != 0 && (buttons & 0x4) &&
         mnSnap_804A0A10.btn_idx == 1)
     {
-        lbAudioAx_80024030(2);
+        sfxMove();
         HSD_JObjReqAnimAll(mnSnap_804A0A10.right_btn, 0.0F);
         mnSnap_804A0A10.btn_idx = 0;
         HSD_JObjAnimAll(snap->left_btn);
@@ -1124,7 +1124,7 @@ void fn_802545C4(void)
             if (((slot == 0) && (mnSnap_804A0A10.card_status[1] != 0)) &&
                 (buttons & 8))
             {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 mnSnap_804A0A10.active_slot = 1;
                 byte_off = 4;
                 for (i = 0; i < 2; i++, byte_off += 8) {
@@ -1155,7 +1155,7 @@ void fn_802545C4(void)
                         (mnSnap_804A0A10.card_status[0] != 0)) &&
                        (buttons & 4))
             {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 mnSnap_804A0A10.active_slot = 0;
                 byte_off2 = 4;
                 for (i = 0; i < 2; i++, byte_off2 += 8) {
@@ -1256,7 +1256,7 @@ void fn_802545C4(void)
                     mnSnap_804A0A10.dlg_text->pos_x = jobj->translate.x - 6.0F;
                     lbAudioAx_80024030(3);
                 } else {
-                    lbAudioAx_80024030(1);
+                    sfxForward();
                     mnSnap_804A0A10.state = 4;
                     mnSnap_804A0A10.cursor_idx = 0;
                     mnSnap_80253640(0);
@@ -1287,7 +1287,7 @@ void fn_802545C4(void)
             mnSnap_80253E90(slot);
         }
         if (mnSnap_804A0A10.dlg_result != 0) {
-            lbAudioAx_80024030(0);
+            sfxBack();
         }
         if ((mnSnap_804A0A10.card_status[mnSnap_804A0A10.active_slot] == 0) ||
             (mnSnap_804A0A10.dlg_result != 0))
@@ -1329,7 +1329,7 @@ void fn_802545C4(void)
                 lbAudioAx_80024030(3);
             } else {
                 mnSnap_804A0A10.state = 6;
-                lbAudioAx_80024030(1);
+                sfxForward();
                 mnSnap_804A0A10.menu_sel = 0;
                 mnSnap_80253AE4(0);
             }
@@ -1378,7 +1378,7 @@ void fn_802545C4(void)
     case 5:
         if (mnSnap_804A0A10.dlg_result == 1) {
             s32 poll_result;
-            lbAudioAx_80024030(1);
+            sfxForward();
             result = lbSnap_8001D5FC(mnSnap_804A0A10.active_slot,
                                      mnSnap_804A0A10.cursor_idx);
             if (result != 0xB) {
@@ -1455,7 +1455,7 @@ void fn_802545C4(void)
                 mnSnap_804A0A10.state = 4;
             }
         } else if (mnSnap_804A0A10.dlg_result == 2) {
-            lbAudioAx_80024030(0);
+            sfxBack();
             mnSnap_804A0A10.dlg_active = 0;
             mnSnap_804A0A10.dlg_timer = 0;
             if (mnSnap_804A0A10.dlg_text != NULL) {
@@ -1473,21 +1473,21 @@ void fn_802545C4(void)
             mnSnap_804A0A10.timer -= 1;
         }
         if (buttons & 1) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             mnSnap_804A0A10.menu_sel -= 1;
             if (mnSnap_804A0A10.menu_sel < 0) {
                 mnSnap_804A0A10.menu_sel = 4;
             }
             mnSnap_80253AE4(0);
         } else if (buttons & 2) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             mnSnap_804A0A10.menu_sel += 1;
             if (mnSnap_804A0A10.menu_sel > 4) {
                 mnSnap_804A0A10.menu_sel = 0;
             }
             mnSnap_80253AE4(0);
         } else if (buttons & 0x20) {
-            lbAudioAx_80024030(0);
+            sfxBack();
             mnSnap_804A0A10.state = 4;
         } else if (buttons & 0x200) {
             while (mnSnap_804A0A10.timer != 0) {
@@ -1498,7 +1498,7 @@ void fn_802545C4(void)
 
             if (mnSnap_804A0A10.menu_sel == 0) {
                 void* thumb_img;
-                lbAudioAx_80024030(1);
+                sfxForward();
                 mnSnap_804A0A10.state = 0xA;
                 HSD_JObjClearFlagsAll(mnSnap_804A0A10.fullview_jobj,
                                       JOBJ_HIDDEN);
@@ -1513,7 +1513,7 @@ void fn_802545C4(void)
                 jobj->u.dobj->mobj->tobj->imagedesc->width = 640;
                 jobj->u.dobj->mobj->tobj->imagedesc->height = 480;
             } else if (mnSnap_804A0A10.menu_sel == 1) {
-                lbAudioAx_80024030(1);
+                sfxForward();
                 mnSnap_804A0A10.state = 0xB;
                 HSD_JObjAnimAll(mnSnap_804A0A10.submenu_jobj);
                 mnSnap_804A0A10.timer = 4;
@@ -1538,7 +1538,7 @@ void fn_802545C4(void)
                                         JOBJ_HIDDEN);
                 }
             } else if (mnSnap_804A0A10.menu_sel == 2) {
-                lbAudioAx_80024030(1);
+                sfxForward();
                 mnSnap_804A0A10.dlg_timer = 9;
                 mnSnap_804A0A10.dlg_active = 1;
                 mnSnap_8025409C(1);
@@ -1584,7 +1584,7 @@ void fn_802545C4(void)
                 lbAudioAx_80024030(7);
                 mnSnap_804A0A10.state = 0x14;
             } else if (mnSnap_804A0A10.menu_sel == 4) {
-                lbAudioAx_80024030(1);
+                sfxForward();
                 mnSnap_804A0A10.dlg_timer = 9;
                 mnSnap_804A0A10.dlg_active = 1;
                 mnSnap_8025409C(1);
@@ -1615,11 +1615,11 @@ void fn_802545C4(void)
     case 10:
         if (buttons & 0x200) {
             mnSnap_804A0A10.state = 4;
-            lbAudioAx_80024030(0);
+            sfxBack();
             HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj, JOBJ_HIDDEN);
         } else if (buttons & 0x20) {
             mnSnap_804A0A10.state = 6;
-            lbAudioAx_80024030(0);
+            sfxBack();
             HSD_JObjSetFlagsAll(mnSnap_804A0A10.fullview_jobj, JOBJ_HIDDEN);
         }
         break;
@@ -1632,7 +1632,7 @@ void fn_802545C4(void)
         }
         if (buttons & 0x200) {
             if (mnSnap_804A0A10.move_idx != mnSnap_804A0A10.cursor_idx) {
-                lbAudioAx_80024030(1);
+                sfxForward();
                 {
                     s32 mi = mnSnap_804A0A10.move_idx;
                     result = lbSnap_8001D7B0(mnSnap_804A0A10.active_slot,
@@ -1650,7 +1650,7 @@ void fn_802545C4(void)
             }
         } else if (buttons & 0x20) {
             next_state = 6;
-            lbAudioAx_80024030(0);
+            sfxBack();
         } else if (buttons & 0xCF) {
             result = mnSnap_80253BE0(
                 buttons, &mnSnap_804A0A10.move_idx,
@@ -1768,7 +1768,7 @@ void fn_802545C4(void)
             }
 
             if (result == 0) {
-                lbAudioAx_80024030(1);
+                sfxForward();
                 mnSnap_804A0A10.state = 0xF;
                 HSD_JObjClearFlags(mnSnap_804A0A10.dlg_btn_r, JOBJ_HIDDEN);
                 HSD_JObjSetTranslateX(mnSnap_804A0A10.progress_jobj, -6.9F);
@@ -1874,7 +1874,7 @@ void fn_802545C4(void)
             }
 
         } else if (mnSnap_804A0A10.dlg_result == 2) {
-            lbAudioAx_80024030(0);
+            sfxBack();
             mnSnap_804A0A10.dlg_active = 0;
             mnSnap_804A0A10.dlg_timer = 0;
             if (mnSnap_804A0A10.dlg_text != NULL) {
@@ -1887,7 +1887,7 @@ void fn_802545C4(void)
 
     case 13:
         if (mnSnap_804A0A10.dlg_result == 2) {
-            lbAudioAx_80024030(0);
+            sfxBack();
             mnSnap_804A0A10.state = 6;
             mnSnap_804A0A10.dlg_active = 0;
             mnSnap_804A0A10.dlg_timer = 0;
@@ -1916,7 +1916,7 @@ void fn_802545C4(void)
 
     case 14:
         if (mnSnap_804A0A10.dlg_result != 0) {
-            lbAudioAx_80024030(0);
+            sfxBack();
             mnSnap_804A0A10.state = 6;
             mnSnap_804A0A10.dlg_active = 0;
             mnSnap_804A0A10.dlg_timer = 0;
@@ -2070,7 +2070,7 @@ void fn_802545C4(void)
         if (mnSnap_804A0A10.dlg_result == 1) {
             s32 do_delete = 0;
             s32 poll_result;
-            lbAudioAx_80024030(1);
+            sfxForward();
             if (lbSnap_8001D5FC(mnSnap_804A0A10.active_slot,
                                 mnSnap_804A0A10.cursor_idx) != 0xB)
             {
@@ -2149,7 +2149,7 @@ void fn_802545C4(void)
                 mnSnap_804A0A10.state = 4;
             }
         } else if (mnSnap_804A0A10.dlg_result == 2) {
-            lbAudioAx_80024030(0);
+            sfxBack();
             mnSnap_804A0A10.dlg_active = 0;
             mnSnap_804A0A10.dlg_timer = 0;
             if (mnSnap_804A0A10.dlg_text != NULL) {
@@ -2215,7 +2215,7 @@ void fn_802545C4(void)
                 lbAudioAx_80024030(3);
             } else {
                 s32 new_slot;
-                lbAudioAx_80024030(1);
+                sfxForward();
                 mnSnap_804A0A10.dlg_active = 0;
                 mnSnap_804A0A10.dlg_timer = 0;
                 if (mnSnap_804A0A10.dlg_text != NULL) {
@@ -2245,7 +2245,7 @@ void fn_802545C4(void)
                 }
             }
         } else if (mnSnap_804A0A10.dlg_result == 2) {
-            lbAudioAx_80024030(0);
+            sfxBack();
             mnSnap_804A0A10.dlg_active = 0;
             mnSnap_804A0A10.dlg_timer = 0;
             if (mnSnap_804A0A10.dlg_text != NULL) {
@@ -2258,7 +2258,7 @@ void fn_802545C4(void)
 
     case 22:
         if (mnSnap_804A0A10.dlg_result == 2) {
-            lbAudioAx_80024030(0);
+            sfxBack();
             mnSnap_804A0A10.state = 6;
             mnSnap_804A0A10.dlg_active = 0;
             mnSnap_804A0A10.dlg_timer = 0;
@@ -2350,7 +2350,7 @@ void fn_802545C4(void)
 
     case 23:
         if (mnSnap_804A0A10.dlg_result == 2) {
-            lbAudioAx_80024030(0);
+            sfxBack();
             mnSnap_804A0A10.state = 6;
             mnSnap_804A0A10.dlg_active = 0;
             mnSnap_804A0A10.dlg_timer = 0;

--- a/src/melee/mn/mnsound.c
+++ b/src/melee/mn/mnsound.c
@@ -156,7 +156,7 @@ void mnSound_802492CC(HSD_GObj* gobj)
             }
         } else if ((s8) menu->unk3 > -100) {
             // move towards sounds
-            lbAudioAx_80024030(2);
+            sfxMove();
             menu->unk3 -= 5;
             mix = menu->unk3;
             mnSound_VolumeAnim(GET_JOBJ(mnSound_804D6C30), mix, 5);
@@ -174,7 +174,7 @@ void mnSound_802492CC(HSD_GObj* gobj)
             }
         } else if ((s8) menu->unk3 < 100) {
             // move towards music
-            lbAudioAx_80024030(2);
+            sfxMove();
             menu->unk3 += 5;
             mix = menu->unk3;
             mnSound_VolumeAnim(GET_JOBJ(mnSound_804D6C30), mix, 18);

--- a/src/melee/mn/mnstagesel.c
+++ b/src/melee/mn/mnstagesel.c
@@ -1,5 +1,7 @@
 #include "mnstagesel.h"
 
+#include "inlines.h"
+
 #include "mnstagesel.static.h"
 
 #include "placeholder.h"
@@ -141,7 +143,7 @@ skip_randomize:
     HSD_JObjAnimAll(gobj->hsd_obj);
     mnStageSel_804D6CAF = 1;
     mnStageSel_804D6CA4 = 0x1E;
-    lbAudioAx_80024030(1);
+    sfxForward();
 }
 
 void fn_80259D84(HSD_GObj* gobj)
@@ -170,7 +172,7 @@ void fn_80259D84(HSD_GObj* gobj)
             {
                 HSD_JObjReqAnimAllByFlags(jobj, 1, 10.0F);
             }
-            lbAudioAx_80024030(2);
+            sfxMove();
             temp_r31->x4 = 0;
             temp_r31->x2 = 2;
             mnStageSel_80259ED8(mnStageSel_804D6CAE);
@@ -764,7 +766,7 @@ void mnStageSel_8025B850_OnFrame(void)
         return;
     }
     if (mnStageSel_804D6C90->no_lras == 0 && mn_8022F218()) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         lb_800145F4();
         HSD_GObjPLink_80390228(mnStageSel_804D6C9C);
         mn_8022F268();
@@ -816,7 +818,7 @@ void mnStageSel_8025B850_OnFrame(void)
     if (mnStageSel_804D6C90->x1 == 0 && (mnStageSel_804D6CA0 & 0x200) &&
         mnStageSel_804D6CAF == 0)
     {
-        lbAudioAx_80024030(0);
+        sfxBack();
         gm_801A4B60();
     }
     if (mnStageSel_804D6CAF == 2) {

--- a/src/melee/mn/mnstagesw.c
+++ b/src/melee/mn/mnstagesw.c
@@ -17,6 +17,7 @@
 #include <melee/lb/lbaudio_ax.h>
 #include <melee/lb/lbcardgame.h>
 #include <melee/lb/lbspdisplay.h>
+#include <melee/mn/inlines.h>
 #include <melee/mn/mnmain.h>
 #include <melee/mn/mnruleplus.h>
 #include <melee/sc/types.h>
@@ -307,7 +308,7 @@ static void fn_80235F80(HSD_GObj* gobj)
     buttons = mn_804A04F0.buttons = mn_80229624(4U);
     PAD_STACK(0x28);
     if (buttons & 0x20) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = 0;
         mnStageSw_8023593C(mnStageSw_804D6BF0);
         lb_8001CE00();
@@ -330,11 +331,11 @@ static void fn_80235F80(HSD_GObj* gobj)
                     if (enabled != 0) {
                         lbAudioAx_80024030(3);
                     } else {
-                        lbAudioAx_80024030(2);
+                        sfxMove();
                         mn_804A04F0.confirmed_selection = 0;
                     }
                 } else {
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     mn_804A04F0.confirmed_selection = 1;
                 }
                 user_data = mnStageSw_804D6BF0->user_data;
@@ -354,7 +355,7 @@ static void fn_80235F80(HSD_GObj* gobj)
             goto check_dpad;
         }
         if (buttons & 0x100) {
-            lbAudioAx_80024030(1);
+            sfxForward();
             result = gm_GetCurrentGameMode();
             switch (result) {
             case GM_MENU:
@@ -371,7 +372,7 @@ static void fn_80235F80(HSD_GObj* gobj)
         }
     check_dpad:
         if (buttons & 0xF) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             mnStageSw_80235DC8(user_data, buttons);
         }
     }

--- a/src/melee/mn/mnvibration.c
+++ b/src/melee/mn/mnvibration.c
@@ -255,7 +255,7 @@ void mnVibration_HandleInput(HSD_GObj* gobj)
     inputs = gm_GetButtonsTriggered(PAD_ALL_CONTROLLERS);
     if (inputs & PAD_CANCEL) {
         MnVibrationData* exit_data;
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_804A04F0.entering_menu = 0;
         mn_80229894(4, 0, 3);
         // Clean up text objects - reload data pointer
@@ -289,7 +289,7 @@ void mnVibration_HandleInput(HSD_GObj* gobj)
             inputs = gm_GetButtonsTriggered(i);
             if (inputs & PAD_CONFIRM) {
                 HSD_JObj* temp_jobj;
-                lbAudioAx_80024030(1);
+                sfxForward();
                 if (GetRumbleSettingOfPort(i) != 0) {
                     HSD_JObj* panel_jobj2;
                     gmMainLib_8015ED4C(i, 0);
@@ -356,7 +356,7 @@ void mnVibration_HandleInput(HSD_GObj* gobj)
             inputs = gm_GetButtonsTriggered(j);
             if ((inputs & PAD_ANY_LEFT) && data->x0[j + 2] == 1) {
                 u8 state;
-                lbAudioAx_80024030(2);
+                sfxMove();
                 data->x0[j + 2] = 0;
                 state = data->x0[j + 2];
                 panel_jobj =
@@ -367,7 +367,7 @@ void mnVibration_HandleInput(HSD_GObj* gobj)
                 inputs = gm_GetButtonsTriggered(j);
                 if ((inputs & PAD_ANY_RIGHT) && data->x0[j + 2] == 0) {
                     u8 state;
-                    lbAudioAx_80024030(2);
+                    sfxMove();
                     data->x0[j + 2] = 1;
                     state = data->x0[j + 2];
                     panel_jobj =
@@ -391,7 +391,7 @@ void mnVibration_HandleInput(HSD_GObj* gobj)
 
     // Handle A button to toggle rumble setting for selected name
     if (inputs_repeat & (1LL << 32)) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         cursor_row = data->x0[1];
         name_idx = mnVibration_GetNameSlot(data, cursor_row);
         rumble_setting = mnVibration_GetNameRumble(name_idx);
@@ -422,7 +422,7 @@ void mnVibration_HandleInput(HSD_GObj* gobj)
                 f32 temp_x;
                 f32 temp_y;
                 f32 temp_z;
-                lbAudioAx_80024030(2);
+                sfxMove();
                 data->x0[1]--;
                 data2 = mnVibration_804D6C28->user_data;
                 (void) data2;
@@ -443,7 +443,7 @@ void mnVibration_HandleInput(HSD_GObj* gobj)
                 HSD_JObjSetTranslateZ(cursor_jobj, temp_z);
             }
         } else if (GetNameCount() > 8 && data->scroll_offset != 0) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             data->scroll_offset--;
             mnVibration_RefreshNameRows(mnVibration_804D6C28);
         }
@@ -465,7 +465,7 @@ void mnVibration_HandleInput(HSD_GObj* gobj)
                 f32 temp_x;
                 f32 temp_y;
                 f32 temp_z;
-                lbAudioAx_80024030(2);
+                sfxMove();
                 data->x0[1]++;
                 data2 = mnVibration_804D6C28->user_data;
                 cursor_jobj = data->cursor_gobj->hsd_obj;
@@ -487,7 +487,7 @@ void mnVibration_HandleInput(HSD_GObj* gobj)
         } else if (GetNameCount() > 8) {
             name_idx = mnVibration_GetNameSlot(data, 8);
             if (name_idx != 0xFF) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 data->scroll_offset++;
                 if (data->scroll_offset >= GetNameCount()) {
                     data->scroll_offset = 0;

--- a/src/melee/ty/toy.c
+++ b/src/melee/ty/toy.c
@@ -31,6 +31,7 @@
 #include "lb/lbspdisplay.h"
 #include "lb/lbvector.h"
 #include "melee/if/textlib.h"
+#include "mn/inlines.h"
 #include "mn/mnmain.h"
 #include "mn/mnsoundtest.h"
 #include "MSL/math.h"
@@ -2910,7 +2911,7 @@ void _Toy_80309404(HSD_GObj* gobj)
     }
 
     if (mn_8022F218() != 0) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
         Toy_80310660(1);
         HSD_GObj_80390CD4(gobj);
@@ -2924,7 +2925,7 @@ void _Toy_80309404(HSD_GObj* gobj)
         trigger = Toy_80305B88();
 
         if (trigger & 0x200) {
-            lbAudioAx_80024030(0);
+            sfxBack();
             Toy_80310660(1);
             HSD_GObj_80390CD4(gobj);
             tyList_803147C4();
@@ -2992,7 +2993,7 @@ void _Toy_80309404(HSD_GObj* gobj)
 
         trigger = Toy_80305B88();
         if (trigger & 0xD00) {
-            lbAudioAx_80024030(1);
+            sfxForward();
             _Toy_sbss_804D6E80 = HSD_CObjGetTop(cobj);
             _Toy_sbss_804D6E84 = HSD_CObjGetBottom(cobj);
             _Toy_sbss_804D6E88 = HSD_CObjGetRight(cobj);
@@ -3051,7 +3052,7 @@ void _Toy_80309404(HSD_GObj* gobj)
         if ((trigger & 0x200) || ((f32) state->x5C > 7200.0f)) {
             ToyJObjNode* jobj_node;
 
-            lbAudioAx_80024030(0);
+            sfxBack();
             _Toy_sbss_804D6E80 = HSD_CObjGetTop(cobj);
             _Toy_sbss_804D6E84 = HSD_CObjGetBottom(cobj);
             _Toy_sbss_804D6E88 = HSD_CObjGetRight(cobj);
@@ -3252,7 +3253,7 @@ void _Toy_80309404(HSD_GObj* gobj)
                     cycle_prev: {
                         s32 total;
 
-                        lbAudioAx_80024030(2);
+                        sfxMove();
                         display->selectedIdx = display->selectedIdx - 1;
                         if (display->selectedIdx < 0) {
                             if ((gm_IsCurrently1PMode() != 0) ||
@@ -3354,7 +3355,7 @@ void _Toy_80309404(HSD_GObj* gobj)
                     cycle_next: {
                         s32 total;
 
-                        lbAudioAx_80024030(2);
+                        sfxMove();
                         display->selectedIdx = display->selectedIdx + 1;
                         if ((gm_IsCurrently1PMode() != 0) ||
                             (gm_GetCurrentGameMode() == GM_TOY_LOTTERY))
@@ -3498,7 +3499,7 @@ void _Toy_80309404(HSD_GObj* gobj)
 
         trigger = Toy_80305B88();
         if (trigger & 0x1000) {
-            lbAudioAx_80024030(2);
+            sfxMove();
             state->x58 = 0;
             ed4->x10 = (s32) (ed4->x10 + 1);
             if (ed4->x10 == 6) {
@@ -3656,7 +3657,7 @@ void _Toy_8030B530(HSD_GObj* arg0)
         trigger = Toy_80305B88();
 
         if (trigger & 0x10) {
-            lbAudioAx_80024030(0);
+            sfxBack();
             if ((s8) state->x61 == 0) {
                 Toy_80310660(1);
                 HSD_GObj_80390CD4(arg0);
@@ -3719,7 +3720,7 @@ void _Toy_8030B530(HSD_GObj* arg0)
                     transition->x20 = 0x40000000;
                     state->x5C = 0;
                     state->x61 = 3;
-                    lbAudioAx_80024030(0);
+                    sfxBack();
                     return;
                 }
             }
@@ -3967,7 +3968,7 @@ void _Toy_8030B530(HSD_GObj* arg0)
 
             if (trig2 & 0x441) {
                 s32 total;
-                lbAudioAx_80024030(2);
+                sfxMove();
                 display->selectedIdx = display->selectedIdx - 1;
                 if (display->selectedIdx < 0) {
                     if ((gm_IsCurrently1PMode() != 0) ||
@@ -4049,7 +4050,7 @@ void _Toy_8030B530(HSD_GObj* arg0)
                 }
             } else {
                 s32 total;
-                lbAudioAx_80024030(2);
+                sfxMove();
                 display->selectedIdx = display->selectedIdx + 1;
                 if ((gm_IsCurrently1PMode() != 0) ||
                     (gm_GetCurrentGameMode() == GM_TOY_LOTTERY))
@@ -4327,7 +4328,7 @@ void _Toy_8030E110(HSD_GObj* arg0)
             trigger = Toy_80305B88();
 
             if (trigger & 0x200) {
-                lbAudioAx_80024030(0);
+                sfxBack();
                 Toy_80310660(1);
                 HSD_GObj_80390CD4(arg0);
                 tyList_803147C4();
@@ -4349,7 +4350,7 @@ void _Toy_8030E110(HSD_GObj* arg0)
                 trigger = Toy_80305B88();
 
                 if (trigger & 0xD00) {
-                    lbAudioAx_80024030(1);
+                    sfxForward();
                     _Toy_sbss_804D6E80 = HSD_CObjGetTop(cobj);
                     _Toy_sbss_804D6E84 = HSD_CObjGetBottom(cobj);
                     _Toy_sbss_804D6E88 = HSD_CObjGetRight(cobj);
@@ -4372,7 +4373,7 @@ void _Toy_8030E110(HSD_GObj* arg0)
 
             if ((trigger & 0x200) || ((f32) state->x5C > 7200.0f)) {
                 ToyJObjNode* jobj_node;
-                lbAudioAx_80024030(0);
+                sfxBack();
                 _Toy_sbss_804D6E80 = HSD_CObjGetTop(cobj);
                 _Toy_sbss_804D6E84 = HSD_CObjGetBottom(cobj);
                 _Toy_sbss_804D6E88 = HSD_CObjGetRight(cobj);
@@ -4536,7 +4537,7 @@ void _Toy_8030E110(HSD_GObj* arg0)
                         }
                     }
                     if ((state->x30 < 0.0f) || (Toy_80305B88() & 0x441)) {
-                        lbAudioAx_80024030(2);
+                        sfxMove();
                         display->selectedIdx =
                             (s16) (display->selectedIdx - 1);
                         if (display->selectedIdx < 0) {
@@ -4623,7 +4624,7 @@ void _Toy_8030E110(HSD_GObj* arg0)
                         }
                     } else if ((state->x30 > 0.0f) || (Toy_80305B88() & 0x822))
                     {
-                        lbAudioAx_80024030(2);
+                        sfxMove();
                         display->selectedIdx =
                             (s16) (display->selectedIdx + 1);
                         {
@@ -4732,7 +4733,7 @@ void _Toy_8030E110(HSD_GObj* arg0)
         after_trophy_cycle:
             trigger = Toy_80305B88();
             if (trigger & 0x1000) {
-                lbAudioAx_80024030(2);
+                sfxMove();
                 state->x58 = 0;
                 M2C_FIELD(ed4, s32*, 0x10) = M2C_FIELD(ed4, s32*, 0x10) + 1;
                 if (M2C_FIELD(ed4, s32*, 0x10) == 6) {
@@ -5619,7 +5620,7 @@ void _Toy_80310B48(HSD_GObj* gobj)
     buttons = Toy_80305B88();
 
     if (buttons & 0x200) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         HSD_GObjPLink_80390228(gobj);
         editor->gobj = NULL;
         ((TyModeState*) Toy_804A284C)->x4 = 1;
@@ -5629,7 +5630,7 @@ void _Toy_80310B48(HSD_GObj* gobj)
     buttons = Toy_80305B88();
 
     if (buttons & 0x1100) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         Toy_80311960();
         valptr = (s16*) editor;
         {
@@ -5674,7 +5675,7 @@ void _Toy_80310B48(HSD_GObj* gobj)
         }
     }
 
-    lbAudioAx_80024030(2);
+    sfxMove();
     editor->values[(s8) editor->selected_slot] =
         (s16) (editor->values[(s8) editor->selected_slot] + 1);
     if ((s16) editor->values[(s8) editor->selected_slot] >
@@ -5699,7 +5700,7 @@ skip_increment:
         }
     }
 
-    lbAudioAx_80024030(2);
+    sfxMove();
     editor->values[(s8) editor->selected_slot] =
         (s16) (editor->values[(s8) editor->selected_slot] - 1);
     if ((s16) editor->values[(s8) editor->selected_slot] < 0) {
@@ -5711,7 +5712,7 @@ skip_increment:
 skip_decrement:
 
     if (!dirX && dirY) {
-        lbAudioAx_80024030(2);
+        sfxMove();
         editor->selected_slot =
             (u8) (s32) ((f32) (s8) editor->selected_slot + dirY);
         if ((s8) editor->selected_slot < 0) {

--- a/src/melee/ty/tydisplay.c
+++ b/src/melee/ty/tydisplay.c
@@ -42,6 +42,7 @@
 #include "lb/lbspdisplay.h"
 #include "lb/lbvector.h"
 #include "melee/if/textlib.h"
+#include "mn/inlines.h"
 #include "mn/mnmain.h"
 #include "MSL/math.h"
 #include "sc/types.h"
@@ -1279,14 +1280,14 @@ void _tyDisplay_8031A4EC(HSD_GObj* arg0)
     }
 
     if (mn_8022F218() != 0) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_8022F268();
         ((TyModeState*) Toy_804A284C)->x4 = 1;
         return;
     }
 
     if (Toy_80305B88() & 0x1200) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         ((TyModeState*) Toy_804A284C)->x4 = 1;
         return;
     }
@@ -1441,7 +1442,7 @@ void _tyDisplay_8031A94C(HSD_GObj* arg0)
     if (Toy_80305C44() & 0x200) {
         _tyDisplay_804D6F28 += 1;
         if (_tyDisplay_804D6F28 > 0x78) {
-            lbAudioAx_80024030(0);
+            sfxBack();
             ((TyModeState*) Toy_804A284C)->x4 = 1;
         }
     } else {

--- a/src/melee/ty/tyfigupon.c
+++ b/src/melee/ty/tyfigupon.c
@@ -41,6 +41,7 @@
 #include "lb/lblanguage.h"
 #include "lb/lbspdisplay.h"
 #include "lb/lbvector.h"
+#include "mn/inlines.h"
 #include "mn/mnmain.h"
 #include "MSL/math.h"
 #include "sc/types.h"
@@ -934,7 +935,7 @@ void _tyFigupon_80316C24(HSD_GObj* arg0)
     }
 
     if (mn_8022F218() != 0) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         mn_8022F268();
         ((TyModeState*) Toy_804A284C)->x4 = 1;
         return;
@@ -942,7 +943,7 @@ void _tyFigupon_80316C24(HSD_GObj* arg0)
 
     if (Toy_80305B88() & 0x200) {
         if (((u32) gm_801623D8() / 10u) == 0 || ef4->x5E <= 1) {
-            lbAudioAx_80024030(0);
+            sfxBack();
             ((TyModeState*) Toy_804A284C)->x4 = 1;
             return;
         }
@@ -983,7 +984,7 @@ void _tyFigupon_80316C24(HSD_GObj* arg0)
             }
             _tyFigupon_803153EC((u32) (s32) pct, 9, 3, 2, 0);
         }
-        lbAudioAx_80024030(2);
+        sfxMove();
         data->x28 = 1;
         return;
     }
@@ -1045,7 +1046,7 @@ void _tyFigupon_80316C24(HSD_GObj* arg0)
                 }
                 _tyFigupon_803153EC((u32) (s32) pct, 9, 3, 2, 0);
             }
-            lbAudioAx_80024030(2);
+            sfxMove();
             data->x28 = 1;
             return;
         }
@@ -1110,7 +1111,7 @@ void _tyFigupon_80316C24(HSD_GObj* arg0)
                     }
                     _tyFigupon_803153EC((u32) (s32) pct, 9, 3, 2, 0);
                 }
-                lbAudioAx_80024030(2);
+                sfxMove();
                 data->x28 = 3;
             }
         } else if (stick_scroll >= 0.1f || (Toy_80305C44() & 0x800) ||
@@ -1158,7 +1159,7 @@ void _tyFigupon_80316C24(HSD_GObj* arg0)
                     }
                     _tyFigupon_803153EC((u32) (s32) pct, 9, 3, 2, 0);
                 }
-                lbAudioAx_80024030(2);
+                sfxMove();
                 data->x28 = 3;
             }
         } else {

--- a/src/melee/ty/tylist.c
+++ b/src/melee/ty/tylist.c
@@ -9,6 +9,7 @@
 #include "lb/lb_00B0.h"
 #include "lb/lbaudio_ax.h"
 #include "lb/lbspdisplay.h"
+#include "mn/inlines.h"
 #include "mn/mnmain.h"
 #include "mn/mnsoundtest.h"
 #include "ty/toy.h"
@@ -366,7 +367,7 @@ s32 _tyList_8031305C(void* a, TyListState* state, s8 movedFlag)
                 }
             }
             if (movedFlag != 0) {
-                lbAudioAx_80024030(2);
+                sfxMove();
             }
         }
     }
@@ -612,7 +613,7 @@ static inline void tyList_80313BD8_inline(TyListState* state,
         if (p->x24 == g->x0C) {
             state->selectedIdx = p->idx;
             state->x278 = p;
-            lbAudioAx_80024030(2);
+            sfxMove();
             HSD_JObjSetTranslateY(state->x288, p->x30);
         }
         _tyList_80312904(p, _tyList_804A2D6C.x0C);
@@ -693,7 +694,7 @@ static void _tyList_80313BD8(HSD_GObj* gobj)
     }
 
     if (mn_8022F218() != 0) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
         Toy_80310660(0);
         _tyList_803148E4(0);
@@ -703,7 +704,7 @@ static void _tyList_80313BD8(HSD_GObj* gobj)
     }
 
     if (Toy_80305B88() & 0x200) {
-        lbAudioAx_80024030(0);
+        sfxBack();
         HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
         Toy_80310660(0);
         _tyList_803148E4(0);
@@ -716,7 +717,7 @@ static void _tyList_80313BD8(HSD_GObj* gobj)
     }
 
     if (Toy_80305B88() & 0x1100) {
-        lbAudioAx_80024030(1);
+        sfxForward();
         HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
         Toy_80310660(0);
         _tyList_803148E4(1);
@@ -737,7 +738,7 @@ static void _tyList_80313BD8(HSD_GObj* gobj)
             state->x29B = 2;
         }
         _tyList_80312BAC(state, g->x0C);
-        lbAudioAx_80024030(1);
+        sfxForward();
         return;
     }
 
@@ -748,7 +749,7 @@ static void _tyList_80313BD8(HSD_GObj* gobj)
             state->x29B = 0;
         }
         _tyList_80312BAC(state, g->x0C);
-        lbAudioAx_80024030(1);
+        sfxForward();
         return;
     }
 


### PR DESCRIPTION
There are existing helper functions that wrap this function with its 3 arguments. If the base function were named and those 3 values were defined as an enum then I don't know how much gain there really is to using this, but this inline already exists and has semantic names so perhaps we want to use them. This also imports a `mn` helper to other areas of the code.

Happy to replace these helper functions instead with the named raw function + named args or just close this PR if this isn't the right direction to be going.