### PR TITLE
Link ft_0852

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -576,7 +576,7 @@ config.libs = [
             Object(Matching, "melee/ft/ft_0819.c"),
             Object(Matching, "melee/ft/ft_081B.c"),
             Object(Matching, "melee/ft/ft_084E.c"),
-            Object(NonMatching, "melee/ft/ft_0852.c"),
+            Object(Matching, "melee/ft/ft_0852.c"),
             Object(Matching, "melee/ft/ftdata.c"),
             Object(Matching, "melee/ft/ftmotionstates.c"),
             Object(Matching, "melee/ft/chara/ftCommon/ftCo_Init.c"),

--- a/src/melee/ft/ft_0852.c
+++ b/src/melee/ft/ft_0852.c
@@ -16,6 +16,7 @@ ft_8045993C_t ft_8045993C[6];
 int ft_8045996C[FTKIND_MAX];
 UnkCostumeStruct lbl_804599F0[5];
 
+/// @todo bss order hack
 static void order_bss(void)
 {
     (void) gFtDataList;

--- a/src/melee/ft/ft_0852.c
+++ b/src/melee/ft/ft_0852.c
@@ -16,6 +16,14 @@ ft_8045993C_t ft_8045993C[6];
 int ft_8045996C[FTKIND_MAX];
 UnkCostumeStruct lbl_804599F0[5];
 
+static void order_bss(void)
+{
+    (void) gFtDataList;
+    (void) ft_8045993C;
+    (void) ft_8045996C;
+    (void) lbl_804599F0;
+}
+
 void ft_8008521C(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);


### PR DESCRIPTION
## What changed

- Mark `melee/ft/ft_0852.c` as matching so it is linked from source.
- Keep the otherwise indirect-only `ft_8045993C` BSS symbol emitted so the following globals retain their original addresses.

## Why

The current decomp.dev report at `7eb151126e626ffc342e285896ac2f1fd78d9092` reports all three functions, the full 836-byte text section, and the full 448-byte data section at 100%. The last remaining function was matched in #3075, but the unit was left `NonMatching` in `configure.py`.

## Validation

- Confirmed no open PR or issue references `ft_0852` or `ft_800852B0`.
- Confirmed the live decomp.dev unit report is 100% for code and data.
- `git diff --check` passes.
- The first CI link attempt identified the missing `ft_8045993C` BSS emission and its resulting 0x30-byte address shift; the follow-up uses the repository's existing no-codegen address-reference pattern to retain it.
- A local full link could not be run because this checkout intentionally has no `orig/GALE01/sys/main.dol`; project CI is the authoritative clean-ROM link check.