### PR TITLE
Match ifStock_802F9F48 (ifstock)

### DIFF
--- a/src/melee/if/ifstock.c
+++ b/src/melee/if/ifstock.c
@@ -661,7 +661,7 @@ void ifStock_802F98E8(unsigned char player, int b)
     }
 }
 
-HSD_GObj* ifStock_802F9F48(int arg)
+static inline HSD_GObj* ifStock_802F9F48_inline(int arg)
 {
     struct ifStock_804A1378* q = &ifStock_804A1378;
     HSD_GObj* gobj = GObj_Create(14, 15, 0);
@@ -684,6 +684,10 @@ HSD_GObj* ifStock_802F9F48(int arg)
     HSD_AObjSetRate(jobj2->u.dobj->mobj->tobj->aobj, 0.0f);
     HSD_JObjAnimAll(jobj);
     return gobj;
+}
+HSD_GObj* ifStock_802F9F48(int arg)
+{
+    return ifStock_802F9F48_inline(arg);
 }
 
 HSD_GObj* ifStock_802FA118(int arg)


### PR DESCRIPTION
## Summary
Matches `ifStock_802F9F48` (100%, 116/116 instruction rows) by moving the body into a `static inline` helper — the inlined helper's parameters become ordinary locals born in parameter-list order, which resolves the callee-saved register rotation that direct declaration ordering could not.

## Verification
Clean build from a fresh worktree at master with `--sym off --max-errors 0`, full `ninja build/GALE01/report.json` (fuzzy 100.0), per-row objdiff-cli: 116/116 rows identical. Unit `main/melee/if/ifstock` rises 95.28 → 95.66.