### PR TITLE
Improve Big Blue and character select matches

### DIFF
--- a/src/melee/gr/grbigblue.c
+++ b/src/melee/gr/grbigblue.c
@@ -1169,8 +1169,7 @@ void grBigBlue_801E6C60(Ground_GObj* gobj)
                     gp->u.bigblue.data[i].xC.z = pos.y + (pos.y - coll_y);
                 }
 
-                y_diff = pos.y -
-                         (target_y = gp->u.bigblue.data[i].xC.z);
+                y_diff = pos.y - (target_y = gp->u.bigblue.data[i].xC.z);
                 if (y_diff < 0.0f) {
                     y_diff = -y_diff;
                 }

--- a/src/melee/gr/grbigblue.c
+++ b/src/melee/gr/grbigblue.c
@@ -1169,8 +1169,8 @@ void grBigBlue_801E6C60(Ground_GObj* gobj)
                     gp->u.bigblue.data[i].xC.z = pos.y + (pos.y - coll_y);
                 }
 
-                target_y = gp->u.bigblue.data[i].xC.z;
-                y_diff = pos.y - target_y;
+                y_diff = pos.y -
+                         (target_y = gp->u.bigblue.data[i].xC.z);
                 if (y_diff < 0.0f) {
                     y_diff = -y_diff;
                 }

--- a/src/melee/mn/mncharsel.c
+++ b/src/melee/mn/mncharsel.c
@@ -1668,6 +1668,18 @@ static inline s32 getIconOffset(unsigned long icon_idx)
 {
     return icon_idx * sizeof(CSSIcon);
 }
+
+static inline s32 getPlayerForDoor(u8 door)
+{
+    if (mnCharSel_804D6CF5 == 1) {
+        if (door != 0) {
+            return mnCharSel_804D6CF1;
+        }
+        return mnCharSel_804D6CF0;
+    }
+    return door;
+}
+
 void mnCharSel_8025FB50(u8 door, s32 arg1)
 {
     s32 icon_idx;
@@ -1683,17 +1695,9 @@ void mnCharSel_8025FB50(u8 door, s32 arg1)
         icon_offset = getIconOffset(icon_idx);
     } while (icons[icon_idx].state == 0);
 
-    if (mnCharSel_804D6CF5 == 1) {
-        if (door != 0) {
-            player = mnCharSel_804D6CF1;
-        } else {
-            player = mnCharSel_804D6CF0;
-        }
-    } else {
-        player = door;
-    }
+    player = getPlayerForDoor(door);
 
-    char_kinds = &all_data->icons[0].char_kind;
+    char_kinds = &icons[0].char_kind;
     mnCharSel_804D6CB0->data.data.players[player].c_kind =
         char_kinds[icon_offset];
 


### PR DESCRIPTION
## What changed

- Combine the Big Blue target-height load with the `y_diff` calculation so MWCC keeps the intended floating-point value flow.
- Extract character-select player lookup into an inline helper.
- Read character kinds from the canonical `icons` table instead of reconstructing the same address through `CSSAllData`.

## Why

These source-equivalent forms produce closer code generation without changing runtime behavior.

Local objdiff measurements against the exact function targets:

- `grBigBlue_801E6C60`: 98.21013% -> 98.29269%
- `mnCharSel_8025FB50`: 97.57485% -> 98.59281%

## Validation

- Recompiled both translation units with GC MWCC 1.2.5n and the project flags.
- Re-ran objdiff against exact target objects.
- `git diff --check` passes.

The full DOL build could not be run locally because `orig/GALE01/sys/main.dol` is not present in this checkout.
