### PR TITLE
Improve fn_8001EBF0 match

### DIFF
--- a/src/melee/lb/lbmthp.c
+++ b/src/melee/lb/lbmthp.c
@@ -153,14 +153,14 @@ size_t fn_8001EBF0(THPDecComp* data)
     height = data->height;
     unk_104_val = data->unk_104;
 
-    data->unk_9C.val1 = (u16) width;
-
     wh = width * height;
+
+    data->unk_9C.val1 = (u16) width;
 
     height = data->height;
     data->unk_9C._pad = (u16) height;
 
-    size = aligned_100 * unk_104_val;
+    size = unk_104_val * aligned_100;
 
     data->unk_9C.val2 = 4;
 


### PR DESCRIPTION
## Summary

- schedule the width-height product before storing the decoder width
- reverse the aligned-size multiplication operands
- reduce `fn_8001EBF0` from five differing instructions to four in the exact scratch target

## Validation

- exact MWCC 1.2.5n scratch comparison: 260-byte function, unchanged size, differing instructions reduced from 5 to 4
- `clang-format`: passed
- `python tools/check/main.py --fix --quiet src/melee/lb/lbmthp.c`: passed
- `git diff --check`: passed

The translation unit is not yet matching; the remaining four instructions are an `r5`/`r6` allocation swap around `unk_100` alignment and `unk_104`.

> AI assistance: Codex helped search source variants and verify the exact compiler output. The submitted change and measurements were reviewed locally.
