### PR TITLE
Improve HSD_SObjLib_803A4A68 stack frame

### DIFF
--- a/src/sysdolphin/baselib/sobjlib.c
+++ b/src/sysdolphin/baselib/sobjlib.c
@@ -274,7 +274,7 @@ void HSD_SObjLib_803A4A68(HSD_SObj* sobj)
     u16 obj_height;
     u8 tex_fmt;
 
-    PAD_STACK(0x20);
+    PAD_STACK(0x8);
 
     if (sobj->x40 & 1) {
         return;


### PR DESCRIPTION
Frame-size fix for HSD_SObjLib_803A4A68: 99.899% to 99.951%.

> PAD_STACK(0x20) overshoots the frame by 24 bytes (224 vs the target's 200). Dropping it to 0x8 matches the frame size and register-save offsets exactly; the remaining delta is the stack slots MWCC picks for the GXColor compound-literal arguments.
