### PR TITLE
Resolve memory card names & structures and add missing gxends()

### DIFF
--- a/src/melee/gm/gm_1BFA.c
+++ b/src/melee/gm/gm_1BFA.c
@@ -135,7 +135,7 @@ static UNK_T* gm_801BFC60(u32 arg0, s32 arg1, u32 arg2, u32 arg3, UNK_T* arg4)
         un_804A1F48.x2 = arg2;
         return (&un_804A1F48.x8);
     }
-    temp_r3 = HSD_MemAlloc(0xC);
+    temp_r3 = HSD_MemAlloc(sizeof(struct un_804A1F48_t));
     if (temp_r3 != NULL) {
         temp_r3->x0 = arg0;
         temp_r3->x4 = arg3;

--- a/src/melee/lb/lbcardgame.c
+++ b/src/melee/lb/lbcardgame.c
@@ -29,26 +29,15 @@ static struct {
     0x300,
 };
 
-static struct {
-    u32 pad[5];
-    struct gmm_x1868* x14;
-    struct {
-        u32 x0;
-        u32 x4;
-        UNK_T x8;
-    } unk_arr[8];
-} lb_803BAB74 = { { 0, 3, 0, 0x1790, 0 },
-                  NULL,
-                  {
-                      { 0x1F2C, 1, NULL },
-                      { 0x1F2C, 1, NULL },
-                      { 0x1F2C, 1, NULL },
-                      { 0x1F2C, 1, NULL },
-                      { 0x1F2C, 1, NULL },
-                      { 0x1F2C, 1, NULL },
-                      { 0x1F2C, 1, NULL },
-                      { -1, 0, NULL },
-                  } };
+// save-data manifest
+static struct CardEntry lb_803BAB74[10] = {
+    { 0, 3, NULL },      { 0x1790, 0, NULL }, /* data = gmMainLib_GetSaveData()
+                                               */
+    { 0x1F2C, 1, NULL }, /* data = &gmMainLib_8015CC4C()[0..6] */
+    { 0x1F2C, 1, NULL }, { 0x1F2C, 1, NULL }, { 0x1F2C, 1, NULL },
+    { 0x1F2C, 1, NULL }, { 0x1F2C, 1, NULL }, { 0x1F2C, 1, NULL },
+    { -1, 0, NULL },
+};
 
 void lb_8001C600(void)
 {
@@ -97,7 +86,7 @@ int lb_8001C820(void)
 
 u32 lb_8001C87C(void)
 {
-    return lb_8001B7E0(0, "SuperSmashBros0110290334", &lb_803BAB74,
+    return lb_8001B7E0(0, "SuperSmashBros0110290334", lb_803BAB74,
                        &lb_803BAB60, &_p(x4));
 }
 
@@ -107,7 +96,7 @@ int lb_8001C8BC(void)
 {
     HSD_ASSERT(0x140, _p(enable));
 
-    return lb_8001BC18(0, "SuperSmashBros0110290334", (void**) &lb_803BAB74,
+    return lb_8001BC18(0, "SuperSmashBros0110290334", (void**) lb_803BAB74,
                        &lb_803BAB60, lb_8001C658(), lb_8001C820(), _p(x5C)[3],
                        &_p(x4));
 }
@@ -151,8 +140,7 @@ enum_t lb_8001CBBC(void)
     if (lb_8001CAF4() != 0) {
         return 0xD;
     }
-    temp_r3 =
-        lb_8001BD34(0, "SuperSmashBros0110290334", &lb_803BAB74, &_p(x4));
+    temp_r3 = lb_8001BD34(0, "SuperSmashBros0110290334", lb_803BAB74, &_p(x4));
     if (temp_r3 != 0 && temp_r3 != 2) {
         _p(x8) = 2;
     }
@@ -180,7 +168,7 @@ static int dont_inline_helper(void)
     }
 
     temp_r24 = lb_8001C820();
-    return lb_8001BE30(0, "SuperSmashBros0110290334", &lb_803BAB74,
+    return lb_8001BE30(0, "SuperSmashBros0110290334", lb_803BAB74,
                        lb_8001C658(), temp_r24, _p(x5C)[3], &_p(x4),
                        fn_8001CC30);
 }
@@ -320,10 +308,10 @@ void lb_8001D21C(void)
     _p(xC) = 0;
     _p(x10) = 0;
     _p(x14) = 0;
-    lb_803BAB74.x14 = gmMainLib_GetSaveData();
+    lb_803BAB74[1].data = (u8*) gmMainLib_GetSaveData();
 
     for (i = 0; i < 7; i++) {
         struct unk* tmp = gmMainLib_8015CC4C();
-        lb_803BAB74.unk_arr[i].x8 = &tmp[i];
+        lb_803BAB74[2 + i].data = (u8*) &tmp[i];
     }
 }

--- a/src/melee/lb/lbcardnew.c
+++ b/src/melee/lb/lbcardnew.c
@@ -311,10 +311,6 @@ void lb_8001A4CC(const char* filename, UNK_T file_entries)
     task->x8 = file_entries;
 }
 
-struct CardEntry {
-    int file_size, file_flags, data_size;
-};
-
 struct SnapshotNode {
     struct SnapshotNode* next;
     u32 time;
@@ -331,7 +327,7 @@ inline void setup_card_entries(void* ctx, void* icon, struct CardEntry* entry)
     while (entry->file_size != -1) {
         if (entry->file_size != 0) {
             hsd_803AC3E0(ctx, i, entry->file_size, entry->file_flags,
-                         entry->data_size);
+                         entry->data);
         }
         i++;
         entry++;
@@ -530,8 +526,8 @@ int lb_8001ACEC(UNK_T file_entries)
         cached_flag = _p(xF4)[i];
         cached_data = _p(xD0)[i];
         if (_p(xF4)[i] != 0) {
-            hsd_result = hsd_803B29D8(&_p(unk_A8), i, entries[i].data_size,
-                                      fn_8001A0B0);
+            hsd_result =
+                hsd_803B29D8(&_p(unk_A8), i, entries[i].data, fn_8001A0B0);
             _p(unk_38)[i].unk_0 = convert_hsdcard_error(hsd_result);
             _p(unk_38)[i].unk_4 = hsd_result;
             file_error = _p(unk_38)[i].unk_0;
@@ -564,8 +560,8 @@ int lb_8001AE38(UNK_T file_entries)
         cached_flag = _p(xF4)[i];
         cached_data = _p(xD0)[i];
         if (_p(xF4)[i] != 0) {
-            hsd_result = hsd_803B2A4C(&_p(unk_A8), i, entries[i].data_size,
-                                      fn_8001A0B0);
+            hsd_result =
+                hsd_803B2A4C(&_p(unk_A8), i, entries[i].data, fn_8001A0B0);
             _p(unk_38)[i].unk_0 = convert_hsdcard_error(hsd_result);
             _p(unk_38)[i].unk_4 = hsd_result;
             file_error = _p(unk_38)[i].unk_0;
@@ -1122,7 +1118,7 @@ int lb_8001C4A8(void* file_entries, void* icon_data)
         while (entry->file_size != -1) {
             if (entry->file_size != 0) {
                 hsd_803AC3E0((struct CardState*) ctx, i, entry->file_size,
-                             entry->file_flags, entry->data_size);
+                             entry->file_flags, entry->data);
             }
             i++;
             entry++;

--- a/src/melee/lb/lbcardnew.h
+++ b/src/melee/lb/lbcardnew.h
@@ -8,6 +8,12 @@
 
 #include <sysdolphin/baselib/gobj.h>
 
+struct CardEntry {
+    int file_size;
+    int file_flags;
+    u8* data;
+};
+
 /* 019BB8 */ int lb_80019BB8(int card_result);
 /* 019C38 */ struct CardTask* lb_80019C38(void);
 /* 019CB0 */ int lb_80019CB0(int result);

--- a/src/melee/lb/lbsnap.c
+++ b/src/melee/lb/lbsnap.c
@@ -305,10 +305,10 @@ int lbSnap_8001DF20(void)
 {
     struct Unk80433380_0* snap = _p(x0);
     struct Unk803BACC8* tmp;
-    lbSnap_803BACC8.x14 = lbSnap_GetSaveDataOffset(snap);
+    lbSnap_803BACC8.entries[0].file_size = lbSnap_GetSaveDataOffset(snap);
     tmp = &lbSnap_803BACC8;
-    lbSnap_803BACC8.x1C = snap;
-    return lb_8001C4A8(&tmp->x14, &lbSnap_803BACC8);
+    lbSnap_803BACC8.entries[0].data = (u8*) snap;
+    return lb_8001C4A8(tmp->entries, &lbSnap_803BACC8);
 }
 #pragma pop
 
@@ -327,9 +327,9 @@ int lbSnap_8001DF6C(int chan)
         int chan_arg = chan;
         _p(slot)[chan].card_result = 8;
         lbSnap_8001D4A4(chan_arg, text);
-        desc->x14 = lbSnap_GetSaveDataOffset(_p(x0));
-        desc->x1C = _p(x0);
-        ret = lb_8001BB48(chan, text, &desc->x14, desc, _p(x4_string),
+        desc->entries[0].file_size = lbSnap_GetSaveDataOffset(_p(x0));
+        desc->entries[0].data = (u8*) _p(x0);
+        ret = lb_8001BB48(chan, text, desc->entries, desc, _p(x4_string),
                           _p(x44_LbMcSnap_MemSnapIconData)[0].offset,
                           _p(x44_LbMcSnap_MemSnapIconData)[1].size, 0);
     }
@@ -349,8 +349,8 @@ int lbSnap_8001E058(int chan, int index)
     ret = ptr->card_result;
     if (ret == 0) {
         lbSnap_FormatTime(chan, index, text);
-        lbSnap_803BACC8.x1C = _p(x0);
-        ret = lb_8001BF04(chan, text, &lbSnap_803BACC8.x14, _p(x4_string),
+        lbSnap_803BACC8.entries[0].data = (u8*) _p(x0);
+        ret = lb_8001BF04(chan, text, lbSnap_803BACC8.entries, _p(x4_string),
                           _p(x44_LbMcSnap_MemSnapIconData)[0].offset,
                           _p(x44_LbMcSnap_MemSnapIconData)[1].size, 0);
     }

--- a/src/melee/lb/lbsnap.static.h
+++ b/src/melee/lb/lbsnap.static.h
@@ -7,6 +7,7 @@
 #include <platform.h>
 
 #include "it/types.h"
+#include "lb/lbcardnew.h"
 #include "lb/types.h"
 
 struct Unk80433380_48 {
@@ -45,19 +46,19 @@ struct Unk80433380 {
     /* 0x54 */ int x54_stateChanged[3];
 }; /* size = 0x60 */
 STATIC_ASSERT(sizeof(struct Unk80433380) == 0x60);
-
+// snapshot save descriptor
 struct Unk803BACC8 {
-    char pad0[0x14];
-    int x14;
-    char pad18[0x1C - 0x18];
-    void* x1C;
-    struct Unk80433380_0* x20;
-    u32 pad[2];
+    /* 0x00 */ u8 icon[0x14];
+    /* 0x14 */ struct CardEntry entries[2];
 };
 
 static struct Unk80433380 lbSnap_80433380;
 static struct Unk803BACC8 lbSnap_803BACC8 = {
-    { 2, 0, 1, 0, 0, 0, 0, 0, 0, 0, 3 }, 0, { 0, 0, 0, 3 }, 0, (void*) -1
+    { 2, 0, 1, 0, 0, 0, 0, 0, 0, 0, 3 },
+    {
+        { 0, 3, NULL },
+        { -1, 0, NULL },
+    },
 };
 
 #endif

--- a/src/sysdolphin/baselib/hsd_3A94.c
+++ b/src/sysdolphin/baselib/hsd_3A94.c
@@ -1530,11 +1530,11 @@ int hsd_803AC340(void* header)
 }
 
 void hsd_803AC3E0(struct CardState* file_desc, int file_idx, int file_size,
-                  int file_flags, int data_size)
+                  int file_flags, u8* data)
 {
     file_desc->x28[file_idx] = file_flags;
     file_desc->x4C[file_idx] = file_size;
-    file_desc->x70[file_idx].size = data_size;
+    file_desc->x70[file_idx].ptr = data;
 }
 
 void fn_803AC3F8(void* arg0, u8* data, s32 file_idx)

--- a/src/sysdolphin/baselib/hsd_3A94.h
+++ b/src/sysdolphin/baselib/hsd_3A94.h
@@ -6,8 +6,7 @@
 #include <Gecko_setjmp.h>
 #include <dolphin/card.h>
 
-typedef union CardFileData {
-    int size;
+typedef struct CardFileData {
     u8* ptr;
 } CardFileData;
 
@@ -45,7 +44,7 @@ typedef struct CardState {
 /* 3AC334 */ UNK_RET fn_803AC334(UNK_PARAMS);
 /* 3AC340 */ int hsd_803AC340(void* header);
 /* 3AC3E0 */ void hsd_803AC3E0(struct CardState* file_desc, int file_idx,
-                               int file_size, int file_flags, int data_size);
+                               int file_size, int file_flags, u8* data);
 /* 3AC3F8 */ void fn_803AC3F8(void*, u8*, s32);
 /* 3AC558 */ void hsd_803AC558(struct CardState*, u8*);
 /* 3AC634 */ u32 fn_803AC634(struct CardState* file_desc, s32 file_idx);

--- a/src/sysdolphin/baselib/hsd_3B27.c
+++ b/src/sysdolphin/baselib/hsd_3B27.c
@@ -2,6 +2,7 @@
 
 #include "hsd_3A94.h"
 
+#include <stddef.h>
 #include <string.h>
 
 typedef struct {
@@ -101,7 +102,7 @@ int hsd_803B2928(s32* arg0, const char* arg1, int arg2, int arg3,
     return 0;
 }
 
-int hsd_803B29D8(s32* ctx, int channel, int size, UNK_T callback)
+int hsd_803B29D8(s32* ctx, int channel, u8* data, UNK_T callback)
 {
     s32 read_idx = hsd_804D7990;
     u8* base = hsd_804D1138;
@@ -120,7 +121,7 @@ int hsd_803B29D8(s32* ctx, int channel, int size, UNK_T callback)
         entry->type = 1;
         entry->f1 = (s32) ctx;
         entry->f2 = channel;
-        entry->f3 = size;
+        entry->f3 = (s32) data;
         entry->f5 = (s32) callback;
         hsd_804D7994 = next % 32;
     }
@@ -128,14 +129,14 @@ int hsd_803B29D8(s32* ctx, int channel, int size, UNK_T callback)
     return 0;
 }
 
-int hsd_803B2A4C(s32* arg0, int arg1, int arg2, void (*arg3)(int, int))
+int hsd_803B2A4C(s32* arg0, int arg1, u8* arg2, void (*arg3)(int, int))
 {
     u8* base = hsd_804D1138;
     s32 read_idx;
     s32 write_idx;
     HsdCmdEntry* entry;
 
-    if (arg0[arg1 + 19] <= 0) {
+    if (arg0[arg1 + offsetof(CardState, x4C) / sizeof(s32)] <= 0) {
         return -257;
     }
 
@@ -154,7 +155,7 @@ int hsd_803B2A4C(s32* arg0, int arg1, int arg2, void (*arg3)(int, int))
         entry->type = 2;
         entry->f1 = (s32) arg0;
         entry->f2 = arg1;
-        entry->f3 = arg2;
+        entry->f3 = (s32) arg2;
         entry->f5 = (s32) arg3;
         hsd_804D7994 = next % 32;
     }

--- a/src/sysdolphin/baselib/hsd_3B27.h
+++ b/src/sysdolphin/baselib/hsd_3B27.h
@@ -8,8 +8,8 @@
 /* 3B286C */ int hsd_803B286C(s32*, UNK_T, const char*, int, int,
                               void (*)(int, int));
 /* 3B2928 */ int hsd_803B2928(s32*, const char*, int, int, void (*)(int, int));
-/* 3B29D8 */ int hsd_803B29D8(s32* ctx, int channel, int size, UNK_T callback);
-/* 3B2A4C */ int hsd_803B2A4C(s32*, int, int, void (*)(int, int));
+/* 3B29D8 */ int hsd_803B29D8(s32* ctx, int channel, u8* data, UNK_T callback);
+/* 3B2A4C */ int hsd_803B2A4C(s32*, int, u8*, void (*)(int, int));
 /* 3B2ADC */ int hsd_803B2ADC(s32* ctx, UNK_T data);
 
 #endif

--- a/src/sysdolphin/baselib/sislib.c
+++ b/src/sysdolphin/baselib/sislib.c
@@ -1853,6 +1853,7 @@ void HSD_SisLib_803A84BC(HSD_GObj* gobj, int pass)
                 GXPosition3f32(min_x, neg_max_y, depth);
                 GXTexCoord2f32(0.0F, 1.0F);
             }
+            GXEnd();
         }
         GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_TEXA, GX_CA_A0, GX_CA_ZERO);
         if (text->x4E != 0) {
@@ -2208,6 +2209,7 @@ void HSD_SisLib_803A84BC(HSD_GObj* gobj, int pass)
                                             GXPosition3f32(glyph_x, neg_quad_bottom, glyph_depth);
                                             GXTexCoord2f32(uv_left, uv_bottom);
                                         }
+                                        GXEnd();
                                     }
                                     text->current_width = (f32) ((text->x88 * (text->x80.x * (32.0F + text->x78.x))) + text->current_width);
                                     if ((u8) text->kerning != 0) {


### PR DESCRIPTION
GXEnd is a noop in melee, so there were some missing ones that the decomp mixed.

Additionally I also resolved the names and structure for some of the memory card & save related variables, in theory it should be matching.