### PR TITLE
lbmthp: privatize dolphin/thp usage

### DIFF
--- a/src/melee/gm/gm_1A9B.c
+++ b/src/melee/gm/gm_1A9B.c
@@ -84,16 +84,7 @@ static char* gmRegend_AllstarThpFiles[] = {
 
 void gm_801A9B30_OnEnter(UNK_T unused)
 {
-    struct {
-        int x0;
-        int x4;
-        int x8;
-        int xC;
-        float x10;
-        float x14;
-        u8 pad[0x40 - 0x18];
-        u32 x40;
-    }* thp_disp;
+    HSD_SObj* thp_disp;
     s32 ckind;
     HSD_GObj* gobj;
     HSD_GObj* sobj_gobj;

--- a/src/melee/lb/lb_01F8.c
+++ b/src/melee/lb/lb_01F8.c
@@ -1,6 +1,7 @@
 #include "lbfile.h"
 #include "lbmthp.h"
 
+#include <dolphin/thp/thp.h>
 #include <sysdolphin/baselib/memory.h>
 #include <sysdolphin/baselib/sobjlib.h>
 #include <sysdolphin/baselib/tobj.h>
@@ -27,7 +28,7 @@ extern struct lbl_804333E0_t Movieplayer;
 
 static struct lbl_804335B8_t lbl_804335B8;
 
-void* lbMthp8001F890(HSD_GObj* gobj)
+HSD_SObj* lbMthp8001F890(HSD_GObj* gobj)
 {
     lbl_804335B8.x70.image_ptr = NULL;
     lbl_804335B8.x70.width = lbl_804335B8.x6C;

--- a/src/melee/lb/lbmthp.c
+++ b/src/melee/lb/lbmthp.c
@@ -1,22 +1,124 @@
 #include "lbmthp.h"
 
-#include "lbmthp.static.h"
-
-#include "baselib/forward.h"
-
-#include "baselib/memory.h"
-#include "baselib/tobj.h"
-#include "baselib/video.h"
-#include "dolphin/os.h"
-#include "lb/lbfile.h"
+#include "lbfile.h"
 
 #include <dolphin/dvd.h>
 #include <dolphin/gx/GXTexture.h>
+#include <dolphin/os.h>
 #include <dolphin/os/OSCache.h>
+#include <dolphin/thp/thp.h>
+#include <baselib/memory.h>
+#include <baselib/tobj.h>
+#include <baselib/video.h>
 #include <sysdolphin/baselib/debug.h>
 #include <sysdolphin/baselib/devcom.h>
 #include <sysdolphin/baselib/sobjlib.h>
-#include <Runtime/runtime.h>
+
+/// @todo This is #THPDecComp.
+struct lbl_804333E0_t {
+    /* 0x000 */ char pad_0[0x20];
+    /* 0x020 */ u32 unk_20;
+    /* 0x024 */ char pad_24[0x1C];
+    /* 0x040 */ u32 unk_40;
+    /* 0x044 */ u32 unk_44;
+    /* 0x048 */ u32 unk_48;
+    /* 0x04C */ void** frame_buffers;
+    /* 0x050 */ void* unk_50;
+    /* 0x054 */ void* unk_54;
+    /* 0x058 */ void* unk_58;
+    /* 0x05C */ char pad_5C[0xC];
+    /* 0x068 */ s32 unk_68;
+    /* 0x06C */ char pad_6C[0x4];
+    /* 0x070 */ s32 unk_70;
+    /* 0x074 */ u32 unk_74;
+    /* 0x078 */ s32 unk_78;
+    /* 0x07C */ s32 unk_7C;
+    /* 0x080 */ s32 unk_80;
+    /* 0x084 */ s32 unk_84;
+    /* 0x088 */ s32 unk_88;
+    /* 0x08C */ u32 unk_8C;
+    /* 0x090 */ s32 unk_90;
+    /* 0x094 */ char pad_94[0x70];
+    /* 0x104 */ u32 unk_104;
+    /* 0x108 */ s32 unk_108;
+    /* 0x10C */ s32 unk_10C;
+    /* 0x110 */ s32 unk_110;
+    /* 0x114 */ char pad_114[0xC];
+    /* 0x120 */ u32 curr_file_offset;
+    /* 0x124 */ u32 currPackedSize;
+    /* 0x128 */ s32 file_entrynum;
+    /* 0x12C */ u32* rate_table;
+    /* 0x130 */ s32 unk_130;
+    /* 0x134 */ u32 unk_134; ///< OS ticks
+    /* 0x138 */ s32 unk_138;
+    /* 0x13C */ u32 unk_13C;
+    /* 0x140 */ void* unk_140;
+    /* 0x144 */ s32 unk_144;
+    /* 0x148 */ s32 unk_148;
+    /* 0x14C */ s32 power;
+    /* 0x150 */ OSAlarm alarm;
+    /* 0x178 */ GXTexObj unk_178;
+    /* 0x198 */ GXTexObj unk_198;
+    /* 0x1B8 */ GXTexObj unk_1B8;
+}; /* size = 0x1D8 */
+
+/* Struct used by fn_8001EBF0 for THP decode component init */
+typedef struct THPDecComp {
+    /* 0x00 */ u8 pad0[0x08];
+    /* 0x08 */ u32 version;
+    /* 0x0C */ u32 buf_size;
+    /* 0x10 */ u32 x_size;
+    /* 0x14 */ u32 y_size;
+    /* 0x18 */ u32 frame_rate;
+    /* 0x1C */ u32 num_frames;
+    /* 0x20 */ u32 first_frame;
+    /* 0x24 */ u32 frame_offsets;
+    /* 0x28 */ u32 first_frame_size;
+    /* 0x2C */ u8 pad2C[0x40 - 0x2C];
+    /* 0x40 */ u32 unk_40;
+    /* 0x44 */ u32 width;
+    /* 0x48 */ u32 height;
+    /* 0x4C */ u32* frame_buffers;
+    /* 0x50 */ void* unk_50;
+    /* 0x54 */ void* unk_54;
+    /* 0x58 */ void* unk_58;
+    /* 0x5C */ u8 pad5C[0x64 - 0x5C];
+    /* 0x64 */ u32 unk_64;
+    /* 0x68 */ s32 unk_68;
+    /* 0x6C */ s32 unk_6C;
+    /* 0x70 */ s32 unk_70;
+    /* 0x74 */ u32 unk_74;
+    /* 0x78 */ u32 unk_78;
+    /* 0x7C */ u32 unk_7C;
+    /* 0x80 */ u32 unk_80;
+    /* 0x84 */ u32 unk_84;
+    /* 0x88 */ u32 unk_88;
+    /* 0x8C */ u32 unk_8C;
+    /* 0x90 */ u32 unk_90;
+    /* 0x94 */ s32 unk_94;
+    /* 0x98 */ s32 unk_98;
+    /* 0x9C */ THPDec_8032FD40_Data unk_9C;
+    /* 0xA8 */ u16 unk_A8;
+    /* 0xAA */ u16 unk_AA;
+    /* 0xAC */ u8 unk_AC;
+    /* 0xAD */ u8 padAD[0x100 - 0xAD];
+    /* 0x100 */ u32 unk_100;
+    /* 0x104 */ u32 unk_104;
+    /* 0x108 */ s32 unk_108;
+    /* 0x10C */ s32 unk_10C;
+    /* 0x110 */ s32 unk_110;
+    /* 0x114 */ u8 pad114[0x11C - 0x114];
+    /* 0x11C */ s32 unk_11C;
+    /* 0x120 */ u32 curr_file_offset;
+    /* 0x124 */ u32 currPackedSize;
+    /* 0x128 */ s32 file_entrynum;
+    /* 0x12C */ u8 pad12C[0x130 - 0x12C];
+    /* 0x130 */ s32 unk_130;
+    /* 0x134 */ s32 unk_134;
+    /* 0x138 */ u32 unk_138;
+    /* 0x13C */ u32 unk_13C;
+    char pad[0x1D8 - 0x140];
+} THPDecComp;
 
 struct lbl_803BAFE8_t {
     /* 0x00 */ s32 x0;
@@ -31,7 +133,7 @@ struct lbl_803BAFE8_t {
 /* 01F294 */ static s32 fn_8001F294(void);
 /* 4333E0 */ static struct lbl_804333E0_t MoviePlayer;
 
-void fn_8001E910(int arg0, int arg1, void* arg2, int cancelflag)
+static void fn_8001E910(int arg0, int arg1, void* arg2, int cancelflag)
 {
     struct lbl_804333E0_t* streamPlayer = &MoviePlayer;
     s32 tick_diff;
@@ -100,7 +202,7 @@ void fn_8001E910(int arg0, int arg1, void* arg2, int cancelflag)
     streamPlayer->unk_110 = 0;
 }
 
-s32 fn_8001EB14(THPDecComp* data, const char* path)
+static s32 fn_8001EB14(THPDecComp* data, const char* path)
 {
     THPInit();
     data->file_entrynum = DVDConvertPathToEntrynum(path);
@@ -186,7 +288,7 @@ size_t fn_8001EBF0(THPDecComp* data)
     return size;
 }
 
-void fn_8001ECF4(THPDecComp* data, void* buf)
+static void fn_8001ECF4(THPDecComp* data, void* buf)
 {
     u32 height;
     u32 width;
@@ -263,7 +365,9 @@ void fn_8001ECF4(THPDecComp* data, void* buf)
     data->unk_98 = (s32) var_r29;
 }
 
-s32 fn_8001EF5C(THPDecComp* data)
+static s32 fn_8001F13C(THPDecComp* streamPlayer);
+
+static s32 fn_8001EF5C(THPDecComp* data)
 {
     s32 spC;
     BOOL intr;
@@ -295,7 +399,7 @@ s32 fn_8001EF5C(THPDecComp* data)
     return data->unk_94;
 }
 
-s32 fn_8001F06C(THPDecComp* data)
+static s32 fn_8001F06C(THPDecComp* data)
 {
     BOOL intr;
 
@@ -474,9 +578,8 @@ void lbMthp_8001F410(const char* filename, u32* rate_table, void* buf,
     OSCreateAlarm(&MoviePlayer.alarm);
     OSSetPeriodicAlarm((OSAlarm*) ((uintptr_t) &MoviePlayer +
                                    offsetof(struct lbl_804333E0_t, alarm)),
-                       __cvt_dbl_usll(OSSecondsToTicks(1.0f / 60)),
-                       __cvt_dbl_usll(OSSecondsToTicks(1.0f / 60)),
-                       fn_8001F2A4);
+                       OSSecondsToTicks(1.0f / 60),
+                       OSSecondsToTicks(1.0f / 60), fn_8001F2A4);
 }
 
 void lbMthp_8001F578(void)
@@ -490,7 +593,7 @@ void lbMthp_8001F578(void)
     OSRestoreInterrupts(intr);
 }
 
-s32 lbMthp_8001F5C4(void)
+int lbMthp_8001F5C4(void)
 {
     return MoviePlayer.unk_84;
 }
@@ -500,17 +603,17 @@ u32 lbMthp_8001F5D4(void)
     return MoviePlayer.unk_134;
 }
 
-s32 lbMthp_8001F5E4(void)
+int lbMthp_8001F5E4(void)
 {
     return MoviePlayer.unk_108;
 }
 
-s32 lbMthp_8001F5F4(void)
+int lbMthp_8001F5F4(void)
 {
     return MoviePlayer.unk_10C;
 }
 
-s32 lbMthp_8001F604(void)
+int lbMthp_8001F604(void)
 {
     return MoviePlayer.unk_144;
 }

--- a/src/melee/lb/lbmthp.c
+++ b/src/melee/lb/lbmthp.c
@@ -5,7 +5,6 @@
 #include <dolphin/dvd.h>
 #include <dolphin/gx/GXTexture.h>
 #include <dolphin/os.h>
-#include <dolphin/os/OSCache.h>
 #include <dolphin/thp/thp.h>
 #include <baselib/memory.h>
 #include <baselib/tobj.h>
@@ -13,54 +12,6 @@
 #include <sysdolphin/baselib/debug.h>
 #include <sysdolphin/baselib/devcom.h>
 #include <sysdolphin/baselib/sobjlib.h>
-
-/// @todo This is #THPDecComp.
-struct lbl_804333E0_t {
-    /* 0x000 */ char pad_0[0x20];
-    /* 0x020 */ u32 unk_20;
-    /* 0x024 */ char pad_24[0x1C];
-    /* 0x040 */ u32 unk_40;
-    /* 0x044 */ u32 unk_44;
-    /* 0x048 */ u32 unk_48;
-    /* 0x04C */ void** frame_buffers;
-    /* 0x050 */ void* unk_50;
-    /* 0x054 */ void* unk_54;
-    /* 0x058 */ void* unk_58;
-    /* 0x05C */ char pad_5C[0xC];
-    /* 0x068 */ s32 unk_68;
-    /* 0x06C */ char pad_6C[0x4];
-    /* 0x070 */ s32 unk_70;
-    /* 0x074 */ u32 unk_74;
-    /* 0x078 */ s32 unk_78;
-    /* 0x07C */ s32 unk_7C;
-    /* 0x080 */ s32 unk_80;
-    /* 0x084 */ s32 unk_84;
-    /* 0x088 */ s32 unk_88;
-    /* 0x08C */ u32 unk_8C;
-    /* 0x090 */ s32 unk_90;
-    /* 0x094 */ char pad_94[0x70];
-    /* 0x104 */ u32 unk_104;
-    /* 0x108 */ s32 unk_108;
-    /* 0x10C */ s32 unk_10C;
-    /* 0x110 */ s32 unk_110;
-    /* 0x114 */ char pad_114[0xC];
-    /* 0x120 */ u32 curr_file_offset;
-    /* 0x124 */ u32 currPackedSize;
-    /* 0x128 */ s32 file_entrynum;
-    /* 0x12C */ u32* rate_table;
-    /* 0x130 */ s32 unk_130;
-    /* 0x134 */ u32 unk_134; ///< OS ticks
-    /* 0x138 */ s32 unk_138;
-    /* 0x13C */ u32 unk_13C;
-    /* 0x140 */ void* unk_140;
-    /* 0x144 */ s32 unk_144;
-    /* 0x148 */ s32 unk_148;
-    /* 0x14C */ s32 power;
-    /* 0x150 */ OSAlarm alarm;
-    /* 0x178 */ GXTexObj unk_178;
-    /* 0x198 */ GXTexObj unk_198;
-    /* 0x1B8 */ GXTexObj unk_1B8;
-}; /* size = 0x1D8 */
 
 /* Struct used by fn_8001EBF0 for THP decode component init */
 typedef struct THPDecComp {
@@ -112,12 +63,19 @@ typedef struct THPDecComp {
     /* 0x120 */ u32 curr_file_offset;
     /* 0x124 */ u32 currPackedSize;
     /* 0x128 */ s32 file_entrynum;
-    /* 0x12C */ u8 pad12C[0x130 - 0x12C];
+    /* 0x12C */ u32* rate_table;
     /* 0x130 */ s32 unk_130;
     /* 0x134 */ s32 unk_134;
     /* 0x138 */ u32 unk_138;
     /* 0x13C */ u32 unk_13C;
-    char pad[0x1D8 - 0x140];
+    /* 0x140 */ void* unk_140;
+    /* 0x144 */ s32 unk_144;
+    /* 0x148 */ s32 unk_148;
+    /* 0x14C */ s32 power;
+    /* 0x150 */ OSAlarm alarm;
+    /* 0x178 */ GXTexObj unk_178;
+    /* 0x198 */ GXTexObj unk_198;
+    /* 0x1B8 */ GXTexObj unk_1B8;
 } THPDecComp;
 
 struct lbl_803BAFE8_t {
@@ -131,11 +89,11 @@ struct lbl_803BAFE8_t {
 }; /* size = 0x18 */
 
 /* 01F294 */ static s32 fn_8001F294(void);
-/* 4333E0 */ static struct lbl_804333E0_t MoviePlayer;
+/* 4333E0 */ static THPDecComp MoviePlayer;
 
 static void fn_8001E910(int arg0, int arg1, void* arg2, int cancelflag)
 {
-    struct lbl_804333E0_t* streamPlayer = &MoviePlayer;
+    THPDecComp* streamPlayer = &MoviePlayer;
     s32 tick_diff;
     s32 var_r0;
     s32 did_request;
@@ -151,7 +109,7 @@ static void fn_8001E910(int arg0, int arg1, void* arg2, int cancelflag)
     if (streamPlayer->unk_74 != 0U) {
         streamPlayer->curr_file_offset += streamPlayer->currPackedSize;
     } else {
-        streamPlayer->curr_file_offset = streamPlayer->unk_20;
+        streamPlayer->curr_file_offset = streamPlayer->first_frame;
     }
     if (streamPlayer->unk_8C == 0) {
         var_r0 = streamPlayer->unk_104 - 1;
@@ -253,9 +211,9 @@ size_t fn_8001EBF0(THPDecComp* data)
     width = data->width;
     height = data->height;
     wh = width * height;
-    data->unk_9C.val1 = (u16) width;
+    data->unk_9C.val1 = width;
     height = data->height;
-    data->unk_9C._pad = (u16) height;
+    data->unk_9C._pad = height;
 
     data->unk_9C.val2 = 4;
 
@@ -267,7 +225,7 @@ size_t fn_8001EBF0(THPDecComp* data)
     size += wh_div4;
     size += wh_div4;
 
-    size += THPDec_8032FD40(&data->unk_9C, (u16) data->height);
+    size += THPDec_8032FD40(&data->unk_9C, data->height);
 
     data->unk_7C = 0;
     data->unk_78 = 0;
@@ -278,8 +236,8 @@ size_t fn_8001EBF0(THPDecComp* data)
     data->unk_94 = -1;
     data->unk_68 = 0;
 
-    data->unk_A8 = (u16) data->width;
-    data->unk_AA = (u16) data->height;
+    data->unk_A8 = data->width;
+    data->unk_AA = data->height;
     data->unk_AC = 0;
 
     size += ALIGN_32(data->unk_104 * 4);
@@ -509,22 +467,21 @@ static inline u32 lbMthp_GetFrame(u32** rate_table, u32 counter)
     return frame;
 }
 
-static inline void lbMthp_GetPlayer(struct lbl_804333E0_t** streamPlayer,
+static inline void lbMthp_GetPlayer(THPDecComp** streamPlayer,
                                     u32*** rate_table)
 {
     *streamPlayer = &MoviePlayer;
     *rate_table = &(*streamPlayer)->rate_table;
 }
 
-static inline THPDecComp*
-lbMthp_GetDecoder(struct lbl_804333E0_t* streamPlayer)
+static inline THPDecComp* lbMthp_GetDecoder(THPDecComp* streamPlayer)
 {
-    return (THPDecComp*) streamPlayer;
+    return streamPlayer;
 }
 
 void fn_8001F2A4(OSAlarm* alarm, OSContext* context)
 {
-    struct lbl_804333E0_t* streamPlayer;
+    THPDecComp* streamPlayer;
     u32** rate_table;
     u32 frame;
 
@@ -557,7 +514,9 @@ void fn_8001F2A4(OSAlarm* alarm, OSContext* context)
 void lbMthp_8001F410(const char* filename, u32* rate_table, void* buf,
                      size_t heap_size, int loop)
 {
+    THPDecComp* streamPlayer;
     size_t memoryRequired;
+    streamPlayer = &MoviePlayer;
 
     HSD_ASSERT(833, !MoviePlayer.power);
     MoviePlayer.power = 1;
@@ -576,9 +535,7 @@ void lbMthp_8001F410(const char* filename, u32* rate_table, void* buf,
     MoviePlayer.unk_144 = 0;
     MoviePlayer.unk_148 = 1;
     OSCreateAlarm(&MoviePlayer.alarm);
-    OSSetPeriodicAlarm((OSAlarm*) ((uintptr_t) &MoviePlayer +
-                                   offsetof(struct lbl_804333E0_t, alarm)),
-                       OSSecondsToTicks(1.0f / 60),
+    OSSetPeriodicAlarm(&streamPlayer->alarm, OSSecondsToTicks(1.0f / 60),
                        OSSecondsToTicks(1.0f / 60), fn_8001F2A4);
 }
 
@@ -641,30 +598,28 @@ HSD_SObj* lbMthp_8001F624(HSD_GObj* gobj, int width, int height)
 
 void lbMthp_8001F67C(HSD_GObj* gobj, int arg1)
 {
-    struct lbl_804333E0_t* streamPlayer = &MoviePlayer;
+    THPDecComp* streamPlayer = &MoviePlayer;
     PAD_STACK(8);
 
-    fn_8001EF5C((THPDecComp*) streamPlayer);
+    fn_8001EF5C(streamPlayer);
     if (streamPlayer->unk_148 != 0) {
         GXInitTexObj(&streamPlayer->unk_178, streamPlayer->unk_50,
-                     (u16) streamPlayer->unk_44, (u16) streamPlayer->unk_48,
-                     GX_TF_I8, GX_CLAMP, GX_CLAMP, 0U);
+                     streamPlayer->width, streamPlayer->height, GX_TF_I8,
+                     GX_CLAMP, GX_CLAMP, 0U);
         GXInitTexObjLOD(&streamPlayer->unk_178, GX_NEAR, GX_NEAR, 0.0f, 0.0f,
                         0.0f, 0U, 0U, GX_ANISO_1);
         GXLoadTexObj(&streamPlayer->unk_178, GX_TEXMAP0);
 
         GXInitTexObj(&streamPlayer->unk_198, streamPlayer->unk_54,
-                     (u16) (streamPlayer->unk_44 >> 1U),
-                     (u16) (streamPlayer->unk_48 >> 1U), GX_TF_I8, GX_CLAMP,
-                     GX_CLAMP, 0U);
+                     streamPlayer->width / 2, streamPlayer->height / 2,
+                     GX_TF_I8, GX_CLAMP, GX_CLAMP, 0U);
         GXInitTexObjLOD(&streamPlayer->unk_198, GX_NEAR, GX_NEAR, 0.0f, 0.0f,
                         0.0f, 0U, 0U, GX_ANISO_1);
         GXLoadTexObj(&streamPlayer->unk_198, GX_TEXMAP1);
 
         GXInitTexObj(&streamPlayer->unk_1B8, streamPlayer->unk_58,
-                     (u16) (streamPlayer->unk_44 >> 1U),
-                     (u16) (streamPlayer->unk_48 >> 1U), GX_TF_I8, GX_CLAMP,
-                     GX_CLAMP, 0U);
+                     streamPlayer->width / 2, streamPlayer->height / 2,
+                     GX_TF_I8, GX_CLAMP, GX_CLAMP, 0U);
         GXInitTexObjLOD(&streamPlayer->unk_1B8, GX_NEAR, GX_NEAR, 0.0f, 0.0f,
                         0.0f, 0U, 0U, GX_ANISO_1);
         GXLoadTexObj(&streamPlayer->unk_1B8, GX_TEXMAP2);

--- a/src/melee/lb/lbmthp.c
+++ b/src/melee/lb/lbmthp.c
@@ -575,7 +575,7 @@ int lbMthp_8001F604(void)
     return MoviePlayer.unk_144;
 }
 
-void lbMthp_8001F614(s32 arg0)
+void lbMthp_8001F614(int arg0)
 {
     MoviePlayer.unk_148 = arg0;
 }

--- a/src/melee/lb/lbmthp.h
+++ b/src/melee/lb/lbmthp.h
@@ -13,7 +13,7 @@ u32 lbMthp_8001F5D4(void);
 int lbMthp_8001F5E4(void);
 int lbMthp_8001F5F4(void);
 int lbMthp_8001F604(void);
-void lbMthp_8001F614(s32 arg0);
+void lbMthp_8001F614(int arg0);
 HSD_SObj* lbMthp_8001F624(HSD_GObj*, int, int);
 void lbMthp_8001F67C(HSD_GObj*, int);
 void lbMthp_8001F800(void);

--- a/src/melee/lb/lbmthp.h
+++ b/src/melee/lb/lbmthp.h
@@ -1,154 +1,25 @@
-#ifndef GALE01_01E8F8
-#define GALE01_01E8F8
+#ifndef MELEE_LB_MTHP_H
+#define MELEE_LB_MTHP_H
 
-#include <placeholder.h>
-#include <platform.h>
-
-#include "lb/forward.h"
 #include <baselib/forward.h>
 
 #include <stddef.h>
-#include <dolphin/gx/GXStruct.h>
-#include <dolphin/thp/thp.h>
 
-/* THPDec function declarations */
-BOOL THPInit(void);
-s32 THPDec_8032F8D4(u32, void*);
-s32 THPDec_8032FD40(THPDec_8032FD40_Data* arg0, u16 height);
-void THPDec_80331340(s32, void*, void*, void*);
-void THPDec_803313D0(s32, void*, void*, void*, u32);
-s32 THPVideoDecode(void*, void*, void*, void*, void*);
-
-/// @todo This is #THPDecComp.
-struct lbl_804333E0_t {
-    /* 0x000 */ char pad_0[0x20];
-    /* 0x020 */ u32 unk_20;
-    /* 0x024 */ char pad_24[0x1C];
-    /* 0x040 */ u32 unk_40;
-    /* 0x044 */ u32 unk_44;
-    /* 0x048 */ u32 unk_48;
-    /* 0x04C */ void** frame_buffers;
-    /* 0x050 */ void* unk_50;
-    /* 0x054 */ void* unk_54;
-    /* 0x058 */ void* unk_58;
-    /* 0x05C */ char pad_5C[0xC];
-    /* 0x068 */ s32 unk_68;
-    /* 0x06C */ char pad_6C[0x4];
-    /* 0x070 */ s32 unk_70;
-    /* 0x074 */ u32 unk_74;
-    /* 0x078 */ s32 unk_78;
-    /* 0x07C */ s32 unk_7C;
-    /* 0x080 */ s32 unk_80;
-    /* 0x084 */ s32 unk_84;
-    /* 0x088 */ s32 unk_88;
-    /* 0x08C */ u32 unk_8C;
-    /* 0x090 */ s32 unk_90;
-    /* 0x094 */ char pad_94[0x70];
-    /* 0x104 */ u32 unk_104;
-    /* 0x108 */ s32 unk_108;
-    /* 0x10C */ s32 unk_10C;
-    /* 0x110 */ s32 unk_110;
-    /* 0x114 */ char pad_114[0xC];
-    /* 0x120 */ u32 curr_file_offset;
-    /* 0x124 */ u32 currPackedSize;
-    /* 0x128 */ s32 file_entrynum;
-    /* 0x12C */ u32* rate_table;
-    /* 0x130 */ s32 unk_130;
-    /* 0x134 */ u32 unk_134; ///< OS ticks
-    /* 0x138 */ s32 unk_138;
-    /* 0x13C */ u32 unk_13C;
-    /* 0x140 */ void* unk_140;
-    /* 0x144 */ s32 unk_144;
-    /* 0x148 */ s32 unk_148;
-    /* 0x14C */ s32 power;
-    /* 0x150 */ OSAlarm alarm;
-    /* 0x178 */ GXTexObj unk_178;
-    /* 0x198 */ GXTexObj unk_198;
-    /* 0x1B8 */ GXTexObj unk_1B8;
-}; /* size = 0x1D8 */
-STATIC_ASSERT(sizeof(struct lbl_804333E0_t) == 0x1D8);
-
-/* Struct used by fn_8001EBF0 for THP decode component init */
-typedef struct THPDecComp {
-    /* 0x00 */ u8 pad0[0x08];
-    /* 0x08 */ u32 version;
-    /* 0x0C */ u32 buf_size;
-    /* 0x10 */ u32 x_size;
-    /* 0x14 */ u32 y_size;
-    /* 0x18 */ u32 frame_rate;
-    /* 0x1C */ u32 num_frames;
-    /* 0x20 */ u32 first_frame;
-    /* 0x24 */ u32 frame_offsets;
-    /* 0x28 */ u32 first_frame_size;
-    /* 0x2C */ u8 pad2C[0x40 - 0x2C];
-    /* 0x40 */ u32 unk_40;
-    /* 0x44 */ u32 width;
-    /* 0x48 */ u32 height;
-    /* 0x4C */ u32* frame_buffers;
-    /* 0x50 */ void* unk_50;
-    /* 0x54 */ void* unk_54;
-    /* 0x58 */ void* unk_58;
-    /* 0x5C */ u8 pad5C[0x64 - 0x5C];
-    /* 0x64 */ u32 unk_64;
-    /* 0x68 */ s32 unk_68;
-    /* 0x6C */ s32 unk_6C;
-    /* 0x70 */ s32 unk_70;
-    /* 0x74 */ u32 unk_74;
-    /* 0x78 */ u32 unk_78;
-    /* 0x7C */ u32 unk_7C;
-    /* 0x80 */ u32 unk_80;
-    /* 0x84 */ u32 unk_84;
-    /* 0x88 */ u32 unk_88;
-    /* 0x8C */ u32 unk_8C;
-    /* 0x90 */ u32 unk_90;
-    /* 0x94 */ s32 unk_94;
-    /* 0x98 */ s32 unk_98;
-    /* 0x9C */ THPDec_8032FD40_Data unk_9C;
-    /* 0xA8 */ u16 unk_A8;
-    /* 0xAA */ u16 unk_AA;
-    /* 0xAC */ u8 unk_AC;
-    /* 0xAD */ u8 padAD[0x100 - 0xAD];
-    /* 0x100 */ u32 unk_100;
-    /* 0x104 */ u32 unk_104;
-    /* 0x108 */ s32 unk_108;
-    /* 0x10C */ s32 unk_10C;
-    /* 0x110 */ s32 unk_110;
-    /* 0x114 */ u8 pad114[0x11C - 0x114];
-    /* 0x11C */ s32 unk_11C;
-    /* 0x120 */ u32 curr_file_offset;
-    /* 0x124 */ u32 currPackedSize;
-    /* 0x128 */ s32 file_entrynum;
-    /* 0x12C */ u8 pad12C[0x130 - 0x12C];
-    /* 0x130 */ s32 unk_130;
-    /* 0x134 */ s32 unk_134;
-    /* 0x138 */ u32 unk_138;
-    /* 0x13C */ u32 unk_13C;
-    char pad[0x1D8 - 0x140];
-} THPDecComp;
-STATIC_ASSERT(sizeof(struct THPDecComp) == sizeof(struct lbl_804333E0_t));
-
-/* 01E910 */ void fn_8001E910(int, int, void*, int);
-/* 01EB14 */ s32 fn_8001EB14(THPDecComp* data, const char* path);
-/* 01EBF0 */ size_t fn_8001EBF0(THPDecComp* data);
-/* 01ECF4 */ void fn_8001ECF4(THPDecComp* data, void* buf);
-/* 01EF5C */ s32 fn_8001EF5C(THPDecComp* data);
-/* 01F06C */ s32 fn_8001F06C(THPDecComp* data);
-/* 01F13C */ s32 fn_8001F13C(THPDecComp* data);
-/* 01F410 */ void lbMthp_8001F410(const char* filename, u32* rate_table,
-                                  void* buf, size_t heap_size, int loop);
-/* 01F578 */ void lbMthp_8001F578(void);
-/* 01F5C4 */ s32 lbMthp_8001F5C4(void);
-/* 01F5D4 */ u32 lbMthp_8001F5D4(void);
-/* 01F5E4 */ s32 lbMthp_8001F5E4(void);
-/* 01F5F4 */ s32 lbMthp_8001F5F4(void);
-/* 01F604 */ s32 lbMthp_8001F604(void);
-/* 01F614 */ void lbMthp_8001F614(s32 arg0);
-/* 01F624 */ HSD_SObj* lbMthp_8001F624(HSD_GObj*, int, int);
-/* 01F67C */ void lbMthp_8001F67C(HSD_GObj*, int);
-/* 01F800 */ void lbMthp_8001F800(void);
-/* 01F87C */ void lbMthp_8001F87C(void);
-/* 01F890 */ void* lbMthp8001F890(HSD_GObj*);
-/* 01F928 */ void lbMthp8001F928(HSD_GObj*, int);
-/* 01FAA0 */ UNK_RET lbMthp8001FAA0(const char* filename, int, int);
+void lbMthp_8001F410(const char* filename, u32* rate_table, void* buf,
+                     size_t heap_size, int loop);
+void lbMthp_8001F578(void);
+int lbMthp_8001F5C4(void);
+u32 lbMthp_8001F5D4(void);
+int lbMthp_8001F5E4(void);
+int lbMthp_8001F5F4(void);
+int lbMthp_8001F604(void);
+void lbMthp_8001F614(s32 arg0);
+HSD_SObj* lbMthp_8001F624(HSD_GObj*, int, int);
+void lbMthp_8001F67C(HSD_GObj*, int);
+void lbMthp_8001F800(void);
+void lbMthp_8001F87C(void);
+HSD_SObj* lbMthp8001F890(HSD_GObj*);
+void lbMthp8001F928(HSD_GObj*, int);
+void lbMthp8001FAA0(const char* filename, int, int);
 
 #endif

--- a/src/melee/lb/lbmthp.h
+++ b/src/melee/lb/lbmthp.h
@@ -1,5 +1,5 @@
-#ifndef MELEE_LB_MTHP_H
-#define MELEE_LB_MTHP_H
+#ifndef GALE01_01E8F8
+#define GALE01_01E8F8
 
 #include <baselib/forward.h>
 

--- a/src/melee/lb/lbmthp.static.h
+++ b/src/melee/lb/lbmthp.static.h
@@ -1,9 +1,0 @@
-#ifndef __GALE01_01E8F8
-#define __GALE01_01E8F8
-
-#include "lbmthp.h" // IWYU pragma: export
-
-#include <dolphin/os/OSAlarm.h>
-#include <baselib/sobjlib.h>
-
-#endif


### PR DESCRIPTION
Dolphin THP is now only used internally by lbmthp, making lbmthp an opaque wrapper library which shields its consumers from the THP details.