### PR TITLE
Match _tyFigupon_803155C8 and tyFigupon_OnEnter_80317D80

### DIFF
--- a/src/melee/ty/tyfigupon.c
+++ b/src/melee/ty/tyfigupon.c
@@ -374,6 +374,53 @@ static inline s32 tyFigupon_GetTotalCount(void)
     return total;
 }
 
+/* Capture sc=x5E before reloading ef4 - shared by OnEnter and case 9. */
+static inline void setupPercentDisplay(struct un_804D6EF4_t* ef4)
+{
+    s32 sc = ef4->x5E;
+    struct un_804D6EF4_t* ef4_3 = _tyFigupon_804D6EF4;
+    f32 pct;
+    f32 fval;
+
+    fval = (f32) (ef4_3->x54 + _tyFigupon_80314B54());
+    if (sc != 0) {
+        sc -= 1;
+    }
+    if (ef4_3->x54 == 0) {
+        pct = 0.0f;
+    } else {
+        pct = ((f32) ef4_3->x54 / fval) + ((f32) (sc * 5) / 100.0f);
+    }
+    if (pct >= 1.0f) {
+        pct = 999.0f;
+    } else {
+        pct *= 1000.0f;
+    }
+    _tyFigupon_803153EC((u32) (s32) pct, 9, 3, 2, 0);
+}
+
+/* Case 9: set bet count to 1 and refresh jobj[8] anim frame.
+ * Declare ef4_2 before anim_frame so MWCC colors them r28/r27. */
+static inline void setupBetAnim(struct un_804D6EF4_t* ef4)
+{
+    struct un_804D6EF4_t* ef4_2;
+    s32 anim_frame;
+
+    anim_frame = 1;
+    ef4->x5E = 1;
+    _tyFigupon_803153EC(ef4->x5E, 6, 2, 0, 0);
+    ef4_2 = _tyFigupon_804D6EF4;
+    if (ef4_2->x5E == 0x14) {
+        anim_frame = 3;
+    }
+    if (ef4_2->x5E <= 1) {
+        anim_frame = 4;
+    }
+    HSD_JObjReqAnimAll(ef4_2->jobjs[8], (f32) anim_frame);
+    HSD_AObjSetRate(ef4_2->jobjs[8]->aobj, 1.0f);
+    HSD_JObjAnimAll(ef4_2->jobjs[8]);
+}
+
 void _tyFigupon_803155C8(void)
 {
     s32 new_var;
@@ -520,45 +567,13 @@ void _tyFigupon_803155C8(void)
         break;
     case 9:
         if ((gm_801623D8() / 10u) != 0) {
-            new_var = 1;
-            ef4->x5E = 1;
-            _tyFigupon_803153EC(ef4->x5E, 6, 2, 0, 0);
-            {
-                struct un_804D6EF4_t* ef4_2 = _tyFigupon_804D6EF4;
-                if (ef4_2->x5E == 0x14) {
-                    new_var = 3;
-                }
-                if (ef4_2->x5E <= 1) {
-                    new_var = 4;
-                }
-                HSD_JObjReqAnimAll(ef4_2->jobjs[8], (f32) new_var);
-                HSD_AObjSetRate(ef4_2->jobjs[8]->aobj, 1.0f);
-                HSD_JObjAnimAll(ef4_2->jobjs[8]);
-            }
+            setupBetAnim(ef4);
         }
-        {
-            struct un_804D6EF4_t* ef4_3 = _tyFigupon_804D6EF4;
-            sc = ef4->x5E;
-            fval = (f32) (ef4_3->x54 + _tyFigupon_80314B54());
-            if (sc != 0) {
-                sc -= 1;
-            }
-            if (ef4_3->x54 == 0) {
-                pct = 0.0f;
-            } else {
-                pct = ((f32) ef4_3->x54 / fval) + ((f32) (sc * 5) / 100.0f);
-            }
-            if (pct >= 1.0f) {
-                pct = 999.0f;
-            } else {
-                pct *= 1000.0f;
-            }
-            _tyFigupon_803153EC((u32) (s32) pct, 9, 3, 2, 0);
-            ef4->x58 = 0;
-            ef4->x56 = 0;
-            HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
-            ef4->x5C = 0;
-        }
+        setupPercentDisplay(ef4);
+        ef4->x58 = 0;
+        ef4->x56 = 0;
+        HSD_GObjProc_8038FE24(HSD_GObj_804D7838);
+        ef4->x5C = 0;
         break;
     }
 }
@@ -1501,8 +1516,6 @@ static inline TyFiguponED4* tyFigupon_InitScene(struct un_804D6EF4_t** ef4_2)
 
 void tyFigupon_OnEnter_80317D80(void* arg0)
 {
-    s16 x54;
-    s32 x5E;
     TyFiguponData* data;
     struct un_804D6EF4_t* ef4;
     TyFiguponED4* ed4;
@@ -1510,8 +1523,6 @@ void tyFigupon_OnEnter_80317D80(void* arg0)
     HSD_Joint* joint;
     HSD_JObj* jobj;
     void* ud;
-    f32 total;
-    f32 pct;
     char* archive_name;
     void* sp20;
     u8 kind;
@@ -1586,27 +1597,7 @@ void tyFigupon_OnEnter_80317D80(void* arg0)
     }
     _tyFigupon_803153EC((s8) ef4->x5E, 6, 2, 0, 0);
     tyFigupon_UpdateRemainingCount(ef4);
-    x5E = ef4->x5E;
-    {
-        struct un_804D6EF4_t* ef4_3 = _tyFigupon_804D6EF4;
-        s32 b54 = _tyFigupon_80314B54();
-        x54 = ef4_3->x54;
-        total = (f32) (x54 + b54);
-    }
-    if (x5E != 0) {
-        x5E -= 1;
-    }
-    if (x54 == 0) {
-        pct = 0.0f;
-    } else {
-        pct = ((f32) x54 / total) + ((f32) (x5E * 5) / 100.0f);
-    }
-    if (pct >= 1.0f) {
-        pct = 999.0f;
-    } else {
-        pct *= 1000.0f;
-    }
-    _tyFigupon_803153EC((s32) pct, 9, 3, 2, 0);
+    setupPercentDisplay(ef4);
     HSD_PadRenewStatus();
 }
 


### PR DESCRIPTION
Two more in tyfigupon.

> Both functions shared duplicated percent-display and bet-anim setup that MWCC needed to see as one emission unit per call site. Pulling each into a local static inline keeps the field access order and register homing of retail; the x54/x5E field types (short/s8) match both original sites.
