### PR TITLE
Replace all `inline` with `static inline`

### DIFF
--- a/src/MSL/ansi_fp.c
+++ b/src/MSL/ansi_fp.c
@@ -6,7 +6,7 @@
 #define __LO(x) (((s32*) &x)[1])
 
 /// @todo somehow make this work with math.h
-inline int _fpclassify(double x)
+static inline int _fpclassify(double x)
 {
     switch (__HI(x) & 0x7FF00000) {
     case 0x7FF00000: {

--- a/src/MSL/ctype.h
+++ b/src/MSL/ctype.h
@@ -23,23 +23,23 @@ extern const unsigned char __upper_map[];
 #define __control (__motion_char | __control_char)
 #define __zero_fill(c) ((int) (unsigned char) (c))
 
-inline int isalpha(int c)
+static inline int isalpha(int c)
 {
     return (int) (__ctype_map[(unsigned char) c] & __letter);
 }
-inline int isdigit(int c)
+static inline int isdigit(int c)
 {
     return (int) (__ctype_map[(unsigned char) c] & __digit);
 }
-inline int isspace(int c)
+static inline int isspace(int c)
 {
     return (int) (__ctype_map[(unsigned char) c] & __whitespace);
 }
-inline int isupper(int c)
+static inline int isupper(int c)
 {
     return (int) (__ctype_map[(unsigned char) c] & __upper_case);
 }
-inline int isxdigit(int c)
+static inline int isxdigit(int c)
 {
     return (int) (__ctype_map[(unsigned char) c] & __hex_digit);
 }

--- a/src/MSL/limits.h
+++ b/src/MSL/limits.h
@@ -36,17 +36,17 @@ extern "C" {
 namespace std {
     template <typename T> class numeric_limits {
     public:
-        inline static T min();
-        inline static T max();
+        static inline T min();
+        static inline T max();
     };
 
     template <> class numeric_limits<char> {
     public:
-        inline static char min()
+        static inline char min()
         {
             return -0x80;
         }
-        inline static char max()
+        static inline char max()
         {
             return 0x7F;
         }
@@ -54,11 +54,11 @@ namespace std {
 
     template <> class numeric_limits<short> {
     public:
-        inline static short min()
+        static inline short min()
         {
             return -0x8000;
         }
-        inline static short max()
+        static inline short max()
         {
             return 0x7FFF;
         }
@@ -66,11 +66,11 @@ namespace std {
 
     template <> class numeric_limits<int> {
     public:
-        inline static int min()
+        static inline int min()
         {
             return -0x80000000;
         }
-        inline static int max()
+        static inline int max()
         {
             return 0x7FFFFFFF;
         }
@@ -78,11 +78,11 @@ namespace std {
 
     template <> class numeric_limits<long> {
     public:
-        inline static long min()
+        static inline long min()
         {
             return -0x80000000;
         }
-        inline static long max()
+        static inline long max()
         {
             return 0x7FFFFFFF;
         }
@@ -90,11 +90,11 @@ namespace std {
 
     template <> class numeric_limits<unsigned char> {
     public:
-        inline static unsigned char min()
+        static inline unsigned char min()
         {
             return 0x0;
         }
-        inline static unsigned char max()
+        static inline unsigned char max()
         {
             return 0xFF;
         }
@@ -102,11 +102,11 @@ namespace std {
 
     template <> class numeric_limits<unsigned short> {
     public:
-        inline static unsigned short min()
+        static inline unsigned short min()
         {
             return 0x0;
         }
-        inline static unsigned short max()
+        static inline unsigned short max()
         {
             return 0xFFFF;
         }
@@ -114,11 +114,11 @@ namespace std {
 
     template <> class numeric_limits<unsigned int> {
     public:
-        inline static unsigned int min()
+        static inline unsigned int min()
         {
             return 0x0;
         }
-        inline static unsigned int max()
+        static inline unsigned int max()
         {
             return 0xFFFFFFFF;
         }
@@ -126,11 +126,11 @@ namespace std {
 
     template <> class numeric_limits<unsigned long> {
     public:
-        inline static unsigned long min()
+        static inline unsigned long min()
         {
             return 0x0;
         }
-        inline static unsigned long max()
+        static inline unsigned long max()
         {
             return 0xFFFFFFFF;
         }

--- a/src/MSL/math_ppc.h
+++ b/src/MSL/math_ppc.h
@@ -29,7 +29,7 @@ extern inline float sqrtf(float x)
 #pragma pop
 #endif
 
-inline float sqrtf_accurate(float x)
+static inline float sqrtf_accurate(float x)
 {
     volatile float y;
     if (x > 0.0f) {

--- a/src/melee/cm/camera.c
+++ b/src/melee/cm/camera.c
@@ -680,7 +680,7 @@ void Camera_8002958C(CameraBounds* bounds, CameraTransformState* transform)
 }
 
 static inline float get_follow_speed(float temp_f4, float spread,
-                              CameraUnkGlobals* globals)
+                                     CameraUnkGlobals* globals)
 {
     if (spread > temp_f4) {
         return globals->x30;

--- a/src/melee/cm/camera.c
+++ b/src/melee/cm/camera.c
@@ -679,7 +679,7 @@ void Camera_8002958C(CameraBounds* bounds, CameraTransformState* transform)
     new_bounds->z_pos = z_pos;
 }
 
-inline float get_follow_speed(float temp_f4, float spread,
+static inline float get_follow_speed(float temp_f4, float spread,
                               CameraUnkGlobals* globals)
 {
     if (spread > temp_f4) {
@@ -693,7 +693,7 @@ inline float get_follow_speed(float temp_f4, float spread,
     }
 }
 
-inline float get_delta(float temp_f)
+static inline float get_delta(float temp_f)
 {
     if (temp_f > 0.0001f) {
         return 1.0f / temp_f;
@@ -1002,7 +1002,7 @@ void Camera_8002A28C(CameraBounds* arg0)
 
 /// @note doesnt check all stages...
 /// probably was a bandaid for problem stages
-inline float get_stage_floor_height(GrKind kind)
+static inline float get_stage_floor_height(GrKind kind)
 {
     float height = -F32_MAX;
     switch (kind) {
@@ -1567,17 +1567,17 @@ void Camera_8002B3D4(void* arg0)
     update_avg_bounds_width();
 }
 
-inline HSD_PadStatus* get_slot_pad(u8 arg0)
+static inline HSD_PadStatus* get_slot_pad(u8 arg0)
 {
     return &HSD_PadCopyStatus[arg0];
 }
 
-inline f32 get_stick_x(HSD_PadStatus* arg0)
+static inline f32 get_stick_x(HSD_PadStatus* arg0)
 {
     return arg0->nml_stickX;
 }
 
-inline f32 get_stick_y(HSD_PadStatus* arg0)
+static inline f32 get_stick_y(HSD_PadStatus* arg0)
 {
     return arg0->nml_stickY;
 }

--- a/src/melee/ef/eflib.c
+++ b/src/melee/ef/eflib.c
@@ -86,7 +86,7 @@ void inline eflib_create_generator_add_appsrt(HSD_Generator** generator,
     }
 }
 
-inline EF_Effect* eflib_create_effect_and_attach(int gfx_id, HSD_GObj* gobj,
+static inline EF_Effect* eflib_create_effect_and_attach(int gfx_id, HSD_GObj* gobj,
                                                  HSD_JObj* jobj)
 {
     EF_Effect* effect = efLib_Create(gfx_id, gobj);
@@ -106,7 +106,7 @@ inline EF_Effect* eflib_create_effect_and_attach(int gfx_id, HSD_GObj* gobj,
     return effect;
 }
 
-inline HSD_Generator* eflib_generator_add_appsrt(HSD_Generator* generator,
+static inline HSD_Generator* eflib_generator_add_appsrt(HSD_Generator* generator,
                                                  s32 status)
 {
     HSD_psAppSRT* psAppSRT;

--- a/src/melee/ef/eflib.c
+++ b/src/melee/ef/eflib.c
@@ -86,8 +86,8 @@ void inline eflib_create_generator_add_appsrt(HSD_Generator** generator,
     }
 }
 
-static inline EF_Effect* eflib_create_effect_and_attach(int gfx_id, HSD_GObj* gobj,
-                                                 HSD_JObj* jobj)
+static inline EF_Effect*
+eflib_create_effect_and_attach(int gfx_id, HSD_GObj* gobj, HSD_JObj* jobj)
 {
     EF_Effect* effect = efLib_Create(gfx_id, gobj);
     if ((effect) != NULL) {
@@ -106,8 +106,8 @@ static inline EF_Effect* eflib_create_effect_and_attach(int gfx_id, HSD_GObj* go
     return effect;
 }
 
-static inline HSD_Generator* eflib_generator_add_appsrt(HSD_Generator* generator,
-                                                 s32 status)
+static inline HSD_Generator*
+eflib_generator_add_appsrt(HSD_Generator* generator, s32 status)
 {
     HSD_psAppSRT* psAppSRT;
 

--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -3015,12 +3015,12 @@ static inline bool ftCo_800A648C_inline1(Item* ip)
     return false;
 }
 
-inline HSD_GObj* ftCo_800A648C_inline2(void)
+static inline HSD_GObj* ftCo_800A648C_inline2(void)
 {
     return HSD_GObj_Entities->items;
 }
 
-inline HSD_GObj* ftCo_800A648C_inline3(HSD_GObj* cur)
+static inline HSD_GObj* ftCo_800A648C_inline3(HSD_GObj* cur)
 {
     return cur->next;
 }

--- a/src/melee/ft/chara/ftCommon/ftCo_FlyReflect.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_FlyReflect.c
@@ -83,7 +83,7 @@ bool ftCo_800C1718(Fighter_GObj* gobj)
 }
 #pragma pop
 
-inline bool ftCo_800C1718_inline(Fighter_GObj* gobj)
+static inline bool ftCo_800C1718_inline(Fighter_GObj* gobj)
 {
     u32 pad = 0;
     Fighter* fp = GET_FIGHTER(gobj);
@@ -151,7 +151,7 @@ bool ftCo_800C17CC(Fighter_GObj* gobj)
     return 0;
 }
 
-inline float fake_sqrtf(float x)
+static inline float fake_sqrtf(float x)
 {
     u32 pad = 0;
     u32 pad2 = 0;

--- a/src/melee/ft/chara/ftCommon/ftCo_ItemThrow.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_ItemThrow.c
@@ -322,7 +322,7 @@ void ftCo_80095744(Fighter_GObj* gobj, int* arg1)
     Item_8026ABD8(fp->item_gobj, &vec, 1);
 }
 
-inline float getAnimSpeed(Fighter_GObj* gobj, int msid)
+static inline float getAnimSpeed(Fighter_GObj* gobj, int msid)
 {
     Fighter* fp;
     float speed = 1;

--- a/src/melee/ft/chara/ftCommon/ftCo_Throw.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_Throw.c
@@ -265,7 +265,7 @@ bool fn_800DD6E4(Fighter_GObj* gobj, int arg)
     return false;
 }
 
-inline static bool ftCo_800DD724_inline1(Fighter* fp)
+static inline bool ftCo_800DD724_inline1(Fighter* fp)
 {
     if (fp->throw_flags_b4) {
         fp->throw_flags_b4 = 0;
@@ -274,7 +274,7 @@ inline static bool ftCo_800DD724_inline1(Fighter* fp)
     return false;
 }
 
-inline static bool ftCo_800DD724_inline2(Fighter* fp)
+static inline bool ftCo_800DD724_inline2(Fighter* fp)
 {
     if (fp->throw_flags_b3) {
         fp->throw_flags_b3 = 0;

--- a/src/melee/ft/chara/ftCommon/ftpickupitem.c
+++ b/src/melee/ft/chara/ftCommon/ftpickupitem.c
@@ -82,7 +82,7 @@ bool ftpickupitem_80094150(Fighter_GObj* gobj, Item_GObj* item_gobj)
     return false;
 }
 
-inline itPickup* ftpickupitem_800942A0_inline(Fighter* fp)
+static inline itPickup* ftpickupitem_800942A0_inline(Fighter* fp)
 {
     return &fp->x294_itPickup;
 }

--- a/src/melee/ft/chara/ftCrazyHand/ftCh_TagGrab.c
+++ b/src/melee/ft/chara/ftCrazyHand/ftCh_TagGrab.c
@@ -23,7 +23,7 @@
 #include <dolphin/mtx.h>
 #include <MetroTRK/intrinsics.h>
 
-inline void func_8015ADD0_inline(HSD_GObj* gobj)
+static inline void func_8015ADD0_inline(HSD_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
     ftCrazyHand_DatAttrs* da = fp->ft_data->ext_attr;

--- a/src/melee/ft/chara/ftCrazyHand/ftCh_Wait1_0.c
+++ b/src/melee/ft/chara/ftCrazyHand/ftCh_Wait1_0.c
@@ -136,7 +136,7 @@ static void ftCh_Init_80156310(HSD_GObj* gobj)
     ftCh_Init_80156018(gobj);
 }
 
-inline void doAnim0(HSD_GObj* gobj)
+static inline void doAnim0(HSD_GObj* gobj)
 {
     /// @todo #GET_FIGHTER
     Fighter* fp = gobj->user_data;
@@ -154,7 +154,7 @@ inline void doAnim0(HSD_GObj* gobj)
     fp->u.mh.x2258 = 0x156;
 }
 
-inline void doAnim1(HSD_GObj* gobj)
+static inline void doAnim1(HSD_GObj* gobj)
 {
     /// @todo #GET_FIGHTER
     Fighter* fp = gobj->user_data;

--- a/src/melee/ft/chara/ftFox/ftFx_SpecialHi.c
+++ b/src/melee/ft/chara/ftFox/ftFx_SpecialHi.c
@@ -737,7 +737,7 @@ void ftFx_SpecialHiBound_Coll(HSD_GObj* gobj)
     }
 }
 
-inline void ftFox_SpecialHiBound_SetVars(HSD_GObj* gobj)
+static inline void ftFox_SpecialHiBound_SetVars(HSD_GObj* gobj)
 {
     vf32 f; // I have a feeling this is a Vec3 struct however
     Fighter* fp = fp = gobj->user_data;

--- a/src/melee/ft/chara/ftFox/ftFx_SpecialLw.c
+++ b/src/melee/ft/chara/ftFox/ftFx_SpecialLw.c
@@ -585,7 +585,7 @@ void ftFx_SpecialAirLwTurn_Coll(HSD_GObj* gobj)
     }
 }
 
-inline void ftFox_SpecialLw_SetReflectVars(HSD_GObj* gobj)
+static inline void ftFox_SpecialLw_SetReflectVars(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     fp->reflecting = true;
@@ -617,7 +617,7 @@ void ftFx_SpecialAirLwTurn_GroundToAir(HSD_GObj* gobj)
     ftFox_SpecialLw_SetReflectVars(gobj);
 }
 
-inline void ftFox_SpecialLwTurn_SetVarAll(HSD_GObj* gobj)
+static inline void ftFox_SpecialLwTurn_SetVarAll(HSD_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
     ftFox_DatAttrs* da = getFtSpecialAttrs(fp);
@@ -652,7 +652,7 @@ bool ftFx_SpecialLwTurn_Check(HSD_GObj* gobj)
     return false;
 }
 
-inline void ftFox_SpecialLwHit_CreateReflectInline(HSD_GObj* gobj)
+static inline void ftFox_SpecialLwHit_CreateReflectInline(HSD_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
     ftFox_DatAttrs* da = getFtSpecialAttrs(fp);

--- a/src/melee/ft/chara/ftFox/ftFx_SpecialN.c
+++ b/src/melee/ft/chara/ftFox/ftFx_SpecialN.c
@@ -135,7 +135,7 @@ bool ftFx_SpecialN_CheckBlasterAction(HSD_GObj* gobj)
     return true;
 }
 
-inline void ftFox_SpecialN_SetNULL(HSD_GObj* gobj)
+static inline void ftFox_SpecialN_SetNULL(HSD_GObj* gobj)
 {
     Fighter* fp = fp = GET_FIGHTER(gobj);
     fp->take_dmg_cb = NULL;
@@ -229,7 +229,7 @@ void ftFx_SpecialN_CreateBlasterShot(HSD_GObj* gobj)
     }
 }
 
-inline void ftFox_SpecialN_SetCall(HSD_GObj* gobj)
+static inline void ftFox_SpecialN_SetCall(HSD_GObj* gobj)
 {
     Fighter* fp = fp = GET_FIGHTER(gobj);
     fp->take_dmg_cb = ftFx_Init_800E5588;

--- a/src/melee/ft/chara/ftFox/ftFx_SpecialS.c
+++ b/src/melee/ft/chara/ftFox/ftFx_SpecialS.c
@@ -417,7 +417,7 @@ void ftFx_SpecialAirS_AirToGround(HSD_GObj* gobj)
     fp->cmd_vars[2] = 0;
 }
 
-inline void ftFox_SpecialS_SetVars(HSD_GObj* gobj)
+static inline void ftFox_SpecialS_SetVars(HSD_GObj* gobj)
 {
     float var;
     Fighter* fp = GET_FIGHTER(gobj);
@@ -568,7 +568,7 @@ void ftFx_SpecialAirSEnd_Coll(HSD_GObj* gobj)
     }
 };
 
-inline void ftFox_SpecialSEnd_SetVars(HSD_GObj* gobj)
+static inline void ftFox_SpecialSEnd_SetVars(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftFox_DatAttrs* da = getFtSpecialAttrs(fp);

--- a/src/melee/ft/chara/ftGameWatch/ftGw_SpecialLw.c
+++ b/src/melee/ft/chara/ftGameWatch/ftGw_SpecialLw.c
@@ -137,7 +137,7 @@ void ftGw_SpecialLw_UpdateBucketModel(HSD_GObj* gobj)
     }
 }
 
-inline void ftGameWatch_SpecialLw_SetVars(HSD_GObj* gobj)
+static inline void ftGameWatch_SpecialLw_SetVars(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     fp->cmd_vars[1] = 0;

--- a/src/melee/ft/chara/ftKirby/ftkirbyspecialfox.c
+++ b/src/melee/ft/chara/ftKirby/ftkirbyspecialfox.c
@@ -272,7 +272,7 @@ void ftKb_SpecialNFx_CreateBlasterShot(Fighter_GObj* gobj)
     ftKb_SpecialNFx_800FDF30(gobj);
 }
 
-inline FtMotionId ftKbGetStartMotionId(HSD_GObj* gobj)
+static inline FtMotionId ftKbGetStartMotionId(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     FtMotionId msid = ftKb_MS_FxSpecialNStart;
@@ -339,7 +339,7 @@ void ftKb_SpecialNFx_800FE100(HSD_GObj* gobj)
     HSD_ASSERT(429, 0);
 }
 
-inline FtMotionId ftKbGetAirStartMotionId(HSD_GObj* gobj)
+static inline FtMotionId ftKbGetAirStartMotionId(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     FtMotionId msid = ftKb_MS_FxSpecialAirNStart;
@@ -399,7 +399,7 @@ void ftKb_SpecialNFx_800FE240(HSD_GObj* gobj)
     HSD_ASSERT(465, 0);
 }
 
-inline FtMotionId ftKbGetLoopMotionId(HSD_GObj* gobj)
+static inline FtMotionId ftKbGetLoopMotionId(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     FtMotionId msid = ftKb_MS_FxSpecialNLoop;
@@ -435,7 +435,7 @@ void ftKb_FxSpecialNStart_Anim(HSD_GObj* gobj)
     }
 }
 
-inline FtMotionId ftKbGetEndMotionId(HSD_GObj* gobj)
+static inline FtMotionId ftKbGetEndMotionId(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     FtMotionId msid = ftKb_MS_FxSpecialNEnd;
@@ -507,7 +507,7 @@ void ftKb_FxSpecialNEnd_Anim(Fighter_GObj* gobj)
     }
 }
 
-inline FtMotionId ftKbGetAirLoopMotionId(HSD_GObj* gobj)
+static inline FtMotionId ftKbGetAirLoopMotionId(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     FtMotionId msid = ftKb_MS_FxSpecialAirNLoop;
@@ -543,7 +543,7 @@ void ftKb_FxSpecialAirNStart_Anim(HSD_GObj* gobj)
     }
 }
 
-inline FtMotionId ftKbGetAirEndMotionId(HSD_GObj* gobj)
+static inline FtMotionId ftKbGetAirEndMotionId(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     FtMotionId msid = ftKb_MS_FxSpecialAirNEnd;

--- a/src/melee/ft/chara/ftKirby/ftkirbyspecialgamewatch.c
+++ b/src/melee/ft/chara/ftKirby/ftkirbyspecialgamewatch.c
@@ -163,7 +163,7 @@ bool ftKb_SpecialNGw_8010D160(Fighter_GObj* gobj)
 }
 
 /// #ftGameWatch_SpecialN_SetVars with callback arg
-inline void setGwVars(HSD_GObj* fighter_gobj)
+static inline void setGwVars(HSD_GObj* fighter_gobj)
 {
     Fighter* fp = GET_FIGHTER(fighter_gobj);
     fp->cmd_vars[0] = 0;

--- a/src/melee/ft/chara/ftKirby/ftkirbyspecialkoopa.c
+++ b/src/melee/ft/chara/ftKirby/ftkirbyspecialkoopa.c
@@ -195,7 +195,7 @@ void ftKb_KpSpecialNStart_Anim(Fighter_GObj* gobj)
     }
 }
 
-inline ftKb_DatAttrs* ftKb_KpSpecialN_Anim_inline(Fighter* arg0)
+static inline ftKb_DatAttrs* ftKb_KpSpecialN_Anim_inline(Fighter* arg0)
 {
     return arg0->dat_attrs;
 }

--- a/src/melee/ft/chara/ftKirby/ftkirbyspecialmars.c
+++ b/src/melee/ft/chara/ftKirby/ftkirbyspecialmars.c
@@ -60,7 +60,7 @@ void fn_8010B2E8(Fighter_GObj* gobj)
     fp->mv.kb.specialn_ms.cur_frame = 0;
 }
 
-inline void setupStartAccessory(HSD_GObj* gobj, Vec3* scale)
+static inline void setupStartAccessory(HSD_GObj* gobj, Vec3* scale)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     HSD_JObj* jobj;
@@ -249,7 +249,7 @@ void ftKb_MsSpecialAirNStart_Coll(Fighter_GObj* gobj)
     }
 }
 
-inline FtMotionId getAirSpecialMotionId(Fighter_GObj* gobj)
+static inline FtMotionId getAirSpecialMotionId(Fighter_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     if (fp->u.kb.hat.kind == FTKIND_MARS) {
@@ -268,7 +268,7 @@ void ftKb_SpecialNMs_8010B868(Fighter_GObj* gobj)
                               fp->cur_anim_frame, 1.0f, 0.0f, NULL);
 }
 
-inline FtMotionId getGroundSpecialMotionId(Fighter_GObj* gobj)
+static inline FtMotionId getGroundSpecialMotionId(Fighter_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     if (fp->u.kb.hat.kind == FTKIND_MARS) {

--- a/src/melee/ft/chara/ftKirby/ftkirbyspecialmewtwo.c
+++ b/src/melee/ft/chara/ftKirby/ftkirbyspecialmewtwo.c
@@ -195,7 +195,7 @@ check:
     efLib_DestroyAll(gobj);
 }
 
-inline void ftKb_SpecialNMt_SetRecoil(Fighter_GObj* gobj)
+static inline void ftKb_SpecialNMt_SetRecoil(Fighter_GObj* gobj)
 {
     Fighter* fp = fp = GET_FIGHTER(gobj);
     ftKb_DatAttrs* da = da = fp->dat_attrs;
@@ -607,7 +607,7 @@ void ftKb_MtSpecialAirNLoopFull_Anim(Fighter_GObj* gobj)
     ft->u.kb.x9C = da->specialn_mt_charge_time;
 }
 
-inline Item_GObj* ftKb_MtSpecialAirNCancel_Anim_inline(Item_GObj* arg0)
+static inline Item_GObj* ftKb_MtSpecialAirNCancel_Anim_inline(Item_GObj* arg0)
 {
     return arg0;
 }

--- a/src/melee/ft/chara/ftKirby/ftkirbyspecialn.c
+++ b/src/melee/ft/chara/ftKirby/ftkirbyspecialn.c
@@ -706,7 +706,7 @@ void ftKb_SpecialLw1_Anim(Fighter_GObj* gobj)
     }
 }
 
-inline void ftKbUnkInline(Fighter_GObj* gobj, int val)
+static inline void ftKbUnkInline(Fighter_GObj* gobj, int val)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     fp->x221C_b4 = val;
@@ -3494,7 +3494,7 @@ static inline void fn_800F9260_DrMario(HSD_GObj* gobj, Fighter* fp, Vec3* pos)
                         fp->facing_dir);
 }
 
-inline s32 fn_800F9260_inline(HSD_GObj* gobj)
+static inline s32 fn_800F9260_inline(HSD_GObj* gobj)
 {
     Fighter* fp2;
     s32 candidates[9];

--- a/src/melee/ft/chara/ftKirby/ftkirbyspecialpikachu.c
+++ b/src/melee/ft/chara/ftKirby/ftkirbyspecialpikachu.c
@@ -49,7 +49,7 @@ void ftKb_SpecialNPk_800F9FD4(Fighter_GObj* gobj)
     ftAnim_8006EBA4(gobj);
 }
 
-inline void ftKb_SpecialN_set_cbs(Fighter_GObj* gobj)
+static inline void ftKb_SpecialN_set_cbs(Fighter_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     fp->death2_cb = (void (*)(HSD_GObj*)) ftKb_Init_800EE74C;

--- a/src/melee/ft/chara/ftKoopa/ftKp_SpecialS.c
+++ b/src/melee/ft/chara/ftKoopa/ftKp_SpecialS.c
@@ -487,11 +487,11 @@ void ftKp_SpecialAirSEndB_Anim(HSD_GObj* gobj)
     doEndBAnim(gobj, ftCo_Fall_Enter);
 }
 
-static inline void ftKoopa_SpecialS_ChangeAction(HSD_GObj* gobj,
-                                          ftKoopa_MotionState kp_msid_f,
-                                          ftCommon_MotionState victim_msid_f,
-                                          ftKoopa_MotionState kp_msid_b,
-                                          ftCommon_MotionState victim_msid_b)
+static inline void
+ftKoopa_SpecialS_ChangeAction(HSD_GObj* gobj, ftKoopa_MotionState kp_msid_f,
+                              ftCommon_MotionState victim_msid_f,
+                              ftKoopa_MotionState kp_msid_b,
+                              ftCommon_MotionState victim_msid_b)
 {
     Fighter* fp = fp = GET_FIGHTER(gobj);
     fp->throw_flags = 0;

--- a/src/melee/ft/chara/ftKoopa/ftKp_SpecialS.c
+++ b/src/melee/ft/chara/ftKoopa/ftKp_SpecialS.c
@@ -383,7 +383,7 @@ void ftKp_SpecialSHit_Anim(HSD_GObj* gobj)
     }
 }
 
-inline void inlineA0(HSD_GObj* gobj)
+static inline void inlineA0(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     if (fp->mv.kp.specials.x4) {
@@ -487,7 +487,7 @@ void ftKp_SpecialAirSEndB_Anim(HSD_GObj* gobj)
     doEndBAnim(gobj, ftCo_Fall_Enter);
 }
 
-inline void ftKoopa_SpecialS_ChangeAction(HSD_GObj* gobj,
+static inline void ftKoopa_SpecialS_ChangeAction(HSD_GObj* gobj,
                                           ftKoopa_MotionState kp_msid_f,
                                           ftCommon_MotionState victim_msid_f,
                                           ftKoopa_MotionState kp_msid_b,
@@ -529,7 +529,7 @@ void ftKp_SpecialAirSHit_IASA(HSD_GObj* gobj)
     }
 }
 
-inline void ftKp_SpecialSWait_IASA_inline(HSD_GObj* gobj)
+static inline void ftKp_SpecialSWait_IASA_inline(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     if (fp->mv.kp.specials.x4) {

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Damage_0.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Damage_0.c
@@ -27,7 +27,7 @@ bool ftMh_MS_343_80151428(Vec3* vec)
     return false;
 }
 
-inline void func_80151484_inline1(HSD_GObj* gobj)
+static inline void func_80151484_inline1(HSD_GObj* gobj)
 {
     /// @todo #GET_FIGHTER
     Fighter* fp = gobj->user_data;

--- a/src/melee/ft/chara/ftMasterHand/ftMh_Wait1_0.c
+++ b/src/melee/ft/chara/ftMasterHand/ftMh_Wait1_0.c
@@ -170,7 +170,7 @@ struct MasterHandDataStuff ftMh_Init_803D40D0 = {
       0, 1, 2, 4, 0, 0, 1, 2, 3, 0, 0, 0, 0, 0, 0 }
 };
 
-inline void doAnim0(HSD_GObj* gobj)
+static inline void doAnim0(HSD_GObj* gobj)
 {
     /// @todo #GET_FIGHTER
     Fighter* fp = gobj->user_data;
@@ -188,7 +188,7 @@ inline void doAnim0(HSD_GObj* gobj)
     fp->u.mh.x2258 = ftMh_MS_Wait2_0;
 }
 
-inline void doAnim1(HSD_GObj* gobj)
+static inline void doAnim1(HSD_GObj* gobj)
 {
     /// @todo #GET_FIGHTER
     Fighter* fp = gobj->user_data;

--- a/src/melee/ft/chara/ftMewtwo/ftMt_SpecialLw.c
+++ b/src/melee/ft/chara/ftMewtwo/ftMt_SpecialLw.c
@@ -146,7 +146,7 @@ void ftMt_SpecialAirLw_Phys(HSD_GObj* gobj)
     ftCommon_ApplyFrictionAir(fp, ca->aerial_friction);
 }
 
-inline void ftMewtwo_SpecialLw_SetCall(HSD_GObj* gobj)
+static inline void ftMewtwo_SpecialLw_SetCall(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     if (fp->u.mt.x222C_disableGObj != NULL) {

--- a/src/melee/ft/chara/ftMewtwo/ftMt_SpecialN.c
+++ b/src/melee/ft/chara/ftMewtwo/ftMt_SpecialN.c
@@ -497,8 +497,8 @@ void ftMt_SpecialNStart_Anim(HSD_GObj* gobj)
     }
 }
 
-static inline void ftMewtwo_SpecialN_CreateHeldShadow(HSD_GObj* gobj, Vec3* pos1,
-                                               Vec3* pos2)
+static inline void ftMewtwo_SpecialN_CreateHeldShadow(HSD_GObj* gobj,
+                                                      Vec3* pos1, Vec3* pos2)
 {
     Fighter* fp = getFighter(gobj);
 

--- a/src/melee/ft/chara/ftMewtwo/ftMt_SpecialN.c
+++ b/src/melee/ft/chara/ftMewtwo/ftMt_SpecialN.c
@@ -359,7 +359,7 @@ void ftMt_SpecialN_PlayChargeSFX(HSD_GObj* gobj)
     }
 }
 
-inline void ftMewtwo_SpecialN_SetCall(HSD_GObj* gobj)
+static inline void ftMewtwo_SpecialN_SetCall(HSD_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
     fp->death2_cb = ftMt_Init_OnDeath2;
@@ -367,7 +367,7 @@ inline void ftMewtwo_SpecialN_SetCall(HSD_GObj* gobj)
     fp->death3_cb = ftMt_Init_OnDeath2;
 }
 
-inline void ftMewtwo_SpecialN_ChangeAction(HSD_GObj* gobj)
+static inline void ftMewtwo_SpecialN_ChangeAction(HSD_GObj* gobj)
 
 {
     Fighter* fp = getFighter(gobj);
@@ -409,7 +409,7 @@ void ftMt_SpecialN_Enter(HSD_GObj* gobj)
     ftMewtwo_SpecialN_ChangeAction(gobj);
 }
 
-inline void ftMewtwo_SpecialAirN_ChangeAction(HSD_GObj* gobj)
+static inline void ftMewtwo_SpecialAirN_ChangeAction(HSD_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
     ftMewtwoAttributes* mewtwoAttrs = getFtSpecialAttrsD(fp);
@@ -497,7 +497,7 @@ void ftMt_SpecialNStart_Anim(HSD_GObj* gobj)
     }
 }
 
-inline void ftMewtwo_SpecialN_CreateHeldShadow(HSD_GObj* gobj, Vec3* pos1,
+static inline void ftMewtwo_SpecialN_CreateHeldShadow(HSD_GObj* gobj, Vec3* pos1,
                                                Vec3* pos2)
 {
     Fighter* fp = getFighter(gobj);
@@ -584,7 +584,7 @@ void ftMt_SpecialNLoopFull_Anim(HSD_GObj* gobj)
         mewtwoAttrs->x0_MEWTWO_SHADOWBALL_CHARGE_CYCLES;
 }
 
-inline void ftMewtwo_SpecialN_RemoveShadowBall2(HSD_GObj* gobj)
+static inline void ftMewtwo_SpecialN_RemoveShadowBall2(HSD_GObj* gobj)
 {
     if (gobj != NULL) {
         Fighter* fp = getFighter(gobj);

--- a/src/melee/ft/chara/ftNess/ftNs_SpecialHi.c
+++ b/src/melee/ft/chara/ftNess/ftNs_SpecialHi.c
@@ -166,7 +166,7 @@ void ftNs_SpecialHiStopGFX(HSD_GObj* gobj) // Removes GFX
 }
 #pragma pop
 
-inline bool check_distance(Vec3* pos, Vec3* pair)
+static inline bool check_distance(Vec3* pos, Vec3* pair)
 {
     if ((ABS(pos->x - pair->x) < 8.333333015441895f) &&
         (ABS(pos->y - pair->y) < 12.333333015441895f))
@@ -639,7 +639,7 @@ block_stuff: {
 }
 }
 
-inline void
+static inline void
 NessFloatMath_PKThunder2(HSD_GObj* gobj) // Required for 0x80118570 to match
 {
     Fighter* fp;
@@ -1156,7 +1156,7 @@ void ftNs_SpecialAirHiRebound_IASA(HSD_GObj* gobj)
     return;
 }
 
-inline void ThunderPhysTimer(HSD_GObj* gobj)
+static inline void ThunderPhysTimer(HSD_GObj* gobj)
 {
     Fighter* temp_fp;
     s32 thunderPhysTimer;
@@ -1305,7 +1305,7 @@ void ftNs_SpecialAirHiEnd_Phys(HSD_GObj* gobj)
     }
 }
 
-inline void ftNess_atan2(HSD_GObj* gobj)
+static inline void ftNess_atan2(HSD_GObj* gobj)
 {
     Fighter* fighter_data2 = GET_FIGHTER(gobj);
 
@@ -1318,7 +1318,7 @@ inline void ftNess_atan2(HSD_GObj* gobj)
             (float) M_PI_2);
 }
 
-inline void* getFtSpecialAttrs2(Fighter* fp)
+static inline void* getFtSpecialAttrs2(Fighter* fp)
 {
     u8 _[4] = { 0 };
 

--- a/src/melee/ft/chara/ftNess/ftNs_SpecialLw.c
+++ b/src/melee/ft/chara/ftNess/ftNs_SpecialLw.c
@@ -663,7 +663,7 @@ bool ftNs_SpecialLwHold_GroundOrAir(
     return true;
 }
 
-inline void MagnetStateVarCalc(HSD_GObj* gobj)
+static inline void MagnetStateVarCalc(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     fp->mv.ns.speciallw.x10 = fp->mv.ns.speciallw.x10 - 1;

--- a/src/melee/ft/chara/ftNess/ftNs_SpecialN.c
+++ b/src/melee/ft/chara/ftNess/ftNs_SpecialN.c
@@ -276,7 +276,7 @@ void ftNs_SpecialNRelease_Anim(HSD_GObj* gobj)
 }
 
 /// Inline to set all variables and match ASM register data
-inline void SetPKFlashAttr(HSD_GObj* gobj)
+static inline void SetPKFlashAttr(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     ftNessAttributes* sa = fp->dat_attrs;
@@ -528,7 +528,7 @@ void ftNs_SpecialAirNRelease_IASA(HSD_GObj* gobj)
 void ftNs_SpecialAirNEnd_IASA(HSD_GObj* gobj) {}
 
 /// Inline to set remaining frames of gravity delay
-inline void GravityDelay(HSD_GObj* gobj)
+static inline void GravityDelay(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
 

--- a/src/melee/ft/chara/ftPurin/ftPr_SpecialHi.c
+++ b/src/melee/ft/chara/ftPurin/ftPr_SpecialHi.c
@@ -39,7 +39,7 @@ static inline void ftPurin_SpecialHi_SetVars(HSD_GObj* gobj)
     }
 }
 
-inline void ftPurin_SpecialHi_SetActionFromFacingDirection(HSD_GObj* gobj,
+static inline void ftPurin_SpecialHi_SetActionFromFacingDirection(HSD_GObj* gobj,
                                                            u32 left_id,
                                                            u32 right_id)
 {
@@ -52,7 +52,7 @@ inline void ftPurin_SpecialHi_SetActionFromFacingDirection(HSD_GObj* gobj,
     }
 }
 
-inline void startHi(HSD_GObj* gobj, int left_id, int right_id)
+static inline void startHi(HSD_GObj* gobj, int left_id, int right_id)
 {
     Fighter* fighter;
 

--- a/src/melee/ft/chara/ftPurin/ftPr_SpecialHi.c
+++ b/src/melee/ft/chara/ftPurin/ftPr_SpecialHi.c
@@ -39,9 +39,9 @@ static inline void ftPurin_SpecialHi_SetVars(HSD_GObj* gobj)
     }
 }
 
-static inline void ftPurin_SpecialHi_SetActionFromFacingDirection(HSD_GObj* gobj,
-                                                           u32 left_id,
-                                                           u32 right_id)
+static inline void
+ftPurin_SpecialHi_SetActionFromFacingDirection(HSD_GObj* gobj, u32 left_id,
+                                               u32 right_id)
 {
     Fighter* fighter = GET_FIGHTER(gobj);
 

--- a/src/melee/ft/chara/ftSamus/ftSs_SpecialLw_0.c
+++ b/src/melee/ft/chara/ftSamus/ftSs_SpecialLw_0.c
@@ -86,7 +86,7 @@ float ftSs_Init_80128AC8(HSD_GObj* gobj, float farg1, float farg2)
     return (-da->x4 * value) + 1.5707963705062866f;
 }
 
-inline void ftSamus_80128B1C_inner(HSD_GObj* gobj, float angle)
+static inline void ftSamus_80128B1C_inner(HSD_GObj* gobj, float angle)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     struct ftCo_DatAttrs* ftAttr = &fp->co_attrs;

--- a/src/melee/ft/chara/ftSamus/ftSs_SpecialLw_1.c
+++ b/src/melee/ft/chara/ftSamus/ftSs_SpecialLw_1.c
@@ -107,12 +107,12 @@ void ftSs_SpecialAirLw_Enter(HSD_GObj* gobj)
     ftSamus_SpecialLw_StartAction_inner(gobj);
 }
 
-inline static void setSamusBits(Fighter* fp, int val)
+static inline void setSamusBits(Fighter* fp, int val)
 {
     fp->mv.ss.unk6.x0 = val;
 }
 
-inline static void checkStateVar1(HSD_GObj* gobj)
+static inline void checkStateVar1(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
 

--- a/src/melee/ft/chara/ftSeak/ftSk_SpecialS.c
+++ b/src/melee/ft/chara/ftSeak/ftSk_SpecialS.c
@@ -288,7 +288,7 @@ void ftSk_SpecialS_80110AEC(HSD_GObj* gobj)
     }
 }
 
-inline void ftSeakSpecialS_LoopChainHitCollisions(HSD_GObj* gobj)
+static inline void ftSeakSpecialS_LoopChainHitCollisions(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     int i;
@@ -301,7 +301,7 @@ inline void ftSeakSpecialS_LoopChainHitCollisions(HSD_GObj* gobj)
     ftSk_SpecialS_ZeroHitboxPositions(gobj);
 }
 
-inline void ftSeakSpecialS_LoopChainHitActivate(HSD_GObj* gobj)
+static inline void ftSeakSpecialS_LoopChainHitActivate(HSD_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     int i;
@@ -314,7 +314,7 @@ inline void ftSeakSpecialS_LoopChainHitActivate(HSD_GObj* gobj)
     fp->x2219_b3 = true;
 }
 
-inline float sumOfSquares(float a, float b)
+static inline float sumOfSquares(float a, float b)
 {
     float c;
 

--- a/src/melee/ft/chara/ftYoshi/ftYs_SpecialLw.c
+++ b/src/melee/ft/chara/ftYoshi/ftYs_SpecialLw.c
@@ -45,7 +45,7 @@ void fn_8012E644(Fighter_GObj* gobj)
     fp->accessory4_cb = NULL;
 }
 
-inline void ftYoshi_SpecialLw_SetVars(HSD_GObj* arg0)
+static inline void ftYoshi_SpecialLw_SetVars(HSD_GObj* arg0)
 {
     Fighter* fp = GET_FIGHTER(arg0);
 

--- a/src/melee/ft/chara/ftZelda/ftZd_SpecialN.c
+++ b/src/melee/ft/chara/ftZelda/ftZd_SpecialN.c
@@ -46,7 +46,7 @@ void ftZd_SpecialN_8013A8AC(HSD_GObj* gobj)
     fp->accessory4_cb = NULL;
 }
 
-inline void startActionHelper(HSD_GObj* gobj)
+static inline void startActionHelper(HSD_GObj* gobj)
 {
     ftZelda_DatAttrs* attributes;
     Fighter* fighter2; // r5

--- a/src/melee/ft/fighter.c
+++ b/src/melee/ft/fighter.c
@@ -2731,7 +2731,7 @@ void Fighter_8006CFE0(Fighter_GObj* gobj)
     }
 }
 
-inline void setBit(Fighter_GObj* gobj)
+static inline void setBit(Fighter_GObj* gobj)
 {
     Fighter* fp = GET_FIGHTER(gobj);
     fp->x2219_b7 = 1;

--- a/src/melee/ft/ft_0852.c
+++ b/src/melee/ft/ft_0852.c
@@ -37,7 +37,7 @@ void ft_8008521C(HSD_GObj* gobj)
     fp->self_vel.z = pos.z - fp->cur_pos.z;
 }
 
-inline void ft_800852B0_Reset_ft_8045993C(ftData** list, int i)
+static inline void ft_800852B0_Reset_ft_8045993C(ftData** list, int i)
 {
     // Bitfields seem off but it is what it is
     ((ft_8045993C_t*) &list[FTKIND_MAX])[i].pad_x0 = 0;

--- a/src/melee/ft/ftcoll.c
+++ b/src/melee/ft/ftcoll.c
@@ -147,7 +147,7 @@ void ftColl_800764DC(Fighter_GObj* gobj)
     }
 }
 
-inline void comboCount_Push(Fighter* fp)
+static inline void comboCount_Push(Fighter* fp)
 {
     Vec3* pos = &fp->coll_data.floor.normal;
     float temp_f2;
@@ -515,7 +515,7 @@ void ftColl_80076CBC(Fighter* fp0, HitCapsule* hit0, Fighter* fp1)
 }
 
 /// @todo #ftColl_80076808
-inline void inlineB0(Fighter* fp0, HitCapsule* hitbox, Fighter* fp1, int arg3)
+static inline void inlineB0(Fighter* fp0, HitCapsule* hitbox, Fighter* fp1, int arg3)
 {
     size_t i;
     for (i = 0; i < ARRAY_SIZE(fp0->x914); i++) {
@@ -1537,12 +1537,12 @@ void ftColl_80078998(HSD_GObj* arg0, HSD_GObj* arg1, float arg2)
 }
 #pragma pop
 
-inline HitCapsule* HitCapsuleGetPtr(Fighter* fp, u32 i)
+static inline HitCapsule* HitCapsuleGetPtr(Fighter* fp, u32 i)
 {
     return &fp->x914[i];
 }
 
-inline void ftGrabDist(Fighter* this_fp, Fighter* victim_fp)
+static inline void ftGrabDist(Fighter* this_fp, Fighter* victim_fp)
 {
     float grab_dist = victim_fp->cur_pos.x - this_fp->cur_pos.x;
     if (grab_dist < 0) {
@@ -3093,7 +3093,7 @@ void ftColl_8007B6A0(Fighter_GObj* gobj)
     ftCo_800BFFD0(fp, 9, false);
 }
 
-inline enum_t inlineC0(Fighter* fp)
+static inline enum_t inlineC0(Fighter* fp)
 {
     return ftCo_800C0694(fp);
 }

--- a/src/melee/ft/ftcoll.c
+++ b/src/melee/ft/ftcoll.c
@@ -515,7 +515,8 @@ void ftColl_80076CBC(Fighter* fp0, HitCapsule* hit0, Fighter* fp1)
 }
 
 /// @todo #ftColl_80076808
-static inline void inlineB0(Fighter* fp0, HitCapsule* hitbox, Fighter* fp1, int arg3)
+static inline void inlineB0(Fighter* fp0, HitCapsule* hitbox, Fighter* fp1,
+                            int arg3)
 {
     size_t i;
     for (i = 0; i < ARRAY_SIZE(fp0->x914); i++) {

--- a/src/melee/ft/ftcommon.c
+++ b/src/melee/ft/ftcommon.c
@@ -918,7 +918,7 @@ void ftCommon_8007E2F4(Fighter* fp, s16 val)
     fp->x1A6A = val;
 }
 
-inline void _func_8007E2FC_inline(HSD_GObj* gobj)
+static inline void _func_8007E2FC_inline(HSD_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
     fp->xE4_ground_accel_1 = 0;
@@ -1489,7 +1489,7 @@ void ftCommon_8007F8E8(HSD_GObj* gobj)
 
 extern void (*ftData_UnkMotionStates1[])(HSD_GObj*);
 
-inline void _func_8007F948_inline(HSD_GObj* gobj)
+static inline void _func_8007F948_inline(HSD_GObj* gobj)
 {
     Fighter* fp = gobj->user_data;
     if (fp->x197C == NULL || fp->x1980 == NULL) {
@@ -1588,7 +1588,7 @@ void ftCommon_8007FC7C(HSD_GObj* gobj, float arg8)
     ft_PlaySFX(fp, 0x11F, 0x7F, 0x40);
 }
 
-inline float fminf(float a, float b)
+static inline float fminf(float a, float b)
 {
     float result = a;
     if (a > b) {

--- a/src/melee/ft/ftlib.c
+++ b/src/melee/ft/ftlib.c
@@ -217,7 +217,7 @@ Fighter_GObj* ftLib_80086368(Vec3* v, Fighter_GObj* gobj, float facing_dir)
     return result;
 }
 
-inline s32 sgn(float x)
+static inline s32 sgn(float x)
 {
     if (x < 0.0f) {
         return -1;
@@ -445,7 +445,7 @@ CollData* ftLib_80086984(HSD_GObj* gobj)
     return Fighter_GetCollData(fp);
 }
 
-inline void vector_add(Vec3* dst, Vec3* src, float x, float y, float z)
+static inline void vector_add(Vec3* dst, Vec3* src, float x, float y, float z)
 {
     dst->x = src->x + x;
     dst->y = src->y + y;
@@ -583,7 +583,7 @@ enum_t ftLib_GetMotionId(HSD_GObj* gobj)
     return fp->motion_id;
 }
 
-inline void helper(HSD_GObj* gobj, s32 arg1, s32 arg2, s32 val)
+static inline void helper(HSD_GObj* gobj, s32 arg1, s32 arg2, s32 val)
 {
     Fighter* fp = gobj->user_data;
 

--- a/src/melee/ft/inlines.h
+++ b/src/melee/ft/inlines.h
@@ -299,7 +299,7 @@ static inline int ftGetFacingDirInt2(Fighter_GObj* gobj)
 #define gmScriptEventUpdatePtr(event, type)                                   \
     (event = (void*) ((uintptr_t) event + 4))
 
-inline CommandInfo* getCmdScript(Fighter* fp)
+static inline CommandInfo* getCmdScript(Fighter* fp)
 {
     return &fp->x3E4_fighterCmdScript;
 }

--- a/src/melee/gm/gm_1832.c
+++ b/src/melee/gm/gm_1832.c
@@ -1977,7 +1977,7 @@ int fn_8018846C(void)
     return result;
 }
 
-inline int fn_801884F8_inline(void)
+static inline int fn_801884F8_inline(void)
 {
     int result;
     TrainingModeState* state = &lbl_80473700;
@@ -2738,7 +2738,7 @@ void gm_80189CDC(StartMeleeData* arg0)
     }
 }
 
-inline void resetText(HSD_Text* text)
+static inline void resetText(HSD_Text* text)
 {
     text->x34.x = 0.7f;
     text->x34.y = 0.6f;

--- a/src/melee/gm/gm_1A3F.c
+++ b/src/melee/gm/gm_1A3F.c
@@ -58,7 +58,7 @@ void gm_801A3F48(GameScene* scene)
     tyDisplay_8031C8B8();
 }
 
-inline u8 nextScene(GameScene* scenes)
+static inline u8 nextScene(GameScene* scenes)
 {
     int i;
     u8 next_scene;
@@ -78,7 +78,7 @@ inline u8 nextScene(GameScene* scenes)
     return next_scene;
 }
 
-inline GameScene* findScene(GameScene* scene)
+static inline GameScene* findScene(GameScene* scene)
 {
     int i, j;
     for (i = gm_80479D30.routing.curr_scene_idx; i < 0xFF; i++) {
@@ -243,7 +243,7 @@ bool gm_Is1PMode(u8 mode)
     return false;
 }
 
-inline GameMode* findMode(u8 idx)
+static inline GameMode* findMode(u8 idx)
 {
     GameMode* cur;
     for (cur = gm_GetAllGameModes(); cur->idx != GM_COUNT; cur++) {

--- a/src/melee/gm/gm_1A45.c
+++ b/src/melee/gm/gm_1A45.c
@@ -254,7 +254,7 @@ GameSceneHandler* gm_FindGameSceneHandler(u8 kind)
     return NULL;
 }
 
-inline u64 maybe_gm_801A48A4(u8 i)
+static inline u64 maybe_gm_801A48A4(u8 i)
 {
     u64 temp_ret = gm_801A48A4(i);
     if (gm_80479D58.unk_10.unk_38_0) {

--- a/src/melee/gm/inlines.h
+++ b/src/melee/gm/inlines.h
@@ -15,7 +15,7 @@ static inline s32 gmClampResultStat(s32 value)
 }
 
 /// @todo Figure out where this goes
-inline s32 fn_801A7FB4_inline(void)
+static inline s32 fn_801A7FB4_inline(void)
 {
     s32 i;
     s32 count;
@@ -28,7 +28,7 @@ inline s32 fn_801A7FB4_inline(void)
     return count;
 }
 
-inline s32 fn_801A7FB4_inline2(void)
+static inline s32 fn_801A7FB4_inline2(void)
 {
     s32 count;
     s32 i;

--- a/src/melee/gr/granime.c
+++ b/src/melee/gr/granime.c
@@ -638,8 +638,8 @@ arg4);
     }
 }*/
 
-static inline bool grAnime_801C6F50_wrapped(HSD_JObj* obj, int flags, void* func,
-                                     u32 type, void* param)
+static inline bool grAnime_801C6F50_wrapped(HSD_JObj* obj, int flags,
+                                            void* func, u32 type, void* param)
 {
     HSD_ASSERT(0x33A, obj);
     if (flags & 0x20) {

--- a/src/melee/gr/granime.c
+++ b/src/melee/gr/granime.c
@@ -115,7 +115,7 @@ void grAnime_801C6620(HSD_PObj* arg0, HSD_ShapeAnim* arg1)
     }
 }
 
-inline HSD_TexAnim* HSD_TexAnimFindById(HSD_TexAnim* cur, int id)
+static inline HSD_TexAnim* HSD_TexAnimFindById(HSD_TexAnim* cur, int id)
 {
     while (cur != NULL) {
         if ((signed) cur->id == id) {
@@ -141,7 +141,7 @@ void grAnime_801C6710(HSD_TObj* tobj, HSD_TexAnim* texanim)
     }
 }
 
-inline void grAnime_801C6710_all(HSD_TObj* tobj, HSD_TexAnim* texanim)
+static inline void grAnime_801C6710_all(HSD_TObj* tobj, HSD_TexAnim* texanim)
 {
     if (tobj != NULL) {
         while (tobj != NULL) {
@@ -225,7 +225,7 @@ void grAnime_801C68F4(HSD_RObj* robj, HSD_RObjAnimJoint* robjanimjoint)
     }
 }
 
-inline void grAnime_801C6960(HSD_RObj* robj, HSD_RObjAnimJoint* arg1)
+static inline void grAnime_801C6960(HSD_RObj* robj, HSD_RObjAnimJoint* arg1)
 {
     HSD_RObj* phi_r31;
     HSD_RObjAnimJoint* phi_r30;
@@ -638,7 +638,7 @@ arg4);
     }
 }*/
 
-inline bool grAnime_801C6F50_wrapped(HSD_JObj* obj, int flags, void* func,
+static inline bool grAnime_801C6F50_wrapped(HSD_JObj* obj, int flags, void* func,
                                      u32 type, void* param)
 {
     HSD_ASSERT(0x33A, obj);

--- a/src/melee/gr/grbattle.c
+++ b/src/melee/gr/grbattle.c
@@ -330,7 +330,7 @@ void grBattle_GObj4_Callback2(Ground_GObj* gobj) {}
 
 void grBattle_GObj4_Callback3(Ground_GObj* gobj) {}
 
-inline void reset_bg_timer(Ground* gp)
+static inline void reset_bg_timer(Ground* gp)
 {
     gp->u.battle_bg.timer = HSD_Randi(1200) + 2400;
 }

--- a/src/melee/gr/grcastle.c
+++ b/src/melee/gr/grcastle.c
@@ -1059,7 +1059,7 @@ void grCastle_801CE9E8(Ground_GObj* gobj)
 
 void grCastle_801CEAC8(Ground_GObj* gobj) {}
 
-inline void zero(Ground* gp, int i, f32 zero)
+static inline void zero(Ground* gp, int i, f32 zero)
 {
     gp->u.castle10.jobjs[i] = NULL;
     gp->u.castle10.effect_a[i] = NULL;

--- a/src/melee/gr/grdynamicattr.c
+++ b/src/melee/gr/grdynamicattr.c
@@ -90,7 +90,7 @@ void grDynamicAttr_801CA224(void)
     }
 }
 
-inline f32 do_sqrtf(f32 x)
+static inline f32 do_sqrtf(f32 x)
 {
     return sqrtf(x);
 }

--- a/src/melee/gr/grgarden.c
+++ b/src/melee/gr/grgarden.c
@@ -300,7 +300,7 @@ bool grGarden_80203248(Ground_GObj* arg)
     return false;
 }
 
-inline float absoluteValue(float fVar1)
+static inline float absoluteValue(float fVar1)
 {
     if (fVar1 < 0.0f) {
         fVar1 = -fVar1;

--- a/src/melee/gr/grinishie1.c
+++ b/src/melee/gr/grinishie1.c
@@ -861,7 +861,7 @@ void grInishie1_801FBCEC(HSD_GObj* gobj, u32 index)
     Camera_80030E44(2, &effect_pos);
 }
 
-inline Item* GET_ITEM2(Item_GObj* arg0)
+static inline Item* GET_ITEM2(Item_GObj* arg0)
 {
     return arg0->user_data;
 }

--- a/src/melee/gr/grlib.c
+++ b/src/melee/gr/grlib.c
@@ -111,7 +111,7 @@ void grLib_801C98A0(HSD_JObj* jobj)
     }
 }
 
-inline HSD_JObj* jobj_child(HSD_JObj* node)
+static inline HSD_JObj* jobj_child(HSD_JObj* node)
 {
     if (node == NULL) {
         return NULL;
@@ -119,7 +119,7 @@ inline HSD_JObj* jobj_child(HSD_JObj* node)
     return node->child;
 }
 
-inline HSD_JObj* jobj_next(HSD_JObj* node)
+static inline HSD_JObj* jobj_next(HSD_JObj* node)
 {
     if (node == NULL) {
         return NULL;

--- a/src/melee/gr/grmaterial.c
+++ b/src/melee/gr/grmaterial.c
@@ -549,7 +549,7 @@ void grMaterial_801C95C4(HSD_GObj* gobj)
 }
 
 // TODO: is this GET_GROUND? calling it directly didn't work.
-inline Ground* grMaterial_801C9604_inline(HSD_GObj* arg0)
+static inline Ground* grMaterial_801C9604_inline(HSD_GObj* arg0)
 {
     return arg0->user_data;
 }

--- a/src/melee/gr/groldyoshi.c
+++ b/src/melee/gr/groldyoshi.c
@@ -328,7 +328,7 @@ static inline s32 randi_between(s32 min, s32 max)
 }
 
 /// @todo For some reason, the normal GET_GROUND didn't work here
-inline Ground* grOldYoshi_8020EFCC_inline(Ground_GObj* arg0)
+static inline Ground* grOldYoshi_8020EFCC_inline(Ground_GObj* arg0)
 {
     return arg0->user_data;
 }

--- a/src/melee/gr/ground.c
+++ b/src/melee/gr/ground.c
@@ -1086,7 +1086,7 @@ HSD_GObj* Ground_801C1E84(void)
 /// extern s8 HSD_GObj_804D7848;
 /// extern float @330;
 
-inline HSD_FogDesc* foo(void)
+static inline HSD_FogDesc* foo(void)
 {
     StageCallbacks* phi_r29;
     StageCallbacks* temp_r29;

--- a/src/melee/gr/grpstadium.c
+++ b/src/melee/gr/grpstadium.c
@@ -291,7 +291,7 @@ void fn_801D13C8(Ground_GObj* gobj)
 }
 
 /// @todo this is a commonly used inline; it should be moved to random.h
-inline int randi(int i)
+static inline int randi(int i)
 {
     if (i != 0) {
         return HSD_Randi(i);
@@ -624,7 +624,7 @@ void grStadium_801D1E1C(Ground_GObj* gobj) {}
 
 extern Vec3 grPs_803B7F80;
 
-inline void mul_vec(Vec* v, float m)
+static inline void mul_vec(Vec* v, float m)
 {
     v->x *= m;
     v->y *= m;
@@ -922,7 +922,7 @@ typedef struct TextWrapper {
 } TextWrapper;
 
 /// @todo can these inlines be merged?
-inline int randi_between_2(int a, int b)
+static inline int randi_between_2(int a, int b)
 {
     int result = b;
     if (b > a) {
@@ -933,7 +933,7 @@ inline int randi_between_2(int a, int b)
     return result;
 }
 
-inline int randi_between(int a, int b)
+static inline int randi_between(int a, int b)
 {
     if (b > a) {
         return a + randi(b - a);
@@ -1305,7 +1305,7 @@ void grStadium_801D3084(HSD_GObj* gobj, int unused)
 
 /// @todo these are commonly used inlines; they should be moved to jobj.h
 
-inline HSD_JObj* jobj_next(HSD_JObj* jobj)
+static inline HSD_JObj* jobj_next(HSD_JObj* jobj)
 {
     if (jobj == NULL) {
         return NULL;
@@ -1313,7 +1313,7 @@ inline HSD_JObj* jobj_next(HSD_JObj* jobj)
     return jobj->next;
 }
 
-inline HSD_JObj* jobj_parent(HSD_JObj* jobj)
+static inline HSD_JObj* jobj_parent(HSD_JObj* jobj)
 {
     if (jobj == NULL) {
         return NULL;
@@ -1321,7 +1321,7 @@ inline HSD_JObj* jobj_parent(HSD_JObj* jobj)
     return jobj->parent;
 }
 
-inline HSD_JObj* jobj_child(HSD_JObj* jobj)
+static inline HSD_JObj* jobj_child(HSD_JObj* jobj)
 {
     if (jobj == NULL) {
         return NULL;

--- a/src/melee/gr/grshrineroute.c
+++ b/src/melee/gr/grshrineroute.c
@@ -803,7 +803,7 @@ bool grShrineRoute_80209BE4(Ground_GObj* arg)
     return false;
 }
 
-inline f32 grShrineRoute_8020A8A4_rand(void)
+static inline f32 grShrineRoute_8020A8A4_rand(void)
 {
     return HSD_Randf();
 }

--- a/src/melee/gr/grstory.c
+++ b/src/melee/gr/grstory.c
@@ -133,7 +133,7 @@ void grStory_801E322C(Ground_GObj* gobj) {}
 
 void grStory_801E3230(Ground_GObj* gobj) {}
 
-inline int randi(int max)
+static inline int randi(int max)
 {
     return max ? HSD_Randi(max) : 0;
 }
@@ -224,7 +224,7 @@ void grStory_801E3414(Ground_GObj* gobj) {}
 
 /// floating point random number centered at 0
 /// with an amplitude of 1
-inline f32 frand_amp1(void)
+static inline f32 frand_amp1(void)
 {
     return 2.0F * (HSD_Randf() - 0.5F);
 }

--- a/src/melee/gr/grzebesroute.c
+++ b/src/melee/gr/grzebesroute.c
@@ -223,13 +223,13 @@ void fn_8020B4D8(void* user_data, int joint_id, CollData* coll, int coll_x50,
 }
 
 /// @todo Useless wrapper
-inline HSD_LObj* HSD_LObjGetNext_padstack(HSD_LObj* arg0)
+static inline HSD_LObj* HSD_LObjGetNext_padstack(HSD_LObj* arg0)
 {
     return HSD_LObjGetNext(arg0);
 }
 
 /// @todo ::HSD_LObjGetType
-inline int HSD_LObjGetType_padstack(HSD_LObj* lobj)
+static inline int HSD_LObjGetType_padstack(HSD_LObj* lobj)
 {
     return lobj->flags & LOBJ_TYPE_MASK;
 }

--- a/src/melee/if/ifnametag.c
+++ b/src/melee/if/ifnametag.c
@@ -352,7 +352,7 @@ void un_802FD468(void)
     HSD_GObjPLink_80390228(un_804D6D68);
 }
 
-inline HSD_GObj* un_802FD4C8_inline(int arg0)
+static inline HSD_GObj* un_802FD4C8_inline(int arg0)
 {
     return GObj_Create(0xE, arg0, 0);
 }

--- a/src/melee/if/ifstatus.c
+++ b/src/melee/if/ifstatus.c
@@ -105,10 +105,10 @@ jobj_flagCheckSetMtxDirtySub(HSD_JObj* jobj) // jobj @ r30 when inlined
     }
 }
 
-inline void jobj_translate_x(HSD_JObj* jobj, float dx);
-inline void jobj_translate_y(HSD_JObj* jobj, float dy);
+static inline void jobj_translate_x(HSD_JObj* jobj, float dx);
+static inline void jobj_translate_y(HSD_JObj* jobj, float dy);
 
-inline void jobj_unk_x(UnkX* value, s32 i)
+static inline void jobj_unk_x(UnkX* value, s32 i)
 {
     HSD_JObj* jobj_r30 = value->x54_jobj[i];
     //@c8
@@ -125,7 +125,7 @@ inline void jobj_unk_x(UnkX* value, s32 i)
     }
 }
 
-inline void jobj_unk_y(UnkX* value, s32 i)
+static inline void jobj_unk_y(UnkX* value, s32 i)
 {
     HSD_JObj* jobj_r30 = value->x54_jobj[i];
     //@184
@@ -145,7 +145,7 @@ inline void jobj_unk_y(UnkX* value, s32 i)
     }
 }
 
-inline void jobj_translate_x(HSD_JObj* jobj, float dx)
+static inline void jobj_translate_x(HSD_JObj* jobj, float dx)
 {
     //@108
     ASSERT_NOT_NULL(jobj, 1102);
@@ -153,7 +153,7 @@ inline void jobj_translate_x(HSD_JObj* jobj, float dx)
     jobj->translate.x += dx;
 }
 
-inline void jobj_translate_y(HSD_JObj* jobj, float dy)
+static inline void jobj_translate_y(HSD_JObj* jobj, float dy)
 {
     //@1b0
     ASSERT_NOT_NULL(jobj, 1114);
@@ -161,7 +161,7 @@ inline void jobj_translate_y(HSD_JObj* jobj, float dy)
     jobj->translate.y += dy;
 }
 
-inline void jobj_unk(UnkX* value)
+static inline void jobj_unk(UnkX* value)
 {
     //@b0
     s32 i;
@@ -173,7 +173,7 @@ inline void jobj_unk(UnkX* value)
     }
 }
 
-inline void* jobj_get(HSD_JObj* jobj_r30, UnkX* value, s32 i)
+static inline void* jobj_get(HSD_JObj* jobj_r30, UnkX* value, s32 i)
 {
     return value->x54_jobj[i];
 }
@@ -220,7 +220,7 @@ void ifStatus_PercentOnDeathAnimationThink(UnkX* value, s32 arg1, s32 arg2)
     }
 }
 
-inline f32 offset_rand(void)
+static inline f32 offset_rand(void)
 {
     return HSD_Randf() - 0.5f;
 }
@@ -642,7 +642,7 @@ void ifStatus_802F5B48(HSD_GObj* gobj)
     }
 }
 
-inline IfDamageState* getPlayerByHUDParent(HSD_GObj* parent)
+static inline IfDamageState* getPlayerByHUDParent(HSD_GObj* parent)
 {
     s32 var_ctr;
     for (var_ctr = 0; var_ctr < 6; var_ctr++) {

--- a/src/melee/if/textlib.c
+++ b/src/melee/if/textlib.c
@@ -133,7 +133,7 @@ void DevText_EraseFirstLine(DevText* text)
     memzero(start_of_line, line_length);
 }
 
-inline int DevText_Clamp(int val, int max)
+static inline int DevText_Clamp(int val, int max)
 {
     if (max <= val) {
         return max - 1;
@@ -267,7 +267,7 @@ void DevText_Erase(DevText* text)
 }
 #pragma pop
 
-inline void DevText_AdvanceLine(DevText* text)
+static inline void DevText_AdvanceLine(DevText* text)
 {
     text->cursor_x = 0;
     if (text->cursor_y < text->h - 1) {

--- a/src/melee/it/it_26B1.c
+++ b/src/melee/it/it_26B1.c
@@ -452,7 +452,7 @@ s32 it_8026B7E8(HSD_GObj* gobj) // Get bit 1 of 0xDC8 word
     return ip->xDC8_word.flags.x1;
 }
 
-inline void RunCallbackUnk(HSD_GObjInteraction proc, HSD_GObj* gobj0,
+static inline void RunCallbackUnk(HSD_GObjInteraction proc, HSD_GObj* gobj0,
                            HSD_GObj* gobj1)
 {
     if (proc != NULL) {

--- a/src/melee/it/it_26B1.c
+++ b/src/melee/it/it_26B1.c
@@ -453,7 +453,7 @@ s32 it_8026B7E8(HSD_GObj* gobj) // Get bit 1 of 0xDC8 word
 }
 
 static inline void RunCallbackUnk(HSD_GObjInteraction proc, HSD_GObj* gobj0,
-                           HSD_GObj* gobj1)
+                                  HSD_GObj* gobj1)
 {
     if (proc != NULL) {
         proc(gobj0, gobj1);

--- a/src/melee/it/it_2725.c
+++ b/src/melee/it/it_2725.c
@@ -1023,7 +1023,7 @@ void it_80274574(Item_GObj* item_gobj)
     it_80274594(item_gobj);
 }
 
-inline void HSD_JObjSetScale_2(HSD_JObj* jobj, Vec3* scale)
+static inline void HSD_JObjSetScale_2(HSD_JObj* jobj, Vec3* scale)
 {
     ((jobj) ? ((void) 0) : __assert("jobj.h", 760, "jobj"));
     jobj->scale = *scale;
@@ -1341,7 +1341,7 @@ void it_80274F28(Item* item, s8 arg1, HSD_GObjEvent arg2,
     item->grabbed_for_victim = arg3;
 }
 
-inline HSD_JObj* get_bone_by_id(Item_GObj* item_gobj, int bone_id)
+static inline HSD_JObj* get_bone_by_id(Item_GObj* item_gobj, int bone_id)
 {
     Item* item = GET_ITEM(item_gobj);
     HSD_JObj* jobj = GET_JOBJ(item_gobj);

--- a/src/melee/it/items/it_2E5A.c
+++ b/src/melee/it/items/it_2E5A.c
@@ -251,7 +251,7 @@ s32 it_802E609C(it_802E5FXX_struct* vars, SpawnItem* spawn)
     return var_r30;
 }
 
-inline void it_802E614C(Item_GObj* parent_gobj1, Item_GObj* parent_gobj2,
+static inline void it_802E614C(Item_GObj* parent_gobj1, Item_GObj* parent_gobj2,
                         SpawnItem* spawn, Vec3* pos, Vec3* vel)
 {
     spawn->kind = It_Kind_Unk4;

--- a/src/melee/it/items/it_2E5A.c
+++ b/src/melee/it/items/it_2E5A.c
@@ -26,6 +26,9 @@
 #include <baselib/jobj.h>
 #include <baselib/random.h>
 
+/* 2E614C */ static void it_802E614C(Item_GObj*, Item_GObj*, SpawnItem*, Vec3*,
+                                     Vec3*);
+
 const Vec3 it_803B8718 = { 0.0f, 0.0f, 0.0f };
 const Vec3 it_803B8724 = { 0.0f, 0.0f, 0.0f };
 
@@ -251,8 +254,9 @@ s32 it_802E609C(it_802E5FXX_struct* vars, SpawnItem* spawn)
     return var_r30;
 }
 
-static inline void it_802E614C(Item_GObj* parent_gobj1, Item_GObj* parent_gobj2,
-                        SpawnItem* spawn, Vec3* pos, Vec3* vel)
+static inline void it_802E614C(Item_GObj* parent_gobj1,
+                               Item_GObj* parent_gobj2, SpawnItem* spawn,
+                               Vec3* pos, Vec3* vel)
 {
     spawn->kind = It_Kind_Unk4;
     spawn->prev_pos = *pos;

--- a/src/melee/it/items/it_2E5A.h
+++ b/src/melee/it/items/it_2E5A.h
@@ -15,8 +15,6 @@
 /* 2E5F00 */ void it_802E5F00(Item_GObj*, Vec3*, Vec3*, s32);
 /* 2E5F8C */ s32 it_802E5F8C(Item_GObj*, Vec3*, s32, s32, f32, f32);
 /* 2E609C */ s32 it_802E609C(it_802E5FXX_struct*, SpawnItem*);
-/* 2E614C */ void it_802E614C(Item_GObj*, Item_GObj*, SpawnItem*, Vec3*,
-                              Vec3*);
 /* 2E61C4 */ s32 it_802E61C4(Item_GObj*, s32, s32);
 /* 2E628C */ void it_802E628C(Item_GObj*, f32, f32);
 /* 2E6380 */ s32 it_802E6380(Item_GObj*, it_802E5FXX_struct*);

--- a/src/melee/it/items/itegg.c
+++ b/src/melee/it/items/itegg.c
@@ -96,7 +96,7 @@ void itEgg_Logic3_Spawned(Item_GObj* gobj)
     it_80288EFC(gobj);
 }
 
-inline s32 attrRand(itEgg_ItemVars* attrs)
+static inline s32 attrRand(itEgg_ItemVars* attrs)
 {
     return HSD_Randi(attrs->rand_max);
 }

--- a/src/melee/it/items/itfoods.c
+++ b/src/melee/it/items/itfoods.c
@@ -74,7 +74,7 @@ HSD_GObj* it_8028FAF4(Item_GObj* arg0, Vec3* arg1)
     return gobj;
 }
 
-inline u32 getRandMax(Article* article)
+static inline u32 getRandMax(Article* article)
 {
     itFoodsAttributes* attr = article->x4_specialAttributes;
     return attr->x0;

--- a/src/melee/it/items/itfoxlaser.c
+++ b/src/melee/it/items/itfoxlaser.c
@@ -27,7 +27,7 @@ ItemStateTable it_803F67D0[] = {
       itFoxlaser_UnkMotion1_Coll },
 };
 
-inline void* getFoxLaser(Item* item)
+static inline void* getFoxLaser(Item* item)
 {
     return &item->xDD4_itemVar;
 }

--- a/src/melee/it/items/ithassam.c
+++ b/src/melee/it/items/ithassam.c
@@ -292,7 +292,7 @@ bool itHassam_UnkMotion1_Coll(Item_GObj* gobj)
 }
 
 static inline void itHassam_802CE400_sub(HSD_GObj* gobj, int msid,
-                                  Item_StateChangeFlags flags)
+                                         Item_StateChangeFlags flags)
 {
     Item* ip = gobj->user_data;
     Item_80268E5C(gobj, msid, flags);

--- a/src/melee/it/items/ithassam.c
+++ b/src/melee/it/items/ithassam.c
@@ -291,7 +291,7 @@ bool itHassam_UnkMotion1_Coll(Item_GObj* gobj)
     return false;
 }
 
-inline void itHassam_802CE400_sub(HSD_GObj* gobj, int msid,
+static inline void itHassam_802CE400_sub(HSD_GObj* gobj, int msid,
                                   Item_StateChangeFlags flags)
 {
     Item* ip = gobj->user_data;

--- a/src/melee/it/items/ithitodeman.c
+++ b/src/melee/it/items/ithitodeman.c
@@ -179,7 +179,7 @@ bool it_802D4564(Item_GObj* gobj)
     return false;
 }
 
-inline Article* it_802D472C_inline(Item* ip)
+static inline Article* it_802D472C_inline(Item* ip)
 {
     return ip->xC4_article_data;
 }

--- a/src/melee/it/items/itkyasarinegg.c
+++ b/src/melee/it/items/itkyasarinegg.c
@@ -137,7 +137,7 @@ bool itKyasarinegg_UnkMotion4_Anim(Item_GObj* gobj)
     it_802751D8(gobj);
 }
 
-inline bool it_damage_inline(Item_GObj* gobj)
+static inline bool it_damage_inline(Item_GObj* gobj)
 {
     Item* egg = GET_ITEM(gobj);
     itKyasarinEggAttributes* ap;

--- a/src/melee/it/items/itleadead.c
+++ b/src/melee/it/items/itleadead.c
@@ -1044,7 +1044,7 @@ Item_GObj* it_802EA9FC(Vec3* pos, s32 facing_dir)
     return gobj;
 }
 
-inline f32 it_802EAAEC_inline(Item* ip2)
+static inline f32 it_802EAAEC_inline(Item* ip2)
 {
     return ip2->xDD4_itemVar.leadead.x3C;
 }

--- a/src/melee/it/items/itlinkarrow.c
+++ b/src/melee/it/items/itlinkarrow.c
@@ -229,7 +229,8 @@ static inline HSD_JObj* itLinkArrow_802A850C_inline(HSD_Joint* joint)
     return jobj;
 }
 
-static inline void itLinkArrow_802A850C_inline_2(Item_GObj* gobj, Quaternion* quat)
+static inline void itLinkArrow_802A850C_inline_2(Item_GObj* gobj,
+                                                 Quaternion* quat)
 {
     int i;
     Item* item;

--- a/src/melee/it/items/itlinkarrow.c
+++ b/src/melee/it/items/itlinkarrow.c
@@ -220,7 +220,7 @@ HSD_GObj* it_802A83E0(f32 facing_dir, Fighter_GObj* arg1, Vec3* arg2,
     return gobj;
 }
 
-inline HSD_JObj* itLinkArrow_802A850C_inline(HSD_Joint* joint)
+static inline HSD_JObj* itLinkArrow_802A850C_inline(HSD_Joint* joint)
 {
     HSD_JObj* jobj;
     if (joint != NULL) {
@@ -229,7 +229,7 @@ inline HSD_JObj* itLinkArrow_802A850C_inline(HSD_Joint* joint)
     return jobj;
 }
 
-inline void itLinkArrow_802A850C_inline_2(Item_GObj* gobj, Quaternion* quat)
+static inline void itLinkArrow_802A850C_inline_2(Item_GObj* gobj, Quaternion* quat)
 {
     int i;
     Item* item;

--- a/src/melee/it/items/itlugia.c
+++ b/src/melee/it/items/itlugia.c
@@ -52,7 +52,7 @@ static inline float my_sqrtf(float x)
     return x;
 }
 
-inline float my_sqrtf_accurate(float x)
+static inline float my_sqrtf_accurate(float x)
 {
     volatile float y;
     if (x > 0.0f) {

--- a/src/melee/it/items/itmariocape.c
+++ b/src/melee/it/items/itmariocape.c
@@ -96,7 +96,7 @@ static void inlineA0(Item_GObj* gobj)
     }
 }
 
-inline void reset(Item_GObj* gobj)
+static inline void reset(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
     if (ip->owner != NULL) {

--- a/src/melee/it/items/itnesspkfirepillar.c
+++ b/src/melee/it/items/itnesspkfirepillar.c
@@ -31,7 +31,7 @@ ItemStateTable it_803F6B60[1] = { 0, itNesspkfirepillar_UnkMotion0_Anim,
                                   itNesspkfirepillar_UnkMotion0_Phys,
                                   itNesspkfirepillar_UnkMotion0_Coll };
 
-inline void itNesspkfirepillar_INLINE_SpawnItem_Init(SpawnItem* spawnitem,
+static inline void itNesspkfirepillar_INLINE_SpawnItem_Init(SpawnItem* spawnitem,
                                                      Vec3* offset,
                                                      f32 facing_dir,
                                                      HSD_GObj* parent1_gobj,

--- a/src/melee/it/items/itnesspkfirepillar.c
+++ b/src/melee/it/items/itnesspkfirepillar.c
@@ -31,11 +31,9 @@ ItemStateTable it_803F6B60[1] = { 0, itNesspkfirepillar_UnkMotion0_Anim,
                                   itNesspkfirepillar_UnkMotion0_Phys,
                                   itNesspkfirepillar_UnkMotion0_Coll };
 
-static inline void itNesspkfirepillar_INLINE_SpawnItem_Init(SpawnItem* spawnitem,
-                                                     Vec3* offset,
-                                                     f32 facing_dir,
-                                                     HSD_GObj* parent1_gobj,
-                                                     HSD_GObj* parent2_gobj)
+static inline void itNesspkfirepillar_INLINE_SpawnItem_Init(
+    SpawnItem* spawnitem, Vec3* offset, f32 facing_dir, HSD_GObj* parent1_gobj,
+    HSD_GObj* parent2_gobj)
 {
     spawnitem->kind = It_Kind_Ness_PKFire_Flame;
     spawnitem->prev_pos = *offset;

--- a/src/melee/it/items/itparasol.c
+++ b/src/melee/it/items/itparasol.c
@@ -109,7 +109,7 @@ bool itParasol_UnkMotion2_Anim(Item_GObj* item_gobj)
     return false;
 }
 
-inline void decelerateItemX(Item* item, f32 decel_x)
+static inline void decelerateItemX(Item* item, f32 decel_x)
 {
     if (fabsf(item->x40_vel.x) > decel_x) {
         if (item->x40_vel.x > decel_x) {

--- a/src/melee/it/items/itsamusbomb.c
+++ b/src/melee/it/items/itsamusbomb.c
@@ -72,7 +72,7 @@ void it_802B4C10(Item_GObj* gobj)
     Item_80268E5C(gobj, 0, 0x11);
 }
 
-inline void itSamusBomb_UnkMotion_Process(Item_GObj* gobj)
+static inline void itSamusBomb_UnkMotion_Process(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
     HSD_JObj* jobj = GET_JOBJ(gobj);
@@ -86,7 +86,7 @@ inline void itSamusBomb_UnkMotion_Process(Item_GObj* gobj)
     }
 }
 
-inline void itSamusBomb_UnkMotion_PreProcess(Item_GObj* gobj)
+static inline void itSamusBomb_UnkMotion_PreProcess(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
     HSD_JObj* jobj = GET_JOBJ(gobj);

--- a/src/melee/it/items/itsamusmissile.c
+++ b/src/melee/it/items/itsamusmissile.c
@@ -202,7 +202,7 @@ void* it_802B66A8(Item_GObj* gobj)
     return efSync_Spawn(0x485, gobj, itGetJObjGrandchild(gobj));
 }
 
-inline void isSamusmissile_MotionAnim(Item_GObj* gobj)
+static inline void isSamusmissile_MotionAnim(Item_GObj* gobj)
 {
     it_802B63F8(gobj);
     {

--- a/src/melee/it/items/itseakneedlethrown.c
+++ b/src/melee/it/items/itseakneedlethrown.c
@@ -551,7 +551,7 @@ bool it_2725_Logic109_ShieldBounced(Item_GObj* gobj)
     return false;
 }
 
-inline bool it_2725_Logic109_HitShield_inline(Item_GObj* gobj, Item* ip)
+static inline bool it_2725_Logic109_HitShield_inline(Item_GObj* gobj, Item* ip)
 {
     itSeakNeedleThrownAttributes* attr =
         ip->xC4_article_data->x4_specialAttributes;

--- a/src/melee/it/items/ittarucann.c
+++ b/src/melee/it/items/ittarucann.c
@@ -58,7 +58,7 @@ ItemStateTable it_803F63C0[] = {
       itTarucann_UnkMotion9_Coll },
 };
 
-inline void inline_itTarucann_SetRotationZ(HSD_GObj* gobj)
+static inline void inline_itTarucann_SetRotationZ(HSD_GObj* gobj)
 {
     HSD_JObj* jobj;
     Item* ip;
@@ -582,7 +582,7 @@ bool itTarucann_UnkMotion7_Anim(Item_GObj* gobj)
     return it_802961E8(gobj);
 }
 
-inline void inline_itTarucann_UnkMotion7_Phys(Item_GObj* gobj)
+static inline void inline_itTarucann_UnkMotion7_Phys(Item_GObj* gobj)
 {
     Item* ip2 = GET_ITEM(gobj);
     ip2->x40_vel.x = ip2->xDD4_itemVar.tarucann.x10;
@@ -637,7 +637,7 @@ void it_802975F4(Item_GObj* gobj)
     Item_8026AE84(ip, 0x12A, 0x7F, 0x40);
 }
 
-inline void itTarucann_UnkMotion9_Anim_inline(HSD_GObj* gobj)
+static inline void itTarucann_UnkMotion9_Anim_inline(HSD_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
     if (ip->xDD4_itemVar.tarucann.x20 == 0) {

--- a/src/melee/it/itgroundcoll.c
+++ b/src/melee/it/itgroundcoll.c
@@ -428,7 +428,7 @@ void it_8026E0F4(Item_GObj* gobj)
     }
 }
 
-inline bool it_8026E_inline(Item_GObj* gobj)
+static inline bool it_8026E_inline(Item_GObj* gobj)
 {
     Item* ip = GET_ITEM(gobj);
     bool cond;

--- a/src/melee/lb/lb_00B0.c
+++ b/src/melee/lb/lb_00B0.c
@@ -98,7 +98,7 @@ bool lb_8000B134(HSD_JObj* jobj)
     return false;
 }
 
-inline HSD_JObj* jobj_parent(HSD_JObj* jobj)
+static inline HSD_JObj* jobj_parent(HSD_JObj* jobj)
 {
     if (jobj == NULL) {
         return NULL;
@@ -433,7 +433,7 @@ void lb_8000C2F8(HSD_JObj* jobj, HSD_JObj* constraint)
     lb_8000C290(jobj, constraint);
 }
 
-inline HSD_RObj* robj_next(HSD_RObj* robj)
+static inline HSD_RObj* robj_next(HSD_RObj* robj)
 {
     if (robj != NULL) {
         return robj->next;
@@ -744,7 +744,7 @@ s32 lb_8000CDA8(s32 i)
     return lb_803BA020[i];
 }
 
-inline HSD_LObj* lobj_next(HSD_LObj* lobj)
+static inline HSD_LObj* lobj_next(HSD_LObj* lobj)
 {
     if (lobj == NULL) {
         return NULL;

--- a/src/melee/lb/lbarchive.c
+++ b/src/melee/lb/lbarchive.c
@@ -255,7 +255,7 @@ bool lbArchive_800171CC(HSD_Archive** dst, const char* filename, void* symbols,
     return preloaded;
 }
 
-inline void Locate(HSD_Archive* archive, intptr_t base_addr)
+static inline void Locate(HSD_Archive* archive, intptr_t base_addr)
 {
     u32 i;
     u32* ptr;

--- a/src/melee/lb/lbcardnew.c
+++ b/src/melee/lb/lbcardnew.c
@@ -318,7 +318,8 @@ struct SnapshotNode {
     u16 blocks;
 };
 
-static inline void setup_card_entries(void* ctx, void* icon, struct CardEntry* entry)
+static inline void setup_card_entries(void* ctx, void* icon,
+                                      struct CardEntry* entry)
 {
     int i;
 
@@ -738,7 +739,8 @@ static inline struct CardTask* setup_task(int a, int b)
     return task;
 }
 
-static inline void lb_8001A4CC_dontinline(const char* filename, void* file_entries)
+static inline void lb_8001A4CC_dontinline(const char* filename,
+                                          void* file_entries)
 {
     lb_8001A4CC(filename, file_entries);
 }
@@ -847,10 +849,10 @@ int lb_8001BB48(int chan, char* filename, void* file_entries, void* save_data,
     return lb_80019CB0(0x10);
 }
 
-static inline int lb_8001BB48_inline(int chan, char* filename, void* file_entries,
-                              void* save_data, const char* write_buf,
-                              int write_offset, int write_len,
-                              UNK_T status_out)
+static inline int lb_8001BB48_inline(int chan, char* filename,
+                                     void* file_entries, void* save_data,
+                                     const char* write_buf, int write_offset,
+                                     int write_len, UNK_T status_out)
 {
     int new_var;
     lb_80019EF0(chan, save_data, status_out, 0);

--- a/src/melee/lb/lbcardnew.c
+++ b/src/melee/lb/lbcardnew.c
@@ -318,7 +318,7 @@ struct SnapshotNode {
     u16 blocks;
 };
 
-inline void setup_card_entries(void* ctx, void* icon, struct CardEntry* entry)
+static inline void setup_card_entries(void* ctx, void* icon, struct CardEntry* entry)
 {
     int i;
 
@@ -730,7 +730,7 @@ int lb_8001B760(int result)
     return result;
 }
 
-inline struct CardTask* setup_task(int a, int b)
+static inline struct CardTask* setup_task(int a, int b)
 {
     struct CardTask* task = lb_80019C38();
     task->x0 = a;
@@ -738,7 +738,7 @@ inline struct CardTask* setup_task(int a, int b)
     return task;
 }
 
-inline void lb_8001A4CC_dontinline(const char* filename, void* file_entries)
+static inline void lb_8001A4CC_dontinline(const char* filename, void* file_entries)
 {
     lb_8001A4CC(filename, file_entries);
 }
@@ -847,7 +847,7 @@ int lb_8001BB48(int chan, char* filename, void* file_entries, void* save_data,
     return lb_80019CB0(0x10);
 }
 
-inline int lb_8001BB48_inline(int chan, char* filename, void* file_entries,
+static inline int lb_8001BB48_inline(int chan, char* filename, void* file_entries,
                               void* save_data, const char* write_buf,
                               int write_offset, int write_len,
                               UNK_T status_out)

--- a/src/melee/lb/lbcollision.c
+++ b/src/melee/lb/lbcollision.c
@@ -311,7 +311,7 @@ float lbColl_80005FC0(Vec3* arg0, Vec3* arg1, Vec3* arg2, float* arg3)
     return x * x + y * y;
 }
 
-inline bool end(Vec3* a, Vec3* b, float unk_sum)
+static inline bool end(Vec3* a, Vec3* b, float unk_sum)
 {
     float y = a->y - b->y;
     float x = a->x - b->x;
@@ -1472,7 +1472,7 @@ block_39:
     return 1;
 }
 
-inline float sqrDistance(Vec3* a, Vec3* b)
+static inline float sqrDistance(Vec3* a, Vec3* b)
 {
     float x = a->x - b->x;
     float y = a->y - b->y;
@@ -1765,7 +1765,7 @@ bool lbColl_8000805C(HitCapsule* arg0, HurtCapsule* arg1, Mtx arg2, s32 arg3,
     return 0;
 }
 
-inline void checkPos(HurtCapsule* hurt, Mtx mtx, float arg5)
+static inline void checkPos(HurtCapsule* hurt, Mtx mtx, float arg5)
 {
     if (!hurt->skip_update_pos) {
         lb_8000B1CC(hurt->bone, &hurt->a_offset, &hurt->a_pos);
@@ -1780,7 +1780,7 @@ inline void checkPos(HurtCapsule* hurt, Mtx mtx, float arg5)
     }
 }
 
-inline void mtxConcat(HurtCapsule* hurt, Mtx mtx)
+static inline void mtxConcat(HurtCapsule* hurt, Mtx mtx)
 {
     Mtx sp34;
     if (mtx != NULL) {
@@ -1788,7 +1788,7 @@ inline void mtxConcat(HurtCapsule* hurt, Mtx mtx)
     }
 }
 
-inline MtxPtr pickMtx(HurtCapsule* hurt, Mtx mtx)
+static inline MtxPtr pickMtx(HurtCapsule* hurt, Mtx mtx)
 {
     MtxPtr var_r9;
     Mtx sp34;
@@ -1800,7 +1800,7 @@ inline MtxPtr pickMtx(HurtCapsule* hurt, Mtx mtx)
     return var_r9;
 }
 
-inline float getHit1C(HitCapsule* hit, float arg3)
+static inline float getHit1C(HitCapsule* hit, float arg3)
 {
     float var_f1;
     if (hit->x43_b1) {

--- a/src/melee/lb/lbdvd.c
+++ b/src/melee/lb/lbdvd.c
@@ -100,7 +100,7 @@ void lbDvd_80017700(int arg0)
     }
 }
 
-inline int same(int a, s32 b)
+static inline int same(int a, s32 b)
 {
     int result = 0;
     if (a == b) {

--- a/src/melee/mn/mncharsel.c
+++ b/src/melee/mn/mncharsel.c
@@ -1212,14 +1212,14 @@ void mnCharSel_8025DB34(u8 arg0)
     }
 }
 
-inline HSD_JObj* lb_80011E24_inline(int i)
+static inline HSD_JObj* lb_80011E24_inline(int i)
 {
     HSD_JObj* jobj;
     lb_80011E24(mnCharSel_804D6CC0, &jobj, i, -1);
     return jobj;
 }
 
-inline void anim_inline(int i, float f)
+static inline void anim_inline(int i, float f)
 {
     HSD_JObj* jobj;
     lb_80011E24(mnCharSel_804D6CC0, &jobj, i, -1);

--- a/src/melee/mn/mndatadel.c
+++ b/src/melee/mn/mndatadel.c
@@ -47,7 +47,7 @@ static void sdata2_order(void)
     (void) 0.0500000007f;
 }
 
-inline f32 mnDataDel_8024E940_inline(HSD_JObj* arg0)
+static inline f32 mnDataDel_8024E940_inline(HSD_JObj* arg0)
 {
     return mn_8022F298(arg0);
 }
@@ -697,8 +697,8 @@ void fn_8024FBA4(HSD_GObj* gobj)
     }
 }
 
-inline HSD_JObj* fn_8024FC48_inline(int arg0);
-inline HSD_JObj* fn_8024FC48_inline(int arg0)
+static inline HSD_JObj* fn_8024FC48_inline(int arg0);
+static inline HSD_JObj* fn_8024FC48_inline(int arg0)
 {
     return (HSD_JObj*) arg0;
 }

--- a/src/melee/mn/mndiagram.c
+++ b/src/melee/mn/mndiagram.c
@@ -1704,7 +1704,7 @@ typedef struct mnDiagram_MainOverlay {
     /* 0x38 */ HSD_Text* text[6];
 } mnDiagram_MainOverlay;
 
-inline Vec3* mnDiagram_PopupAnimProc_Inline(mnDiagram_AnimTable* arg0,
+static inline Vec3* mnDiagram_PopupAnimProc_Inline(mnDiagram_AnimTable* arg0,
                                             int arg1)
 {
     return &arg0->points[arg1];
@@ -1815,7 +1815,7 @@ void mnDiagram_PopupAnimProc(void* arg0)
     }
 }
 
-inline void mnDiagram_FormatPopupNumber(char* buf, u32 val)
+static inline void mnDiagram_FormatPopupNumber(char* buf, u32 val)
 {
     int digit_count = mn_GetDigitCount(val);
     int i;

--- a/src/melee/mn/mndiagram.c
+++ b/src/melee/mn/mndiagram.c
@@ -1705,7 +1705,7 @@ typedef struct mnDiagram_MainOverlay {
 } mnDiagram_MainOverlay;
 
 static inline Vec3* mnDiagram_PopupAnimProc_Inline(mnDiagram_AnimTable* arg0,
-                                            int arg1)
+                                                   int arg1)
 {
     return &arg0->points[arg1];
 }

--- a/src/melee/mn/mnevent.c
+++ b/src/melee/mn/mnevent.c
@@ -271,7 +271,7 @@ void mnEvent_8024D5B0(HSD_GObj* gobj, u8 event)
     HSD_SisLib_803A6B98(temp_r3_2, 0.0f, 0.0f, mnEvent_804D5044);
 }
 
-inline MnEventData* GET_EVENTDATA(HSD_GObj* gobj)
+static inline MnEventData* GET_EVENTDATA(HSD_GObj* gobj)
 {
     return gobj->user_data;
 }

--- a/src/melee/mn/mngallery.c
+++ b/src/melee/mn/mngallery.c
@@ -299,7 +299,7 @@ void fn_80258ED0(HSD_GObj* gobj)
     }
 }
 
-inline void fn_802590C4_inline(HSD_GObj* gobj)
+static inline void fn_802590C4_inline(HSD_GObj* gobj)
 {
     s32 i;
     struct mnGallery_804D6C88_userdata* tmp;

--- a/src/melee/mn/mninfobonus.c
+++ b/src/melee/mn/mninfobonus.c
@@ -27,7 +27,7 @@
 #include <lb/lbaudio_ax.h>
 #include <sc/types.h>
 
-inline int mnInfoBonus_802528F8_inline(int j)
+static inline int mnInfoBonus_802528F8_inline(int j)
 {
     if (*mnInfoBonus_804D6C80) {
         return true;
@@ -35,7 +35,7 @@ inline int mnInfoBonus_802528F8_inline(int j)
     return gm_8016F120(j);
 }
 
-inline void textSize(HSD_Text* text)
+static inline void textSize(HSD_Text* text)
 {
     text->font_size.x = 0.0521F;
     text->font_size.y = 0.0521F;
@@ -74,12 +74,12 @@ int mnInfoBonus_802528F8(void)
     return var_r30;
 }
 
-inline int mnInfoBonus_802528F8_wrapper(void)
+static inline int mnInfoBonus_802528F8_wrapper(void)
 {
     return mnInfoBonus_802528F8();
 }
 
-inline int mnInfoBonus_802529B4_inline0(int i)
+static inline int mnInfoBonus_802529B4_inline0(int i)
 {
     if (*mnInfoBonus_804D6C80 != 0) {
         return 1;
@@ -87,7 +87,7 @@ inline int mnInfoBonus_802529B4_inline0(int i)
     return gm_8016F120(i);
 }
 
-inline int mnInfoBonus_802529B4_inline1(int i)
+static inline int mnInfoBonus_802529B4_inline1(int i)
 {
     return ((u16) gm_8016F208(i) - 2) * 3;
 }
@@ -127,7 +127,7 @@ void mnInfoBonus_802529B4(void)
     }
 }
 
-inline void mnInfoBonus_80252ADC_inline(HSD_Text* text)
+static inline void mnInfoBonus_80252ADC_inline(HSD_Text* text)
 {
     text->x34.x = 0.034F;
     text->x34.y = 0.034F;
@@ -220,7 +220,7 @@ void fn_80252C50(HSD_GObj* gobj)
     }
 }
 
-inline HSD_JObj* fn_80252E4C_inline_GetJObjNext(HSD_JObj* jobj)
+static inline HSD_JObj* fn_80252E4C_inline_GetJObjNext(HSD_JObj* jobj)
 {
     if (jobj == NULL) {
         return NULL;
@@ -228,7 +228,7 @@ inline HSD_JObj* fn_80252E4C_inline_GetJObjNext(HSD_JObj* jobj)
     return jobj->next;
 }
 
-inline HSD_JObj* fn_80252E4C_inline_GetJObjChild(HSD_JObj* jobj)
+static inline HSD_JObj* fn_80252E4C_inline_GetJObjChild(HSD_JObj* jobj)
 {
     if (jobj == NULL) {
         return NULL;
@@ -266,7 +266,7 @@ void fn_80252E4C(HSD_GObj* arg0)
     HSD_JObjAnimAll(temp_r30);
 }
 
-inline HSD_JObj* mnInfoBonus_inline_GetJObjNext(HSD_JObj* jobj)
+static inline HSD_JObj* mnInfoBonus_inline_GetJObjNext(HSD_JObj* jobj)
 {
     if (jobj == NULL) {
         return NULL;
@@ -274,7 +274,7 @@ inline HSD_JObj* mnInfoBonus_inline_GetJObjNext(HSD_JObj* jobj)
     return jobj->next;
 }
 
-inline HSD_JObj* mnInfoBonus_inline_GetJObjChild(HSD_JObj* jobj)
+static inline HSD_JObj* mnInfoBonus_inline_GetJObjChild(HSD_JObj* jobj)
 {
     if (jobj == NULL) {
         return NULL;
@@ -282,12 +282,12 @@ inline HSD_JObj* mnInfoBonus_inline_GetJObjChild(HSD_JObj* jobj)
     return jobj->child;
 }
 
-inline void mnInfoBonus_inline_SetGObjFlag(HSD_GObjProc* gobjproc)
+static inline void mnInfoBonus_inline_SetGObjFlag(HSD_GObjProc* gobjproc)
 {
     gobjproc->flags_3 = HSD_GObj_804D783C;
 }
 
-inline void mnInfoBonus_80252F8C_inline0(struct mnInfoBonus_804A09B0_t* o)
+static inline void mnInfoBonus_80252F8C_inline0(struct mnInfoBonus_804A09B0_t* o)
 {
     HSD_GObj* gobj;
     HSD_JObj* jobj;

--- a/src/melee/mn/mninfobonus.c
+++ b/src/melee/mn/mninfobonus.c
@@ -287,7 +287,8 @@ static inline void mnInfoBonus_inline_SetGObjFlag(HSD_GObjProc* gobjproc)
     gobjproc->flags_3 = HSD_GObj_804D783C;
 }
 
-static inline void mnInfoBonus_80252F8C_inline0(struct mnInfoBonus_804A09B0_t* o)
+static inline void
+mnInfoBonus_80252F8C_inline0(struct mnInfoBonus_804A09B0_t* o)
 {
     HSD_GObj* gobj;
     HSD_JObj* jobj;

--- a/src/melee/mn/mnmain.c
+++ b/src/melee/mn/mnmain.c
@@ -49,6 +49,8 @@
 #include <melee/mn/mnvibration.h>
 #include <melee/sc/types.h>
 
+/* 22C068 */ static void mn_8022C068(HSD_LObj*, int, int);
+
 static HSD_GObj* mn_804D6BA8;
 static HSD_GObj* mn_804D6BAC;
 static HSD_GObj* mn_804D6BB0;

--- a/src/melee/mn/mnmain.c
+++ b/src/melee/mn/mnmain.c
@@ -1126,12 +1126,12 @@ static inline void UpdateAnimationLoop(HSD_JObj* jobj,
     }
 }
 
-inline f32 GetAnimStartFrame(AnimLoopSettings* anim_loop)
+static inline f32 GetAnimStartFrame(AnimLoopSettings* anim_loop)
 {
     return anim_loop->start_frame;
 }
 
-inline f32 GetAnimEndFrame(AnimLoopSettings* anim_loop)
+static inline f32 GetAnimEndFrame(AnimLoopSettings* anim_loop)
 {
     return anim_loop->end_frame;
 }
@@ -1763,7 +1763,7 @@ int mn_8022C010(int menu_kind, int selection)
 
 MenuFlow mn_804A04F0;
 
-inline void mn_8022C068(HSD_LObj* lobj, int unused, int div)
+static inline void mn_8022C068(HSD_LObj* lobj, int unused, int div)
 {
     int diff;
 

--- a/src/melee/mn/mnmain.h
+++ b/src/melee/mn/mnmain.h
@@ -75,7 +75,6 @@ typedef struct _MenuInputState {
 /* 22BEDC */ void mn_8022BEDC(HSD_GObj*);
 /* 22BFBC */ GXColor* mn_8022BFBC(int);
 /* 22C010 */ int mn_8022C010(int, int);
-/* 22C068 */ void mn_8022C068(HSD_LObj*, int, int);
 /* 22C128 */ void fn_8022C128(HSD_GObj*);
 /* 22C304 */ void mn_8022C304(void);
 /* 22C4F4 */ void mn_8022C4F4(HSD_GObj*);

--- a/src/melee/mn/mnname.c
+++ b/src/melee/mn/mnname.c
@@ -104,7 +104,7 @@ int GetNameCount(void)
     return count;
 }
 
-inline int GetNumNameList(void)
+static inline int GetNumNameList(void)
 {
     int i;
     int count = 0;
@@ -124,7 +124,7 @@ bool IsNameListFull(void)
     return true;
 }
 
-inline bool checkStringRest(char* ptr)
+static inline bool checkStringRest(char* ptr)
 {
     char* term = &mnName_StringTerminator;
     char* cmp = &mnName_804D4BF0;
@@ -909,7 +909,7 @@ mnName_FindAnimLoop(AnimLoopSettings* const* tableBase, f32 frame)
     HSD_ASSERTREPORT(0x3DC, NULL, "But AnimFrame!!!\n");
 }
 
-inline f32 mnName_80238C34_inline(HSD_JObj* jobj)
+static inline f32 mnName_80238C34_inline(HSD_JObj* jobj)
 {
     return mn_8022F298(jobj);
 }

--- a/src/melee/mn/mnnamenew.c
+++ b/src/melee/mn/mnnamenew.c
@@ -792,7 +792,7 @@ bool NameContainsOnlySpaces(void)
 }
 #pragma pop
 
-inline void CopyCurrentNameToNametag(struct NameTagData* nametag)
+static inline void CopyCurrentNameToNametag(struct NameTagData* nametag)
 {
     s32 idx;
     u8* text;
@@ -856,7 +856,7 @@ s32 WriteCharactersForNameAtIndex(u8 arg0, s32 arg1)
     return ret;
 }
 
-inline char** AddCharacterToName_getGlyphs(GlyphRow* arg0, u8 arg1)
+static inline char** AddCharacterToName_getGlyphs(GlyphRow* arg0, u8 arg1)
 {
     return (char**) &arg0[arg1];
 }

--- a/src/melee/mn/mnruleplus.c
+++ b/src/melee/mn/mnruleplus.c
@@ -356,7 +356,7 @@ void mn_802324E4(u8 time_limit, MenuRulesPlusData* data)
     mnRulePlus_AnimZeros(jobjs);
 }
 
-inline void mn_80232660_inline(HSD_JObj* jobj)
+static inline void mn_80232660_inline(HSD_JObj* jobj)
 {
     AnimLoopSettings* settings;
     AnimLoopSettings* p294;

--- a/src/melee/mn/mnvibration.c
+++ b/src/melee/mn/mnvibration.c
@@ -194,7 +194,7 @@ static inline u8 mnVibration_GetNameSlot(MnVibrationData* data, s32 j)
     return (u8) name_idx;
 }
 
-inline u8 mnVibration_GetNameRumble(s32 name_idx)
+static inline u8 mnVibration_GetNameRumble(s32 name_idx)
 {
     return GetPersistentNameData(name_idx)->rumble_toggle;
 }

--- a/src/melee/mp/mpcoll.c
+++ b/src/melee/mp/mpcoll.c
@@ -116,14 +116,14 @@ void mpCollPrev(CollData* cd)
 }
 
 /// 80041DD0 https://decomp.me/scratch/1KPLe
-inline void clamp_above(float* value, float min)
+static inline void clamp_above(float* value, float min)
 {
     if (*value < min) {
         *value = min;
     }
 }
 
-inline void clamp_below(float* value, float max)
+static inline void clamp_below(float* value, float max)
 {
     if (*value > max) {
         *value = max;
@@ -335,7 +335,7 @@ void mpColl_80042384(CollData* cd)
 }
 
 /// 800424DC https://decomp.me/scratch/DhzDB
-inline void update_min_max(float* min, float* max, float val)
+static inline void update_min_max(float* min, float* max, float val)
 {
     if (*min > val) {
         *min = val;
@@ -458,7 +458,7 @@ void mpColl_LoadECB_JObj(CollData* coll, u32 flags)
 }
 
 /// 8004293C https://decomp.me/scratch/H4EUT
-inline void update_min_max_2(float* min, float* max, float val)
+static inline void update_min_max_2(float* min, float* max, float val)
 {
     if (*max < val) {
         *max = val;
@@ -467,14 +467,14 @@ inline void update_min_max_2(float* min, float* max, float val)
     }
 }
 
-inline void clamp_above_2(float* value, float min)
+static inline void clamp_above_2(float* value, float min)
 {
     if (*value < min) {
         *value = min;
     }
 }
 
-inline void clamp_below_2(float* value, float max)
+static inline void clamp_below_2(float* value, float max)
 {
     if (*value > max) {
         *value = max;
@@ -670,7 +670,7 @@ void mpColl_LoadECB(CollData* coll)
 #pragma pop
 
 /// 80042DB0 https://decomp.me/scratch/GbMpk
-inline void Vec2_Interpolate(float time, Vec2* dest, Vec2* src)
+static inline void Vec2_Interpolate(float time, Vec2* dest, Vec2* src)
 {
     dest->x += time * (src->x - dest->x);
     dest->y += time * (src->y - dest->y);
@@ -922,7 +922,7 @@ void mpColl_800436E4(CollData* coll, float arg1)
 }
 
 /// 80043754 https://decomp.me/scratch/JEEcj
-inline float max_inline(float a, float b)
+static inline float max_inline(float a, float b)
 {
     return (a > b) ? a : b;
 }

--- a/src/melee/pl/plbonuslib.c
+++ b/src/melee/pl/plbonuslib.c
@@ -88,7 +88,7 @@ bool pl_8003D60C(int arg0)
     }
 }
 
-inline bool unk_cond(int arg0, int temp_r23)
+static inline bool unk_cond(int arg0, int temp_r23)
 {
     if (temp_r23 == 6 || temp_r23 == arg0 ||
         pl_CheckIfSameTeam(arg0, temp_r23))
@@ -99,7 +99,7 @@ inline bool unk_cond(int arg0, int temp_r23)
     }
 }
 
-inline bool between_A1_D0(int x)
+static inline bool between_A1_D0(int x)
 {
     if (x >= 0xA1 && x < 0xD0) {
         return true;
@@ -525,7 +525,7 @@ u32 pl_8003E420(int arg0)
     return sum;
 }
 
-inline int match_item_kind(int kind)
+static inline int match_item_kind(int kind)
 {
     if (kind >= It_Common_Start && kind < It_Common_End) {
         return kind;
@@ -880,7 +880,7 @@ void fn_8003EE2C(int arg0, int arg1)
     }
 }
 
-inline unsigned int plBonusLib_8003F294_inline(plActionStats* stats,
+static inline unsigned int plBonusLib_8003F294_inline(plActionStats* stats,
                                                int attack)
 {
     return pl_800386D8(stats, attack);

--- a/src/melee/pl/plbonuslib.c
+++ b/src/melee/pl/plbonuslib.c
@@ -881,7 +881,7 @@ void fn_8003EE2C(int arg0, int arg1)
 }
 
 static inline unsigned int plBonusLib_8003F294_inline(plActionStats* stats,
-                                               int attack)
+                                                      int attack)
 {
     return pl_800386D8(stats, attack);
 }

--- a/src/melee/ty/toy.c
+++ b/src/melee/ty/toy.c
@@ -73,7 +73,7 @@ int Toy_GetTrophyTotal(void)
     }
 }
 
-inline static u16* idk(void)
+static inline u16* idk(void)
 {
     if (gm_IsCurrently1PMode() || gm_GetCurrentGameMode() == GM_TOY_LOTTERY) {
         return &Toy_804A284C[5];
@@ -217,7 +217,7 @@ bool _Toy_80304CC8_noinline(int arg0)
     return Toy_80304CC8(arg0);
 }
 
-inline static unsigned short* Toy_80304D30_idk(void)
+static inline unsigned short* Toy_80304D30_idk(void)
 {
     if (gm_IsCurrently1PMode() || gm_GetCurrentGameMode() == GM_TOY_LOTTERY) {
         return &Toy_804A284C[5];
@@ -226,12 +226,12 @@ inline static unsigned short* Toy_80304D30_idk(void)
     }
 }
 
-inline static int Toy_80304D30_48C0(int arg0)
+static inline int Toy_80304D30_48C0(int arg0)
 {
     return Toy_80304D30_idk()[arg0] & 0xFF;
 }
 
-inline static bool Toy_80304D30_4B0C(int arg0)
+static inline bool Toy_80304D30_4B0C(int arg0)
 {
     unsigned short* v;
     unsigned short s;
@@ -1809,7 +1809,7 @@ typedef union ToyPanelLabelData {
     char* ptrs[1];
 } ToyPanelLabelData;
 
-inline static void Toy_AddPanelAnims(HSD_JObj* jobj,
+static inline void Toy_AddPanelAnims(HSD_JObj* jobj,
                                      HSD_ShapeAnimJoint* shapanim,
                                      HSD_MatAnimJoint* matanim,
                                      HSD_AnimJoint* anim)

--- a/src/melee/ty/tydisplay.c
+++ b/src/melee/ty/tydisplay.c
@@ -2362,7 +2362,7 @@ s32 tyDisplay_8031C454(s32 arg0)
     return result;
 }
 
-inline void* un_8031C5E4_inline(HSD_Archive** arg0, u8 arg1, const char* arg2)
+static inline void* un_8031C5E4_inline(HSD_Archive** arg0, u8 arg1, const char* arg2)
 {
     return HSD_ArchiveGetPublicAddress(arg0[arg1], arg2);
 }

--- a/src/melee/ty/tydisplay.c
+++ b/src/melee/ty/tydisplay.c
@@ -2362,7 +2362,8 @@ s32 tyDisplay_8031C454(s32 arg0)
     return result;
 }
 
-static inline void* un_8031C5E4_inline(HSD_Archive** arg0, u8 arg1, const char* arg2)
+static inline void* un_8031C5E4_inline(HSD_Archive** arg0, u8 arg1,
+                                       const char* arg2)
 {
     return HSD_ArchiveGetPublicAddress(arg0[arg1], arg2);
 }

--- a/src/melee/vi/vi.h
+++ b/src/melee/vi/vi.h
@@ -12,7 +12,7 @@
 /* 31CA04 */ void vi_8031CA04(HSD_GObj*);
 /* 31CAAC */ void vi_8031CAAC(void);
 
-inline void vi_RunCamera(HSD_GObj* gobj, u8 erase_colors[4], u64 prio)
+static inline void vi_RunCamera(HSD_GObj* gobj, u8 erase_colors[4], u64 prio)
 {
     if (HSD_CObjSetCurrent(GET_COBJ(gobj))) {
         HSD_SetEraseColor(erase_colors[0], erase_colors[1], erase_colors[2],

--- a/src/melee/vi/vi1201v2.c
+++ b/src/melee/vi/vi1201v2.c
@@ -149,7 +149,7 @@ void un_8032074C(HSD_GObj* gobj)
     }
 }
 
-inline HSD_GObj* GET_EVENTDATA(void)
+static inline HSD_GObj* GET_EVENTDATA(void)
 {
     return GObj_Create(0xE, 0xF, 0);
 }

--- a/src/sysdolphin/baselib/archive.c
+++ b/src/sysdolphin/baselib/archive.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <dolphin/os.h>
 
-inline void Locate(HSD_Archive* archive)
+static inline void Locate(HSD_Archive* archive)
 {
     u32 i;
     u32* ptr;

--- a/src/sysdolphin/baselib/class.c
+++ b/src/sysdolphin/baselib/class.c
@@ -321,7 +321,8 @@ static inline HSD_ClassInfo* HSD_PushClassInfo(HSD_ClassInfo* class_info)
     return ret = class_info;
 }
 
-static inline bool hsdChangeClass_inline(HSD_Obj* object, HSD_ClassInfo* class_info)
+static inline bool hsdChangeClass_inline(HSD_Obj* object,
+                                         HSD_ClassInfo* class_info)
 {
     HSD_ClassInfo* var_r29;
     HSD_ClassInfo* var_r28;

--- a/src/sysdolphin/baselib/class.c
+++ b/src/sysdolphin/baselib/class.c
@@ -310,18 +310,18 @@ void* hsdNew(HSD_ClassInfo* i)
     return cls;
 }
 
-inline HSD_ClassInfo* HSD_GetClassInfo(HSD_Obj* object)
+static inline HSD_ClassInfo* HSD_GetClassInfo(HSD_Obj* object)
 {
     return object->parent.class_info;
 }
 
-inline HSD_ClassInfo* HSD_PushClassInfo(HSD_ClassInfo* class_info)
+static inline HSD_ClassInfo* HSD_PushClassInfo(HSD_ClassInfo* class_info)
 {
     HSD_ClassInfo* ret;
     return ret = class_info;
 }
 
-inline bool hsdChangeClass_inline(HSD_Obj* object, HSD_ClassInfo* class_info)
+static inline bool hsdChangeClass_inline(HSD_Obj* object, HSD_ClassInfo* class_info)
 {
     HSD_ClassInfo* var_r29;
     HSD_ClassInfo* var_r28;

--- a/src/sysdolphin/baselib/cobj.c
+++ b/src/sysdolphin/baselib/cobj.c
@@ -1260,7 +1260,7 @@ HSD_CObj* HSD_CObjAlloc(void)
     return cobj;
 }
 
-inline static void CObjResetFlags(HSD_CObj* cobj, u32 flags)
+static inline void CObjResetFlags(HSD_CObj* cobj, u32 flags)
 {
     if (cobj == NULL) {
         return;

--- a/src/sysdolphin/baselib/displayfunc.c
+++ b/src/sysdolphin/baselib/displayfunc.c
@@ -89,7 +89,7 @@ Vec3 zOne = { 0, 0, 1 };
 Vec3 yOne = { 0, 1, 0 };
 Vec3 zOne2 = { 0, 0, 1 };
 
-inline f32 HSD_MtxColMagFloat(MtxPtr mtx, int col)
+static inline f32 HSD_MtxColMagFloat(MtxPtr mtx, int col)
 {
     return sqrtf((mtx[0][col] * mtx[0][col]) + (mtx[1][col] * mtx[1][col]) +
                  (mtx[2][col] * mtx[2][col]));

--- a/src/sysdolphin/baselib/fobj.c
+++ b/src/sysdolphin/baselib/fobj.c
@@ -85,7 +85,7 @@ void HSD_FObjReqAnimAll(HSD_FObj* fobj, f32 startframe)
 }
 
 static inline void FObj_FlushKeyData(HSD_FObj* fobj, void* obj,
-                              HSD_ObjUpdateFunc obj_update, f32 rate)
+                                     HSD_ObjUpdateFunc obj_update, f32 rate)
 {
     if (fobj->op_intrp == HSD_A_OP_KEY) {
         HSD_FObjInterpretAnim(fobj, obj, obj_update, rate);

--- a/src/sysdolphin/baselib/fobj.c
+++ b/src/sysdolphin/baselib/fobj.c
@@ -51,7 +51,7 @@ u32 HSD_FObjGetState(HSD_FObj* fobj)
     return fobj->flags & 0xF;
 }
 
-inline void HSD_FObjReqAnim(HSD_FObj* fobj, f32 startframe)
+static inline void HSD_FObjReqAnim(HSD_FObj* fobj, f32 startframe)
 {
     if (fobj == NULL) {
         return;
@@ -84,7 +84,7 @@ void HSD_FObjReqAnimAll(HSD_FObj* fobj, f32 startframe)
     }
 }
 
-inline void FObj_FlushKeyData(HSD_FObj* fobj, void* obj,
+static inline void FObj_FlushKeyData(HSD_FObj* fobj, void* obj,
                               HSD_ObjUpdateFunc obj_update, f32 rate)
 {
     if (fobj->op_intrp == HSD_A_OP_KEY) {
@@ -295,7 +295,7 @@ static u32 FObjAnimKey(HSD_FObj* fobj)
     return HSD_FObjSetState(fobj, st == FOBJ_LOAD_DATA0 ? 3 : 4);
 }
 
-inline u32 FObjLoadData(HSD_FObj* fobj)
+static inline u32 FObjLoadData(HSD_FObj* fobj)
 {
     if ((unsigned) (fobj->ad - fobj->ad_head) >= fobj->length) {
         return 6;

--- a/src/sysdolphin/baselib/gobj.c
+++ b/src/sysdolphin/baselib/gobj.c
@@ -43,7 +43,7 @@ static GObjFuncs HSD_GObj_80408610 = {
     HSD_GObj_80408600,
 };
 
-inline void GObj_SetFlag1_inline(HSD_GObjProc* proc, u8 value)
+static inline void GObj_SetFlag1_inline(HSD_GObjProc* proc, u8 value)
 {
     while (proc != NULL) {
         proc->flags_1 = value;
@@ -51,7 +51,7 @@ inline void GObj_SetFlag1_inline(HSD_GObjProc* proc, u8 value)
     }
 }
 
-inline void GObj_SetFlag2_inline(HSD_GObjProc* proc, u8 value)
+static inline void GObj_SetFlag2_inline(HSD_GObjProc* proc, u8 value)
 {
     while (proc != NULL) {
         proc->flags_2 = value;
@@ -146,7 +146,7 @@ u32 HSD_GObj_80390EB8(s32 i)
     return HSD_GObj_804085F0[i];
 }
 
-inline void render_gobj(HSD_GObj* cur, int i)
+static inline void render_gobj(HSD_GObj* cur, int i)
 {
     HSD_GObj* saved = HSD_GObj_804D7814;
     HSD_GObj_804D7814 = cur;

--- a/src/sysdolphin/baselib/gobj.h
+++ b/src/sysdolphin/baselib/gobj.h
@@ -130,7 +130,6 @@ HSD_GObj* GObj_Create(u16 classifier, u8 p_link, u8 priority);
 void HSD_GObj_JObjCallback(HSD_GObj* gobj, int arg1);
 void HSD_GObj_80390CD4(HSD_GObj* gobj);
 void HSD_GObj_80390CFC(void);
-void render_gobj(HSD_GObj* cur, int i);
 void HSD_GObj_80390FC0(void);
 void HSD_GObj_LObjCallback(HSD_GObj* gobj, int unused);
 void HSD_GObj_FogCallback(HSD_GObj* gobj, int unused);

--- a/src/sysdolphin/baselib/gobjgxlink.c
+++ b/src/sysdolphin/baselib/gobjgxlink.c
@@ -65,7 +65,7 @@ void GObj_SetupGXLinkMax(HSD_GObj* gobj, GObj_RenderFunc render_cb,
     GObj_GXReorder(gobj, i);
 }
 
-inline HSD_GObj* GObj_GXFindPrioPosition(HSD_GObj* gobj)
+static inline HSD_GObj* GObj_GXFindPrioPosition(HSD_GObj* gobj)
 {
     HSD_GObj* i;
 
@@ -122,7 +122,7 @@ void HSD_GObjGXLink_8039084C(HSD_GObj* gobj)
     gobj->next_gx = NULL;
 }
 
-inline HSD_GObj* get_by_prio(HSD_GObj* gobj)
+static inline HSD_GObj* get_by_prio(HSD_GObj* gobj)
 {
     HSD_GObj* cur = HSD_GObjGXLinkHead[gobj->gx_link];
     while (cur != NULL && cur->render_priority < gobj->render_priority) {

--- a/src/sysdolphin/baselib/gobjplink.c
+++ b/src/sysdolphin/baselib/gobjplink.c
@@ -28,12 +28,12 @@ void GObj_PReorder(HSD_GObj* gobj, HSD_GObj* hiprio_gobj)
 
 extern HSD_ObjAllocData gobj_alloc_data;
 
-inline HSD_GObj* gobj_allocate(void)
+static inline HSD_GObj* gobj_allocate(void)
 {
     return HSD_ObjAlloc(&gobj_alloc_data);
 }
 
-inline void gobj_first_lower_prio(HSD_GObj* gobj)
+static inline void gobj_first_lower_prio(HSD_GObj* gobj)
 {
     HSD_GObj* var_r4 = plinklow_gobjs[gobj->p_link];
     while (var_r4 != NULL && var_r4->p_priority > gobj->p_priority) {
@@ -42,7 +42,7 @@ inline void gobj_first_lower_prio(HSD_GObj* gobj)
     GObj_PReorder(gobj, var_r4);
 }
 
-inline void gobj_first_higher_prio(HSD_GObj* gobj)
+static inline void gobj_first_higher_prio(HSD_GObj* gobj)
 {
     HSD_GObj* var_r4 = ((HSD_GObj**) HSD_GObj_Entities)[gobj->p_link];
     while (var_r4 != NULL && var_r4->p_priority < gobj->p_priority) {

--- a/src/sysdolphin/baselib/gobjproc.c
+++ b/src/sysdolphin/baselib/gobjproc.c
@@ -142,7 +142,7 @@ void HSD_GObjProc_8038FCE4(HSD_GObjProc* gproc)
     }
 }
 
-inline void assertProc(HSD_GObjProc* gproc)
+static inline void assertProc(HSD_GObjProc* gproc)
 {
     HSD_ASSERT(31, gproc);
 }

--- a/src/sysdolphin/baselib/hsd_3A94.c
+++ b/src/sysdolphin/baselib/hsd_3A94.c
@@ -1627,7 +1627,7 @@ u32 fn_803AC634(struct CardState* file_desc, s32 file_idx)
     }
 }
 
-inline u32 fn_803AC6B8_first_block_count(struct CardState* file_desc)
+static inline u32 fn_803AC6B8_first_block_count(struct CardState* file_desc)
 {
     if (file_desc->x4C[0] <= 0) {
         return 0;
@@ -1720,7 +1720,7 @@ static inline s32 fn_803AC6B8_blocks_before(struct CardState* file_desc,
     return total;
 }
 
-inline u32 fn_803AC7DC_block_count(struct CardState* file_desc, s32 file_idx)
+static inline u32 fn_803AC7DC_block_count(struct CardState* file_desc, s32 file_idx)
 {
     if (file_desc->x4C[file_idx] <= 0) {
         return 0;
@@ -1789,7 +1789,7 @@ s32 fn_803AC7DC(CardState* state)
     return total + extra;
 }
 
-inline s32 fn_803ACB74(s32 seq_a, s32 seq_b)
+static inline s32 fn_803ACB74(s32 seq_a, s32 seq_b)
 {
     s32 diff;
 
@@ -4960,7 +4960,7 @@ void hsd_803B24E4(s32* ctx, int channel, int file_no, void* work_buf)
     ctx[0] = (s32) work_buf;
 }
 
-inline HsdCmdEntry* hsd_803B2550_inline(u8* arg0, s32 arg1)
+static inline HsdCmdEntry* hsd_803B2550_inline(u8* arg0, s32 arg1)
 {
     return &((HsdCmdEntry*) (arg0 + 0x1210))[arg1];
 }

--- a/src/sysdolphin/baselib/hsd_3A94.c
+++ b/src/sysdolphin/baselib/hsd_3A94.c
@@ -81,6 +81,8 @@ typedef struct CardQueueEntry {
     fn_803ACFC0((state), (block_idx), (file_id), (seq_num), (payload),        \
                 (payload_len), (file_idx))
 
+/* 3A949C */ static void hsd_803A949C(s32 chan, s32 arg1);
+/* 3ACB74 */ static s32 fn_803ACB74(s32 seq_a, s32 seq_b);
 /* 4D1138 */ extern u8 hsd_804D1138[0x10];
 /* 4D1148 */ extern u32 hsd_804D1148[0x80][0x9];
 /* 4D2348 */ extern __baselib_UnkType003 hsd_804D2348;
@@ -104,7 +106,6 @@ typedef struct CardQueueEntry {
 /* 4D79C0 */ s32 hsd_804D79C0;
 /* 4D79C4 */ s32 hsd_804D79C4;
 /* 4D79C8 */ u8 hsd_804D79C8;
-/* 3A949C */ void hsd_803A949C(s32 chan, s32 arg1);
 
 static inline s32 hsd_803A949C_Close(CardState* state)
 {
@@ -1720,7 +1721,8 @@ static inline s32 fn_803AC6B8_blocks_before(struct CardState* file_desc,
     return total;
 }
 
-static inline u32 fn_803AC7DC_block_count(struct CardState* file_desc, s32 file_idx)
+static inline u32 fn_803AC7DC_block_count(struct CardState* file_desc,
+                                          s32 file_idx)
 {
     if (file_desc->x4C[file_idx] <= 0) {
         return 0;

--- a/src/sysdolphin/baselib/hsd_3A94.h
+++ b/src/sysdolphin/baselib/hsd_3A94.h
@@ -50,7 +50,6 @@ typedef struct CardState {
 /* 3AC634 */ u32 fn_803AC634(struct CardState* file_desc, s32 file_idx);
 /* 3AC6B8 */ s32 fn_803AC6B8(struct CardState* file_desc, s32 file_count);
 /* 3AC7DC */ s32 fn_803AC7DC(CardState*);
-/* 3ACB74 */ s32 fn_803ACB74(s32 seq_a, s32 seq_b);
 /* 3ACBE8 */ s32 fn_803ACBE8(CardState* state, s32 block_idx);
 /* 3ACC0C */ s32 fn_803ACC0C(CardState* state, s32 block_idx, s32 file_id,
                              s32 seq_num, void* expected_data, s32 data_size);

--- a/src/sysdolphin/baselib/id.c
+++ b/src/sysdolphin/baselib/id.c
@@ -23,12 +23,12 @@ void HSD_IDSetup(void)
     memset(&default_table, 0, sizeof(HSD_IDTable));
 }
 
-inline u32 hash(u32 id)
+static inline u32 hash(u32 id)
 {
     return id % 0x65;
 }
 
-inline IDEntry* IDEntryAlloc(void)
+static inline IDEntry* IDEntryAlloc(void)
 {
     IDEntry* entry;
 
@@ -67,7 +67,7 @@ void HSD_IDInsertToTable(HSD_IDTable* table, u32 id, void* data)
     }
 }
 
-inline void IDEntryFree(IDEntry* entry)
+static inline void IDEntryFree(IDEntry* entry)
 {
     HSD_ObjFree(HSD_IDGetAllocData(), entry);
 }

--- a/src/sysdolphin/baselib/jobj.c
+++ b/src/sysdolphin/baselib/jobj.c
@@ -127,7 +127,7 @@ void HSD_JObjWalkTree(HSD_JObj* jobj, HSD_JObjWalkTreeCallback cb,
     }
 }
 
-inline bool has_scl(HSD_JObj* jobj)
+static inline bool has_scl(HSD_JObj* jobj)
 {
     bool result = false;
     if (jobj != NULL && jobj->scl != NULL) {
@@ -608,7 +608,7 @@ void HSD_JObjSetDefaultClass(HSD_ClassInfo* info)
     default_class = info;
 }
 
-inline HSD_JObj* JObjLoadJointSub(HSD_Joint* joint, HSD_JObj* parent)
+static inline HSD_JObj* JObjLoadJointSub(HSD_Joint* joint, HSD_JObj* parent)
 {
     HSD_JObj* jobj;
     HSD_ClassInfo* info;
@@ -946,7 +946,7 @@ void HSD_JObjAddDObj(HSD_JObj* jobj, HSD_DObj* dobj)
     jobj->u.dobj = dobj;
 }
 
-inline HSD_RObj* robj_set_next(HSD_RObj* robj, HSD_RObj* next)
+static inline HSD_RObj* robj_set_next(HSD_RObj* robj, HSD_RObj* next)
 {
     if (robj == NULL) {
         return next;
@@ -1063,7 +1063,7 @@ HSD_JObj* HSD_JObjGetCurrent(void)
     return current_jobj;
 }
 
-inline HSD_JObj* jobj_get_joint2(HSD_JObj* jobj)
+static inline HSD_JObj* jobj_get_joint2(HSD_JObj* jobj)
 {
     while (jobj != NULL) {
         if ((jobj->flags & JOBJ_EFFECTOR) == JOBJ_JOINT2) {
@@ -1074,7 +1074,7 @@ inline HSD_JObj* jobj_get_joint2(HSD_JObj* jobj)
     return NULL;
 }
 
-inline HSD_JObj* jobj_get_effector(HSD_JObj* jobj)
+static inline HSD_JObj* jobj_get_effector(HSD_JObj* jobj)
 {
     while (jobj != NULL) {
         if ((jobj->flags & JOBJ_EFFECTOR) == JOBJ_EFFECTOR) {

--- a/src/sysdolphin/baselib/jobj.h
+++ b/src/sysdolphin/baselib/jobj.h
@@ -246,7 +246,8 @@ static inline void HSD_JObjSetMtxDirtyOutOfLine(HSD_JObj* jobj)
     HSD_JObjSetMtxDirtyOutOfLineLeaf(jobj);
 }
 
-static inline void HSD_JObjSetupMatrix(HSD_JObj* jobj)
+/// @todo Non-static inline
+inline void HSD_JObjSetupMatrix(HSD_JObj* jobj)
 {
     if (!jobj || !HSD_JObjMtxIsDirty(jobj)) {
         return;

--- a/src/sysdolphin/baselib/jobj.h
+++ b/src/sysdolphin/baselib/jobj.h
@@ -246,7 +246,7 @@ static inline void HSD_JObjSetMtxDirtyOutOfLine(HSD_JObj* jobj)
     HSD_JObjSetMtxDirtyOutOfLineLeaf(jobj);
 }
 
-inline void HSD_JObjSetupMatrix(HSD_JObj* jobj)
+static inline void HSD_JObjSetupMatrix(HSD_JObj* jobj)
 {
     if (!jobj || !HSD_JObjMtxIsDirty(jobj)) {
         return;

--- a/src/sysdolphin/baselib/lobj.c
+++ b/src/sysdolphin/baselib/lobj.c
@@ -649,7 +649,7 @@ void HSD_LObjDeleteCurrent(HSD_LObj* lobj)
     }
 }
 
-inline void LObjRemoveAll(void)
+static inline void LObjRemoveAll(void)
 {
     int i;
     for (i = 0; i < MAX_GXLIGHT; i++) {
@@ -682,7 +682,7 @@ void HSD_LObjSetCurrentAll(HSD_LObj* lobj)
     HSD_LObjAddCurrent(lobj);
 }
 
-inline void LObjReplaceAll(HSD_LObj* lobj)
+static inline void LObjReplaceAll(HSD_LObj* lobj)
 {
     int i;
     HSD_LObj* cur;

--- a/src/sysdolphin/baselib/lobj.h
+++ b/src/sysdolphin/baselib/lobj.h
@@ -110,7 +110,7 @@ struct HSD_LObjInfo {
 #define HSD_LOBJ_INFO(i) ((HSD_LObjInfo*) (i))
 #define HSD_LOBJ_METHOD(o) HSD_LOBJ_INFO(HSD_OBJECT_METHOD((o)))
 
-inline u8 HSD_LObjGetPriority(HSD_LObj* lobj)
+static inline u8 HSD_LObjGetPriority(HSD_LObj* lobj)
 {
     HSD_ASSERT(367, lobj);
     return lobj->priority;

--- a/src/sysdolphin/baselib/mtx.c
+++ b/src/sysdolphin/baselib/mtx.c
@@ -11,7 +11,7 @@ HSD_ObjAllocData HSD_Mtx_804C2310;
 HSD_ObjAllocData HSD_Mtx_804C233C;
 
 /// Calculates the determinant of the top 3x3 section of a 3x4 matrix
-inline f32 HSD_CalcDeterminantMatrix3x4(Mtx m)
+static inline f32 HSD_CalcDeterminantMatrix3x4(Mtx m)
 {
     return m[0][0] * m[1][1] * m[2][2] + m[0][1] * m[1][2] * m[2][0] +
            m[0][2] * m[1][0] * m[2][1] - m[2][0] * m[1][1] * m[0][2] -
@@ -202,7 +202,7 @@ void HSD_MtxInverseTranspose(Mtx src, Mtx dest)
     }
 }
 
-inline f32 calcVal(f32 x, f32 y)
+static inline f32 calcVal(f32 x, f32 y)
 {
     if (fabsf_bitwise(x) <= FLOAT_MIN) {
         if (y >= 0) {

--- a/src/sysdolphin/baselib/objalloc.c
+++ b/src/sysdolphin/baselib/objalloc.c
@@ -125,7 +125,7 @@ void HSD_ObjFree(HSD_ObjAllocData* data, void* obj)
     data->used -= 1;
 }
 
-inline void removeAll(HSD_ObjAllocData* data)
+static inline void removeAll(HSD_ObjAllocData* data)
 {
     HSD_ObjAllocData** cur = &alloc_datas;
     while (*cur != NULL) {

--- a/src/sysdolphin/baselib/robj.c
+++ b/src/sysdolphin/baselib/robj.c
@@ -342,7 +342,7 @@ static inline HSD_RObj* inlined_HSD_RObjGetByType(HSD_RObj* robj, u32 type,
     return NULL;
 }
 
-inline f32 HSD_MtxColMagFloat(MtxPtr mtx, int col)
+static inline f32 HSD_MtxColMagFloat(MtxPtr mtx, int col)
 {
     return sqrtf((mtx[0][col] * mtx[0][col]) + (mtx[1][col] * mtx[1][col]) +
                  (mtx[2][col] * mtx[2][col]));

--- a/src/sysdolphin/baselib/spline.c
+++ b/src/sysdolphin/baselib/spline.c
@@ -7,6 +7,9 @@
 #include <math.h>
 #include <MetroTRK/intrinsics.h>
 
+static void splGetCardinalPoint(Vec3*, Vec3*, f32, f32);
+static void splGetBezierPoint(Vec3*, Vec3*, f32);
+
 f32 splGetHelmite(f32 fterm, f32 time, f32 p0, f32 p1, f32 d0, f32 d1)
 {
     f32 _3t2_T2;
@@ -155,7 +158,8 @@ static inline f32* spl_GetCoeffs(HSD_Spline* spl, s32 idx)
     return spl->segPoly[idx];
 }
 
-static inline f32 spl_IterateSimpsonsMiddle(const f32 coeffs[5], const f32 dx, f32 t)
+static inline f32 spl_IterateSimpsonsMiddle(const f32 coeffs[5], const f32 dx,
+                                            f32 t)
 {
     f32 var_f24 = 0.0F;
     s32 i;

--- a/src/sysdolphin/baselib/spline.c
+++ b/src/sysdolphin/baselib/spline.c
@@ -28,7 +28,7 @@ f32 splGetHelmite(f32 fterm, f32 time, f32 p0, f32 p1, f32 d0, f32 d1)
                                      (p1 * (-_2t3_T3 + _3t2_T2))));
 }
 
-inline void splGetCardinalPoint(Vec3* p, Vec3* cp, f32 tension, f32 u)
+static inline void splGetCardinalPoint(Vec3* p, Vec3* cp, f32 tension, f32 u)
 {
     f32 u2 = u * u;
     f32 u3 = u2 * u;
@@ -62,7 +62,7 @@ static void splGetBSplinePoint(Vec3* p, Vec3* cp, f32 u)
     p->z = (cp[0].z * b0) + (cp[1].z * b1) + (cp[2].z * b2) + (cp[3].z * b3);
 }
 
-inline void splGetBezierPoint(Vec3* p, Vec3* cp, f32 u)
+static inline void splGetBezierPoint(Vec3* p, Vec3* cp, f32 u)
 {
     f32 u_1 = 1.0F - u;
     f32 u2 = u * u;
@@ -150,12 +150,12 @@ static f32 splArcLengthPolynomial(const f32 coeffs[5], f32 t)
     return sqrtf__Ff(result);
 }
 
-inline f32* spl_GetCoeffs(HSD_Spline* spl, s32 idx)
+static inline f32* spl_GetCoeffs(HSD_Spline* spl, s32 idx)
 {
     return spl->segPoly[idx];
 }
 
-inline f32 spl_IterateSimpsonsMiddle(const f32 coeffs[5], const f32 dx, f32 t)
+static inline f32 spl_IterateSimpsonsMiddle(const f32 coeffs[5], const f32 dx, f32 t)
 {
     f32 var_f24 = 0.0F;
     s32 i;

--- a/src/sysdolphin/baselib/spline.h
+++ b/src/sysdolphin/baselib/spline.h
@@ -16,8 +16,6 @@ struct HSD_Spline {
 };
 
 f32 splGetHelmite(f32, f32, f32, f32, f32, f32);
-void splGetCardinalPoint(Vec3*, Vec3*, f32, f32);
-void splGetBezierPoint(Vec3*, Vec3*, f32);
 void splGetSplinePoint(Vec3*, HSD_Spline*, f32);
 f32 splArcLengthGetParameter(HSD_Spline*, f32);
 void splArcLengthPoint(Vec3*, HSD_Spline*, f32);


### PR DESCRIPTION
Kind of a lazy stopgap at the moment. Need to eliminate `inline` keyword where possible, and move `static` keyword to the declaration (not the definition).

https://github.com/r-burns/doldecomp-melee/pull/2#issuecomment-5305776649
