### PR TITLE
Restore descriptive names in `hsd_3A94`

### DIFF
--- a/src/sysdolphin/baselib/hsd_3A94.c
+++ b/src/sysdolphin/baselib/hsd_3A94.c
@@ -3351,15 +3351,15 @@ s32 fn_803AF3F0(CardState* state, s32 arg1, s32 arg2, s32 arg3, s32 arg4)
         s32 ofs = state->x20;
         s32 fd = state->x4;
         s32 retries;
-        s32 r;
+        s32 open_result;
         for (retries = 0; retries < 10; retries++) {
-            r = CARDFastOpen(fd, ofs, &state->file_info);
-            if (r != -1) {
+            open_result = CARDFastOpen(fd, ofs, &state->file_info);
+            if (open_result != -1) {
                 break;
             }
         }
-        if (r < 0) {
-            return r;
+        if (open_result < 0) {
+            return open_result;
         }
     }
 


### PR DESCRIPTION
Follow-up promised on #3050.

> Audited the whole file body-for-body against the pre-rewrite version (ee4311b). 65 of 72 shared functions are byte-identical. The helper renames in the rewrite turned out to be consolidation onto the pre-existing shared fn_803AC6B8_blocks_before rather than de-naming, so those stand. One genuine naming regression was found and restored: the CARDFastOpen retry result in fn_803AF3F0 was flattened from open_result to r. Both matched functions stay at 100 and total matched bytes are unchanged.
