### PR TITLE
Match gm_801A4014 and link gm_1A3F

### DIFF
--- a/config/GALE01/symbols.txt
+++ b/config/GALE01/symbols.txt
@@ -26118,6 +26118,7 @@ gmCamera_VsCameraTextLayout = .bss:0x80479C20; // type:object size:0x10 scope:lo
 controller_map = .bss:0x80479C30; // type:object size:0x100 scope:local data:4byte
 ...bss.0 = .bss:0x80479C30; // type:label scope:local
 gm_80479D30 = .bss:0x80479D30; // type:object size:0x14 scope:local data:byte
+...bss.0 = .bss:0x80479D30; // type:label scope:local
 gm_80479D48 = .bss:0x80479D48; // type:object size:0x10 scope:global
 ...bss.0 = .bss:0x80479D48; // type:label scope:local
 gm_80479D58 = .bss:0x80479D58; // type:object size:0x40 scope:global data:4byte

--- a/configure.py
+++ b/configure.py
@@ -1147,7 +1147,7 @@ config.libs = [
             Object(Matching, "melee/gm/gmcamera.c"),
             Object(Matching, "melee/gm/gm_1A33.c"),
             Object(Matching, "melee/gm/gm_1A36.c"),
-            Object(Testing, "melee/gm/gm_1A3F.c"),
+            Object(Matching, "melee/gm/gm_1A3F.c"),
             Object(Matching, "melee/gm/gm_1A45.c"),
             Object(Matching, "melee/gm/gmscdata.c"),
             Object(Matching, "melee/gm/gmmenu.c"),

--- a/src/melee/gm/gm_1A3F.c
+++ b/src/melee/gm/gm_1A3F.c
@@ -59,24 +59,31 @@ void gm_801A3F48(GameScene* scene)
     tyDisplay_8031C8B8();
 }
 
+static inline u8 firstScene(GameScene* scene)
+{
+    for (; scene->idx != 0xFF; scene++) {
+        return scene->idx;
+    }
+    return 0;
+}
+
 static inline u8 nextScene(GameScene* scenes)
 {
+    GameScene* it = scenes;
+    u8 current = gm_80479D30.routing.curr_scene_idx;
     int i;
     u8 next_scene;
     GameScene* cur = scenes;
 
-    for (i = 0; scenes[i].idx != 0xFF; i++) {
-        if (cur->idx > gm_80479D30.routing.curr_scene_idx) {
+    for (i = 0; (next_scene = it->idx) != 0xFF; i++) {
+        if (cur->idx > current) {
             return scenes[i].idx;
         }
         cur++;
+        it++;
     }
 
-    next_scene = scenes[0].idx;
-    if (next_scene == 0xFF) {
-        next_scene = 0;
-    }
-    return next_scene;
+    return firstScene(scenes);
 }
 
 static inline GameScene* findScene(GameScene* scene)
@@ -98,6 +105,7 @@ void gm_801A4014(GameMode* mode)
     GameScene* scene;
     GameState* gm;
     struct GameSceneInfo* info;
+    u32 dead;
     u32 unused[2];
 
     gm = &gm_80479D30;
@@ -111,7 +119,9 @@ void gm_801A4014(GameMode* mode)
         scene->Prep(scene);
     }
     info = &scene->info;
-    handler = gm_FindGameSceneHandler(scene->info.class_id);
+    handler = (GameSceneHandler*) ((uintptr_t) gm_FindGameSceneHandler(
+                                      info->class_id) |
+                                  (dead = 0));
     gm_801A4BD4();
     gm_801A4B88(info);
     if (handler->OnLoad != NULL) {

--- a/src/melee/gm/gm_1A3F.c
+++ b/src/melee/gm/gm_1A3F.c
@@ -61,7 +61,12 @@ void gm_801A3F48(GameScene* scene)
 
 static inline u8 firstScene(GameScene* scene, u8 sentinel)
 {
-    for (; scene->idx != sentinel; scene++) {
+    for (; scene->idx != 0xFF; scene++) {
+        do {
+            if (scene->idx == sentinel) {
+                break;
+            }
+        } while (0);
         return scene->idx;
     }
     return 0;

--- a/src/melee/gm/gm_1A3F.c
+++ b/src/melee/gm/gm_1A3F.c
@@ -59,9 +59,9 @@ void gm_801A3F48(GameScene* scene)
     tyDisplay_8031C8B8();
 }
 
-static inline u8 firstScene(GameScene* scene)
+static inline u8 firstScene(GameScene* scene, u8 sentinel)
 {
-    for (; scene->idx != 0xFF; scene++) {
+    for (; scene->idx != sentinel; scene++) {
         return scene->idx;
     }
     return 0;
@@ -83,7 +83,7 @@ static inline u8 nextScene(GameScene* scenes)
         it++;
     }
 
-    return firstScene(scenes);
+    return firstScene(scenes, next_scene);
 }
 
 static inline GameScene* findScene(GameScene* scene)
@@ -120,8 +120,8 @@ void gm_801A4014(GameMode* mode)
     }
     info = &scene->info;
     handler = (GameSceneHandler*) ((uintptr_t) gm_FindGameSceneHandler(
-                                      info->class_id) |
-                                  (dead = 0));
+                                       info->class_id) |
+                                   (dead = 0));
     gm_801A4BD4();
     gm_801A4B88(info);
     if (handler->OnLoad != NULL) {


### PR DESCRIPTION
This function is on the critical path when loading scenes / it is hit when booting the game before any input is sent. Technically gmmain_lib fails first but this function is needed for anything interesting to happen too