### PR TITLE
Match ftCo_800B33B0

### DIFF
--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -8385,7 +8385,7 @@ void ftCo_800B2AFC(Fighter* fp)
 
 static inline int ftCo_800B33B0_IsIgnoredFloor(int line1)
 {
-    return ftCo_800A1B38_noinline(line1) != 0;
+    return ftCo_800A1B38_noinline(line1);
 }
 
 static inline void ftCo_CpuUpdateRecoveryScale(Fighter* fp,
@@ -8454,8 +8454,12 @@ void ftCo_800B33B0(Fighter* fp)
                                   (Fighter_GObj*) found);
         }
     }
-    if (result != 0 && ftCo_800B33B0_IsIgnoredFloor(line1)) {
-    } else {
+    if (result == 0) {
+        goto assign;
+    }
+    switch (ftCo_800B33B0_IsIgnoredFloor(line1)) {
+    case 0:
+    assign:
         found = result;
     }
     if (found != 0) {


### PR DESCRIPTION
Matches `ftCo_800B33B0` in `src/melee/ft/chara/ftCommon/ftCo_0A01.c`.

The remaining diff was the branch shape of the ignored-floor check after `mpCheckFloor`: retail emits `beq`/`beq`/`b` into a shared `found = result` block, which a folded `&&` condition cannot produce. A one-case `switch` (with the `result == 0` path entering the case body via `goto`) reproduces the branch structure, and dropping the `!= 0` normalization from the `IsIgnoredFloor` wrapper removes the `neg`/`subic`/`subfe` selector materialization.

Verified 100% with a full clean build; no other function changed.