### PR TITLE
 ci: Build melee-gcc-native 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,6 +240,18 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v5
 
+  native-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+    - uses: cachix/install-nix-action@v31
+    - uses: cachix/cachix-action@v17
+      with:
+        name: doldecomp-melee
+    - run: nix build .#melee-gcc-native -L
+
   build-nix:
     name: Nix
     runs-on: ubuntu-latest

--- a/.nix/CMakeLists.txt
+++ b/.nix/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(melee-native LANGUAGES C)
+
+include(GNUInstallDirs)
+
+set(SOURCES
+    src/sysdolphin/baselib/gobj.c
+    src/sysdolphin/baselib/wobj.c
+)
+
+add_library(melee STATIC ${SOURCES})
+
+target_compile_definitions(melee PRIVATE BUGFIX)
+
+target_include_directories(melee PRIVATE
+    $ENV{AURORA_SRC}/include
+    src
+    src/Runtime
+    src/melee
+    src/melee/ft/chara
+    src/sysdolphin
+)
+
+install(TARGETS melee LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")

--- a/.nix/melee-gcc-native.nix
+++ b/.nix/melee-gcc-native.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  aurora-src,
+}:
+stdenv.mkDerivation {
+  name = "melee-gcc-native";
+
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../src/sysdolphin
+      ../src/Runtime
+    ];
+  };
+
+  postPatch = ''
+    cp ${./CMakeLists.txt} CMakeLists.txt
+  '';
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  env.AURORA_SRC = aurora-src;
+
+  __structuredAttrs = true;
+}

--- a/.nix/overlay.nix
+++ b/.nix/overlay.nix
@@ -12,7 +12,7 @@ final: prev: {
     })
   ];
 
-  clang-format-minimal = final.runCommand "clang-format-minimal" {} ''
+  clang-format-minimal = final.runCommand "clang-format-minimal" { } ''
     mkdir -p $out/bin/
     cp ${final.clang.cc}/bin/clang-format $out/bin/
   '';
@@ -24,6 +24,15 @@ final: prev: {
         nix-store --add-fixed sha256 main.dol
     '';
     hash = "sha256-3CFQRRNCQ1C9oXp8ZegjcbRREqXfwenydJqLerDv9kY=";
+  };
+
+  melee-gcc-native = final.pkgsi686Linux.callPackage ./melee-gcc-native.nix { };
+
+  aurora-src = final.fetchFromGitHub {
+    owner = "r-burns";
+    repo = "aurora";
+    rev = "melee";
+    hash = "sha256-N7Rp95Bll8zcYmB+vYRRRq7pGsr/3XMz+vRrjcn61ec=";
   };
 
   default = final.melee;


### PR DESCRIPTION
Build melee's C sources using a native toolchain to enforce conformance
with modern C development practices.

This is intended as a "ratchet check"; currently only a few sources
build successfully, but we will gradually increase enforcement of this
check over the entire repo.