### PR TITLE
Use FighterKind/CharacterKind enum names for raw kind literals

### DIFF
--- a/src/melee/ft/chara/ftCrazyHand/ftCh_GrabUnk1_B174.c
+++ b/src/melee/ft/chara/ftCrazyHand/ftCh_GrabUnk1_B174.c
@@ -165,7 +165,7 @@ void fn_8015B2C0(HSD_GObj* gobj)
 
 bool fn_8015B4EC(Vec3* vec)
 {
-    HSD_GObj* gobj = ftBossLib_8015C3E8(28);
+    HSD_GObj* gobj = ftBossLib_8015C3E8(FTKIND_CREZYH);
     if (gobj != NULL) {
         Fighter* fp = GET_FIGHTER(gobj);
         lb_8000B1CC(fp->parts[FtPart_WaistN].joint, 0, vec);

--- a/src/melee/ft/chara/ftKirby/ftkirby.c
+++ b/src/melee/ft/chara/ftKirby/ftkirby.c
@@ -2742,7 +2742,7 @@ void ftKb_Init_OnDeath(HSD_GObj* gobj)
     fp->u.kb.hat.x0 = 0;
     fp->u.kb.hat.x4 = HSD_Randi(5) + 1;
     fp->u.kb.hat.jobj = NULL;
-    fp->u.kb.hat.kind = 4;
+    fp->u.kb.hat.kind = FTKIND_KIRBY;
     fp->u.kb.hat.x14.data = 0;
     fp->u.kb.x60 = 0;
     fp->u.kb.x64 = 0;

--- a/src/melee/ft/chara/ftKirby/ftkirbyspecialn.c
+++ b/src/melee/ft/chara/ftKirby/ftkirbyspecialn.c
@@ -1940,7 +1940,7 @@ void ftKb_SpecialN_800F5D04(Fighter_GObj* gobj, bool arg1)
         it_802ADA1C(&pos, &vel, fp2->facing_dir);
         ft_PlaySFX(fp, 0x22305, 0x7F, 0x40);
     }
-    new_var->u.kb.hat.kind = 4;
+    new_var->u.kb.hat.kind = FTKIND_KIRBY;
 }
 
 void ftKb_SpecialN_800F5DE8(Fighter_GObj* gobj)
@@ -3526,7 +3526,7 @@ void fn_800F9260(HSD_GObj* gobj)
     s32 pick;
     HSD_JObj* joint;
 
-    if (fp->u.kb.hat.kind != 4) {
+    if (fp->u.kb.hat.kind != FTKIND_KIRBY) {
         if (ftCheckThrowB0(fp)) {
             lb_8000B1CC(
                 fp->parts[ftParts_GetBoneIndex(fp, FtPart_LHandN)].joint, NULL,

--- a/src/melee/ft/chara/ftMars/ftMs_SpecialLw.c
+++ b/src/melee/ft/chara/ftMars/ftMs_SpecialLw.c
@@ -344,13 +344,13 @@ static inline void ftMs_SpecialLw_80139140_inline(HSD_GObj* gobj)
     Fighter* fp = GET_FIGHTER(gobj);
     if (!fp->x2219_b0) {
         switch (ftLib_GetKind(gobj)) {
-        case 18:
+        case FTKIND_MARS:
             efSync_Spawn(
                 1265, gobj,
                 fp->parts[ftParts_GetBoneIndex(fp, FtPart_RShoulderN)].joint,
                 &fp->facing_dir);
             break;
-        case 26:
+        case FTKIND_EMBLEM:
             efSync_Spawn(
                 1296, gobj,
                 fp->parts[ftParts_GetBoneIndex(fp, FtPart_RShoulderN)].joint,

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Damage_0.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Damage_0.c
@@ -18,7 +18,7 @@
 
 bool ftMh_MS_343_80151428(Vec3* vec)
 {
-    HSD_GObj* gobj = ftBossLib_8015C3E8(27);
+    HSD_GObj* gobj = ftBossLib_8015C3E8(FTKIND_MASTERH);
     if (gobj != NULL) {
         Fighter* fp = GET_FIGHTER(gobj);
         lb_8000B1CC(fp->parts[FtPart_WaistN].joint, 0, vec);

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Slam.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Slam.c
@@ -62,7 +62,7 @@ void ftMh_Slam_Coll(HSD_GObj* gobj) {}
 void ftMh_MS_380_80155194(HSD_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
-    HSD_GObj* gobj1 = ftBossLib_8015C3E8(28);
+    HSD_GObj* gobj1 = ftBossLib_8015C3E8(FTKIND_CREZYH);
     if (!ftBossLib_8015C31C()) {
         ftCh_Init_8015A2B0(gobj1);
     }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_TagApplaud.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_TagApplaud.c
@@ -56,7 +56,7 @@ void ftMh_TagApplaud_Coll(HSD_GObj* gobj) {}
 void ftMh_MS_383_80155484(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
-    HSD_GObj* gobj1 = ftBossLib_8015C3E8(28);
+    HSD_GObj* gobj1 = ftBossLib_8015C3E8(FTKIND_CREZYH);
     if (ftBossLib_8015C31C() == 0) {
         ftCh_Init_8015A560(gobj1);
     }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_TagCrush.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_TagCrush.c
@@ -50,7 +50,7 @@ void ftMh_MS_382_801552F8(HSD_GObj* gobj)
     Fighter* fp = gobj->user_data;
     fp->cmd_vars[1] = 0;
     {
-        HSD_GObj* gobj_2 = ftBossLib_8015C3E8(28);
+        HSD_GObj* gobj_2 = ftBossLib_8015C3E8(FTKIND_CREZYH);
         if (!ftBossLib_8015C31C()) {
             ftCh_Init_8015A3F4(gobj_2);
         }

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Wait1_0.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Wait1_0.c
@@ -222,7 +222,7 @@ void ftMh_Wait1_0_Anim(HSD_GObj* gobj)
 
             ftBossLib_8015BD24(fp->x1A88.level, &fp->u.mh.x223C,
                                fp->u.mh.x2238, da->x18, da->x20, da->x1C);
-            if (ftBossLib_8015C44C(28) == ftMh_MS_TagRockPaper) {
+            if (ftBossLib_8015C44C(FTKIND_CREZYH) == ftMh_MS_TagRockPaper) {
                 // Crazy Hand Combo Attack
                 switch (ftBossLib_8015C4C4()) {
                 case ftMh_MS_Squeezing1:

--- a/src/melee/ft/chara/ftPikachu/ftPk_SpecialN.c
+++ b/src/melee/ft/chara/ftPikachu/ftPk_SpecialN.c
@@ -67,10 +67,10 @@ void ftPk_SpecialN_Anim(HSD_GObj* gobj)
             sp14.z = 0.0f;
             it_802B338C(gobj, &sp14, fp->facing_dir, pika_attr->x14);
             switch (ftLib_GetKind(gobj)) {
-            case 12:
+            case FTKIND_PIKACHU:
                 ft_PlaySFX(fp, 240076, 127, 64);
                 break;
-            case 23:
+            case FTKIND_PICHU:
                 ft_PlaySFX(fp, 230067, 127, 64);
                 break;
             }
@@ -101,10 +101,10 @@ void ftPk_SpecialAirN_Anim(HSD_GObj* gobj)
             sp14.z = 0.0f;
             it_802B338C(gobj, &sp14, fp->facing_dir, pika_attr->x14);
             switch (ftLib_GetKind(gobj)) {
-            case 12:
+            case FTKIND_PIKACHU:
                 ft_PlaySFX(fp, 240076, 127, 64);
                 break;
-            case 23:
+            case FTKIND_PICHU:
                 ft_PlaySFX(fp, 230067, 127, 64);
                 break;
             }

--- a/src/melee/ft/fighter.c
+++ b/src/melee/ft/fighter.c
@@ -2869,10 +2869,10 @@ void Fighter_ProcessHit_8006D1EC(Fighter_GObj* gobj)
 
             } else {
                 switch (fp->kind) {
-                case 0x1B:
+                case FTKIND_MASTERH:
                     ftMh_MS_341_8014FE58(gobj);
                     break;
-                case 0x1C:
+                case FTKIND_CREZYH:
                     ftCh_Init_80156014(gobj);
                     break;
                 default:

--- a/src/melee/ft/forward.h
+++ b/src/melee/ft/forward.h
@@ -119,7 +119,7 @@ typedef enum FighterKind {
     /* 1F */ FTKIND_GKOOPS,
     /* 20 */ FTKIND_SANDBAG,
     /* 21 */ FTKIND_NONE,
-    /* 22 */ FTKIND_MAX = FTKIND_NONE
+    /* 21 */ FTKIND_MAX = FTKIND_NONE
 } FighterKind;
 
 typedef enum CharacterKind {

--- a/src/melee/ft/ft_0877.c
+++ b/src/melee/ft/ft_0877.c
@@ -250,7 +250,7 @@ s32 ft_80087C1C(void)
 
     for (gobj = HSD_GObj_Entities->fighters; gobj != 0; gobj = gobj->next) {
         ftKind = (GET_FIGHTER(gobj))->kind;
-        if (ftKind < 27) {
+        if (ftKind < FTKIND_MASTERH) {
             result = result | 1 << ftKind;
         }
     }

--- a/src/melee/gm/gm_1601.c
+++ b/src/melee/gm/gm_1601.c
@@ -3249,7 +3249,7 @@ s32 gm_80166A98(MatchEnd* arg0, u8 arg1, s8 arg2, u8 arg3, s8 arg4, u8 arg5,
 
     for (i = 0; i < 4; i++) {
         arg0->player_standings[i].x30 += 6 - i;
-        if (arg0->player_standings[i].character_kind == 0x21) {
+        if (arg0->player_standings[i].character_kind == CHKIND_NONE) {
             arg0->player_standings[i].slot_type = 3;
         } else if (HSD_PadMasterStatus[(u8) i].err == 0) {
             arg0->player_standings[i].slot_type = 0;
@@ -3257,9 +3257,9 @@ s32 gm_80166A98(MatchEnd* arg0, u8 arg1, s8 arg2, u8 arg3, s8 arg4, u8 arg5,
             arg0->player_standings[i].slot_type = 1;
         }
 
-        if (arg0->player_standings[i].character_kind == 0x13) {
-            arg0->player_standings[i].character_kind = 0x12;
-            arg0->player_standings[i].character_id = 7;
+        if (arg0->player_standings[i].character_kind == CKIND_SEAK) {
+            arg0->player_standings[i].character_kind = CKIND_ZELDA;
+            arg0->player_standings[i].character_id = FTKIND_SEAK;
         }
     }
 
@@ -4385,7 +4385,7 @@ s32 fn_801693A8(void)
 
 static inline bool gm_801693BC_inline(u8 ckind)
 {
-    if (ckind - 0x1B <= 1) {
+    if (ckind - CKIND_BOY <= 1) {
         return true;
     }
     return false;

--- a/src/melee/gm/gm_1B0FF.c
+++ b/src/melee/gm/gm_1B0FF.c
@@ -236,10 +236,10 @@ void gm_801B13B8(GameScene* arg0)
         temp_r28->players[i].xE = 4;
     }
 
-    temp_r28->players[0].c_kind = 6;
-    temp_r28->players[1].c_kind = 8;
-    temp_r28->players[2].c_kind = 6;
-    temp_r28->players[3].c_kind = 6;
+    temp_r28->players[0].c_kind = CKIND_LINK;
+    temp_r28->players[1].c_kind = CKIND_MARIO;
+    temp_r28->players[2].c_kind = CKIND_LINK;
+    temp_r28->players[3].c_kind = CKIND_LINK;
 
     temp_r28->players[0].slot_type = Gm_PKind_Human;
     temp_r28->players[1].slot_type = Gm_PKind_Human;

--- a/src/melee/gm/gm_1B14.c
+++ b/src/melee/gm/gm_1B14.c
@@ -719,7 +719,7 @@ void gm_801B2298_OnInit(void)
         temp_r31->data.players[i].color = i;
         temp_r31->data.players[i].xE = 0;
         if (i != 0) {
-            temp_r31->data.players[1].c_kind = 0x21;
+            temp_r31->data.players[1].c_kind = CHKIND_NONE;
         }
         gm_80473814.players[i] = temp_r31->data.players[i];
     }

--- a/src/melee/gm/gm_1BA8.c
+++ b/src/melee/gm/gm_1BA8.c
@@ -473,7 +473,7 @@ void gm_801BAD70(GameScene* arg0)
             }
             if ((s8) ((struct gm_evlevel*) *lvlpp)
                     ->player_init[player_idx]
-                    ->c_kind == 0x21)
+                    ->c_kind == CHKIND_NONE)
             {
                 s8* t = &ev->x8 + player_idx - 1;
                 s8 v = *t;
@@ -768,7 +768,7 @@ void gm_801BB758(GameScene* arg0)
     }
     gm_80173EEC();
     gm_80172898(0x10);
-    if (kind != 0x21) {
+    if (kind != CHKIND_MAX) {
         gm_801736E8(ev->x0, ev->x1, ev->x6, ev->x4, kind, GM_MENU);
         gm_ChangeGameModeAfterCurrentScene(GM_CHALLENGER_APPROACH);
         return;
@@ -1709,7 +1709,7 @@ void gm_801BC670(HSD_GObj* arg0)
         temp_r31->x2C = temp_r30->x0;
         temp_r31->x30 = 0;
     }
-    if (Player_80036394(0) == 7) {
+    if (Player_80036394(0) == FTKIND_SEAK) {
         temp_r31->x38 = 0x13;
     } else {
         temp_r31->x38 = 0x21;

--- a/src/melee/gm/gmclassic.c
+++ b/src/melee/gm/gmclassic.c
@@ -631,7 +631,7 @@ void gmClassic_OnLoad(void)
 void gmClassic_OnInit(void)
 {
     struct gmm_x0_528_t* temp_r3 = gmMainLib_8015CDC8();
-    temp_r3->c_kind = 0x21;
+    temp_r3->c_kind = CHKIND_NONE;
     temp_r3->color = 0;
     temp_r3->stocks = 3;
     temp_r3->cpu_level = 0;
@@ -710,8 +710,8 @@ void gmClassic_801B3500(GameScene* arg0)
 
     ally_count = 1;
     ckind = ad->x0.ckind;
-    if (ckind == 0x12 && ad->x0.xC.x12 != 0) {
-        sd->x0D[0] = 0x13;
+    if (ckind == CKIND_ZELDA && ad->x0.xC.x12 != 0) {
+        sd->x0D[0] = CKIND_SEAK;
     } else {
         sd->x0D[0] = ckind;
     }

--- a/src/melee/gm/gmregclear.c
+++ b/src/melee/gm/gmregclear.c
@@ -846,12 +846,12 @@ s32 gm_8017CE34(StartMeleeData* arg0, UnkAdventureData* arg1, s8* arg2,
     }
 
     player_ckind = (u8) arg1->x0.ckind;
-    if ((player_ckind == 0x12) && ((u8) arg1->x0.xC.x12 != 0)) {
-        player_ckind = 0x13;
+    if ((player_ckind == CKIND_ZELDA) && ((u8) arg1->x0.xC.x12 != 0)) {
+        player_ckind = CKIND_SEAK;
     } else if (((arg1->x0.x8 & 0x80) != 0) && ((u8) arg1->x0.x9 == 1) &&
-               ((s8) player_ckind == 0xE))
+               ((s8) player_ckind == CKIND_POPONANA))
     {
-        player_ckind = 0x20;
+        player_ckind = CHKIND_POPO;
     }
 
     gm_801B0620(arg0->players, player_ckind, arg1->x0.color, player_stocks,
@@ -992,18 +992,20 @@ s32 gm_8017CE34(StartMeleeData* arg0, UnkAdventureData* arg1, s8* arg2,
                 arg0->players[player_idx].xC_b2 = 1;
                 arg0->players[player_idx].xE = 0x1B;
             }
-            if ((s32) arg0->players[player_idx].c_kind == 0x1D) {
+            if ((s32) arg0->players[player_idx].c_kind == CKIND_GKOOPS) {
                 arg0->players[player_idx].xC_b1 = 0;
             }
             enemy_ckind = (u8) arg0->players[player_idx].c_kind;
-            if (((s8) enemy_ckind == 0x1A) || ((s8) enemy_ckind == 0x1E)) {
+            if (((s8) enemy_ckind == CKIND_MASTERH) ||
+                ((s8) enemy_ckind == CKIND_CREZYH))
+            {
                 arg0->players[player_idx].xC_b7 = 1;
                 arg0->players[player_idx].hp = 0x12C;
                 arg0->players[player_idx].xD_b2 = 1;
                 arg0->players[player_idx].xD_b0 = 1;
                 arg0->players[player_idx].xD_b2 = 1;
                 arg0->players[player_idx].spawn_dir = -1;
-                if ((s32) arg0->players[player_idx].c_kind == 0x1E) {
+                if ((s32) arg0->players[player_idx].c_kind == CKIND_CREZYH) {
                     arg0->players[player_idx].slot_type = 3;
                 }
                 boss_count += 1;
@@ -3485,7 +3487,7 @@ void gm_80182174(void)
 
     gm_8016795C(&lbl_80472ED8.xC);
 
-    ((volatile lbl_80472ED8_t*) &lbl_80472ED8)->xC.c_kind = 0x1B;
+    ((volatile lbl_80472ED8_t*) &lbl_80472ED8)->xC.c_kind = CKIND_BOY;
     ((volatile lbl_80472ED8_t*) &lbl_80472ED8)->xC.slot_type = 1;
     ((volatile lbl_80472ED8_t*) &lbl_80472ED8)->xC.stocks = 1;
     ((volatile lbl_80472ED8_t*) &lbl_80472ED8)->xC.xD_b4 = 1;

--- a/src/melee/gm/gmresultplayer.c
+++ b/src/melee/gm/gmresultplayer.c
@@ -1403,11 +1403,13 @@ void fn_8017A078(s32 arg0)
 
     if (mode == 0) {
         s32 kind = disp->state.char_kind[arg0];
-        if (kind == 5 && (u8) disp->state.variant[arg0] == 1) {
+        if (kind == CKIND_KOOPA && (u8) disp->state.variant[arg0] == 1) {
             eye.z += 6.0f;
-        } else if (kind == 9 && (u8) disp->state.variant[arg0] == 1) {
+        } else if (kind == CKIND_MARS && (u8) disp->state.variant[arg0] == 1) {
             eye.z += 7.5f;
-        } else if (kind == 0 && (u8) disp->state.variant[arg0] == 2) {
+        } else if (kind == CKIND_CAPTAIN &&
+                   (u8) disp->state.variant[arg0] == 2)
+        {
             eye.z += 6.0f;
         }
     }

--- a/src/melee/gm/gmtoulib.c
+++ b/src/melee/gm/gmtoulib.c
@@ -2252,10 +2252,10 @@ void fn_8018F888(void)
 
 static inline int fn_8018FA24_inline0(int char_kind)
 {
-    if (char_kind < 0x13) {
+    if (char_kind < CKIND_SEAK) {
         return char_kind;
     }
-    if (char_kind == 0x1D) {
+    if (char_kind == CKIND_GKOOPS) {
         return 5;
     }
     return char_kind + 1;

--- a/src/melee/mn/mncharsel.c
+++ b/src/melee/mn/mncharsel.c
@@ -1771,7 +1771,7 @@ s32 mnCharSel_8025FDEC(u8 door)
     css = mnCharSel_804D6CB0;
     c_kind = css->data.data.players[player].c_kind;
 
-    if (c_kind < 0x1A) {
+    if (c_kind < CKIND_PLAYABLE_COUNT) {
         if (c_kind !=
             all_data->icons[mnCharSel_803F0DFC.doors[door].sel_icon].char_kind)
         {
@@ -2114,7 +2114,7 @@ void mnCharSel_CursorThink(HSD_GObj* gobj)
                                             }
                                             mnCharSel_804D6CB0->data.data
                                                 .players[player_idx]
-                                                .c_kind = 0x21;
+                                                .c_kind = CHKIND_NONE;
                                         }
                                     }
                                     mnCharSel_8025DB34(grabbed);
@@ -4452,7 +4452,8 @@ s32 mnCharSel_802640A0(void)
             }
         }
         if (found >= 0x19) {
-            mnCharSel_804D6CB0->data.data.players[player].c_kind = 0x1A;
+            mnCharSel_804D6CB0->data.data.players[player].c_kind =
+                CKIND_PLAYABLE_COUNT;
             if ((u8) mnCharSel_804D6CB0->data.data.players[player].slot_type ==
                 1)
             {

--- a/src/melee/pl/player.c
+++ b/src/melee/pl/player.c
@@ -1925,7 +1925,7 @@ void Player_InitOrResetPlayer(s32 slot)
     player = &player_slots[slot];
 
     player->player_state = 0;
-    player->player_character = 8;
+    player->player_character = CKIND_MARIO;
     transformed0 = &player->transformed[0];
     transformed1 = &player->transformed[1];
 

--- a/src/melee/vi/vi1201v2.c
+++ b/src/melee/vi/vi1201v2.c
@@ -131,8 +131,8 @@ void un_803205F4(void)
     HSD_JObjReqAnimAll(jobj, 251.0f);
     HSD_GObj_SetupProc(gobj, mn_8022EAE0, 0);
 
-    Player_80036E20(0x1D, un_804D701C, 8);
-    Player_SetPlayerCharacter(1, 0x1D);
+    Player_80036E20(CKIND_GKOOPS, un_804D701C, 8);
+    Player_SetPlayerCharacter(1, CKIND_GKOOPS);
     Player_SetCostumeId(1, 0);
     Player_SetPlayerId(1, 0);
     Player_SetSlottype(1, 2);


### PR DESCRIPTION
From Claude:
> Replace 54 raw integer literals with their existing FTKIND_*/CKIND_*/CHKIND_* enum names across 23 TUs: ftLib_GetKind switches, ftBossLib_8015C3E8/8015C44C arguments, Kirby hat kind stores, and c_kind/character_kind comparisons and assignments. Duplicate-value entries are spelled by context: the gm_1BA8 guard reuses CHKIND_MAX to match its own assignment, empty slots use CHKIND_NONE, the boss check uses CKIND_MASTERH, and the CSS bounds use CKIND_PLAYABLE_COUNT.
>
> Also correct the off-by-one /* 22 */ index comment on FTKIND_MAX, which equals FTKIND_NONE at 0x21.

I've never seen an enum use `=` to assign itself to the value of another member before but `22` does seem wrong there.