### PR TITLE
Match vec_normalize_check

### DIFF
--- a/src/sysdolphin/baselib/cobj.c
+++ b/src/sysdolphin/baselib/cobj.c
@@ -656,6 +656,20 @@ static inline f64 cobj_fabsf_p(f32* v)
     return __fabsf(*v);
 }
 
+int (vec_normalize_check)(Vec3* src, Vec3* dst)
+{
+    if (!src || !dst) {
+        return -1;
+    }
+    if (fabsf_bitwise(src->x) <= FLT_MIN && fabsf_bitwise(src->y) <= FLT_MIN &&
+        fabsf_bitwise(src->z) <= FLT_MIN)
+    {
+        return -1;
+    }
+    PSVECNormalize(src, dst);
+    return 0;
+}
+
 static int roll2upvec(HSD_CObj* cobj, Vec3* up, float roll)
 {
     int res;

--- a/src/sysdolphin/baselib/util.h
+++ b/src/sysdolphin/baselib/util.h
@@ -21,7 +21,7 @@ extern Mtx HSD_identityMtx;
 #define DEG_TO_RAD 0.017453292519943295
 #define RAD_TO_DEG 57.29577951308232
 
-static inline int vec_normalize_check(Vec3* src, Vec3* dst)
+static inline int vec_normalize_check_inline(Vec3* src, Vec3* dst)
 {
     if (!src || !dst) {
         return -1;
@@ -34,6 +34,8 @@ static inline int vec_normalize_check(Vec3* src, Vec3* dst)
     PSVECNormalize(src, dst);
     return 0;
 }
+
+#define vec_normalize_check(src, dst) vec_normalize_check_inline((src), (dst))
 
 static inline f32 atan2f_check(s8 y, s8 x)
 {


### PR DESCRIPTION
Adds the out-of-line `vec_normalize_check` definition to `cobj.c`, matching the 180-byte function at `0x1414` in `cobj.o` (previously completed from the original binary, not matched).

The camera-code callers in `cobj.c` keep inlining the function: the `static inline` in `util.h` is renamed to `vec_normalize_check_inline` and bridged by a macro, so the out-of-line copy can coexist in the same TU — the same pattern the repo already uses for `HSD_JObjSetMtxDirty`.

Verified locally:
- full `ninja` build passes, DOL checksum matches the original
- objdiff reports `vec_normalize_check` at 100% fuzzy (180B), no caller regressions (cobj unit 100%)

> AI-assisted summary: the missing out-of-line instance was found via a symbol audit (orig object vs .c definitions); the function body is verbatim from the existing util.h inline; the macro-bridge + parenthesized-name definition follows the repo's HSD_JObjSetMtxDirty pattern to satisfy mwcc's redefinition rules. The identifier rename (`vec_normalize_check` → `vec_normalize_check_inline`) is a mechanical consequence of that pattern, not a semantic change.
