### PR TITLE
Use GrKind/StKind names at the last raw stage-kind sites

### DIFF
--- a/src/melee/gm/gmregtyfall.c
+++ b/src/melee/gm/gmregtyfall.c
@@ -206,7 +206,7 @@ void gm_801A68D8(void)
     lb_8000FCDC();
     mpColl_80041C78();
     Ground_801C0378(0x40);
-    Stage_802251E8(0, NULL);
+    Stage_802251E8(St_Kind_Dummy, NULL);
     Item_80266FA8();
     Item_80266FCC();
     Stage_8022524C();

--- a/src/melee/gm/gmresultplayer.c
+++ b/src/melee/gm/gmresultplayer.c
@@ -1688,7 +1688,7 @@ void fn_8017AA78(u8* arg0)
     lb_8000FCDC();
     mpColl_80041C78();
     Ground_801C0378(0x40);
-    Stage_802251E8(0, NULL);
+    Stage_802251E8(St_Kind_Dummy, NULL);
     Stage_8022524C();
     Item_80266FA8();
     Item_80266FCC();

--- a/src/melee/it/items/itarwinglaser.c
+++ b/src/melee/it/items/itarwinglaser.c
@@ -439,9 +439,9 @@ static void itArwinglaser_UnkMotion3_Phys(Item_GObj* gobj)
         grCorneria_801DDCF0(&corneria_offset);
         ip->pos.x += corneria_offset.x;
         ip->pos.y += corneria_offset.y;
-        /* fallthrough */
+        // fallthrough
     case Gr_Kind_Venom:
-        return;
+        break;
     }
 }
 

--- a/src/melee/it/items/itarwinglaser.c
+++ b/src/melee/it/items/itarwinglaser.c
@@ -435,12 +435,12 @@ static void itArwinglaser_UnkMotion3_Phys(Item_GObj* gobj)
     HSD_JObjSetScale(jobj, &scale_vec);
 
     switch (Stage_8022519C(Stage_80225194())) {
-    case 14:
+    case Gr_Kind_Corneria:
         grCorneria_801DDCF0(&corneria_offset);
         ip->pos.x += corneria_offset.x;
         ip->pos.y += corneria_offset.y;
         /* fallthrough */
-    case 15:
+    case Gr_Kind_Venom:
         return;
     }
 }


### PR DESCRIPTION
`Stage_802251E8` takes a StKind / literal StKind everywhere else so replacing 0 with the defined value there. Also 1 small case for shared code around Arwing lasers still uses magic numbers in `itArwinglaser_UnkMotion3_Phys`.
