### PR TITLE
Match mnSnap_80253964 (mnsnap)

### DIFF
--- a/src/melee/mn/mnsnap.c
+++ b/src/melee/mn/mnsnap.c
@@ -394,6 +394,7 @@ void mnSnap_80253964(void)
     s32 j;
     s32 page = mnSnap_804A0A10.cur_page;
     s32 base = page * 4;
+    page = page;
 
     PAD_STACK(8);
 


### PR DESCRIPTION
Matches `mnSnap_80253964` (99.90% → **100%**).

One-line fix: `page = page;` after `s32 base = page * 4;` keeps `page` live across the first loop, fixing the callee-saved register rotation in the tail. Same idiom already used at `mnsnap.c:653`.

Verified with a clean CI-flag build (`--sym off --max-errors 0`); all other functions in the unit unchanged.