### PR TITLE
Improve ftCo_80097AF4 matching

### DIFF
--- a/src/melee/ft/chara/ftCommon/ftCo_DownBound.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_DownBound.c
@@ -163,13 +163,17 @@ void ftCo_8009794C(Fighter_GObj* gobj)
 void ftCo_80097AF4(Fighter_GObj* gobj)
 {
     HSD_JObj* jobj;
+    Fighter_GObj* temp;
     Fighter* fp = gobj->user_data;
     float rot0;
     float rot1;
+    float param_else;
+    float param_true;
+    UNUSED float param_dummy;
 
     jobj = fp->parts[ftParts_GetBoneIndex(fp, FtPart_HipN)].joint;
     HSD_JObjSetupMatrix(jobj);
-    PAD_STACK(56);
+    PAD_STACK(48);
     if (fp->x2226_b0) {
         rot0 = jobj->mtx[0][2];
         rot1 = jobj->mtx[1][2];
@@ -188,17 +192,17 @@ void ftCo_80097AF4(Fighter_GObj* gobj)
                 b = !b;
             }
             Fighter_ChangeMotionState(
-                gobj, b ? ftCo_MS_DownBoundU : ftCo_MS_DownBoundD,
+                temp = gobj, b ? ftCo_MS_DownBoundU : ftCo_MS_DownBoundD,
                 Ft_MF_SkipNametagVis | Ft_MF_KeepColAnimPartHitStatus, 0, 1, 0,
                 NULL);
-            ftCo_800978D4(gobj);
+            ftCo_800978D4_inline(gobj, &param_true);
             fp->x67C = 255;
             fp->x67D = 255;
             ftCommon_8007E2F4(fp, 511);
         }
         ftCommon_8007CCE8(fp);
     } else {
-        ftCo_800978D4(gobj);
+        ftCo_800978D4_inline(gobj, &param_else);
         Camera_80030E44(4, &fp->cur_pos);
         if (fp->facing_dir * rot0 > 0) {
             ft_8008A2BC(gobj);


### PR DESCRIPTION
Improves `ftCo_80097AF4` by inlining the existing effect helper at its two call sites and preserving the local lifetimes used by MWCC.

Measured with the project permuter scorer:
- before: 419
- after: 105
- target/candidate: 147 instructions each

Validation:
- `pre-commit run clang-format --files src/melee/ft/chara/ftCommon/ftCo_DownBound.c`
- `pre-commit run style-check --files src/melee/ft/chara/ftCommon/ftCo_DownBound.c`
- isolated MWCC rebuild and scorer recheck: 105