### PR TITLE
Link `lbmthp`

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -512,7 +512,7 @@ config.libs = [
             Object(NonMatching, "melee/lb/lbsnap.c"),
             Object(Matching, "melee/lb/lbgx.c"),
             Object(Matching, "melee/lb/lbanim.c"),
-            Object(NonMatching, "melee/lb/lbmthp.c"),
+            Object(Matching, "melee/lb/lbmthp.c"),
             Object(Matching, "melee/lb/lb_01F8.c"),
             Object(NonMatching, "melee/lb/lbbgflash.c"),
             Object(Matching, "melee/lb/lbrefract.c"),

--- a/src/melee/lb/lbmthp.c
+++ b/src/melee/lb/lbmthp.c
@@ -16,9 +16,6 @@
 #include <sysdolphin/baselib/debug.h>
 #include <sysdolphin/baselib/devcom.h>
 #include <sysdolphin/baselib/sobjlib.h>
-#include <melee/lb/lbanim.h>
-#include <melee/lb/types.h>
-#include <MSL/string.h>
 #include <Runtime/runtime.h>
 
 struct lbl_803BAFE8_t {
@@ -31,6 +28,7 @@ struct lbl_803BAFE8_t {
     /* 0x14 */ s32 x14;
 }; /* size = 0x18 */
 
+/* 01F294 */ static s32 fn_8001F294(void);
 /* 4333E0 */ static struct lbl_804333E0_t MoviePlayer;
 
 void fn_8001E910(int arg0, int arg1, void* arg2, int cancelflag)
@@ -372,10 +370,14 @@ s32 fn_8001F13C(THPDecComp* streamPlayer)
     return OSRestoreInterrupts(intr);
 }
 
+/// @todo Stripped code leading to function that can't be inlined?
+#pragma push
+#pragma dont_inline on
 s32 fn_8001F294(void)
 {
     return MoviePlayer.unk_110;
 }
+#pragma pop
 
 static inline u32 lbMthp_GetFrame(u32** rate_table, u32 counter)
 {

--- a/src/melee/lb/lbmthp.c
+++ b/src/melee/lb/lbmthp.c
@@ -372,7 +372,10 @@ s32 fn_8001F13C(THPDecComp* streamPlayer)
     return OSRestoreInterrupts(intr);
 }
 
-s32 fn_8001F294(void);
+s32 fn_8001F294(void)
+{
+    return MoviePlayer.unk_110;
+}
 
 static inline u32 lbMthp_GetFrame(u32** rate_table, u32 counter)
 {
@@ -583,11 +586,6 @@ void lbMthp_8001F800(void)
 
         MoviePlayer.power = 0;
     }
-}
-
-s32 fn_8001F294(void)
-{
-    return MoviePlayer.unk_110;
 }
 
 void lbMthp_8001F87C(void)

--- a/src/melee/lb/lbmthp.c
+++ b/src/melee/lb/lbmthp.c
@@ -144,23 +144,19 @@ size_t fn_8001EBF0(THPDecComp* data)
     u32 height;
     u32 wh;
     u32 wh_div4;
-    PAD_STACK(16);
+    PAD_STACK(8);
 
     data->unk_104 = 0x20;
 
-    width = data->width;
-    aligned_100 = ALIGN_32(data->unk_100);
-    height = data->height;
     unk_104_val = data->unk_104;
-
-    data->unk_9C.val1 = (u16) width;
-
+    aligned_100 = ALIGN_32(data->unk_100);
+    size = aligned_100 * unk_104_val;
+    width = data->width;
+    height = data->height;
     wh = width * height;
-
+    data->unk_9C.val1 = (u16) width;
     height = data->height;
     data->unk_9C._pad = (u16) height;
-
-    size = aligned_100 * unk_104_val;
 
     data->unk_9C.val2 = 4;
 

--- a/src/melee/lb/lbmthp.h
+++ b/src/melee/lb/lbmthp.h
@@ -134,7 +134,6 @@ STATIC_ASSERT(sizeof(struct THPDecComp) == sizeof(struct lbl_804333E0_t));
 /* 01EF5C */ s32 fn_8001EF5C(THPDecComp* data);
 /* 01F06C */ s32 fn_8001F06C(THPDecComp* data);
 /* 01F13C */ s32 fn_8001F13C(THPDecComp* data);
-/* 01F294 */ s32 fn_8001F294(void);
 /* 01F410 */ void lbMthp_8001F410(const char* filename, u32* rate_table,
                                   void* buf, size_t heap_size, int loop);
 /* 01F578 */ void lbMthp_8001F578(void);


### PR DESCRIPTION
## What changed

- Port the exact `fn_8001EBF0` match from [decomp.me scratch fExuC](https://decomp.me/scratch/fExuC).
- Use the matching stack size and expression/load ordering.
- Place the now-static `fn_8001F294` in binary address order and prevent it from being inlined into `lbMthp_8001F800`.
- Mark `melee/lb/lbmthp.c` as matching.

## Validation

- decomp.me score: `0` (match)
- local GC/1.2.5n full-object `.text`: `100%`
- `pre-commit run --all-files`
- GitHub Actions: GALE01 link, diff, test, and Nix all pass

The matched scratch was created anonymously as "Deadly Jay (anon)" and is credited above.