### PR TITLE
Improve gm_801BFCFC register allocation

### DIFF
--- a/src/melee/gm/gm_1BFA.c
+++ b/src/melee/gm/gm_1BFA.c
@@ -154,13 +154,13 @@ void gm_801BFCFC(GameScene* arg0)
     s32 var_r27_2;
     u32* temp_r29;
     u8* var_r27;
+    u32 var_r28_3;
     u8* var_r28;
     UNK_T* temp_r3;
     u8* var_r28_2;
     u32 var_r25_2;
     int var_r25;
     u32* temp_r29_2;
-    u32 var_r28_3;
     UNK_T* var_r31;
     s32 var_r30;
     u8* var_r26;


### PR DESCRIPTION
## Summary
- move `var_r28_3` earlier in the local declaration order
- make the third loop byte-exact without changing behavior or control flow
- reduce the decomp.me matcher score from 130 to 95

## Verification
- `python3 tools/check/main.py --fix --quiet src/melee/gm/gm_1BFA.c`
- `git diff --check`
- rebuilt `gm_801BFCFC` with GC/1.2.5n using the exported target context
- confirmed target and candidate remain 160 instructions
- confirmed matcher score: 130 before, 95 after