### PR TITLE
Match fn_80397814 (debugconsole_main)

### DIFF
--- a/src/sysdolphin/baselib/debugconsole_main.c
+++ b/src/sysdolphin/baselib/debugconsole_main.c
@@ -2774,7 +2774,7 @@ void* fn_80397814(void* arg)
         }
         if (node != NULL) {
             if (node->child != NULL) {
-                hsd_80397520(node->child);
+                hsd_80397520(ps_node_child(node));
             }
             if (node->callback != NULL) {
                 node->callback(node);


### PR DESCRIPTION
`fn_80397814` has two `hsd_80397520()` call sites guarded by `node->child != NULL`. The second already uses the `ps_node_child()` accessor added in #2899; the first still dereferenced `node->child` directly. Using the accessor at both sites matches.

99.410 -> 100.0