### PR TITLE
Improve particle command interpreter matching

### DIFF
--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -55,7 +55,7 @@ typedef union {
     u8 bytes[4];
 } ParticleFloatBytes;
 
-static const f32 particle_zero = 0.0F;
+static volatile const f32 particle_zero = 0.0F;
 
 void hsd_803983A4(HSD_Generator* gen)
 {
@@ -2863,12 +2863,12 @@ do_life:
 
         pp->vel.z += gp->aux.tornado.vel;
 
-        if ((R = gp->radius) < *(volatile const f32*) &particle_zero) {
+        if ((R = gp->radius) < particle_zero) {
             R = -R;
         }
         {
             f32 ang;
-            if ((ang = gp->angle) < *(volatile const f32*) &particle_zero) {
+            if ((ang = gp->angle) < particle_zero) {
                 ang = -ang;
             }
             R = pp->vel.y * (pp->vel.z * tanf(ang) + R);

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1432,13 +1432,16 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                 /* Size interpolation with random */
                 {
                     f32 range;
-                    pp->sizeCount = *pc++;
                     {
-                        u16 cnt = pp->sizeCount;
+                        u8* count_pc = pc;
+                        u16 cnt;
+                        pp->sizeCount = *count_pc++;
+                        cnt = pp->sizeCount;
                         if (cnt & 0x80) {
-                            cnt = ((cnt & 0x7F) << 8) + *pc++;
+                            cnt = ((cnt & 0x7F) << 8) + *count_pc++;
                             pp->sizeCount = cnt;
                         }
+                        pc = count_pc;
                     }
                     {
                         u8* p = pc + 1;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -646,8 +646,8 @@ s32 hsd_803991D8(HSD_Generator* gen, HSD_JObj* jobj, f32 force, f32 range)
     return 0;
 }
 
-// @TODO: Currently 93.95% match - register allocation differences (stmw
-// r20 vs r21), r27/r28 swap, and PC advance codegen patterns
+// @TODO: Currently 95.43% match - register allocation differences and
+// remaining PC advance codegen patterns
 void* hsd_8039930C(void* pp_arg, void* prev_arg)
 {
     HSD_Particle* pp = pp_arg;
@@ -799,33 +799,30 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0x80:
                 /* Set position */
                 if (opcode & 1) {
-                    u8* _p = pc + 1;
-                    ((u8*) &fval)[0] = pc[0];
-                    _p += 3;
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc = _p;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->pos.x = fval;
                 }
                 if (opcode & 2) {
-                    u8* _p = pc + 1;
-                    ((u8*) &fval)[0] = pc[0];
-                    _p += 3;
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc = _p;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->pos.y = fval;
                 }
                 if (opcode & 4) {
-                    u8* _p = pc + 1;
-                    ((u8*) &fval)[0] = pc[0];
-                    _p += 3;
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc = _p;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->pos.z = fval;
                 }
                 break;
@@ -833,27 +830,30 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0x88:
                 /* Add to position */
                 if (opcode & 1) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->pos.x += fval;
                 }
                 if (opcode & 2) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->pos.y += fval;
                 }
                 if (opcode & 4) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->pos.z += fval;
                 }
                 break;
@@ -861,27 +861,30 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0x90:
                 /* Set velocity */
                 if (opcode & 1) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->vel.x = fval;
                 }
                 if (opcode & 2) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->vel.y = fval;
                 }
                 if (opcode & 4) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->vel.z = fval;
                 }
                 break;
@@ -889,27 +892,30 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0x98:
                 /* Add to velocity */
                 if (opcode & 1) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->vel.x += fval;
                 }
                 if (opcode & 2) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->vel.y += fval;
                 }
                 if (opcode & 4) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->vel.z += fval;
                 }
                 break;
@@ -925,11 +931,14 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                             pp->sizeCount = cnt;
                         }
                     }
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    {
+                        u8* p = pc;
+                        fbytes[0] = *p++;
+                        fbytes[1] = *p++;
+                        fbytes[2] = *p++;
+                        fbytes[3] = *p++;
+                        pc = p;
+                    }
                     pp->sizeTarget = fval;
                     if (pp->sizeCount == 0) {
                         pp->size = pp->sizeTarget;
@@ -944,11 +953,14 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
 
             case 0xA2:
                 /* Set gravity */
-                ((u8*) &fval)[0] = pc[0];
-                ((u8*) &fval)[1] = pc[1];
-                ((u8*) &fval)[2] = pc[2];
-                ((u8*) &fval)[3] = pc[3];
-                pc += 4;
+                {
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
+                }
                 pp->grav = fval;
                 if (pp->grav == 0.0F) {
                     pp->kind &= ~1;
@@ -959,11 +971,14 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
 
             case 0xA3:
                 /* Set friction */
-                ((u8*) &fval)[0] = pc[0];
-                ((u8*) &fval)[1] = pc[1];
-                ((u8*) &fval)[2] = pc[2];
-                ((u8*) &fval)[3] = pc[3];
-                pc += 4;
+                {
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
+                }
                 pp->fric = fval;
                 if (pp->fric == 1.0F) {
                     pp->kind &= ~2;
@@ -1092,8 +1107,12 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         gchild->idnum = pp->idnum;
                         if (pp->gen != NULL) {
                             HSD_JObj* jobj = pp->gen->jobj;
-                            gchild->jobj = jobj;
-                            ref_INC(jobj);
+                            if (gchild != NULL) {
+                                gchild->jobj = jobj;
+                                if (jobj != NULL) {
+                                    ref_INC(jobj);
+                                }
+                            }
                         }
                         gchild->type |= 0x100;
                         if (pp->gen != NULL) {
@@ -1151,8 +1170,12 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     gchild->idnum = pp->idnum;
                     if (pp->gen != NULL) {
                         HSD_JObj* jobj = pp->gen->jobj;
-                        gchild->jobj = jobj;
-                        ref_INC(jobj);
+                        if (gchild != NULL) {
+                            gchild->jobj = jobj;
+                            if (jobj != NULL) {
+                                ref_INC(jobj);
+                            }
+                        }
                     }
                     gchild->type |= 0x100;
                     if (pp->gen != NULL) {
@@ -1216,8 +1239,12 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     gchild->idnum = pp->idnum;
                     if (pp->gen != NULL) {
                         HSD_JObj* jobj = pp->gen->jobj;
-                        gchild->jobj = jobj;
-                        ref_INC(jobj);
+                        if (gchild != NULL) {
+                            gchild->jobj = jobj;
+                            if (jobj != NULL) {
+                                ref_INC(jobj);
+                            }
+                        }
                     }
                     gchild->type |= 0x100;
                     if (pp->gen != NULL) {
@@ -1309,11 +1336,14 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
 
             case 0xA9:
                 /* Call force function with float parameter */
-                ((u8*) &fval)[0] = pc[0];
-                ((u8*) &fval)[1] = pc[1];
-                ((u8*) &fval)[2] = pc[2];
-                ((u8*) &fval)[3] = pc[3];
-                pc += 4;
+                {
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
+                }
                 hsd_80398F8C(pp, fval);
                 break;
 
@@ -1385,11 +1415,14 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
 
             case 0xAB:
                 /* Velocity scale */
-                ((u8*) &fval)[0] = pc[0];
-                ((u8*) &fval)[1] = pc[1];
-                ((u8*) &fval)[2] = pc[2];
-                ((u8*) &fval)[3] = pc[3];
-                pc += 4;
+                {
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
+                }
                 pp->vel.x *= fval;
                 pp->vel.y *= fval;
                 pp->vel.z *= fval;
@@ -1407,17 +1440,22 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                             pp->sizeCount = cnt;
                         }
                     }
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pp->sizeTarget = fval;
-                    ((u8*) &fval)[0] = pc[4];
-                    ((u8*) &fval)[1] = pc[5];
-                    ((u8*) &fval)[2] = pc[6];
-                    ((u8*) &fval)[3] = pc[7];
-                    range = fval;
-                    pc += 8;
+                    {
+                        u8* p = pc + 1;
+                        u8* next = p + 4;
+                        fbytes[0] = pc[0];
+                        next += 3;
+                        fbytes[1] = pc[1];
+                        fbytes[2] = pc[2];
+                        fbytes[3] = pc[3];
+                        pp->sizeTarget = fval;
+                        fbytes[0] = pc[4];
+                        fbytes[1] = pc[5];
+                        fbytes[2] = pc[6];
+                        fbytes[3] = pc[7];
+                        range = fval;
+                        pc = next;
+                    }
                     pp->sizeTarget += range * HSD_Randf();
                     if (pp->sizeCount == 0) {
                         pp->size = pp->sizeTarget;
@@ -1549,11 +1587,14 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                             pp->rotateCount = cnt;
                         }
                     }
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    {
+                        u8* p = pc;
+                        fbytes[0] = *p++;
+                        fbytes[1] = *p++;
+                        fbytes[2] = *p++;
+                        fbytes[3] = *p++;
+                        pc = p;
+                    }
                     pp->rotateTarget += fval;
                     if (pp->rotateCount == 0) {
                         pp->rotate = pp->rotateTarget;
@@ -1564,12 +1605,10 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xB7:
                 /* Aim velocity toward JObj */
                 {
-                    int idx = *pc++;
-                    HSD_JObj* jobj;
+                    HSD_JObj* jobj = hsd_804D08E8[*pc++ + pp->pJObjOfs];
                     f32 dx, dy, dz, dist_sq, dist;
-                    f32 vel_mag_sq, vel_mag;
+                    f32 vel_mag_sq;
 
-                    jobj = hsd_804D08E8[idx + pp->pJObjOfs];
                     if (jobj == NULL) {
                         break;
                     }
@@ -1582,7 +1621,18 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     dy -= pp->pos.y;
                     dz = jobj->mtx[2][3];
                     dz -= pp->pos.z;
-                    vel_mag = sqrtf(vel_mag_sq);
+                    if (vel_mag_sq > 0.0F) {
+                        double guess = __frsqrte((double) vel_mag_sq);
+                        volatile f32 result;
+                        guess =
+                            0.5 * guess * (3.0 - guess * guess * vel_mag_sq);
+                        guess =
+                            0.5 * guess * (3.0 - guess * guess * vel_mag_sq);
+                        guess =
+                            0.5 * guess * (3.0 - guess * guess * vel_mag_sq);
+                        result = (f32) (vel_mag_sq * guess);
+                        vel_mag_sq = result;
+                    }
                     dist_sq = dy * dy + dx * dx;
                     dist_sq += dz * dz;
                     if (dist_sq == 0.0) {
@@ -1590,7 +1640,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     }
                     dist = sqrtf(dist_sq);
                     {
-                        f32 scale = vel_mag / dist;
+                        f32 scale = vel_mag_sq / dist;
                         pp->vel.x = dx * scale;
                         pp->vel.y = dy * scale;
                         pp->vel.z = dz * scale;
@@ -1601,21 +1651,24 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xB8:
                 /* Force toward JObj with kill on proximity */
                 {
-                    int idx = *pc++;
+                    u8* p = pc;
+                    int idx = *p++;
                     f32 force, range;
 
-                    ((u8*) &fval)[0] = *pc++;
-                    ((u8*) &fval)[1] = *pc++;
-                    ((u8*) &fval)[2] = *pc++;
-                    ((u8*) &fval)[3] = *pc++;
+                    idx += pp->pJObjOfs;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
                     force = fval;
-                    ((u8*) &fval)[0] = *pc++;
-                    ((u8*) &fval)[1] = *pc++;
-                    ((u8*) &fval)[2] = *pc++;
-                    ((u8*) &fval)[3] = *pc++;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
                     range = fval;
+                    pc = p;
                     {
-                        HSD_JObj* jobj = hsd_804D08E8[idx + pp->pJObjOfs];
+                        HSD_JObj* jobj = hsd_804D08E8[idx];
                         if (hsd_803991D8((HSD_Generator*) pp, jobj, force,
                                          range) != 0)
                         {
@@ -1956,17 +2009,20 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     f32 base_speed, random_range, target_speed;
                     f32 mag;
 
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    base_speed = fval;
-                    ((u8*) &fval)[0] = pc[4];
-                    ((u8*) &fval)[1] = pc[5];
-                    ((u8*) &fval)[2] = pc[6];
-                    ((u8*) &fval)[3] = pc[7];
-                    random_range = fval;
-                    pc += 8;
+                    {
+                        u8* p = pc;
+                        fbytes[0] = *p++;
+                        fbytes[1] = *p++;
+                        fbytes[2] = *p++;
+                        fbytes[3] = *p++;
+                        base_speed = fval;
+                        fbytes[0] = *p++;
+                        fbytes[1] = *p++;
+                        fbytes[2] = *p++;
+                        fbytes[3] = *p++;
+                        random_range = fval;
+                        pc = p;
+                    }
                     target_speed = base_speed + random_range * HSD_Randf();
                     mag = pp->vel.x * pp->vel.x + pp->vel.y * pp->vel.y +
                           pp->vel.z * pp->vel.z;
@@ -1982,22 +2038,25 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
 
             case 0xBE:
                 /* Velocity component multiply */
-                ((u8*) &fval)[0] = pc[0];
-                ((u8*) &fval)[1] = pc[1];
-                ((u8*) &fval)[2] = pc[2];
-                ((u8*) &fval)[3] = pc[3];
-                pp->vel.x *= fval;
-                ((u8*) &fval)[0] = pc[4];
-                ((u8*) &fval)[1] = pc[5];
-                ((u8*) &fval)[2] = pc[6];
-                ((u8*) &fval)[3] = pc[7];
-                pp->vel.y *= fval;
-                ((u8*) &fval)[0] = pc[8];
-                ((u8*) &fval)[1] = pc[9];
-                ((u8*) &fval)[2] = pc[10];
-                ((u8*) &fval)[3] = pc[11];
-                pc += 12;
-                pp->vel.z *= fval;
+                {
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pp->vel.x *= fval;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pp->vel.y *= fval;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
+                    pp->vel.z *= fval;
+                }
                 break;
 
             case 0xBF:
@@ -2485,11 +2544,12 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                 /* UserData set */
                 {
                     int idx = *pc++;
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     if (pp->gen->userfunc != NULL &&
                         pp->gen->userfunc->setUserData != NULL)
                     {
@@ -2572,11 +2632,14 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
 
             case 0xE8:
                 /* Trail control */
-                ((u8*) &fval)[0] = pc[0];
-                ((u8*) &fval)[1] = pc[1];
-                ((u8*) &fval)[2] = pc[2];
-                ((u8*) &fval)[3] = pc[3];
-                pc += 4;
+                {
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
+                }
                 if (fval < 0.0F) {
                     pp->kind &= ~Trail;
                 } else {
@@ -2672,23 +2735,28 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xED:
                 /* Rotate interpolation with random */
                 {
-                    f32 base_val;
                     f32 range_val;
+                    f32 base_val;
                     int timing;
                     f32 result;
 
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    base_val = fval;
-                    ((u8*) &fval)[0] = pc[4];
-                    ((u8*) &fval)[1] = pc[5];
-                    ((u8*) &fval)[2] = pc[6];
-                    ((u8*) &fval)[3] = pc[7];
-                    range_val = fval;
-                    timing = pc[8];
-                    pc += 9;
+                    {
+                        u8* p = pc + 1;
+                        u8* pc2;
+                        fbytes[0] = pc[0];
+                        pc2 = p + 4;
+                        fbytes[1] = pc[1];
+                        fbytes[2] = pc[2];
+                        fbytes[3] = pc[3];
+                        base_val = fval;
+                        fbytes[0] = pc[4];
+                        fbytes[1] = pc[5];
+                        fbytes[2] = pc[6];
+                        fbytes[3] = pc[7];
+                        range_val = fval;
+                        pc = pc2 + 4;
+                        timing = p[7];
+                    }
 
                     if (timing != 0) {
                         s32 randi = (s32) ((f32) (timing + 1) * HSD_Randf());
@@ -2805,19 +2873,17 @@ do_life:
 
         pp->vel.z += gp->aux.tornado.vel;
 
-        R = gp->radius;
-        if (R < 0.0F) {
+        if ((R = gp->radius) < 0.0F) {
             R = -R;
         }
         {
-            f32 ang = gp->angle;
-            if (ang < 0.0F) {
+            f32 ang;
+            if ((ang = gp->angle) < 0.0F) {
                 ang = -ang;
             }
-            R = pp->vel.z * tanf(ang) + R;
+            R = pp->vel.y * (pp->vel.z * tanf(ang) + R);
         }
         pp->vel.x += gp->grav;
-        R *= pp->vel.y;
 
         d = R * cosf(pp->vel.x);
         e = R * sinf(pp->vel.x);

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -2497,9 +2497,10 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         f32 a_rand;
                         a_rand = HSD_Randf();
                         delta = (s8) *pc++;
-                        delta_float =
-                            (f32) (s32) ((f32) (timing + 1) * a_rand) /
-                            (f32) timing * (f32) (delta * 2);
+                        delta_float = (f32) (delta * 2);
+                        delta_float *=
+                            (f32) (s32) ((f32) (timing + 1) * a_rand);
+                        delta_float /= (f32) timing;
                         if (flags & 0x10) {
                             val = delta_float + (f32) pp->primColTarget.a;
                             if (val < 0.0F) {

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -2473,9 +2473,10 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         f32 a_rand;
                         a_rand = HSD_Randf();
                         delta = (s8) *pc++;
-                        delta_float =
-                            (f32) (s32) ((f32) (timing + 1) * a_rand) /
-                            (f32) timing * (f32) (delta * 2);
+                        delta_float = (f32) (delta * 2);
+                        delta_float *=
+                            (f32) (s32) ((f32) (timing + 1) * a_rand);
+                        delta_float /= (f32) timing;
                         if (flags & 0x10) {
                             val = delta_float + (f32) pp->primColTarget.a;
                             if (val < 0.0F) {

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1602,17 +1602,18 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                 /* Aim velocity toward JObj */
                 {
                     HSD_JObj* jobj = hsd_804D08E8[*pc++ + pp->pJObjOfs];
-                    f32 dx, dy, dz, dist_sq, dist;
+                    f32 dz, dy, dx, dist_sq, dist;
                     f32 vel_mag_sq;
 
                     if (jobj == NULL) {
                         break;
                     }
                     HSD_JObjSetupMatrix(jobj);
-                    vel_mag_sq = pp->vel.x * pp->vel.x + pp->vel.y * pp->vel.y;
+                    vel_mag_sq = pp->vel.x * pp->vel.x +
+                                 pp->vel.y * pp->vel.y +
+                                 pp->vel.z * pp->vel.z;
                     dx = jobj->mtx[0][3];
                     dx -= pp->pos.x;
-                    vel_mag_sq += pp->vel.z * pp->vel.z;
                     dy = jobj->mtx[1][3];
                     dy -= pp->pos.y;
                     dz = jobj->mtx[2][3];

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1573,17 +1573,18 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                 /* Aim velocity toward JObj */
                 {
                     HSD_JObj* jobj = hsd_804D08E8[*pc++ + pp->pJObjOfs];
-                    f32 dx, dy, dz, dist_sq, dist;
+                    f32 dz, dy, dx, dist_sq, dist;
                     f32 vel_mag_sq;
 
                     if (jobj == NULL) {
                         break;
                     }
                     HSD_JObjSetupMatrix(jobj);
-                    vel_mag_sq = pp->vel.x * pp->vel.x + pp->vel.y * pp->vel.y;
+                    vel_mag_sq = pp->vel.x * pp->vel.x +
+                                 pp->vel.y * pp->vel.y +
+                                 pp->vel.z * pp->vel.z;
                     dx = jobj->mtx[0][3];
                     dx -= pp->pos.x;
-                    vel_mag_sq += pp->vel.z * pp->vel.z;
                     dy = jobj->mtx[1][3];
                     dy -= pp->pos.y;
                     dz = jobj->mtx[2][3];

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -653,7 +653,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
     HSD_Particle* pp = pp_arg;
     HSD_Particle* prev = prev_arg;
     u8* pc;
-    int operand;
+    u16 operand;
     u8 opcode;
     u8 cls;
     HSD_Particle* child;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1979,7 +1979,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xBD:
                 /* Normalize velocity to target speed */
                 {
-                    f32 base_speed, random_range, target_speed;
+                    f32 base_speed, random_range;
                     f32 mag;
 
                     {
@@ -1996,15 +1996,15 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         random_range = fval;
                         pc = p;
                     }
-                    target_speed = base_speed + random_range * HSD_Randf();
+                    base_speed += random_range * HSD_Randf();
                     mag = pp->vel.x * pp->vel.x + pp->vel.y * pp->vel.y +
                           pp->vel.z * pp->vel.z;
                     mag = sqrtf(mag);
                     if (mag > 0.0F) {
-                        target_speed /= mag;
-                        pp->vel.x *= target_speed;
-                        pp->vel.y *= target_speed;
-                        pp->vel.z *= target_speed;
+                        base_speed /= mag;
+                        pp->vel.x *= base_speed;
+                        pp->vel.y *= base_speed;
+                        pp->vel.z *= base_speed;
                     }
                 }
                 break;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -2497,9 +2497,9 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         f32 a_rand;
                         a_rand = HSD_Randf();
                         delta = (s8) *pc++;
-                        delta_float = (f32) (delta * 2);
-                        delta_float *=
+                        delta_float =
                             (f32) (s32) ((f32) (timing + 1) * a_rand);
+                        delta_float *= (f32) (delta * 2);
                         delta_float /= (f32) timing;
                         if (flags & 0x10) {
                             val = delta_float + (f32) pp->primColTarget.a;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -612,103 +612,8 @@ s32 hsd_803991D8(HSD_Generator* gen, HSD_JObj* jobj, f32 force, f32 range)
     return 0;
 }
 
-static inline void psUpdateParticle(HSD_Particle* pp)
-{
-    if (pp->kind & Tornado) {
-        HSD_Generator* gp = pp->gen;
-        f32 sinA, sinB, cosA, cosB;
-        f32 R;
-        f32 d, e, nd, vz;
-        f32 t0, t1, t2, t3, t4;
-
-        sinA = sinf(pp->grav);
-        sinB = sinf(pp->fric);
-        cosA = cosf(pp->grav);
-        cosB = cosf(pp->fric);
-
-        pp->vel.z += gp->aux.tornado.vel;
-
-        R = gp->radius;
-        if (R < 0.0F) {
-            R = -R;
-        }
-        {
-            f32 ang = gp->angle;
-            if (ang < 0.0F) {
-                ang = -ang;
-            }
-            R = pp->vel.z * tanf(ang) + R;
-        }
-        pp->vel.x += gp->grav;
-        R *= pp->vel.y;
-
-        d = R * cosf(pp->vel.x);
-        e = R * sinf(pp->vel.x);
-        nd = -d;
-        vz = pp->vel.z;
-
-        t0 = vz * sinB;
-        t1 = e * cosA;
-        t2 = nd * sinA;
-        t3 = d * cosB + t0;
-        t0 = vz * sinA;
-        t1 = sinB * t2 + t1;
-        pp->pos.x = gp->pos.x + t3;
-        t2 = nd * cosA;
-        t4 = e * sinA;
-        t1 = cosB * t0 + t1;
-        t0 = vz * cosA;
-        t4 = sinB * t2 - t4;
-        pp->pos.y = gp->pos.y + t1;
-        t4 = cosB * t0 + t4;
-        pp->pos.z = gp->pos.z + t4;
-    } else {
-        if (pp->kind & 1) {
-            pp->vel.y -= pp->grav;
-        }
-        if (pp->kind & 2) {
-            pp->vel.x *= pp->fric;
-            pp->vel.y *= pp->fric;
-            pp->vel.z *= pp->fric;
-        }
-        pp->pos.x += pp->vel.x;
-        pp->pos.y += pp->vel.y;
-        pp->pos.z += pp->vel.z;
-    }
-
-    if (pp->kind & 0x8000) {
-        s32 jobj_idx = (pp->kind >> 12) & 7;
-        HSD_JObj* jobj;
-        HSD_JObj** jobj_slot;
-
-        if (hsd_804D08E8[jobj_idx] == NULL) {
-            HSD_JObj* new_jobj = HSD_JObjAlloc();
-            if (new_jobj != NULL) {
-                hsd_8039CF4C(jobj_idx + 1, new_jobj);
-                HSD_JObjUnref(new_jobj);
-            }
-        }
-
-        jobj_slot = &hsd_804D08E8[jobj_idx];
-        jobj = *jobj_slot;
-
-        if (jobj != NULL) {
-            HSD_JObjSetupMatrix(jobj);
-
-            jobj = *jobj_slot;
-            HSD_JObjAddTranslationX(jobj, pp->pos.x - jobj->mtx[0][3]);
-
-            jobj = *jobj_slot;
-            HSD_JObjAddTranslationY(jobj, pp->pos.y - jobj->mtx[1][3]);
-
-            jobj = *jobj_slot;
-            HSD_JObjAddTranslationZ(jobj, pp->pos.z - jobj->mtx[2][3]);
-        }
-    }
-}
-
-// @TODO: Currently 93.95% match - register allocation differences (stmw
-// r20 vs r21), r27/r28 swap, and PC advance codegen patterns
+// @TODO: Currently 95.43% match - register allocation differences and
+// remaining PC advance codegen patterns
 void* hsd_8039930C(void* pp_arg, void* prev_arg)
 {
     HSD_Particle* pp = pp_arg;
@@ -865,33 +770,30 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0x80:
                 /* Set position */
                 if (opcode & 1) {
-                    u8* _p = pc + 1;
-                    ((u8*) &fval)[0] = pc[0];
-                    _p += 3;
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc = _p;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->pos.x = fval;
                 }
                 if (opcode & 2) {
-                    u8* _p = pc + 1;
-                    ((u8*) &fval)[0] = pc[0];
-                    _p += 3;
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc = _p;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->pos.y = fval;
                 }
                 if (opcode & 4) {
-                    u8* _p = pc + 1;
-                    ((u8*) &fval)[0] = pc[0];
-                    _p += 3;
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc = _p;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->pos.z = fval;
                 }
                 break;
@@ -899,27 +801,30 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0x88:
                 /* Add to position */
                 if (opcode & 1) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->pos.x += fval;
                 }
                 if (opcode & 2) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->pos.y += fval;
                 }
                 if (opcode & 4) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->pos.z += fval;
                 }
                 break;
@@ -927,27 +832,30 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0x90:
                 /* Set velocity */
                 if (opcode & 1) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->vel.x = fval;
                 }
                 if (opcode & 2) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->vel.y = fval;
                 }
                 if (opcode & 4) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->vel.z = fval;
                 }
                 break;
@@ -955,27 +863,30 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0x98:
                 /* Add to velocity */
                 if (opcode & 1) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->vel.x += fval;
                 }
                 if (opcode & 2) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->vel.y += fval;
                 }
                 if (opcode & 4) {
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->vel.z += fval;
                 }
                 break;
@@ -991,11 +902,14 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                             pp->sizeCount = cnt;
                         }
                     }
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    {
+                        u8* p = pc;
+                        fbytes[0] = *p++;
+                        fbytes[1] = *p++;
+                        fbytes[2] = *p++;
+                        fbytes[3] = *p++;
+                        pc = p;
+                    }
                     pp->sizeTarget = fval;
                     if (pp->sizeCount == 0) {
                         pp->size = pp->sizeTarget;
@@ -1010,11 +924,14 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
 
             case 0xA2:
                 /* Set gravity */
-                ((u8*) &fval)[0] = pc[0];
-                ((u8*) &fval)[1] = pc[1];
-                ((u8*) &fval)[2] = pc[2];
-                ((u8*) &fval)[3] = pc[3];
-                pc += 4;
+                {
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
+                }
                 pp->grav = fval;
                 if (pp->grav == 0.0F) {
                     pp->kind &= ~1;
@@ -1025,11 +942,14 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
 
             case 0xA3:
                 /* Set friction */
-                ((u8*) &fval)[0] = pc[0];
-                ((u8*) &fval)[1] = pc[1];
-                ((u8*) &fval)[2] = pc[2];
-                ((u8*) &fval)[3] = pc[3];
-                pc += 4;
+                {
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
+                }
                 pp->fric = fval;
                 if (pp->fric == 1.0F) {
                     pp->kind &= ~2;
@@ -1387,11 +1307,14 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
 
             case 0xA9:
                 /* Call force function with float parameter */
-                ((u8*) &fval)[0] = pc[0];
-                ((u8*) &fval)[1] = pc[1];
-                ((u8*) &fval)[2] = pc[2];
-                ((u8*) &fval)[3] = pc[3];
-                pc += 4;
+                {
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
+                }
                 hsd_80398F8C(pp, fval);
                 break;
 
@@ -1463,11 +1386,14 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
 
             case 0xAB:
                 /* Velocity scale */
-                ((u8*) &fval)[0] = pc[0];
-                ((u8*) &fval)[1] = pc[1];
-                ((u8*) &fval)[2] = pc[2];
-                ((u8*) &fval)[3] = pc[3];
-                pc += 4;
+                {
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
+                }
                 pp->vel.x *= fval;
                 pp->vel.y *= fval;
                 pp->vel.z *= fval;
@@ -1485,17 +1411,22 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                             pp->sizeCount = cnt;
                         }
                     }
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pp->sizeTarget = fval;
-                    ((u8*) &fval)[0] = pc[4];
-                    ((u8*) &fval)[1] = pc[5];
-                    ((u8*) &fval)[2] = pc[6];
-                    ((u8*) &fval)[3] = pc[7];
-                    range = fval;
-                    pc += 8;
+                    {
+                        u8* p = pc + 1;
+                        u8* next = p + 4;
+                        fbytes[0] = pc[0];
+                        next += 3;
+                        fbytes[1] = pc[1];
+                        fbytes[2] = pc[2];
+                        fbytes[3] = pc[3];
+                        pp->sizeTarget = fval;
+                        fbytes[0] = pc[4];
+                        fbytes[1] = pc[5];
+                        fbytes[2] = pc[6];
+                        fbytes[3] = pc[7];
+                        range = fval;
+                        pc = next;
+                    }
                     pp->sizeTarget += range * HSD_Randf();
                     if (pp->sizeCount == 0) {
                         pp->size = pp->sizeTarget;
@@ -1627,11 +1558,14 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                             pp->rotateCount = cnt;
                         }
                     }
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    {
+                        u8* p = pc;
+                        fbytes[0] = *p++;
+                        fbytes[1] = *p++;
+                        fbytes[2] = *p++;
+                        fbytes[3] = *p++;
+                        pc = p;
+                    }
                     pp->rotateTarget += fval;
                     if (pp->rotateCount == 0) {
                         pp->rotate = pp->rotateTarget;
@@ -1642,12 +1576,10 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xB7:
                 /* Aim velocity toward JObj */
                 {
-                    int idx = *pc++;
-                    HSD_JObj* jobj;
+                    HSD_JObj* jobj = hsd_804D08E8[*pc++ + pp->pJObjOfs];
                     f32 dx, dy, dz, dist_sq, dist;
-                    f32 vel_mag_sq, vel_mag;
+                    f32 vel_mag_sq;
 
-                    jobj = hsd_804D08E8[idx + pp->pJObjOfs];
                     if (jobj == NULL) {
                         break;
                     }
@@ -1660,7 +1592,18 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     dy -= pp->pos.y;
                     dz = jobj->mtx[2][3];
                     dz -= pp->pos.z;
-                    vel_mag = sqrtf(vel_mag_sq);
+                    if (vel_mag_sq > 0.0F) {
+                        double guess = __frsqrte((double) vel_mag_sq);
+                        volatile f32 result;
+                        guess =
+                            0.5 * guess * (3.0 - guess * guess * vel_mag_sq);
+                        guess =
+                            0.5 * guess * (3.0 - guess * guess * vel_mag_sq);
+                        guess =
+                            0.5 * guess * (3.0 - guess * guess * vel_mag_sq);
+                        result = (f32) (vel_mag_sq * guess);
+                        vel_mag_sq = result;
+                    }
                     dist_sq = dy * dy + dx * dx;
                     dist_sq += dz * dz;
                     if (dist_sq == 0.0) {
@@ -1668,7 +1611,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     }
                     dist = sqrtf(dist_sq);
                     {
-                        f32 scale = vel_mag / dist;
+                        f32 scale = vel_mag_sq / dist;
                         pp->vel.x = dx * scale;
                         pp->vel.y = dy * scale;
                         pp->vel.z = dz * scale;
@@ -1679,21 +1622,24 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xB8:
                 /* Force toward JObj with kill on proximity */
                 {
-                    int idx = *pc++;
+                    u8* p = pc;
+                    int idx = *p++;
                     f32 force, range;
 
-                    ((u8*) &fval)[0] = *pc++;
-                    ((u8*) &fval)[1] = *pc++;
-                    ((u8*) &fval)[2] = *pc++;
-                    ((u8*) &fval)[3] = *pc++;
+                    idx += pp->pJObjOfs;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
                     force = fval;
-                    ((u8*) &fval)[0] = *pc++;
-                    ((u8*) &fval)[1] = *pc++;
-                    ((u8*) &fval)[2] = *pc++;
-                    ((u8*) &fval)[3] = *pc++;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
                     range = fval;
+                    pc = p;
                     {
-                        HSD_JObj* jobj = hsd_804D08E8[idx + pp->pJObjOfs];
+                        HSD_JObj* jobj = hsd_804D08E8[idx];
                         if (hsd_803991D8((HSD_Generator*) pp, jobj, force,
                                          range) != 0)
                         {
@@ -2039,17 +1985,20 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     f32 base_speed, random_range, target_speed;
                     f32 mag;
 
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    base_speed = fval;
-                    ((u8*) &fval)[0] = pc[4];
-                    ((u8*) &fval)[1] = pc[5];
-                    ((u8*) &fval)[2] = pc[6];
-                    ((u8*) &fval)[3] = pc[7];
-                    random_range = fval;
-                    pc += 8;
+                    {
+                        u8* p = pc;
+                        fbytes[0] = *p++;
+                        fbytes[1] = *p++;
+                        fbytes[2] = *p++;
+                        fbytes[3] = *p++;
+                        base_speed = fval;
+                        fbytes[0] = *p++;
+                        fbytes[1] = *p++;
+                        fbytes[2] = *p++;
+                        fbytes[3] = *p++;
+                        random_range = fval;
+                        pc = p;
+                    }
                     target_speed = base_speed + random_range * HSD_Randf();
                     mag = pp->vel.x * pp->vel.x + pp->vel.y * pp->vel.y +
                           pp->vel.z * pp->vel.z;
@@ -2065,22 +2014,25 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
 
             case 0xBE:
                 /* Velocity component multiply */
-                ((u8*) &fval)[0] = pc[0];
-                ((u8*) &fval)[1] = pc[1];
-                ((u8*) &fval)[2] = pc[2];
-                ((u8*) &fval)[3] = pc[3];
-                pp->vel.x *= fval;
-                ((u8*) &fval)[0] = pc[4];
-                ((u8*) &fval)[1] = pc[5];
-                ((u8*) &fval)[2] = pc[6];
-                ((u8*) &fval)[3] = pc[7];
-                pp->vel.y *= fval;
-                ((u8*) &fval)[0] = pc[8];
-                ((u8*) &fval)[1] = pc[9];
-                ((u8*) &fval)[2] = pc[10];
-                ((u8*) &fval)[3] = pc[11];
-                pc += 12;
-                pp->vel.z *= fval;
+                {
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pp->vel.x *= fval;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pp->vel.y *= fval;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
+                    pp->vel.z *= fval;
+                }
                 break;
 
             case 0xBF:
@@ -2568,11 +2520,12 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                 /* UserData set */
                 {
                     int idx = *pc++;
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    pc += 4;
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     if (pp->gen->userfunc != NULL &&
                         pp->gen->userfunc->setUserData != NULL)
                     {
@@ -2655,11 +2608,14 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
 
             case 0xE8:
                 /* Trail control */
-                ((u8*) &fval)[0] = pc[0];
-                ((u8*) &fval)[1] = pc[1];
-                ((u8*) &fval)[2] = pc[2];
-                ((u8*) &fval)[3] = pc[3];
-                pc += 4;
+                {
+                    u8* p = pc;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
+                }
                 if (fval < 0.0F) {
                     pp->kind &= ~Trail;
                 } else {
@@ -2755,23 +2711,28 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xED:
                 /* Rotate interpolation with random */
                 {
-                    f32 base_val;
                     f32 range_val;
+                    f32 base_val;
                     int timing;
                     f32 result;
 
-                    ((u8*) &fval)[0] = pc[0];
-                    ((u8*) &fval)[1] = pc[1];
-                    ((u8*) &fval)[2] = pc[2];
-                    ((u8*) &fval)[3] = pc[3];
-                    base_val = fval;
-                    ((u8*) &fval)[0] = pc[4];
-                    ((u8*) &fval)[1] = pc[5];
-                    ((u8*) &fval)[2] = pc[6];
-                    ((u8*) &fval)[3] = pc[7];
-                    range_val = fval;
-                    timing = pc[8];
-                    pc += 9;
+                    {
+                        u8* p = pc + 1;
+                        u8* pc2;
+                        fbytes[0] = pc[0];
+                        pc2 = p + 4;
+                        fbytes[1] = pc[1];
+                        fbytes[2] = pc[2];
+                        fbytes[3] = pc[3];
+                        base_val = fval;
+                        fbytes[0] = pc[4];
+                        fbytes[1] = pc[5];
+                        fbytes[2] = pc[6];
+                        fbytes[3] = pc[7];
+                        range_val = fval;
+                        pc = pc2 + 4;
+                        timing = p[7];
+                    }
 
                     if (timing != 0) {
                         s32 randi = (s32) ((f32) (timing + 1) * HSD_Randf());
@@ -2872,7 +2833,101 @@ do_life:
         }
     }
 
-    psUpdateParticle(pp);
+    /* --- Physics update --- */
+    if (pp->kind & Tornado) {
+        /* Tornado rotational physics */
+        HSD_Generator* gp = pp->gen;
+        f32 sinA, sinB, cosA, cosB;
+        f32 R;
+        f32 d, e, nd, vz;
+        f32 t0, t1, t2, t3, t4;
+
+        sinA = sinf(pp->grav);
+        sinB = sinf(pp->fric);
+        cosA = cosf(pp->grav);
+        cosB = cosf(pp->fric);
+
+        pp->vel.z += gp->aux.tornado.vel;
+
+        if ((R = gp->radius) < 0.0F) {
+            R = -R;
+        }
+        {
+            f32 ang;
+            if ((ang = gp->angle) < 0.0F) {
+                ang = -ang;
+            }
+            R = pp->vel.y * (pp->vel.z * tanf(ang) + R);
+        }
+        pp->vel.x += gp->grav;
+
+        d = R * cosf(pp->vel.x);
+        e = R * sinf(pp->vel.x);
+        nd = -d;
+        vz = pp->vel.z;
+
+        /* Rotation matrix application */
+        t0 = vz * sinB;
+        t1 = e * cosA;
+        t2 = nd * sinA;
+        t3 = d * cosB + t0;
+        t0 = vz * sinA;
+        t1 = sinB * t2 + t1;
+        pp->pos.x = gp->pos.x + t3;
+        t2 = nd * cosA;
+        t4 = e * sinA;
+        t1 = cosB * t0 + t1;
+        t0 = vz * cosA;
+        t4 = sinB * t2 - t4;
+        pp->pos.y = gp->pos.y + t1;
+        t4 = cosB * t0 + t4;
+        pp->pos.z = gp->pos.z + t4;
+    } else {
+        /* Simple physics */
+        if (pp->kind & 1) {
+            pp->vel.y -= pp->grav;
+        }
+        if (pp->kind & 2) {
+            pp->vel.x *= pp->fric;
+            pp->vel.y *= pp->fric;
+            pp->vel.z *= pp->fric;
+        }
+        pp->pos.x += pp->vel.x;
+        pp->pos.y += pp->vel.y;
+        pp->pos.z += pp->vel.z;
+    }
+
+    /* JObj attachment - update JObj position to match particle */
+    if (pp->kind & 0x8000) {
+        s32 jobj_idx = (pp->kind >> 12) & 7;
+        HSD_JObj* jobj;
+        HSD_JObj** jobj_slot;
+
+        /* Allocate JObj if slot is empty */
+        if (hsd_804D08E8[jobj_idx] == NULL) {
+            HSD_JObj* new_jobj = HSD_JObjAlloc();
+            if (new_jobj != NULL) {
+                hsd_8039CF4C(jobj_idx + 1, new_jobj);
+                HSD_JObjUnref(new_jobj);
+            }
+        }
+
+        jobj_slot = &hsd_804D08E8[jobj_idx];
+        jobj = *jobj_slot;
+
+        if (jobj != NULL) {
+            HSD_JObjSetupMatrix(jobj);
+
+            jobj = *jobj_slot;
+            HSD_JObjAddTranslationX(jobj, pp->pos.x - jobj->mtx[0][3]);
+
+            jobj = *jobj_slot;
+            HSD_JObjAddTranslationY(jobj, pp->pos.y - jobj->mtx[1][3]);
+
+            jobj = *jobj_slot;
+            HSD_JObjAddTranslationZ(jobj, pp->pos.z - jobj->mtx[2][3]);
+        }
+    }
 
     /* Callback */
     if (pp->callback != NULL) {

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1403,13 +1403,16 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                 /* Size interpolation with random */
                 {
                     f32 range;
-                    pp->sizeCount = *pc++;
                     {
-                        u16 cnt = pp->sizeCount;
+                        u8* count_pc = pc;
+                        u16 cnt;
+                        pp->sizeCount = *count_pc++;
+                        cnt = pp->sizeCount;
                         if (cnt & 0x80) {
-                            cnt = ((cnt & 0x7F) << 8) + *pc++;
+                            cnt = ((cnt & 0x7F) << 8) + *count_pc++;
                             pp->sizeCount = cnt;
                         }
+                        pc = count_pc;
                     }
                     {
                         u8* p = pc + 1;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1948,11 +1948,11 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xBC:
                 /* PoseNum with random */
                 {
-                    int randRange;
+                    f32 randRange;
 
                     pp->poseNum = *pc++;
                     randRange = *pc++;
-                    pp->poseNum = (u8) (s32) ((f32) randRange * HSD_Randf() +
+                    pp->poseNum = (u8) (s32) (randRange * HSD_Randf() +
                                               (f32) pp->poseNum);
                     {
                         u8 bank = pp->bank;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1526,18 +1526,21 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                                   16);
                     }
                     {
-                        pp->aCmpCount = *pc++;
+                        u8* p = pc;
+                        pp->aCmpCount = *p++;
                         {
                             u16 cnt = pp->aCmpCount;
                             if (cnt & 0x80) {
-                                cnt = ((cnt & 0x7F) << 8) + *pc++;
+                                cnt = ((cnt & 0x7F) << 8) + *p++;
                                 pp->aCmpCount = cnt;
                             }
                         }
+                        pc = p;
+                        pp->aCmpMode = *pc++;
+                        pp->aCmpParam1Target = pc[0];
+                        pp->aCmpParam2Target = pc[1];
+                        pc += 2;
                     }
-                    pp->aCmpMode = *pc++;
-                    pp->aCmpParam1Target = *pc++;
-                    pp->aCmpParam2Target = *pc++;
                     if (pp->aCmpCount == 0) {
                         pp->aCmpParam1 = pp->aCmpParam1Target;
                         pp->aCmpParam2 = pp->aCmpParam2Target;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1416,16 +1416,18 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xAB:
                 /* Velocity scale */
                 {
+                    f32 scale;
                     u8* p = pc;
                     fbytes[0] = *p++;
                     fbytes[1] = *p++;
                     fbytes[2] = *p++;
                     fbytes[3] = *p++;
                     pc = p;
+                    scale = fval;
+                    pp->vel.x *= scale;
+                    pp->vel.y *= scale;
+                    pp->vel.z *= scale;
                 }
-                pp->vel.x *= fval;
-                pp->vel.y *= fval;
-                pp->vel.z *= fval;
                 break;
 
             case 0xAC:
@@ -2008,7 +2010,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                 /* Normalize velocity to target speed */
                 {
                     f32 base_speed, random_range;
-                    f32 mag;
+                    f32 mag, root;
 
                     {
                         u8* p = pc;
@@ -2027,9 +2029,9 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     base_speed += random_range * HSD_Randf();
                     mag = pp->vel.x * pp->vel.x + pp->vel.y * pp->vel.y +
                           pp->vel.z * pp->vel.z;
-                    mag = sqrtf(mag);
-                    if (mag > 0.0F) {
-                        base_speed /= mag;
+                    root = sqrtf(mag);
+                    if (root > 0.0) {
+                        base_speed /= root;
                         pp->vel.x *= base_speed;
                         pp->vel.y *= base_speed;
                         pp->vel.z *= base_speed;
@@ -2643,18 +2645,20 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xE8:
                 /* Trail control */
                 {
+                    f32 trail;
                     u8* p = pc;
                     fbytes[0] = *p++;
                     fbytes[1] = *p++;
                     fbytes[2] = *p++;
                     fbytes[3] = *p++;
                     pc = p;
-                }
-                if (fval < 0.0F) {
-                    pp->kind &= ~Trail;
-                } else {
-                    pp->kind |= Trail;
-                    pp->trail = fval;
+                    trail = fval;
+                    if (trail < 0.0F) {
+                        pp->kind &= ~Trail;
+                    } else {
+                        pp->kind |= Trail;
+                        pp->trail = trail;
+                    }
                 }
                 break;
 

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1631,7 +1631,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         result = (f32) (vel_mag_sq * guess);
                         vel_mag_sq = result;
                     }
-                    dist_sq = dy * dy + dx * dx;
+                    dist_sq = dx * dx + dy * dy;
                     dist_sq += dz * dz;
                     if (dist_sq == 0.0) {
                         break;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -2867,9 +2867,9 @@ do_life:
         /* Tornado rotational physics */
         HSD_Generator* gp = pp->gen;
         f32 sinA, sinB, cosA, cosB;
-        f32 R;
-        f32 d, e, nd, vz;
         f32 t0, t1, t2, t3, t4;
+        f32 d, e, nd, vz;
+        f32 R;
 
         sinA = sinf(pp->grav);
         sinB = sinf(pp->fric);

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1556,12 +1556,11 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         }
                     }
                     {
-                        u8* p = pc;
-                        fbytes[0] = *p++;
-                        fbytes[1] = *p++;
-                        fbytes[2] = *p++;
-                        fbytes[3] = *p++;
-                        pc = p;
+                        fbytes[0] = pc[0];
+                        fbytes[1] = pc[1];
+                        fbytes[2] = pc[2];
+                        fbytes[3] = pc[3];
+                        pc += 4;
                     }
                     pp->rotateTarget += fval;
                     if (pp->rotateCount == 0) {

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -2843,9 +2843,9 @@ do_life:
         /* Tornado rotational physics */
         HSD_Generator* gp = pp->gen;
         f32 sinA, sinB, cosA, cosB;
-        f32 R;
-        f32 d, e, nd, vz;
         f32 t0, t1, t2, t3, t4;
+        f32 d, e, nd, vz;
+        f32 R;
 
         sinA = sinf(pp->grav);
         sinB = sinf(pp->fric);

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1602,7 +1602,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         result = (f32) (vel_mag_sq * guess);
                         vel_mag_sq = result;
                     }
-                    dist_sq = dy * dy + dx * dx;
+                    dist_sq = dx * dx + dy * dy;
                     dist_sq += dz * dz;
                     if (dist_sq == 0.0) {
                         break;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1585,12 +1585,11 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         }
                     }
                     {
-                        u8* p = pc;
-                        fbytes[0] = *p++;
-                        fbytes[1] = *p++;
-                        fbytes[2] = *p++;
-                        fbytes[3] = *p++;
-                        pc = p;
+                        fbytes[0] = pc[0];
+                        fbytes[1] = pc[1];
+                        fbytes[2] = pc[2];
+                        fbytes[3] = pc[3];
+                        pc += 4;
                     }
                     pp->rotateTarget += fval;
                     if (pp->rotateCount == 0) {

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -55,6 +55,8 @@ typedef union {
     u8 bytes[4];
 } ParticleFloatBytes;
 
+static const f32 particle_zero = 0.0F;
+
 void hsd_803983A4(HSD_Generator* gen)
 {
     HSD_JObj* jobj;
@@ -1581,8 +1583,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     }
                     HSD_JObjSetupMatrix(jobj);
                     vel_mag_sq = pp->vel.x * pp->vel.x +
-                                 pp->vel.y * pp->vel.y +
-                                 pp->vel.z * pp->vel.z;
+                                 pp->vel.y * pp->vel.y + pp->vel.z * pp->vel.z;
                     dx = jobj->mtx[0][3];
                     dx -= pp->pos.x;
                     dy = jobj->mtx[1][3];
@@ -2854,12 +2855,12 @@ do_life:
 
         pp->vel.z += gp->aux.tornado.vel;
 
-        if ((R = gp->radius) < 0.0F) {
+        if ((R = gp->radius) < *(volatile const f32*) &particle_zero) {
             R = -R;
         }
         {
             f32 ang;
-            if ((ang = gp->angle) < 0.0F) {
+            if ((ang = gp->angle) < *(volatile const f32*) &particle_zero) {
                 ang = -ang;
             }
             R = pp->vel.y * (pp->vel.z * tanf(ang) + R);
@@ -2905,8 +2906,6 @@ do_life:
     /* JObj attachment - update JObj position to match particle */
     if (pp->kind & 0x8000) {
         s32 jobj_idx = (pp->kind >> 12) & 7;
-        HSD_JObj* jobj;
-        HSD_JObj** jobj_slot;
 
         /* Allocate JObj if slot is empty */
         if (hsd_804D08E8[jobj_idx] == NULL) {
@@ -2917,20 +2916,21 @@ do_life:
             }
         }
 
-        jobj_slot = &hsd_804D08E8[jobj_idx];
-        jobj = *jobj_slot;
+        {
+            HSD_JObj* jobj;
 
-        if (jobj != NULL) {
-            HSD_JObjSetupMatrix(jobj);
+            if ((jobj = hsd_804D08E8[jobj_idx]) != NULL) {
+                HSD_JObjSetupMatrix(jobj);
 
-            jobj = *jobj_slot;
-            HSD_JObjAddTranslationX(jobj, pp->pos.x - jobj->mtx[0][3]);
+                jobj = hsd_804D08E8[jobj_idx];
+                HSD_JObjAddTranslationX(jobj, pp->pos.x - jobj->mtx[0][3]);
 
-            jobj = *jobj_slot;
-            HSD_JObjAddTranslationY(jobj, pp->pos.y - jobj->mtx[1][3]);
+                jobj = hsd_804D08E8[jobj_idx];
+                HSD_JObjAddTranslationY(jobj, pp->pos.y - jobj->mtx[1][3]);
 
-            jobj = *jobj_slot;
-            HSD_JObjAddTranslationZ(jobj, pp->pos.z - jobj->mtx[2][3]);
+                jobj = hsd_804D08E8[jobj_idx];
+                HSD_JObjAddTranslationZ(jobj, pp->pos.z - jobj->mtx[2][3]);
+            }
         }
     }
 

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -931,14 +931,11 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                             pp->sizeCount = cnt;
                         }
                     }
-                    {
-                        u8* p = pc;
-                        fbytes[0] = *p++;
-                        fbytes[1] = *p++;
-                        fbytes[2] = *p++;
-                        fbytes[3] = *p++;
-                        pc = p;
-                    }
+                    fbytes[0] = pc[0];
+                    fbytes[1] = pc[1];
+                    fbytes[2] = pc[2];
+                    fbytes[3] = pc[3];
+                    pc += 4;
                     pp->sizeTarget = fval;
                     if (pp->sizeCount == 0) {
                         pp->size = pp->sizeTarget;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -2003,7 +2003,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xBD:
                 /* Normalize velocity to target speed */
                 {
-                    f32 base_speed, random_range, target_speed;
+                    f32 base_speed, random_range;
                     f32 mag;
 
                     {
@@ -2020,15 +2020,15 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         random_range = fval;
                         pc = p;
                     }
-                    target_speed = base_speed + random_range * HSD_Randf();
+                    base_speed += random_range * HSD_Randf();
                     mag = pp->vel.x * pp->vel.x + pp->vel.y * pp->vel.y +
                           pp->vel.z * pp->vel.z;
                     mag = sqrtf(mag);
                     if (mag > 0.0F) {
-                        target_speed /= mag;
-                        pp->vel.x *= target_speed;
-                        pp->vel.y *= target_speed;
-                        pp->vel.z *= target_speed;
+                        base_speed /= mag;
+                        pp->vel.x *= base_speed;
+                        pp->vel.y *= base_speed;
+                        pp->vel.z *= base_speed;
                     }
                 }
                 break;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -995,7 +995,8 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     int idx;
                     int palflag;
 
-                    idx = (pc[0] << 8) + pc[1];
+                    idx = pc[0] << 8;
+                    idx += pc[1];
                     pc += 2;
 
                     if (linkNo >= 8) {
@@ -1046,7 +1047,8 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     int bank;
 
                     bank = pp->bank;
-                    idx = (pc[0] << 8) + pc[1];
+                    idx = pc[0] << 8;
+                    idx += pc[1];
                     pc += 2;
 
                     if (ptclref_804D0E5C[bank] != NULL) {
@@ -1099,7 +1101,8 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                 {
                     int idx;
 
-                    idx = (pc[0] << 8) + pc[1];
+                    idx = pc[0] << 8;
+                    idx += pc[1];
                     pc += 2;
                     gchild = hsd_8039F05C(pp->linkNo, pp->bank, idx);
                     if (gchild != NULL) {
@@ -1160,7 +1163,8 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     u8 flags;
                     HSD_psAppSRT* srt;
 
-                    idx = (pc[0] << 8) + pc[1];
+                    idx = pc[0] << 8;
+                    idx += pc[1];
                     flags = pc[2];
                     pc += 3;
                     gchild = hsd_8039F05C(pp->linkNo, pp->bank, idx);
@@ -1224,7 +1228,8 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     u8 flags;
                     HSD_psAppSRT* srt;
 
-                    idx = (pc[0] << 8) + pc[1];
+                    idx = pc[0] << 8;
+                    idx += pc[1];
                     flags = pc[2];
                     pc += 3;
 
@@ -1291,8 +1296,10 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                 {
                     int baseLife;
                     int randomRange;
-                    baseLife = (pc[0] << 8) + pc[1];
-                    randomRange = (pc[2] << 8) + pc[3];
+                    baseLife = pc[0] << 8;
+                    baseLife += pc[1];
+                    randomRange = pc[2] << 8;
+                    randomRange += pc[3];
                     pc += 4;
                     pp->life =
                         baseLife + (s32) ((f32) randomRange * HSD_Randf());
@@ -1690,7 +1697,8 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     int idx;
                     int palflag;
 
-                    idx = (pc[0] << 8) + pc[1];
+                    idx = pc[0] << 8;
+                    idx += pc[1];
                     pc += 2;
 
                     if (linkNo >= 8) {
@@ -1747,7 +1755,8 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     int bank;
 
                     bank = pp->bank;
-                    idx = (pc[0] << 8) + pc[1];
+                    idx = pc[0] << 8;
+                    idx += pc[1];
                     pc += 2;
 
                     if (ptclref_804D0E5C[bank] != NULL) {

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1555,18 +1555,21 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                                   16);
                     }
                     {
-                        pp->aCmpCount = *pc++;
+                        u8* p = pc;
+                        pp->aCmpCount = *p++;
                         {
                             u16 cnt = pp->aCmpCount;
                             if (cnt & 0x80) {
-                                cnt = ((cnt & 0x7F) << 8) + *pc++;
+                                cnt = ((cnt & 0x7F) << 8) + *p++;
                                 pp->aCmpCount = cnt;
                             }
                         }
+                        pc = p;
+                        pp->aCmpMode = *pc++;
+                        pp->aCmpParam1Target = pc[0];
+                        pp->aCmpParam2Target = pc[1];
+                        pc += 2;
                     }
-                    pp->aCmpMode = *pc++;
-                    pp->aCmpParam1Target = *pc++;
-                    pp->aCmpParam2Target = *pc++;
                     if (pp->aCmpCount == 0) {
                         pp->aCmpParam1 = pp->aCmpParam1Target;
                         pp->aCmpParam2 = pp->aCmpParam2Target;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1387,16 +1387,18 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xAB:
                 /* Velocity scale */
                 {
+                    f32 scale;
                     u8* p = pc;
                     fbytes[0] = *p++;
                     fbytes[1] = *p++;
                     fbytes[2] = *p++;
                     fbytes[3] = *p++;
                     pc = p;
+                    scale = fval;
+                    pp->vel.x *= scale;
+                    pp->vel.y *= scale;
+                    pp->vel.z *= scale;
                 }
-                pp->vel.x *= fval;
-                pp->vel.y *= fval;
-                pp->vel.z *= fval;
                 break;
 
             case 0xAC:
@@ -1984,7 +1986,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                 /* Normalize velocity to target speed */
                 {
                     f32 base_speed, random_range;
-                    f32 mag;
+                    f32 mag, root;
 
                     {
                         u8* p = pc;
@@ -2003,9 +2005,9 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     base_speed += random_range * HSD_Randf();
                     mag = pp->vel.x * pp->vel.x + pp->vel.y * pp->vel.y +
                           pp->vel.z * pp->vel.z;
-                    mag = sqrtf(mag);
-                    if (mag > 0.0F) {
-                        base_speed /= mag;
+                    root = sqrtf(mag);
+                    if (root > 0.0) {
+                        base_speed /= root;
                         pp->vel.x *= base_speed;
                         pp->vel.y *= base_speed;
                         pp->vel.z *= base_speed;
@@ -2619,18 +2621,20 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xE8:
                 /* Trail control */
                 {
+                    f32 trail;
                     u8* p = pc;
                     fbytes[0] = *p++;
                     fbytes[1] = *p++;
                     fbytes[2] = *p++;
                     fbytes[3] = *p++;
                     pc = p;
-                }
-                if (fval < 0.0F) {
-                    pp->kind &= ~Trail;
-                } else {
-                    pp->kind |= Trail;
-                    pp->trail = fval;
+                    trail = fval;
+                    if (trail < 0.0F) {
+                        pp->kind &= ~Trail;
+                    } else {
+                        pp->kind |= Trail;
+                        pp->trail = trail;
+                    }
                 }
                 break;
 

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -65,7 +65,7 @@ typedef union {
     u8 bytes[4];
 } ParticleFloatBytes;
 
-static const f32 particle_zero = 0.0F;
+static volatile const f32 particle_zero = 0.0F;
 
 void hsd_803983A4(HSD_Generator* gen)
 {
@@ -2887,12 +2887,12 @@ do_life:
 
         pp->vel.z += gp->aux.tornado.vel;
 
-        if ((R = gp->radius) < *(volatile const f32*) &particle_zero) {
+        if ((R = gp->radius) < particle_zero) {
             R = -R;
         }
         {
             f32 ang;
-            if ((ang = gp->angle) < *(volatile const f32*) &particle_zero) {
+            if ((ang = gp->angle) < particle_zero) {
                 ang = -ang;
             }
             R = pp->vel.y * (pp->vel.z * tanf(ang) + R);

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -966,7 +966,8 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     int idx;
                     int palflag;
 
-                    idx = (pc[0] << 8) + pc[1];
+                    idx = pc[0] << 8;
+                    idx += pc[1];
                     pc += 2;
 
                     if (linkNo >= 8) {
@@ -1017,7 +1018,8 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     int bank;
 
                     bank = pp->bank;
-                    idx = (pc[0] << 8) + pc[1];
+                    idx = pc[0] << 8;
+                    idx += pc[1];
                     pc += 2;
 
                     if (ptclref_804D0E5C[bank] != NULL) {
@@ -1070,7 +1072,8 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                 {
                     int idx;
 
-                    idx = (pc[0] << 8) + pc[1];
+                    idx = pc[0] << 8;
+                    idx += pc[1];
                     pc += 2;
                     gchild = hsd_8039F05C(pp->linkNo, pp->bank, idx);
                     if (gchild != NULL) {
@@ -1131,7 +1134,8 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     u8 flags;
                     HSD_psAppSRT* srt;
 
-                    idx = (pc[0] << 8) + pc[1];
+                    idx = pc[0] << 8;
+                    idx += pc[1];
                     flags = pc[2];
                     pc += 3;
                     gchild = hsd_8039F05C(pp->linkNo, pp->bank, idx);
@@ -1195,7 +1199,8 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     u8 flags;
                     HSD_psAppSRT* srt;
 
-                    idx = (pc[0] << 8) + pc[1];
+                    idx = pc[0] << 8;
+                    idx += pc[1];
                     flags = pc[2];
                     pc += 3;
 
@@ -1262,8 +1267,10 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                 {
                     int baseLife;
                     int randomRange;
-                    baseLife = (pc[0] << 8) + pc[1];
-                    randomRange = (pc[2] << 8) + pc[3];
+                    baseLife = pc[0] << 8;
+                    baseLife += pc[1];
+                    randomRange = pc[2] << 8;
+                    randomRange += pc[3];
                     pc += 4;
                     pp->life =
                         baseLife + (s32) ((f32) randomRange * HSD_Randf());
@@ -1661,7 +1668,8 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     int idx;
                     int palflag;
 
-                    idx = (pc[0] << 8) + pc[1];
+                    idx = pc[0] << 8;
+                    idx += pc[1];
                     pc += 2;
 
                     if (linkNo >= 8) {
@@ -1718,7 +1726,8 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     int bank;
 
                     bank = pp->bank;
-                    idx = (pc[0] << 8) + pc[1];
+                    idx = pc[0] << 8;
+                    idx += pc[1];
                     pc += 2;
 
                     if (ptclref_804D0E5C[bank] != NULL) {

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1616,7 +1616,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                 /* Aim velocity toward JObj */
                 {
                     HSD_JObj* jobj = hsd_804D08E8[*pc++ + pp->pJObjOfs];
-                    f32 dz, dy, dx, dist_sq, dist;
+                    f32 dz, dy, dx, dist_sq;
                     f32 vel_mag_sq;
 
                     if (jobj == NULL) {
@@ -1648,9 +1648,17 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     if (dist_sq == 0.0) {
                         break;
                     }
-                    dist = sqrtf(dist_sq);
+                    if (dist_sq > 0.0F) {
+                        double guess = __frsqrte((double) dist_sq);
+                        volatile f32 result;
+                        guess = 0.5 * guess * (3.0 - guess * guess * dist_sq);
+                        guess = 0.5 * guess * (3.0 - guess * guess * dist_sq);
+                        guess = 0.5 * guess * (3.0 - guess * guess * dist_sq);
+                        result = (f32) (dist_sq * guess);
+                        dist_sq = result;
+                    }
                     {
-                        f32 scale = vel_mag_sq / dist;
+                        f32 scale = vel_mag_sq / dist_sq;
                         pp->vel.x = dx * scale;
                         pp->vel.y = dy * scale;
                         pp->vel.z = dz * scale;
@@ -2208,7 +2216,10 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                 {
                     s32 step;
                     s8 delta;
-                    f32 rand_val;
+                    f32 rand_r;
+                    f32 rand_g;
+                    f32 rand_b;
+                    f32 rand_a;
                     f32 val;
 
                     if (pp->primColCount != 0) {
@@ -2260,11 +2271,11 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                                   16);
                     }
 
-                    rand_val = HSD_Randf();
+                    rand_r = HSD_Randf();
 
                     delta = (s8) *pc++;
-                    rand_val *= (f32) (delta * 2);
-                    val = rand_val + (f32) pp->primColTarget.r;
+                    rand_r *= (f32) (delta * 2);
+                    val = rand_r + (f32) pp->primColTarget.r;
                     if (val < 0.0F) {
                         val = 0.0F;
                     }
@@ -2272,7 +2283,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         val = 255.0F;
                     }
                     pp->primColTarget.r = (u8) (s32) val;
-                    val = rand_val + (f32) pp->envColTarget.r;
+                    val = rand_r + (f32) pp->envColTarget.r;
                     if (val < 0.0F) {
                         val = 0.0F;
                     }
@@ -2281,10 +2292,10 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     }
                     pp->envColTarget.r = (u8) (s32) val;
 
-                    rand_val = HSD_Randf();
+                    rand_g = HSD_Randf();
                     delta = (s8) *pc++;
-                    rand_val *= (f32) (delta * 2);
-                    val = rand_val + (f32) pp->primColTarget.g;
+                    rand_g *= (f32) (delta * 2);
+                    val = rand_g + (f32) pp->primColTarget.g;
                     if (val < 0.0F) {
                         val = 0.0F;
                     }
@@ -2292,7 +2303,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         val = 255.0F;
                     }
                     pp->primColTarget.g = (u8) (s32) val;
-                    val = rand_val + (f32) pp->envColTarget.g;
+                    val = rand_g + (f32) pp->envColTarget.g;
                     if (val < 0.0F) {
                         val = 0.0F;
                     }
@@ -2301,10 +2312,10 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     }
                     pp->envColTarget.g = (u8) (s32) val;
 
-                    rand_val = HSD_Randf();
+                    rand_b = HSD_Randf();
                     delta = (s8) *pc++;
-                    rand_val *= (f32) (delta * 2);
-                    val = rand_val + (f32) pp->primColTarget.b;
+                    rand_b *= (f32) (delta * 2);
+                    val = rand_b + (f32) pp->primColTarget.b;
                     if (val < 0.0F) {
                         val = 0.0F;
                     }
@@ -2312,7 +2323,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         val = 255.0F;
                     }
                     pp->primColTarget.b = (u8) (s32) val;
-                    val = rand_val + (f32) pp->envColTarget.b;
+                    val = rand_b + (f32) pp->envColTarget.b;
                     if (val < 0.0F) {
                         val = 0.0F;
                     }
@@ -2321,10 +2332,10 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     }
                     pp->envColTarget.b = (u8) (s32) val;
 
-                    rand_val = HSD_Randf();
+                    rand_a = HSD_Randf();
                     delta = (s8) *pc++;
-                    rand_val *= (f32) (delta * 2);
-                    val = rand_val + (f32) pp->primColTarget.a;
+                    rand_a *= (f32) (delta * 2);
+                    val = rand_a + (f32) pp->primColTarget.a;
                     if (val < 0.0F) {
                         val = 0.0F;
                     }
@@ -2332,7 +2343,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         val = 255.0F;
                     }
                     pp->primColTarget.a = (u8) (s32) val;
-                    val = rand_val + (f32) pp->envColTarget.a;
+                    val = rand_a + (f32) pp->envColTarget.a;
                     if (val < 0.0F) {
                         val = 0.0F;
                     }

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1587,7 +1587,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                 /* Aim velocity toward JObj */
                 {
                     HSD_JObj* jobj = hsd_804D08E8[*pc++ + pp->pJObjOfs];
-                    f32 dz, dy, dx, dist_sq, dist;
+                    f32 dz, dy, dx, dist_sq;
                     f32 vel_mag_sq;
 
                     if (jobj == NULL) {
@@ -1619,9 +1619,17 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     if (dist_sq == 0.0) {
                         break;
                     }
-                    dist = sqrtf(dist_sq);
+                    if (dist_sq > 0.0F) {
+                        double guess = __frsqrte((double) dist_sq);
+                        volatile f32 result;
+                        guess = 0.5 * guess * (3.0 - guess * guess * dist_sq);
+                        guess = 0.5 * guess * (3.0 - guess * guess * dist_sq);
+                        guess = 0.5 * guess * (3.0 - guess * guess * dist_sq);
+                        result = (f32) (dist_sq * guess);
+                        dist_sq = result;
+                    }
                     {
-                        f32 scale = vel_mag_sq / dist;
+                        f32 scale = vel_mag_sq / dist_sq;
                         pp->vel.x = dx * scale;
                         pp->vel.y = dy * scale;
                         pp->vel.z = dz * scale;
@@ -2184,7 +2192,10 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                 {
                     s32 step;
                     s8 delta;
-                    f32 rand_val;
+                    f32 rand_r;
+                    f32 rand_g;
+                    f32 rand_b;
+                    f32 rand_a;
                     f32 val;
 
                     if (pp->primColCount != 0) {
@@ -2236,11 +2247,11 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                                   16);
                     }
 
-                    rand_val = HSD_Randf();
+                    rand_r = HSD_Randf();
 
                     delta = (s8) *pc++;
-                    rand_val *= (f32) (delta * 2);
-                    val = rand_val + (f32) pp->primColTarget.r;
+                    rand_r *= (f32) (delta * 2);
+                    val = rand_r + (f32) pp->primColTarget.r;
                     if (val < 0.0F) {
                         val = 0.0F;
                     }
@@ -2248,7 +2259,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         val = 255.0F;
                     }
                     pp->primColTarget.r = (u8) (s32) val;
-                    val = rand_val + (f32) pp->envColTarget.r;
+                    val = rand_r + (f32) pp->envColTarget.r;
                     if (val < 0.0F) {
                         val = 0.0F;
                     }
@@ -2257,10 +2268,10 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     }
                     pp->envColTarget.r = (u8) (s32) val;
 
-                    rand_val = HSD_Randf();
+                    rand_g = HSD_Randf();
                     delta = (s8) *pc++;
-                    rand_val *= (f32) (delta * 2);
-                    val = rand_val + (f32) pp->primColTarget.g;
+                    rand_g *= (f32) (delta * 2);
+                    val = rand_g + (f32) pp->primColTarget.g;
                     if (val < 0.0F) {
                         val = 0.0F;
                     }
@@ -2268,7 +2279,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         val = 255.0F;
                     }
                     pp->primColTarget.g = (u8) (s32) val;
-                    val = rand_val + (f32) pp->envColTarget.g;
+                    val = rand_g + (f32) pp->envColTarget.g;
                     if (val < 0.0F) {
                         val = 0.0F;
                     }
@@ -2277,10 +2288,10 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     }
                     pp->envColTarget.g = (u8) (s32) val;
 
-                    rand_val = HSD_Randf();
+                    rand_b = HSD_Randf();
                     delta = (s8) *pc++;
-                    rand_val *= (f32) (delta * 2);
-                    val = rand_val + (f32) pp->primColTarget.b;
+                    rand_b *= (f32) (delta * 2);
+                    val = rand_b + (f32) pp->primColTarget.b;
                     if (val < 0.0F) {
                         val = 0.0F;
                     }
@@ -2288,7 +2299,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         val = 255.0F;
                     }
                     pp->primColTarget.b = (u8) (s32) val;
-                    val = rand_val + (f32) pp->envColTarget.b;
+                    val = rand_b + (f32) pp->envColTarget.b;
                     if (val < 0.0F) {
                         val = 0.0F;
                     }
@@ -2297,10 +2308,10 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     }
                     pp->envColTarget.b = (u8) (s32) val;
 
-                    rand_val = HSD_Randf();
+                    rand_a = HSD_Randf();
                     delta = (s8) *pc++;
-                    rand_val *= (f32) (delta * 2);
-                    val = rand_val + (f32) pp->primColTarget.a;
+                    rand_a *= (f32) (delta * 2);
+                    val = rand_a + (f32) pp->primColTarget.a;
                     if (val < 0.0F) {
                         val = 0.0F;
                     }
@@ -2308,7 +2319,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         val = 255.0F;
                     }
                     pp->primColTarget.a = (u8) (s32) val;
-                    val = rand_val + (f32) pp->envColTarget.a;
+                    val = rand_a + (f32) pp->envColTarget.a;
                     if (val < 0.0F) {
                         val = 0.0F;
                     }

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -923,19 +923,20 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xA0:
                 /* Set size interpolation target */
                 {
-                    pp->sizeCount = *pc++;
+                    u8* p = pc;
+                    pp->sizeCount = *p++;
                     {
                         u16 cnt = pp->sizeCount;
                         if (cnt & 0x80) {
-                            cnt = ((cnt & 0x7F) << 8) + *pc++;
+                            cnt = ((cnt & 0x7F) << 8) + *p++;
                             pp->sizeCount = cnt;
                         }
                     }
-                    fbytes[0] = pc[0];
-                    fbytes[1] = pc[1];
-                    fbytes[2] = pc[2];
-                    fbytes[3] = pc[3];
-                    pc += 4;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->sizeTarget = fval;
                     if (pp->sizeCount == 0) {
                         pp->size = pp->sizeTarget;
@@ -1576,21 +1577,20 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xB6:
                 /* Rotate interpolation setup */
                 {
-                    pp->rotateCount = *pc++;
+                    u8* p = pc;
+                    pp->rotateCount = *p++;
                     {
                         u16 cnt = pp->rotateCount;
                         if (cnt & 0x80) {
-                            cnt = ((cnt & 0x7F) << 8) + *pc++;
+                            cnt = ((cnt & 0x7F) << 8) + *p++;
                             pp->rotateCount = cnt;
                         }
                     }
-                    {
-                        fbytes[0] = pc[0];
-                        fbytes[1] = pc[1];
-                        fbytes[2] = pc[2];
-                        fbytes[3] = pc[3];
-                        pc += 4;
-                    }
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->rotateTarget += fval;
                     if (pp->rotateCount == 0) {
                         pp->rotate = pp->rotateTarget;
@@ -2094,11 +2094,15 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                                            (s32) pp->primColTarget.a)) >>
                                   16);
                     }
-                    pp->primColCount = *pc++;
-                    cnt = pp->primColCount;
-                    if (cnt & 0x80) {
-                        cnt = ((cnt & 0x7F) << 8) + *pc++;
-                        pp->primColCount = cnt;
+                    {
+                        u8* p = pc;
+                        pp->primColCount = *p++;
+                        cnt = pp->primColCount;
+                        if (cnt & 0x80) {
+                            cnt = ((cnt & 0x7F) << 8) + *p++;
+                            pp->primColCount = cnt;
+                        }
+                        pc = p;
                     }
                     pp->primColTarget = pp->primCol;
                     if (opcode & 1) {
@@ -2152,11 +2156,15 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                                            (s32) pp->envColTarget.a)) >>
                                   16);
                     }
-                    pp->envColCount = *pc++;
-                    cnt = pp->envColCount;
-                    if (cnt & 0x80) {
-                        cnt = ((cnt & 0x7F) << 8) + *pc++;
-                        pp->envColCount = cnt;
+                    {
+                        u8* p = pc;
+                        pp->envColCount = *p++;
+                        cnt = pp->envColCount;
+                        if (cnt & 0x80) {
+                            cnt = ((cnt & 0x7F) << 8) + *p++;
+                            pp->envColCount = cnt;
+                        }
+                        pc = p;
                     }
                     pp->envColTarget = pp->envCol;
                     if (opcode & 1) {

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -902,14 +902,11 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                             pp->sizeCount = cnt;
                         }
                     }
-                    {
-                        u8* p = pc;
-                        fbytes[0] = *p++;
-                        fbytes[1] = *p++;
-                        fbytes[2] = *p++;
-                        fbytes[3] = *p++;
-                        pc = p;
-                    }
+                    fbytes[0] = pc[0];
+                    fbytes[1] = pc[1];
+                    fbytes[2] = pc[2];
+                    fbytes[3] = pc[3];
+                    pc += 4;
                     pp->sizeTarget = fval;
                     if (pp->sizeCount == 0) {
                         pp->size = pp->sizeTarget;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -2473,9 +2473,9 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                         f32 a_rand;
                         a_rand = HSD_Randf();
                         delta = (s8) *pc++;
-                        delta_float = (f32) (delta * 2);
-                        delta_float *=
+                        delta_float =
                             (f32) (s32) ((f32) (timing + 1) * a_rand);
+                        delta_float *= (f32) (delta * 2);
                         delta_float /= (f32) timing;
                         if (flags & 0x10) {
                             val = delta_float + (f32) pp->primColTarget.a;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -65,6 +65,8 @@ typedef union {
     u8 bytes[4];
 } ParticleFloatBytes;
 
+static const f32 particle_zero = 0.0F;
+
 void hsd_803983A4(HSD_Generator* gen)
 {
     HSD_JObj* jobj;
@@ -1610,8 +1612,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                     }
                     HSD_JObjSetupMatrix(jobj);
                     vel_mag_sq = pp->vel.x * pp->vel.x +
-                                 pp->vel.y * pp->vel.y +
-                                 pp->vel.z * pp->vel.z;
+                                 pp->vel.y * pp->vel.y + pp->vel.z * pp->vel.z;
                     dx = jobj->mtx[0][3];
                     dx -= pp->pos.x;
                     dy = jobj->mtx[1][3];
@@ -2878,12 +2879,12 @@ do_life:
 
         pp->vel.z += gp->aux.tornado.vel;
 
-        if ((R = gp->radius) < 0.0F) {
+        if ((R = gp->radius) < *(volatile const f32*) &particle_zero) {
             R = -R;
         }
         {
             f32 ang;
-            if ((ang = gp->angle) < 0.0F) {
+            if ((ang = gp->angle) < *(volatile const f32*) &particle_zero) {
                 ang = -ang;
             }
             R = pp->vel.y * (pp->vel.z * tanf(ang) + R);
@@ -2929,8 +2930,6 @@ do_life:
     /* JObj attachment - update JObj position to match particle */
     if (pp->kind & 0x8000) {
         s32 jobj_idx = (pp->kind >> 12) & 7;
-        HSD_JObj* jobj;
-        HSD_JObj** jobj_slot;
 
         /* Allocate JObj if slot is empty */
         if (hsd_804D08E8[jobj_idx] == NULL) {
@@ -2941,20 +2940,21 @@ do_life:
             }
         }
 
-        jobj_slot = &hsd_804D08E8[jobj_idx];
-        jobj = *jobj_slot;
+        {
+            HSD_JObj* jobj;
 
-        if (jobj != NULL) {
-            HSD_JObjSetupMatrix(jobj);
+            if ((jobj = hsd_804D08E8[jobj_idx]) != NULL) {
+                HSD_JObjSetupMatrix(jobj);
 
-            jobj = *jobj_slot;
-            HSD_JObjAddTranslationX(jobj, pp->pos.x - jobj->mtx[0][3]);
+                jobj = hsd_804D08E8[jobj_idx];
+                HSD_JObjAddTranslationX(jobj, pp->pos.x - jobj->mtx[0][3]);
 
-            jobj = *jobj_slot;
-            HSD_JObjAddTranslationY(jobj, pp->pos.y - jobj->mtx[1][3]);
+                jobj = hsd_804D08E8[jobj_idx];
+                HSD_JObjAddTranslationY(jobj, pp->pos.y - jobj->mtx[1][3]);
 
-            jobj = *jobj_slot;
-            HSD_JObjAddTranslationZ(jobj, pp->pos.z - jobj->mtx[2][3]);
+                jobj = hsd_804D08E8[jobj_idx];
+                HSD_JObjAddTranslationZ(jobj, pp->pos.z - jobj->mtx[2][3]);
+            }
         }
     }
 

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -1977,11 +1977,11 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xBC:
                 /* PoseNum with random */
                 {
-                    int randRange;
+                    f32 randRange;
 
                     pp->poseNum = *pc++;
                     randRange = *pc++;
-                    pp->poseNum = (u8) (s32) ((f32) randRange * HSD_Randf() +
+                    pp->poseNum = (u8) (s32) (randRange * HSD_Randf() +
                                               (f32) pp->poseNum);
                     {
                         u8 bank = pp->bank;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -619,7 +619,7 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
     HSD_Particle* pp = pp_arg;
     HSD_Particle* prev = prev_arg;
     u8* pc;
-    int operand;
+    u16 operand;
     u8 opcode;
     u8 cls;
     HSD_Particle* child;

--- a/src/sysdolphin/baselib/particle.c
+++ b/src/sysdolphin/baselib/particle.c
@@ -894,19 +894,20 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xA0:
                 /* Set size interpolation target */
                 {
-                    pp->sizeCount = *pc++;
+                    u8* p = pc;
+                    pp->sizeCount = *p++;
                     {
                         u16 cnt = pp->sizeCount;
                         if (cnt & 0x80) {
-                            cnt = ((cnt & 0x7F) << 8) + *pc++;
+                            cnt = ((cnt & 0x7F) << 8) + *p++;
                             pp->sizeCount = cnt;
                         }
                     }
-                    fbytes[0] = pc[0];
-                    fbytes[1] = pc[1];
-                    fbytes[2] = pc[2];
-                    fbytes[3] = pc[3];
-                    pc += 4;
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->sizeTarget = fval;
                     if (pp->sizeCount == 0) {
                         pp->size = pp->sizeTarget;
@@ -1547,21 +1548,20 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
             case 0xB6:
                 /* Rotate interpolation setup */
                 {
-                    pp->rotateCount = *pc++;
+                    u8* p = pc;
+                    pp->rotateCount = *p++;
                     {
                         u16 cnt = pp->rotateCount;
                         if (cnt & 0x80) {
-                            cnt = ((cnt & 0x7F) << 8) + *pc++;
+                            cnt = ((cnt & 0x7F) << 8) + *p++;
                             pp->rotateCount = cnt;
                         }
                     }
-                    {
-                        fbytes[0] = pc[0];
-                        fbytes[1] = pc[1];
-                        fbytes[2] = pc[2];
-                        fbytes[3] = pc[3];
-                        pc += 4;
-                    }
+                    fbytes[0] = *p++;
+                    fbytes[1] = *p++;
+                    fbytes[2] = *p++;
+                    fbytes[3] = *p++;
+                    pc = p;
                     pp->rotateTarget += fval;
                     if (pp->rotateCount == 0) {
                         pp->rotate = pp->rotateTarget;
@@ -2070,11 +2070,15 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                                            (s32) pp->primColTarget.a)) >>
                                   16);
                     }
-                    pp->primColCount = *pc++;
-                    cnt = pp->primColCount;
-                    if (cnt & 0x80) {
-                        cnt = ((cnt & 0x7F) << 8) + *pc++;
-                        pp->primColCount = cnt;
+                    {
+                        u8* p = pc;
+                        pp->primColCount = *p++;
+                        cnt = pp->primColCount;
+                        if (cnt & 0x80) {
+                            cnt = ((cnt & 0x7F) << 8) + *p++;
+                            pp->primColCount = cnt;
+                        }
+                        pc = p;
                     }
                     pp->primColTarget = pp->primCol;
                     if (opcode & 1) {
@@ -2128,11 +2132,15 @@ void* hsd_8039930C(void* pp_arg, void* prev_arg)
                                            (s32) pp->envColTarget.a)) >>
                                   16);
                     }
-                    pp->envColCount = *pc++;
-                    cnt = pp->envColCount;
-                    if (cnt & 0x80) {
-                        cnt = ((cnt & 0x7F) << 8) + *pc++;
-                        pp->envColCount = cnt;
+                    {
+                        u8* p = pc;
+                        pp->envColCount = *p++;
+                        cnt = pp->envColCount;
+                        if (cnt & 0x80) {
+                            cnt = ((cnt & 0x7F) << 8) + *p++;
+                            pp->envColCount = cnt;
+                        }
+                        pc = p;
                     }
                     pp->envColTarget = pp->envCol;
                     if (opcode & 1) {


### PR DESCRIPTION
## What changed

- recover post-increment bytecode reads across particle commands
- align command operand width and pointer walks with the original interpreter
- improve size, rotation, aim, random-pose, and velocity-normalization code generation
- preserve the size-interpolation count cursor through variable-width operands
- preserve decoded velocity-scale and trail values across particle writes
- split big-endian spawn indices to recover the original instruction scheduling
- separate per-channel color-random lifetimes to recover the original FPR allocation
- lower the aim-distance square root in place to match the original refinement sequence
- recover tornado-physics constant loads and register allocation
- reuse the translation unit existing volatile zero constant
- align repeated JObj attachment loads and translation updates

## Why

`hsd_8039930C` is a 15,264-byte particle command interpreter and one of the largest unmatched functions in the project. The remaining differences are primarily expression ordering, pointer-update shapes, constant lifetimes, and register allocation rather than behavioral gaps.

These source-equivalent changes preserve particle behavior while moving the generated PowerPC code closer to the original. The local exact-compiler comparison improves from 93.83255% on the base revision to 96.82888%. The current generated function is 15,260 bytes, four bytes short of the target, while the candidate `.sdata2` section matches the target 96-byte size. Authoritative PR CI reports 492 additional matched bytes and improves `hsd_8039930C` from 94.44% to 97.67%.

## Validation

- exact MWCC 1.2.5n translation-unit compile
- function extraction and objdiff comparison
- `clang-format --dry-run --Werror src/sysdolphin/baselib/particle.c`
- `python3 tools/check/main.py --quiet src/sysdolphin/baselib/particle.c`
- `git diff --check origin/master...HEAD`

The full local Ninja build requires `orig/GALE01/sys/main.dol`, which is not present in this checkout. The authoritative link, test, and decomp.dev results are expected from the PR checks.