### PR TITLE
Improve fn_801701C0 match to 98.94%

### DIFF
--- a/src/melee/gm/gm_16F1.c
+++ b/src/melee/gm/gm_16F1.c
@@ -1075,8 +1075,8 @@ int fn_801701C0(void* arg0, int arg1, int arg2)
                     p++;
                 }
             }
-            if (!(x58[arg1].x3 & 1) && rankings[arg1] == 0 &&
-                x58[arg1].x20 == 0)
+            if (!(*((u8*) x58 + arg1 * sizeof(*x58) + 3) & 1) &&
+                rankings[arg1] == 0 && x58[arg1].x20 == 0)
             {
                 return 1;
             }
@@ -1098,13 +1098,15 @@ int fn_801701C0(void* arg0, int arg1, int arg2)
                         p++;
                     }
                 }
-                if (!(x58[arg1].x3 & 1) && x58[arg1].x5 == 0 &&
-                    x58[arg1].x20 == 0)
+                if (!(*((u8*) x58 + arg1 * sizeof(*x58) + 3) & 1) &&
+                    x58[arg1].x5 == 0 && x58[arg1].x20 == 0)
                 {
                     return 1;
                 }
             } else {
-                if (!(x58[arg1].x3 & 1) && x58[arg1].x20 == 0) {
+                if (!(*((u8*) x58 + arg1 * sizeof(*x58) + 3) & 1) &&
+                    x58[arg1].x20 == 0)
+                {
                     return 1;
                 }
             }


### PR DESCRIPTION
## Summary

- load the three `x3` flag bytes by byte offset before rematerializing the player record
- restore the target instruction order and exact 6,344-byte function size
- improve `fn_801701C0` from 98.51009% to 98.93884% in the relocation-stripped MWCC comparison

## Validation

- exact MWCC 1.2.5n comparison: 98.93884%, size 6,344 bytes
- clang-format pre-commit hook
- changed-file style check
- full source style sweep
- `git diff --check`

The local retail-DOL matrix was unavailable because this checkout does not contain the required user-owned game binary; the pull request CI will run that matrix.

Generated with Codex.