### PR TITLE
improvement: Improved fnCo_80095EFC to 97%

### DIFF
--- a/src/melee/ft/chara/ftCommon/ftCo_ItemThrow.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_ItemThrow.c
@@ -542,32 +542,36 @@ void ftCo_80095EFC(Fighter_GObj* gobj)
                     fp->cmd_vars[1] = 0;
                 }
                 {
-                    ftCo_ItemThrowAttrs* throw_speed_arr = (ftCo_ItemThrowAttrs*) Fighter_804D6550;
+                    ftCo_ItemThrowAttrs* throw_speed_arr =
+                        (ftCo_ItemThrowAttrs*) Fighter_804D6550;
                     float cd_xB4 = co_attrs->heavy_throw_velocity_multiplier;
-                    float base_throw_speed = cd_xB4 * throw_speed_arr[fp->motion_id - ftCo_MS_LightThrowF].x8;
+                    float base_throw_speed =
+                        cd_xB4 *
+                        throw_speed_arr[fp->motion_id - ftCo_MS_LightThrowF]
+                            .x8;
                     float throw_speed = throw_scale * base_throw_speed;
                     float fsm = -fp->cmd_timer / fp->frame_speed_mul;
-                    vec2.x = fsm * (fp->mv.co.itemthrow4.x8.x - vec0.x) + vec0.x;
-                    vec2.y = fsm * (fp->mv.co.itemthrow4.x8.y - vec0.y) + vec0.y;
+                    vec2.x =
+                        fsm * (fp->mv.co.itemthrow4.x8.x - vec0.x) + vec0.x;
+                    vec2.y =
+                        fsm * (fp->mv.co.itemthrow4.x8.y - vec0.y) + vec0.y;
                     vec2.z = 0;
-                    pl_8003E978(fp->player_id, fp->x221F_b4,
-                            fp->item_gobj, vec2.y,
-                            base_throw_speed, cd_xB4, throw_speed,
-                            vec0.x, vec0.y, fsm);
+                    pl_8003E978(fp->player_id, fp->x221F_b4, fp->item_gobj,
+                                vec2.y, base_throw_speed, cd_xB4, throw_speed,
+                                vec0.x, vec0.y, fsm);
                     {
                         FtMoveId msid = fp->motion_id;
                         if (msid == (FtMoveId) ftCo_MS_LightThrowDrop) {
                             Item_8026AC74(fp->item_gobj, &vec2, &vec1,
-                                            throw_speed);
-                        } else if (msid >= (FtMoveId) ftCo_MS_LightThrowF4)
-                        {
+                                          throw_speed);
+                        } else if (msid >= (FtMoveId) ftCo_MS_LightThrowF4) {
                             if (itIsHeavy(fp->item_gobj) == 1) {
                                 ftCommon_8007EBAC(fp, 29, 0);
                             } else {
                                 ftCommon_8007EBAC(fp, 27, 0);
                             }
                             Item_8026AD20(fp->item_gobj, &vec2, &vec1,
-                                            throw_speed, true);
+                                          throw_speed, true);
                         } else {
                             if (itIsHeavy(fp->item_gobj) == 1) {
                                 ftCommon_8007EBAC(fp, 28, 0);
@@ -575,7 +579,7 @@ void ftCo_80095EFC(Fighter_GObj* gobj)
                                 ftCommon_8007EBAC(fp, 26, 0);
                             }
                             Item_8026AD20(fp->item_gobj, &vec2, &vec1,
-                                            throw_speed, false);
+                                          throw_speed, false);
                         }
                     }
                 }

--- a/src/melee/ft/chara/ftCommon/ftCo_ItemThrow.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_ItemThrow.c
@@ -527,7 +527,7 @@ void ftCo_80095EFC(Fighter_GObj* gobj)
     Vec3 vec1;
     Vec3 vec2;
 
-    PAD_STACK(0x8);
+    PAD_STACK(0x4);
 
     if (fp->item_gobj != NULL) {
         lb_8000B1CC(it_80272C90(fp->item_gobj), NULL, &vec0);
@@ -542,50 +542,40 @@ void ftCo_80095EFC(Fighter_GObj* gobj)
                     fp->cmd_vars[1] = 0;
                 }
                 {
-                    float fsm = -fp->cmd_timer / fp->frame_speed_mul;
+                    ftCo_ItemThrowAttrs* throw_speed_arr = (ftCo_ItemThrowAttrs*) Fighter_804D6550;
                     float cd_xB4 = co_attrs->heavy_throw_velocity_multiplier;
-                    float base_throw_speed =
-                        cd_xB4 * ((ftCo_ItemThrowAttrs*)
-                                      Fighter_804D6550)[fp->motion_id -
-                                                        ftCo_MS_LightThrowF]
-                                     .x8;
+                    float base_throw_speed = cd_xB4 * throw_speed_arr[fp->motion_id - ftCo_MS_LightThrowF].x8;
                     float throw_speed = throw_scale * base_throw_speed;
+                    float fsm = -fp->cmd_timer / fp->frame_speed_mul;
+                    vec2.x = fsm * (fp->mv.co.itemthrow4.x8.x - vec0.x) + vec0.x;
+                    vec2.y = fsm * (fp->mv.co.itemthrow4.x8.y - vec0.y) + vec0.y;
+                    vec2.z = 0;
+                    pl_8003E978(fp->player_id, fp->x221F_b4,
+                            fp->item_gobj, vec2.y,
+                            base_throw_speed, cd_xB4, throw_speed,
+                            vec0.x, vec0.y, fsm);
                     {
-                        vec2.x = fsm * (fp->mv.co.itemthrow4.x8.x - vec0.x) +
-                                 vec0.x;
+                        FtMoveId msid = fp->motion_id;
+                        if (msid == (FtMoveId) ftCo_MS_LightThrowDrop) {
+                            Item_8026AC74(fp->item_gobj, &vec2, &vec1,
+                                            throw_speed);
+                        } else if (msid >= (FtMoveId) ftCo_MS_LightThrowF4)
                         {
-                            vec2.y =
-                                fsm * (fp->mv.co.itemthrow4.x8.y - vec0.y) +
-                                vec0.y;
-                            vec2.z = 0;
-                            pl_8003E978(fp->player_id, fp->x221F_b4,
-                                        fp->item_gobj, vec2.y,
-                                        base_throw_speed, cd_xB4, throw_speed,
-                                        vec0.x, vec0.y, fsm);
-                        }
-                        {
-                            FtMoveId msid = fp->motion_id;
-                            if (msid == (FtMoveId) ftCo_MS_LightThrowDrop) {
-                                Item_8026AC74(fp->item_gobj, &vec2, &vec1,
-                                              throw_speed);
-                            } else if (msid >= (FtMoveId) ftCo_MS_LightThrowF4)
-                            {
-                                if (itIsHeavy(fp->item_gobj) == 1) {
-                                    ftCommon_8007EBAC(fp, 29, 0);
-                                } else {
-                                    ftCommon_8007EBAC(fp, 27, 0);
-                                }
-                                Item_8026AD20(fp->item_gobj, &vec2, &vec1,
-                                              throw_speed);
+                            if (itIsHeavy(fp->item_gobj) == 1) {
+                                ftCommon_8007EBAC(fp, 29, 0);
                             } else {
-                                if (itIsHeavy(fp->item_gobj) == 1) {
-                                    ftCommon_8007EBAC(fp, 28, 0);
-                                } else {
-                                    ftCommon_8007EBAC(fp, 26, 0);
-                                }
-                                Item_8026AD20(fp->item_gobj, &vec2, &vec1,
-                                              throw_speed);
+                                ftCommon_8007EBAC(fp, 27, 0);
                             }
+                            Item_8026AD20(fp->item_gobj, &vec2, &vec1,
+                                            throw_speed, true);
+                        } else {
+                            if (itIsHeavy(fp->item_gobj) == 1) {
+                                ftCommon_8007EBAC(fp, 28, 0);
+                            } else {
+                                ftCommon_8007EBAC(fp, 26, 0);
+                            }
+                            Item_8026AD20(fp->item_gobj, &vec2, &vec1,
+                                            throw_speed, false);
                         }
                     }
                 }

--- a/src/melee/it/item.c
+++ b/src/melee/it/item.c
@@ -2065,7 +2065,8 @@ void Item_8026AC74(HSD_GObj* gobj, Vec3* arg1, Vec3* arg2, f32 arg3)
 
 void Item_8026AD20(HSD_GObj* gobj, Vec3* arg1, Vec3* arg2, f32 arg3, bool arg4)
 {
-    // What is arg4 used for? Was looking at ftCo_ItemThrow and it seems to correspond to some kind of flag
+    // What is arg4 used for? Was looking at ftCo_ItemThrow and it seems to
+    // correspond to some kind of flag
     Item* item_data = GetItemData(gobj);
     it_802731E0(gobj);
     item_data->xC44 = arg3;

--- a/src/melee/it/item.c
+++ b/src/melee/it/item.c
@@ -2063,8 +2063,9 @@ void Item_8026AC74(HSD_GObj* gobj, Vec3* arg1, Vec3* arg2, f32 arg3)
     }
 }
 
-void Item_8026AD20(HSD_GObj* gobj, Vec3* arg1, Vec3* arg2, f32 arg3)
+void Item_8026AD20(HSD_GObj* gobj, Vec3* arg1, Vec3* arg2, f32 arg3, bool arg4)
 {
+    // What is arg4 used for? Was looking at ftCo_ItemThrow and it seems to correspond to some kind of flag
     Item* item_data = GetItemData(gobj);
     it_802731E0(gobj);
     item_data->xC44 = arg3;

--- a/src/melee/it/item.h
+++ b/src/melee/it/item.h
@@ -42,7 +42,7 @@ struct ItemStateDesc;
                                 Fighter_Part part);
 /* 26ABD8 */ void Item_8026ABD8(Item_GObj* gobj, Vec3* pos, float);
 /* 26AC74 */ void Item_8026AC74(HSD_GObj* gobj, Vec3*, Vec3*, float);
-/* 26AD20 */ void Item_8026AD20(HSD_GObj* gobj, Vec3*, Vec3*, float);
+/* 26AD20 */ void Item_8026AD20(HSD_GObj* gobj, Vec3*, Vec3*, float, bool);
 /* 26ADC0 */ void Item_8026ADC0(HSD_GObj* gobj);
 /* 26AE10 */ void Item_OnUserDataRemove(void* user_data);
 /* 26AE10 */ void lbl_8026AE10(void* user_data);


### PR DESCRIPTION
Last few things before `ftCo_ItemThrow` is 100% matching to my knowledge are (see screenshot for details):
1. some regswaps for calculating vec2.x and vec2.y, which also seem to affect an extra lfs before `pl_8003E978`
2. scheduling on setting vec2.z to 0

<img width="1688" height="436" alt="image" src="https://github.com/user-attachments/assets/b1cb485f-a9e5-4fd5-9681-af3a428369ec" />

Includes edit to `Item_8026AD20` (`item`) that appears to be a missing parameter.
