### PR TITLE
Match hsd_80394950, hsd_80396188, hsd_80396E40 (debugconsole_main)

### DIFF
--- a/src/sysdolphin/baselib/debugconsole_main.c
+++ b/src/sysdolphin/baselib/debugconsole_main.c
@@ -753,9 +753,10 @@ void hsd_80394668(void)
 void hsd_80394950(OSContext* ctx)
 {
     OSContext tmp;
+    int i;
+    int j;
     OSContext* saved;
     BOOL irq;
-    int i;
     u8* p;
 
     if (!(ctx->state & OS_CONTEXT_STATE_FPSAVED)) {
@@ -777,16 +778,16 @@ void hsd_80394950(OSContext* ctx)
 
     OSReport("- PSF -----------------------------------------------\n");
 
-    i = 0;
+    j = 0;
     p = (u8*) ctx;
     do {
         u32 val0 = ((u32*) p)[0x24];
         u32 val1 = ((u32*) p)[0x25];
-        OSReport("R%02d=%08X:%08X (%e, %e)\n", i, val0, val1, ((f32*) p)[0x24],
+        OSReport("R%02d=%08X:%08X (%e, %e)\n", j, val0, val1, ((f32*) p)[0x24],
                  ((f32*) p)[0x25]);
-        i++;
+        j++;
         p += 8;
-    } while (i < 32);
+    } while (j < 32);
 
     OSClearContext(&tmp);
     OSSetCurrentContext(saved);
@@ -1714,9 +1715,9 @@ static inline s32 hsd_80396188_calc_col(void)
 static inline void hsd_80396188_draw_rows(char* buf, s32 col, u32** addr,
                                           s32* i)
 {
-    s32* x8 = &hsd_804CF810.x8;
     s32* x4 = &hsd_804CF810.x4;
     s32* x40 = &hsd_804CF810.x40;
+    s32* x8 = &hsd_804CF810.x8;
 
     hsd_80394434(lbl_804D62CC);
     *i = 0;
@@ -1738,23 +1739,28 @@ static inline void hsd_80396188_draw_rows(char* buf, s32 col, u32** addr,
     *x4 = col;
 }
 
+static inline void* hsd_80396188_get_x50(void)
+{
+    return hsd_804CF810.x50;
+}
+
 void hsd_80396188(void)
 {
-    void* saved;
     s32 col;
     s32 i;
     u32* addr;
     char buf[64];
     void* tmp;
-    PAD_STACK(20);
+    void* saved;
+    PAD_STACK(12);
 
     addr = (u32*) lbl_8040BAF0.x10;
-    saved = hsd_804CF810.x50;
-    col = ((hsd_804CF810.x20 - 0x2E) / 2) * 11 + 20;
+    saved = hsd_80396188_get_x50();
+    i = hsd_804CF810.x20 - 0x2E;
     hsd_804CF810.x50 = &lbl_8040AB00;
-    hsd_804CF810.x4 = col;
+    hsd_804CF810.x4 = (i / 2) * 11 + 20;
     hsd_804CF810.x8 = hsd_804CF810.x40 - 0x7C;
-    hsd_80396188_draw_rows(buf, col, &addr, &i);
+    hsd_80396188_draw_rows(buf, (i / 2) * 11 + 20, &addr, &i);
     hsd_804CF810.x8 = hsd_804CF810.x40 - 0x36;
     hsd_80394434(lbl_804D62D4);
     hsd_804CF810.x50 = saved;
@@ -2136,15 +2142,17 @@ static char* lbl_804D630C = "+-------------------------------+";
 
 // @TODO: Currently 86.10% match - .bss.0 relocation affects register
 // allocation
+static inline void* hsd_80396E40_get_x50(void)
+{
+    return hsd_804CF810.x50;
+}
+
 void hsd_80396E40(int keycode)
 {
     struct ParticleScreenState* sp = &hsd_804CF810;
     char buf[64];
-    void* saved;
     s32 row;
     s32 i;
-    s32 spr_u;
-    s32 spr_l;
     s32 bat_u;
     s32 bat_l;
     char* perm;
@@ -2157,25 +2165,35 @@ void hsd_80396E40(int keycode)
     s32 bit;
     char* ptr;
     s32 j;
-    char ch;
+    s32 ch;
+    void* saved;
+    PAD_STACK(8);
 
-    saved = hsd_804CF810.x50;
+    saved = hsd_80396E40_get_x50();
     row = sp->x1C - 1;
     hsd_804CF810.x50 = &lbl_8040AB00;
     hsd_804CF810.x4 = 0x106;
-    hsd_804CF810.x8 = (hsd_804CF810.x40 - 0x28) - (row + 1) * 14;
-    row--;
-    if (keycode < 0x220 && keycode >= 0x218) {
+    i = row--;
+    hsd_804CF810.x8 = (hsd_804CF810.x40 - 0x28) - (i + 1) * 14;
+    switch (keycode) {
+    case 0x218:
+    case 0x219:
+    case 0x21A:
+    case 0x21B:
+    case 0x21C:
+    case 0x21D:
+    case 0x21E:
+    case 0x21F:
         hsd_80394434(lbl_804D62FC);
-    } else {
+        break;
+    default:
         hsd_80394434(lbl_804D6300);
+        break;
     }
     i = 0;
-    spr_u = 0x219;
-    spr_l = 0x218;
     do {
-        bat_u = baselib_mfspr(spr_u);
-        bat_l = baselib_mfspr(spr_l);
+        bat_u = baselib_mfspr(0x219 + i * 2);
+        bat_l = baselib_mfspr(0x218 + i * 2);
         switch (bat_u & 2) {
         case 0:
             perm = "N/A";
@@ -2227,24 +2245,20 @@ void hsd_80396E40(int keycode)
             } else {
                 ch = '0';
             }
-            ptr[7] = ch;
+            ptr[7] = (char) ch;
             ptr++;
         }
         hsd_804CF810.x4 = 0x106;
-        hsd_804CF810.x8 = (hsd_804CF810.x40 - 0x28) - (row + 1) * 14;
-        row--;
+        hsd_804CF810.x8 = (hsd_804CF810.x40 - 0x28) - (row-- + 1) * 14;
         hsd_80394434(buf);
         sprintf(buf, lbl_804D6308, bat_l & 0xFFFC0000, bat_u & 0xFFFC0000);
         hsd_804CF810.x4 = 0x106;
-        hsd_804CF810.x8 = (hsd_804CF810.x40 - 0x28) - (row + 1) * 14;
-        row--;
+        hsd_804CF810.x8 = (hsd_804CF810.x40 - 0x28) - (row-- + 1) * 14;
         hsd_80394434(buf);
         i++;
-        spr_u += 2;
-        spr_l += 2;
     } while (i < 4);
     hsd_804CF810.x4 = 0x106;
-    hsd_804CF810.x8 = (hsd_804CF810.x40 - 0x28) - (row + 1) * 14;
+    hsd_804CF810.x8 = (hsd_804CF810.x40 - 0x28) - (row-- + 1) * 14;
     hsd_80394434(lbl_804D630C);
     hsd_804CF810.x50 = saved;
 }


### PR DESCRIPTION
Matches three functions in `debugconsole_main.c`:

- `hsd_80394950` (98.31% → **100%**) — split the two loops' counters into separate `i`/`j` variables.
- `hsd_80396188` (95.81% → **100%**) — getter-lift inlines for `saved` + pointer decl reorder + `PAD_STACK(12)`.
- `hsd_80396E40` (86.21% → **100%**) — `switch` over the SPR range, `mfspr(0x219 + i * 2)` inline, `i = row--` old-value temp, `(char)` store cast, `PAD_STACK(8)`.

Verified with a clean CI-flag build (`--sym off --max-errors 0`); all other functions in the unit unchanged.