### PR TITLE
Improve ftCo_8008DCE0 stack frame

### DIFF
--- a/src/melee/ft/chara/ftCommon/ftCo_Damage.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Damage.c
@@ -276,6 +276,7 @@ void ftCo_8008DCE0(Fighter_GObj* gobj, int arg1, float facing_dir)
     float y;
     int var_r27 = 1;
     float kb_applied = fp->dmg.kb_applied;
+    PAD_STACK(0x28);
     Fighter_8006CDA4(fp, fp->dmg.x1838_percentTemp);
     fp->dmg.x18d8.kb_applied1 = kb_applied;
     pl_80040270(fp->player_id, fp->x221F_b4, kb_applied);


### PR DESCRIPTION
Frame-size fix for ftCo_8008DCE0: 99.166% to 99.247%.

> The frame was 40 bytes short of the target. PAD_STACK(0x28) after the kb_applied local realigns the spill and save-area offsets, closing 41 of the 63 mismatched instructions. What remains is an f30/f31 assignment-order tie-break for the two scaled knockback locals and its two downstream effects.
