### PR TITLE
Match mnSnap_80253964

### DIFF
--- a/src/melee/mn/mnsnap.c
+++ b/src/melee/mn/mnsnap.c
@@ -211,14 +211,11 @@ static void mnSnap_8025329C(void)
             jobj = mnSnap_GetThumbJObj(p52, snap);
             HSD_ASSERT(193, jobj);
             HSD_ASSERT(194, jobj->u.dobj);
-            /* String order from the other branch of the inlined tobj chain. */
+            /// @todo data order hack
             (void) "jobj->u.dobj->mobj";
             (void) "jobj->u.dobj->mobj->tobj";
             (void) "jobj->u.dobj->mobj->tobj->imagedesc";
-            /* Anchor "jobj.h" early so pooled literals follow the original
-             * order jobj, jobj.h, %03d, %d (MWCC pools in first-use order).
-             * Without this the pool emits jobj.h after "%d" and every
-             * reference below resolves to an offset unlike the original. */
+            /// @todo sdata order hack
             (void) "jobj.h";
             HSD_ASSERT(195, jobj->u.dobj->next);
             HSD_ASSERT(196, jobj->u.dobj->next->next);

--- a/src/melee/mn/mnsnap.c
+++ b/src/melee/mn/mnsnap.c
@@ -215,6 +215,11 @@ static void mnSnap_8025329C(void)
             (void) "jobj->u.dobj->mobj";
             (void) "jobj->u.dobj->mobj->tobj";
             (void) "jobj->u.dobj->mobj->tobj->imagedesc";
+            /* Anchor "jobj.h" early so pooled literals follow the original
+             * order jobj, jobj.h, %03d, %d (MWCC pools in first-use order).
+             * Without this the pool emits jobj.h after "%d" and every
+             * reference below resolves to an offset unlike the original. */
+            (void) "jobj.h";
             HSD_ASSERT(195, jobj->u.dobj->next);
             HSD_ASSERT(196, jobj->u.dobj->next->next);
             HSD_ASSERT(197, jobj->u.dobj->next->next->mobj);


### PR DESCRIPTION
Matches `mnSnap_80253964`, which sat at 99.79% because three small-data (`sda21`) references to assert/format strings pointed at different pool offsets than the original build.

| Function          | Before | After |
|-------------------|--------|-------|
| `mnSnap_80253964` | 99.79% | 100%  |

Restoring the original string layout also moves several other partial functions in this file closer to matching, with nothing regressing: `fn_802545C4` 99.51 -> 99.58, `mnSnap_8025409C` 99.76 -> 99.92, `mnSnap_80257F24` 93.28 -> 93.32.

**Compiler behavior:** with `-str reuse`, MWCC keeps a single copy of each string literal per translation unit and emits them in first-use order, and every `__assert`/format-string argument references that copy through a small-data relocation whose offset must land exactly where it did in the original object. There, the strings are pooled as `jobj`, `jobj.h`, `%03d`, `%d`; but since the first `"jobj.h"` occurrence in the source sits below the printfs, the pool came out `jobj`, `%03d`, `%d`, `jobj.h` instead, shifting every later reference onto the wrong offset. Adding a `(void) "jobj.h";` statement above the printfs references the literal without emitting code and restores the original layout, mirroring the existing `(void)` anchors directly above the change.

> This match was produced by an AI agent.
