### PR TITLE
Match fn_8018D50C and fn_8018E46C

### DIFF
--- a/src/melee/gm/gmtoulib.c
+++ b/src/melee/gm/gmtoulib.c
@@ -1198,16 +1198,10 @@ void fn_8018C8D4(BracketEntry* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4,
 static GXColor const lbl_804DA684 = { 255, 255, 0, 255 };
 
 /// Draws tournament bracket connector lines with optional tail segments.
-void fn_8018D50C(BracketEntry* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4,
+void fn_8018D50C(BracketEntry* data, s32 arg1, s32 arg2, s32 arg3, s32 arg4,
                  s32 arg5)
 {
     TmData* tm;
-    /// @todo Redundant cast and assignment improves match
-#ifdef MUST_MATCH
-    BracketEntry* data = (BracketEntry*) arg0;
-#else
-    BracketEntry* data = arg0;
-#endif
     f32 thickness;
     f32 neg_thickness;
     s32 right;
@@ -1448,15 +1442,19 @@ static const GXColor lbl_804DA69C = { 255, 255, 0, 255 };
 void fn_8018DF68(BracketEntry* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4,
                  s32 arg5)
 {
-    GXColor right_color;
-    GXColor left_third_color;
     GXColor line_color;
     GXColor first_color;
-    GXColor slot3_vertical_color;
-    GXColor slot0_horizontal_color;
+    GXColor right_color;
+    GXColor left_third_color;
     GXColor right_third_color;
     GXColor horizontal_color;
     GXColor slot0_vertical_color;
+    GXColor slot0_horizontal_color;
+    GXColor slot1_vertical_color;
+    GXColor slot1_horizontal_color;
+    GXColor slot2_vertical_color;
+    GXColor slot2_horizontal_color;
+    GXColor slot3_vertical_color;
     GXColor slot3_horizontal_color;
     f32 neg_thickness;
     f32 thickness;
@@ -1513,8 +1511,6 @@ void fn_8018DF68(BracketEntry* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4,
             return;
         }
         if (arg0->slots[1].x4C == 0) {
-            GXColor slot1_vertical_color;
-            GXColor slot1_horizontal_color;
             GXColor* entry_color = &arg0->x20;
             slot1_vertical_color = *entry_color;
             DrawRectangle(left_third, arg2, thickness, arg4,
@@ -1529,8 +1525,6 @@ void fn_8018DF68(BracketEntry* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4,
             return;
         }
         if (arg0->slots[2].x4C == 0) {
-            GXColor slot2_horizontal_color;
-            GXColor slot2_vertical_color;
             GXColor* entry_color = &arg0->x20;
             slot2_vertical_color = *entry_color;
             DrawRectangle(right_third, arg2, thickness, arg4,

--- a/src/melee/gm/gmtoulib.c
+++ b/src/melee/gm/gmtoulib.c
@@ -901,7 +901,7 @@ static GXColor const lbl_804DA67C = { 0xFF, 0xFF, 0, 0xFF };
 
 /// Draws tournament bracket lines for different bracket types (0-3).
 void fn_8018C8D4(BracketEntry* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4,
-                 s32 arg5, s32 arg6, f32 farg0)
+                 s32 arg5)
 {
     /// @todo Redundant cast and assignment improves match
 #ifdef MUST_MATCH
@@ -1199,7 +1199,7 @@ static GXColor const lbl_804DA684 = { 255, 255, 0, 255 };
 
 /// Draws tournament bracket connector lines with optional tail segments.
 void fn_8018D50C(BracketEntry* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4,
-                 s32 arg5, s32 arg6, f32 farg0)
+                 s32 arg5)
 {
     TmData* tm;
     /// @todo Redundant cast and assignment improves match
@@ -1213,7 +1213,7 @@ void fn_8018D50C(BracketEntry* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4,
     s32 right;
     s32 bottom;
     GXColor c0, c1, c2, c3, c4, c5, c6, c7, c8, c9;
-    GXColor c10, c11, c12, c13, c14, c15, c16, c17, c18;
+    GXColor c10, c11, c12, c13, c14, c15, c16, c17, c18, c19;
 
     tm = gm_GetTournamentData();
     c0 = lbl_804DA684;
@@ -1352,17 +1352,16 @@ void fn_8018D50C(BracketEntry* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4,
                     }
                 }
             } else {
-                bottom = arg2 + 0x1E;
                 c18 = c0;
                 {
                     GXColor* color = &c18;
-                    DrawRectangle((f32) right, (f32) bottom, thickness, -30.0f,
-                                  color);
+                    DrawRectangle((f32) right, (f32) (arg2 + 0x1E), thickness,
+                                  -30.0f, color);
                 }
                 if (data->x20.g == 0 && data->slots[0].x4C != 0) {
-                    c17 = data->x20;
-                    DrawRectangle((f32) right, (f32) bottom, thickness, -30.0f,
-                                  &c17);
+                    c19 = data->x20;
+                    DrawRectangle((f32) right, (f32) (arg2 + 0x1E), thickness,
+                                  -30.0f, &c19);
                 }
             }
         }
@@ -1377,7 +1376,7 @@ static inline int fn_8018DC18_inline0(BracketEntry* data)
 }
 
 void fn_8018DC18(BracketEntry* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4,
-                 s32 arg5, s32 arg6, f32 farg0)
+                 s32 arg5)
 {
     f32 thickness;
     f32 neg_thickness;
@@ -1447,7 +1446,7 @@ void fn_8018DC18(BracketEntry* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4,
 static const GXColor lbl_804DA69C = { 255, 255, 0, 255 };
 
 void fn_8018DF68(BracketEntry* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4,
-                 s32 arg5, s32 arg6, f32 farg0)
+                 s32 arg5)
 {
     GXColor right_color;
     GXColor left_third_color;
@@ -1567,7 +1566,6 @@ void fn_8018E46C(HSD_GObj* gobj, int unused)
 {
     BracketEntry* data;
     s32 temp;
-    int new_var;
     s32 r30;
 
     data = gobj->user_data;
@@ -1583,24 +1581,20 @@ void fn_8018E46C(HSD_GObj* gobj, int unused)
     hsd_80391A04(1.0F, 1.0F, 1);
     switch (data->x3) {
     case 0:
-        new_var = data->x18;
         fn_8018C8D4(data, data->xC - (s32) (0.5f * data->x1C), -data->x10,
-                    data->x14, -new_var, r30, data->xC, 0.5f);
+                    data->x14, -data->x18, r30);
         break;
     case 1:
-        new_var = data->x18;
         fn_8018D50C(data, data->xC - (s32) (0.5f * data->x1C), -data->x10,
-                    data->x14, -new_var, r30, data->xC, 0.5f);
+                    data->x14, -data->x18, r30);
         break;
     case 2:
-        new_var = data->x18;
         fn_8018DC18(data, data->xC - (s32) (0.5f * data->x1C), -data->x10,
-                    data->x14, -new_var, r30, data->xC, 0.5f);
+                    data->x14, -data->x18, r30);
         break;
     case 3:
-        new_var = data->x18;
         fn_8018DF68(data, data->xC - (s32) (0.5f * data->x1C), -data->x10,
-                    data->x14, -new_var, r30, data->xC, 0.5f);
+                    data->x14, -data->x18, r30);
         break;
     }
 }

--- a/src/melee/gm/gmtoulib.c
+++ b/src/melee/gm/gmtoulib.c
@@ -917,7 +917,7 @@ void fn_8018C8D4(BracketEntry* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4,
     s32 half, center, right, left;
     GXColor c10, c11, c12, c13, c14, c15, c16, c17, c18, c19;
     GXColor c20, c21, c22, c23, c24, c25, c26, c27, c28, c29;
-    GXColor c30, c31;
+    GXColor c30, c31, c32, c33;
 
     c0 = lbl_804DA67C;
     thickness = data->x1C;
@@ -1178,15 +1178,15 @@ void fn_8018C8D4(BracketEntry* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4,
                 DrawRectangle((f32) right, (f32) arg2, thickness,
                               (f32) third_h, color);
             }
-            c2 = data->x20;
+            c32 = data->x20;
             {
-                GXColor* color = &c2;
+                GXColor* color = &c32;
                 DrawRectangle((f32) center, (f32) mid_y, (f32) half,
                               neg_thickness, color);
             }
-            c3 = data->x20;
+            c33 = data->x20;
             {
-                GXColor* color = &c3;
+                GXColor* color = &c33;
                 DrawRectangle((f32) center, (f32) mid_y, thickness,
                               (f32) ((arg4 / 6) - 1), color);
             }
@@ -1383,7 +1383,7 @@ void fn_8018DC18(BracketEntry* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4,
     s32 right;
     s32 half;
     s32 center;
-    GXColor c0, c1, c2, c3, c4, c5, c6, c7;
+    GXColor c0, c1, c2, c3, c4, c5, c6, c7, c8, c9;
 
     c0 = col;
     thickness = arg0->x1C;
@@ -1435,10 +1435,10 @@ void fn_8018DC18(BracketEntry* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4,
         }
         {
             GXColor* entry_color = &arg0->x20;
-            c7 = *entry_color;
-            DrawRectangle(right, arg2, thickness, arg4, &c7);
-            c7 = *entry_color;
-            DrawRectangle(center, arg5, half + thickness, neg_thickness, &c7);
+            c8 = *entry_color;
+            DrawRectangle(right, arg2, thickness, arg4, &c8);
+            c9 = *entry_color;
+            DrawRectangle(center, arg5, half + thickness, neg_thickness, &c9);
         }
     }
 }

--- a/src/melee/gm/gmtoulib.h
+++ b/src/melee/gm/gmtoulib.h
@@ -15,14 +15,10 @@
 /* 18A970 */ void fn_8018A970(int);
 /* 18AA74 */ void fn_8018AA74(HSD_JObj*, s32, s32);
 /* 18B090 */ void fn_8018B090(HSD_GObj*);
-/* 18C8D4 */ void fn_8018C8D4(BracketEntry*, s32, s32, s32, s32, s32, s32,
-                              f32);
-/* 18D50C */ void fn_8018D50C(BracketEntry*, s32, s32, s32, s32, s32, s32,
-                              f32);
-/* 18DC18 */ void fn_8018DC18(BracketEntry*, s32, s32, s32, s32, s32, s32,
-                              f32);
-/* 18DF68 */ void fn_8018DF68(BracketEntry*, s32, s32, s32, s32, s32, s32,
-                              f32);
+/* 18C8D4 */ void fn_8018C8D4(BracketEntry*, s32, s32, s32, s32, s32);
+/* 18D50C */ void fn_8018D50C(BracketEntry*, s32, s32, s32, s32, s32);
+/* 18DC18 */ void fn_8018DC18(BracketEntry*, s32, s32, s32, s32, s32);
+/* 18DF68 */ void fn_8018DF68(BracketEntry*, s32, s32, s32, s32, s32);
 /* 18E46C */ void fn_8018E46C(HSD_GObj*, int);
 /* 18E618 */ void fn_8018E618(int, float, int);
 /* 18E85C */ void fn_8018E85C(DynamicModelDesc*, s32);


### PR DESCRIPTION
Technically we’re 65 bytes short of 90%, we’re at 89.998%. So match a bit more to get 90% for real