### PR TITLE
Clean up preprocessor conditions

### DIFF
--- a/src/MSL/stdbool.h
+++ b/src/MSL/stdbool.h
@@ -1,5 +1,3 @@
-/// @file
-/// @todo Assumes @c __PPCGEKKO__.
 #ifndef STDBOOL_H
 #define STDBOOL_H
 

--- a/src/MetroTRK/dolphin_trk.c
+++ b/src/MetroTRK/dolphin_trk.c
@@ -7,6 +7,7 @@
 #include "ppc_except.h"
 #include "ppc_targimpl.h"
 
+// For labels in ::InitMetroTRK
 #ifdef MWERKS_GEKKO
 #include "mpc_7xx_603e.h"
 #endif

--- a/src/MetroTRK/dolphin_trk_glue.c
+++ b/src/MetroTRK/dolphin_trk_glue.c
@@ -3,9 +3,9 @@
 #include <placeholder.h>
 
 #ifdef MWERKS_GEKKO
-#include "MetroTRK/mem_TRK.h"
-#include "MetroTRK/targimpl.h"
-#include "MetroTRK/trk.h"
+#include "mem_TRK.h"
+#include "targimpl.h"
+#include "trk.h"
 #endif
 
 #include <dolphin/amc/AmcExi2Comm.h>

--- a/src/MetroTRK/dolphin_trk_glue.c
+++ b/src/MetroTRK/dolphin_trk_glue.c
@@ -1,7 +1,5 @@
 #include "dolphin_trk_glue.h"
 
-#include <placeholder.h>
-
 #ifdef MWERKS_GEKKO
 #include "mem_TRK.h"
 #include "targimpl.h"

--- a/src/MetroTRK/flush_cache.h
+++ b/src/MetroTRK/flush_cache.h
@@ -1,7 +1,6 @@
 #ifndef _METROTRK_FLUSH_CACHE_H
 #define _METROTRK_FLUSH_CACHE_H
 
-#include <placeholder.h>
 #include <platform.h>
 
 ASM void TRK_flush_cache(u32 addr, u32 length);

--- a/src/MetroTRK/mpc_7xx_603e.h
+++ b/src/MetroTRK/mpc_7xx_603e.h
@@ -1,7 +1,7 @@
 #ifndef GALE01_32A868
 #define GALE01_32A868
 
-#include <placeholder.h>
+#include <platform.h>
 
 /* 32A868 */ ASM void TRKSaveExtended1Block(void);
 /* 32AA20 */ ASM void TRKRestoreExtended1Block(void);

--- a/src/Runtime/Gecko_setjmp.c
+++ b/src/Runtime/Gecko_setjmp.c
@@ -2,9 +2,8 @@
 
 #include <placeholder.h>
 
-#ifdef MWERKS_GEKKO
-asm int __setjmp(register __jmp_buf* env)
-{ // clang-format off
+ASM int __setjmp(register __jmp_buf* env){
+#ifdef MWERKS_GEKKO // clang-format off
     nofralloc
     mflr	r5
     mfcr	r6
@@ -35,17 +34,12 @@ asm int __setjmp(register __jmp_buf* env)
     stfd	fp0,env->fpscr	//	save FPSCR
     li		r3,0
     blr
-} // clang-format on
-#else
-int __setjmp(register __jmp_buf* env)
-{
-    NOT_IMPLEMENTED;
+#endif // clang-format on
 }
-#endif
 
-#ifdef MWERKS_GEKKO
-asm void longjmp(register __jmp_buf* env, register int val)
-{ // clang-format off
+ASM void longjmp(register __jmp_buf* env, register int val)
+{
+#ifdef MWERKS_GEKKO // clang-format off
     nofralloc
     lwz		r5,env->pc
     lwz		r6,env->cr
@@ -79,10 +73,5 @@ asm void longjmp(register __jmp_buf* env, register int val)
     bnelr					//	return 'val'
     li		r3,1			//	return 1
     blr
-} // clang-format on
-#else
-void longjmp(register __jmp_buf* env, register int val)
-{
-    NOT_IMPLEMENTED;
+#endif // clang-format on
 }
-#endif

--- a/src/Runtime/Gecko_setjmp.c
+++ b/src/Runtime/Gecko_setjmp.c
@@ -1,6 +1,6 @@
 #include "Gecko_setjmp.h"
 
-#include <placeholder.h>
+#include <platform.h>
 
 ASM int __setjmp(register __jmp_buf* env){
 #ifdef MWERKS_GEKKO // clang-format off

--- a/src/Runtime/__init_cpp_exceptions.c
+++ b/src/Runtime/__init_cpp_exceptions.c
@@ -1,4 +1,3 @@
-#include <placeholder.h>
 #include <platform.h>
 
 #include <__init_cpp_exceptions.h>
@@ -29,8 +28,6 @@ void __init_cpp_exceptions(void)
     if (fragmentID == -2) {
         fragmentID = __register_fragment(_eti_init_info, GetR2());
     }
-#else
-    NOT_IMPLEMENTED;
 #endif
 }
 

--- a/src/Runtime/__va_arg.c
+++ b/src/Runtime/__va_arg.c
@@ -1,13 +1,14 @@
-#include <placeholder.h>
+#include <platform.h> // IWYU pragma: keep
 
 #include <stdarg.h>
 
-#ifdef __MWERKS__
-
+#ifdef MWERKS_GEKKO
 #define ALIGN(addr, size) (((uintptr_t) (addr) + ((size) - 1)) & ~((size) - 1))
+#endif
 
 void* __va_arg(va_list v_list, unsigned char type)
 {
+#ifdef MWERKS_GEKKO
     char* addr;
     char* reg = &v_list->gpr;
     int g_reg = v_list->gpr;
@@ -53,13 +54,5 @@ void* __va_arg(va_list v_list, unsigned char type)
     }
 
     return addr;
-}
-
-#else
-
-void* __va_arg(va_list v_list, unsigned char type)
-{
-    NOT_IMPLEMENTED;
-}
-
 #endif
+}

--- a/src/Runtime/platform.h
+++ b/src/Runtime/platform.h
@@ -38,6 +38,20 @@ typedef bool (*Predicate)(void);
 #define MWERKS_GEKKO
 #endif
 
+#ifdef __MWERKS__
+#define ASM asm
+#else
+#define ASM
+#endif
+
+#ifndef UNUSED
+#if defined(__clang__) || defined(__GNUC__)
+#define UNUSED __attribute__((unused))
+#else
+#define UNUSED
+#endif
+#endif
+
 #ifndef ATTRIBUTE_ALIGN
 #if defined(__MWERKS__) || defined(__GNUC__)
 #define ATTRIBUTE_ALIGN(num) __attribute__((aligned(num)))
@@ -98,7 +112,7 @@ typedef bool (*Predicate)(void);
 #endif
 #endif
 
-#ifdef __PPCGEKKO__
+#ifdef MWERKS_GEKKO
 #define qr0 0
 #define qr1 1
 #define qr2 2

--- a/src/Runtime/runtime.c
+++ b/src/Runtime/runtime.c
@@ -1,7 +1,5 @@
 #include "runtime.h"
 
-#include <placeholder.h>
-
 static const unsigned long __constants[] = {
     0x00000000, 0x00000000, 0x41F00000, 0x00000000, 0x41E00000, 0x00000000,
 };

--- a/src/Runtime/runtime.h
+++ b/src/Runtime/runtime.h
@@ -1,7 +1,6 @@
 #ifndef RUNTIME_RUNTIME_H
 #define RUNTIME_RUNTIME_H
 
-#include <placeholder.h>
 #include <platform.h>
 
 ASM void __div2u(void);

--- a/src/melee/gm/gm_1601.c
+++ b/src/melee/gm/gm_1601.c
@@ -3162,19 +3162,14 @@ void gm_80166378(lbl_8046B6A0_24C_t* arg0_raw)
     fn_801661E0(arg0);
 }
 
-#ifdef MUST_MATCH
 float fn_80166A8C(register Vec3* src, register Vec3* dst)
 {
+#ifdef MWERKS_GEKKO
     register float x = src->x;
     asm { psq_st x, Vec3.x(dst), 1, qr3 }
     return x;
-}
-#else
-float fn_80166A8C(register Vec3* src, register Vec3* dst)
-{
-    NOT_IMPLEMENTED;
-}
 #endif
+}
 
 // Probably some code to setup or end a 4 player match?
 s32 gm_80166A98(MatchEnd* arg0, u8 arg1, s8 arg2, u8 arg3, s8 arg4, u8 arg5,

--- a/src/melee/lb/lbarq.c
+++ b/src/melee/lb/lbarq.c
@@ -34,7 +34,7 @@ typedef struct lbArqHandle {
 
 /// @todo Non-inlined function forces loop in ::lbArq_80014BD0 to yield to
 ///       interrupts. Pragma solution likely fake.
-#ifdef MWERKS_GEKKO
+#ifdef __MWERKS__
 #pragma push
 #pragma dont_inline on
 #endif
@@ -42,7 +42,7 @@ static lbArqState lbArq_80014ABC(lbArqNode* arg0)
 {
     return arg0->state;
 }
-#ifdef MWERKS_GEKKO
+#ifdef __MWERKS__
 #pragma pop
 #endif
 

--- a/src/melee/lb/lbfile.c
+++ b/src/melee/lb/lbfile.c
@@ -22,7 +22,7 @@ static void lbFile_8001615C(int dcreq, int args, void* buf, bool cancelflag)
 
 /// @todo Non-inlined function forces loop in ::lbFile_800161C4 to yield to
 ///       interrupts. Pragma solution likely fake.
-#ifdef MWERKS_GEKKO
+#ifdef __MWERKS__
 #pragma push
 #pragma dont_inline on
 #endif
@@ -31,7 +31,7 @@ static bool discIsDone(void)
     lb_800195D0();
     return cancel;
 }
-#ifdef MWERKS_GEKKO
+#ifdef __MWERKS__
 #pragma pop
 #endif
 

--- a/src/melee/lb/lbmthp.c
+++ b/src/melee/lb/lbmthp.c
@@ -435,7 +435,7 @@ s32 fn_8001F13C(THPDecComp* streamPlayer)
 
 /// @todo Non-inlined function forces loop in ::lbMthp_8001F800 to yield to
 ///       interrupts. Pragma solution likely fake.
-#ifdef MWERKS_GEKKO
+#ifdef __MWERKS__
 #pragma push
 #pragma dont_inline on
 #endif
@@ -443,7 +443,7 @@ s32 fn_8001F294(void)
 {
     return MoviePlayer.unk_110;
 }
-#ifdef MWERKS_GEKKO
+#ifdef __MWERKS__
 #pragma pop
 #endif
 

--- a/src/placeholder.h
+++ b/src/placeholder.h
@@ -9,19 +9,6 @@ typedef void (*jmp_t)(void);
 /// A jump table
 typedef jmp_t jtbl_t[];
 
-#if defined(__clang__) || defined(__GNUC__)
-#include <dolphin/os.h> // IWYU pragma: keep
-#define NOT_IMPLEMENTED                                                       \
-    OSPanic(__FILE__, __LINE__, "%s is not implemented!", __func__)
-#elif M2CTX
-#define NOT_IMPLEMENTED
-#elif defined(__MWERKS__) && defined(MUST_MATCH)
-#define NOT_IMPLEMENTED asm { nop }
-#else
-#define NOT_IMPLEMENTED                                                       \
-    OSPanic(__FILE__, __LINE__, "Function is not implemented!")
-#endif
-
 #ifndef MWERKS_GEKKO
 #define __frsqrte(x) sqrt(x)
 #define sqrtf__Ff(x) sqrtf(x)
@@ -63,20 +50,6 @@ typedef jmp_t jtbl_t[];
 
 #define U32_TO_F32 4503599627370496.0
 #define S32_TO_F32 4503601774854144.0
-
-#ifdef MWERKS_GEKKO
-#define ASM asm
-#else
-#define ASM
-#endif
-
-#ifndef UNUSED
-#if defined(__clang__) || defined(__GNUC__)
-#define UNUSED __attribute__((unused))
-#else
-#define UNUSED
-#endif
-#endif
 
 #define PAD_STACK(bytes)                                                      \
     do {                                                                      \


### PR DESCRIPTION
* Prefer `__MWERKS__` to `MWERKS_GEKKO` in most cases;
  use `MWERKS_GEKKO` only when intrinsics/asm are involved
* Remove `NOT_IMPLEMENTED` macro (ports can write their own stubs)
* Prefer `MWERKS_GEKKO` over raw `__PPCGEKKO__`
* Move `ASM` and `UNUSED` to `platform.h`
