### PR TITLE
Partially match `mnCharSel_8025FDEC`

### DIFF
--- a/src/melee/mn/mncharsel.c
+++ b/src/melee/mn/mncharsel.c
@@ -290,7 +290,7 @@ void mnCharSel_8025C020(int arg0)
                     HSD_SisLib_803A70A0(mnCharSel_804D6CDC, 0, "%d \x8c\xc2",
                                         target_count);
                 } else {
-                    HSD_SisLib_803A70A0(mnCharSel_804D6CDC, 0, "%d",
+                    HSD_SisLib_803A70A0(mnCharSel_804D6CDC, 0, "%d \x81\x40",
                                         target_count);
                 }
             } else {
@@ -334,7 +334,7 @@ void mnCharSel_8025C020(int arg0)
                 (f32) (int) (10.0f * (gm_801631F0() / 30.4788f)) / 10.0f);
         }
         break;
-    case 23:
+    case TRAINING_MODE:
         if (arg0 == 0) {
             HSD_SisLib_803A70A0(mnCharSel_804D6CDC, 0, "%d",
                                 gm_80163274(hud_index));
@@ -4016,8 +4016,11 @@ s32 mnCharSel_802640A0(void)
         HSD_JObjAddAnimAll(mnCharSel_804D6CC0, ANIM[3].anim, ANIM[3].matanim,
                            ANIM[3].shapeanim);
     }
-    HSD_GObjObject_80390A70(mnCharSel_804D6CBC, HSD_GObj_804D7849,
-                            mnCharSel_804D6CC0);
+    {
+        u8 obj_kind = HSD_GObj_804D7849;
+        HSD_GObjObject_80390A70(mnCharSel_804D6CBC, obj_kind,
+                                mnCharSel_804D6CC0);
+    }
     GObj_SetupGXLink(mnCharSel_804D6CBC, HSD_GObj_JObjCallback, 1, 0x80);
     HSD_GObj_SetupProc(mnCharSel_804D6CBC, fn_8025F0E0, 4);
     HSD_JObjReqAnimAll(mnCharSel_804D6CC0, 0.0f);
@@ -4117,13 +4120,17 @@ s32 mnCharSel_802640A0(void)
                         HSD_AObjStopAnim, AOBJ_ARG_AOV, 0, 0);
         ck = mnCharSel_804D6CB0->data.data.players[mnCharSel_804D6CF1].c_kind;
         if ((s8) ck >= CKIND_PLAYABLE_COUNT || gm_IsCKindUnlocked(ck) == 0) {
+            u8* char_kinds;
+            s32 icon_off;
             do {
                 i = HSD_Randi(0x19);
             } while ((u8) icons[i].state == 0);
+            char_kinds = &icons[0].char_kind;
+            icon_off = getIconOffset(i);
             mnCharSel_804D6CB0->data.data.players[mnCharSel_804D6CF1].c_kind =
-                icons[i].char_kind;
+                char_kinds[icon_off];
             mnCharSel_804D6CB0->data.data.players[mnCharSel_804D6CF1].color =
-                HSD_Randi((s32) gm_80169238(icons[i].char_kind));
+                HSD_Randi((s32) gm_80169238(char_kinds[icon_off]));
         }
     }
 
@@ -4199,7 +4206,7 @@ s32 mnCharSel_802640A0(void)
         }
         for (found = 0; found < 0x19; found++) {
             u8 ck = mnCharSel_804D6CB0->data.data.players[player].c_kind;
-            if ((s8) ck == (s8) icons[found].char_kind &&
+            if ((s8) ck == icons[found].char_kind &&
                 gm_IsCKindUnlocked(ck) != 0)
             {
                 break;
@@ -4402,7 +4409,8 @@ s32 mnCharSel_802640A0(void)
     }
 
     if ((u8) mnCharSel_804D6CF5 == 1) {
-        switch (mnCharSel_804D6CB0->match_type) {
+        CSSData* css = mnCharSel_804D6CB0;
+        switch (css->match_type) {
         case REG_CLASSIC:
         case REG_ADVENTURE:
         case REG_ALLSTAR:
@@ -4413,8 +4421,7 @@ s32 mnCharSel_802640A0(void)
             spD4 = mnCharSel_804DC594;
             {
                 u8 cpu_level =
-                    mnCharSel_804D6CB0->data.data.players[mnCharSel_804D6CF0]
-                        .cpu_level;
+                    css->data.data.players[mnCharSel_804D6CF0].cpu_level;
                 CSS_ALL->doors_data.xce = cpu_level;
                 CSS_ALL->doors_data.xcd = cpu_level;
             }
@@ -4886,8 +4893,9 @@ s32 mnCharSel_802640A0(void)
                     hval =
                         (u8) mnCharSel_804D6CB0->data.data.players[i].handicap;
                 }
-                if (hval != 0) {
-                } else {
+                /* switch forces MWCC beq/b double-branch (not bne) */
+                switch (hval) {
+                case 0:
                     hval = 1;
                 }
                 {


### PR DESCRIPTION
Two more in the character select screen.

> mnCharSel_8025FDEC needed the icon lookup routed through the CSSIcon stride (char_kinds[getIconOffset(i)]) to keep the index math in the registers retail uses. The "%d" format string gains a trailing SJIS full-width space ("%d \x81\x40"), matching the sibling literal two calls down; this is a rodata content correction recovered from the string pool, and the data section byte count is checked by the bot below.
