### PR TITLE
Fix Item_8026AD20 argument

### DIFF
--- a/src/melee/ft/chara/ftCommon/ftCo_ItemThrow.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_ItemThrow.c
@@ -554,16 +554,19 @@ void ftCo_80095EFC(Fighter_GObj* gobj)
                                                         ftCo_MS_LightThrowF]
                                      .x8;
                     float throw_speed = throw_scale * base_throw_speed;
+                    // Needed for matching register allocation.
+                    float item_throw_speed = throw_speed;
                     {
                         vec2.x = fsm * (fp->mv.co.itemthrow4.x8.x - vec0.x) +
                                  vec0.x;
                         {
-                            vec2.y =
+                            float vec1_y =
                                 fsm * (fp->mv.co.itemthrow4.x8.y - vec0.y) +
                                 vec0.y;
+                            vec2.y = vec1_y;
                             vec2.z = 0;
                             pl_8003E978(fp->player_id, fp->x221F_b4,
-                                        fp->item_gobj, vec2.y,
+                                        fp->item_gobj, vec1_y,
                                         base_throw_speed, cd_xB4, throw_speed,
                                         vec0.x, vec0.y, fsm);
                         }
@@ -571,7 +574,7 @@ void ftCo_80095EFC(Fighter_GObj* gobj)
                             FtMoveId msid = fp->motion_id;
                             if (msid == (FtMoveId) ftCo_MS_LightThrowDrop) {
                                 Item_8026AC74(fp->item_gobj, &vec2, &vec1,
-                                              throw_speed);
+                                              item_throw_speed);
                             } else if (msid >= (FtMoveId) ftCo_MS_LightThrowF4)
                             {
                                 if (itIsHeavy(fp->item_gobj) == 1) {
@@ -580,7 +583,7 @@ void ftCo_80095EFC(Fighter_GObj* gobj)
                                     ftCommon_8007EBAC(fp, 27, 0);
                                 }
                                 Item_8026AD20(fp->item_gobj, &vec2, &vec1,
-                                              throw_speed, 1);
+                                              item_throw_speed, 1);
                             } else {
                                 if (itIsHeavy(fp->item_gobj) == 1) {
                                     ftCommon_8007EBAC(fp, 28, 0);
@@ -588,7 +591,7 @@ void ftCo_80095EFC(Fighter_GObj* gobj)
                                     ftCommon_8007EBAC(fp, 26, 0);
                                 }
                                 Item_8026AD20(fp->item_gobj, &vec2, &vec1,
-                                              throw_speed, 0);
+                                              item_throw_speed, 0);
                             }
                         }
                     }

--- a/src/melee/ft/chara/ftCommon/ftCo_ItemThrow.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_ItemThrow.c
@@ -580,7 +580,7 @@ void ftCo_80095EFC(Fighter_GObj* gobj)
                                     ftCommon_8007EBAC(fp, 27, 0);
                                 }
                                 Item_8026AD20(fp->item_gobj, &vec2, &vec1,
-                                              throw_speed);
+                                              throw_speed, 1);
                             } else {
                                 if (itIsHeavy(fp->item_gobj) == 1) {
                                     ftCommon_8007EBAC(fp, 28, 0);
@@ -588,7 +588,7 @@ void ftCo_80095EFC(Fighter_GObj* gobj)
                                     ftCommon_8007EBAC(fp, 26, 0);
                                 }
                                 Item_8026AD20(fp->item_gobj, &vec2, &vec1,
-                                              throw_speed);
+                                              throw_speed, 0);
                             }
                         }
                     }

--- a/src/melee/it/item.c
+++ b/src/melee/it/item.c
@@ -2069,7 +2069,7 @@ void Item_8026AC74(HSD_GObj* gobj, Vec3* arg1, Vec3* arg2, f32 arg3)
     }
 }
 
-void Item_8026AD20(HSD_GObj* gobj, Vec3* arg1, Vec3* arg2, f32 arg3)
+void Item_8026AD20(HSD_GObj* gobj, Vec3* arg1, Vec3* arg2, f32 arg3, int arg4)
 {
     Item* item_data = GetItemData(gobj);
     it_802731E0(gobj);

--- a/src/melee/it/item.h
+++ b/src/melee/it/item.h
@@ -42,7 +42,7 @@ struct ItemStateDesc;
                                 Fighter_Part part);
 /* 26ABD8 */ void Item_8026ABD8(Item_GObj* gobj, Vec3* pos, float);
 /* 26AC74 */ void Item_8026AC74(HSD_GObj* gobj, Vec3*, Vec3*, float);
-/* 26AD20 */ void Item_8026AD20(HSD_GObj* gobj, Vec3*, Vec3*, float);
+/* 26AD20 */ void Item_8026AD20(HSD_GObj* gobj, Vec3*, Vec3*, float, int);
 /* 26ADC0 */ void Item_8026ADC0(HSD_GObj* gobj);
 /* 26AE10 */ void Item_OnUserDataRemove(void* user_data);
 /* 26AE10 */ void lbl_8026AE10(void* user_data);


### PR DESCRIPTION
## What changed

- Add the retail fifth integer argument to `Item_8026AD20`'s declaration and definition.
- Pass `1` from the forward-throw path and `0` from the backward-throw path in `ftCo_80095EFC`.

## Why

The retail `ftCo_80095EFC` call sites materialize `r6` immediately before both `Item_8026AD20` calls. The current four-argument prototype omitted those instructions even though the callee does not consume the value.

## Impact

This restores both missing call-site instructions and improves the remaining unmatched function without changing `Item_8026AD20`'s body behavior.

## Validation

- Exact MWCC GC/1.2.5n compile of `ftCo_ItemThrow.c` and `item.c`
- Function scorer: removed two missing instructions from `ftCo_80095EFC` (penalty 1410 to 1210)
- `python3 tools/check/main.py --fix --quiet`
- `clang-format 22.1.0 --dry-run --Werror`
- `git diff --check`
