### PR TITLE
Match AXDriver_8038CFF4

### DIFF
--- a/src/sysdolphin/baselib/axdriver.c
+++ b/src/sysdolphin/baselib/axdriver.c
@@ -615,7 +615,7 @@ int AXDriver_8038CFF4(int sound_id, u8 volume, u8 pan, int track, int channel)
 
     enabled = OSDisableInterrupts();
     v->flags = (v->flags & ~SMSTATE_MASK) | SMSTATE_ACTIVE;
-    unk_inline(v, &AXDriver_804D7790);
+    unk_inline(v, &AXDriver_804D7794);
     AXDriver_804D77D0++;
     OSRestoreInterrupts(enabled);
 


### PR DESCRIPTION
Matches `AXDriver_8038CFF4` in `src/sysdolphin/baselib/axdriver.c` (99.89% → **100%**).

One-line fix: the voice was linked onto `AXDriver_804D7790`, but the relocation in the original binary targets `AXDriver_804D7794` (the adjacent list head). The build report may show no change for this function since its fuzzy metric relaxes data-relocation targets; the per-symbol objdiff shows the relocation mismatch resolved.