### PR TITLE
Use CollLineKind names at the remaining raw line-kind sites

### DIFF
--- a/src/melee/ft/ft_0899.c
+++ b/src/melee/ft/ft_0899.c
@@ -197,7 +197,9 @@ void ft_80089B08(Fighter_GObj* gobj)
                 {
                     s32 next_check = mpLineGetNext(line_id);
                     s32 next_id = next_check;
-                    if (next_check != -1 && (mpLineGetKind(next_id) & 1)) {
+                    if (next_check != -1 &&
+                        (mpLineGetKind(next_id) & CollLine_Floor))
+                    {
                         mpLineGetNormal(next_id, &sp1C);
                         adj_angle = fp->facing_dir * atan2f(sp1C.x, sp1C.y);
                     }
@@ -205,7 +207,9 @@ void ft_80089B08(Fighter_GObj* gobj)
                 {
                     s32 prev_check = mpLineGetPrev(line_id);
                     s32 prev_id = prev_check;
-                    if (prev_check != -1 && (mpLineGetKind(prev_id) & 1)) {
+                    if (prev_check != -1 &&
+                        (mpLineGetKind(prev_id) & CollLine_Floor))
+                    {
                         mpLineGetNormal(prev_id, &sp1C);
                         adj_angle =
                             0.5f * ((fp->facing_dir * atan2f(sp1C.x, sp1C.y)) +

--- a/src/melee/gr/grpushon.c
+++ b/src/melee/gr/grpushon.c
@@ -715,16 +715,16 @@ DynamicsDesc* grPushOn_80219458(enum_t arg0)
             }
             if (joint == 2) {
                 kind = mpLineGetKind(arg0);
-                if (kind == 1) {
+                if (kind == CollLine_Floor) {
                     return yakumono_param->x8;
                 }
-                if (kind == 2) {
+                if (kind == CollLine_Ceiling) {
                     return yakumono_param->xC;
                 }
-                if (kind == 4) {
+                if (kind == CollLine_RightWall) {
                     return yakumono_param->x10;
                 }
-                if (kind == 8) {
+                if (kind == CollLine_LeftWall) {
                     return yakumono_param->x14;
                 }
                 return NULL;

--- a/src/melee/mp/mplib.c
+++ b/src/melee/mp/mplib.c
@@ -5232,7 +5232,7 @@ bool mpLib_80056C54(int line_id, Vec3* pos, int* line_id_out, Vec3* vec_out,
         }
     }
     if (line_id != -1) {
-        if (!(mpLineGetKind(line_id) & 1)) {
+        if (!(mpLineGetKind(line_id) & CollLine_Floor)) {
             line_id = -1;
         }
     }


### PR DESCRIPTION
From Claude:
> grpushon's yakumono parameter ladder spells the same CollLine_* names its structural twins in grtfox/grtmewtwo already use, and the three mpLineGetKind masks spell CollLine_Floor. The adjacent joint-index comparisons in grpushon are left numeric because they test mpJointFromLine results, not line kinds.