### PR TITLE
Match _tyFigupon_80316420

### DIFF
--- a/src/melee/ty/toy.c
+++ b/src/melee/ty/toy.c
@@ -2248,9 +2248,11 @@ s32 Toy_803082F8(s16 idx)
     return Toy_803063D4((s16) Toy_80308354(idx), 2, 0x128);
 }
 
-s32 Toy_80308328(s16 idx)
+s32 Toy_80308328(s32 idx)
 {
-    return Toy_803063D4(idx, 2, 0x128);
+    s16 id = idx;
+
+    return Toy_803063D4(id, 2, 0x128);
 }
 
 s32 Toy_80308354(s16 idx)

--- a/src/melee/ty/toy.h
+++ b/src/melee/ty/toy.h
@@ -49,7 +49,7 @@
 /* 30813C */ char* Toy_8030813C(int trophy_id);
 /* 308250 */ void Toy_80308250(u8* arg0, s16 arg1, s32 arg2);
 /* 3082F8 */ s32 Toy_803082F8(s16 idx);
-/* 308328 */ s32 Toy_80308328(s16 idx);
+/* 308328 */ s32 Toy_80308328(s32 idx);
 /* 308354 */ s32 Toy_80308354(s16 idx);
 /* 3083D8 */ void Toy_803083D8(HSD_JObj* jobj, s32 arg1);
 /* 3087F4 */ HSD_GObj* Toy_803087F4(void*);


### PR DESCRIPTION
> Corrects Toy_80308328’s argument width while preserving the trophy ID narrowing. The affected functions match exactly.