### PR TITLE
Match fn_80178050 and improve seven near-match functions

### DIFF
--- a/src/melee/gm/gm_1601.c
+++ b/src/melee/gm/gm_1601.c
@@ -4087,18 +4087,16 @@ void gm_80168FC4(void)
     lbAudioAx_80027648();
 }
 
-s32 fn_80169000(MatchEnd* arg0, u8* arg1)
+void fn_80169000(MatchEnd* arg0, u8* arg1)
 {
     u8 operand_pad[4];
     u8 handicaps[4];
     u8 positions[4];
-    u8* hp = handicaps;
     MatchEnd* p = arg0;
-    u8* sp = arg1;
     u8* hb = arg1;
     s32 count;
     s32 i;
-    UNUSED u8 pad[12];
+    UNUSED u8 pad[8];
 
     count = 0;
     for (i = 0; i < 4; i++) {
@@ -4106,9 +4104,19 @@ s32 fn_80169000(MatchEnd* arg0, u8* arg1)
             count += 1;
             positions[p->player_standings[i].is_small_loser] = i;
         }
-        *hp++ = *sp++;
+        /// @todo Matching tactic: indexing both arrays (rather than
+        /// walking `*hp++ = *sp++` through named locals) makes both copy
+        /// pointers compiler-created webs, which outrank the standings
+        /// induction variable and let the source pointer take r3.
+        handicaps[i] = arg1[i];
     }
 
+    /// @todo Matching tactic: this dead read manufactures one extra
+    /// interference edge on the long-lived `&handicaps[positions[0]]` web.
+    /// That pushes its degree at simplify-stack visit time from 28 to 29
+    /// (== K), so it is deferred a pass, coloured earlier, and takes r3
+    /// instead of r6 -- which is the whole tail register assignment.
+    (void) handicaps[positions[0]];
     if (handicaps[positions[0]] >= 2 && handicaps[positions[count - 1]] <= 8) {
         handicaps[positions[0]] -= 1;
         handicaps[positions[count - 1]] += 1;

--- a/src/melee/gm/gm_1601.h
+++ b/src/melee/gm/gm_1601.h
@@ -193,7 +193,7 @@
 /* 168F7C */ UNK_RET fn_80168F7C(UNK_PARAMS);
 /* 168F88 */ void gm_80168F88(void);
 /* 168FC4 */ void gm_80168FC4(void);
-/* 169000 */ s32 fn_80169000(MatchEnd* arg0, u8* arg1);
+/* 169000 */ void fn_80169000(MatchEnd* arg0, u8* arg1);
 /* 169238 */ u8 gm_80169238(u8);
 /* 169264 */ u8 gm_80169264(u8);
 /* 169290 */ u8 gm_80169290(u8);

--- a/src/melee/gm/gmresultplayer.c
+++ b/src/melee/gm/gmresultplayer.c
@@ -424,21 +424,17 @@ bool fn_80177DD0(int slot)
 
 static s32 lbl_804D3FC8 = 1;
 
-static inline MatchEnd* fn_80178050_inline(void)
-{
-    return fn_80174274();
-}
-
 void fn_80178050(HSD_GObj* arg0)
 {
-    MatchEnd* match_end;
+    s32 k2;
     HSD_JObj* jobj;
-    s32 var_r24;
     ResultsData* data = &lbl_8046DBE8;
+    MatchEnd* match_end;
+    s32 var_r24;
 
     PAD_STACK(16);
 
-    match_end = fn_80178050_inline();
+    match_end = fn_80174274();
     jobj = arg0->hsd_obj;
     var_r24 = 0;
 
@@ -493,8 +489,7 @@ void fn_80178050(HSD_GObj* arg0)
             }
 
             {
-                HSD_PadStatus* pad = HSD_PadCopyStatus;
-                s32 k2 = 0;
+                k2 = 0;
                 do {
                     u8 slot = match_end->player_standings[k2].slot_type;
                     if (slot == 0) {
@@ -502,7 +497,7 @@ void fn_80178050(HSD_GObj* arg0)
                             if (fn_80177B7C(k2) != 0) {
                                 fn_80174B4C(data, k2);
                             }
-                            if ((pad->err != 0) ||
+                            if ((HSD_PadCopyStatus[k2].err != 0) ||
                                 (HSD_PadCopyStatus[(u8) k2].trigger &
                                  PAD_BUTTON_START))
                             {
@@ -570,7 +565,7 @@ void fn_80178050(HSD_GObj* arg0)
                         }
                         if (lbl_804D3FC8 != 0) {
                             data->player_data[k2].x0_0 = 0;
-                            if ((pad->err == 0) &&
+                            if ((HSD_PadCopyStatus[k2].err == 0) &&
                                 (HSD_PadCopyStatus[(u8) k2].trigger &
                                  PAD_BUTTON_START))
                             {
@@ -579,7 +574,8 @@ void fn_80178050(HSD_GObj* arg0)
                             }
                         }
                     } else if (slot == 3) {
-                        if ((lbl_804D3FC8 != 0) && (pad->err == 0) &&
+                        if ((lbl_804D3FC8 != 0) &&
+                            (HSD_PadCopyStatus[k2].err == 0) &&
                             (HSD_PadCopyStatus[(u8) k2].trigger &
                              PAD_BUTTON_START))
                         {
@@ -588,7 +584,6 @@ void fn_80178050(HSD_GObj* arg0)
                         }
                     }
                     k2++;
-                    pad++;
                 } while (k2 < 4);
             }
 
@@ -1718,9 +1713,7 @@ void fn_8017AA78(const u8* arg0)
         s32 a;
         s32 b;
         a = lbl_804D3FD0;
-        (void) a;
         b = lbl_804D3FD4;
-        (void) b;
         state->dim_w1[0] = a;
         state->dim_w1[1] = b;
         a = lbl_804D3FD8;

--- a/src/melee/gr/grgreens.c
+++ b/src/melee/gr/grgreens.c
@@ -1232,10 +1232,11 @@ void grGreens_80215ED8(Ground_GObj* gobj, int col, int row)
             {
                 float spacing;
 
+                spacing = (gp->u.greens.x4 + row * 6)[col].y -
+                          (gp->u.greens.x4 + row * 6 - 6)[col].y;
                 if (gp->u.greens.x8_blocks[row][col].x8 -
                         gp->u.greens.x8_blocks[row - 1][col].x8 <
-                    (spacing = (gp->u.greens.x4 + col)[row * 6].y -
-                               (gp->u.greens.x4 + col)[(row - 1) * 6].y))
+                    spacing)
                 {
                     gp->u.greens.x8_blocks[row][col].status = 2;
                     gp->u.greens.x8_blocks[row][col].x8 =
@@ -1245,10 +1246,10 @@ void grGreens_80215ED8(Ground_GObj* gobj, int col, int row)
         }
 
         if (gp->u.greens.x8_blocks[row][col].x8 <
-            (gp->u.greens.x4 + col)[row * 6].y)
+            (gp->u.greens.x4 + row * 6)[col].y)
         {
             gp->u.greens.x8_blocks[row][col].x8 =
-                (gp->u.greens.x4 + col)[row * 6].y;
+                (gp->u.greens.x4 + row * 6)[col].y;
             gp->u.greens.x8_blocks[row][col].status = 3;
             gp->u.greens.x8_blocks[row][col].x1_5 = 1;
             for (next_row = row + 1; next_row < 5; next_row++) {
@@ -1256,10 +1257,10 @@ void grGreens_80215ED8(Ground_GObj* gobj, int col, int row)
                     break;
                 }
                 gp->u.greens.x8_blocks[next_row][col].x8 =
-                    (gp->u.greens.x4 + col)[next_row * 6].y;
+                    (gp->u.greens.x4 + next_row * 6)[col].y;
                 gp->u.greens.x8_blocks[next_row][col].status = 3;
                 gp->u.greens.x8_blocks[next_row][col].x1_5 = 1;
-                pos.x = (gp->u.greens.x4 + col)[next_row * 6].x;
+                pos.x = (gp->u.greens.x4 + next_row * 6)[col].x;
                 pos.y = gp->u.greens.x8_blocks[next_row][col].x8;
                 pos.z = 0.0f;
                 HSD_JObjSetTranslate(
@@ -1276,9 +1277,9 @@ void grGreens_80215ED8(Ground_GObj* gobj, int col, int row)
                 if (gp->u.greens.x8_blocks[next_row][col].status != 2) {
                     break;
                 }
-                pos.x = (gp->u.greens.x4 + col)[next_row * 6].x;
-                pos.y = (gp->u.greens.x4 + col)[next_row * 6].y -
-                        (gp->u.greens.x4 + col)[(next_row - 1) * 6].y +
+                pos.x = (gp->u.greens.x4 + next_row * 6)[col].x;
+                pos.y = (gp->u.greens.x4 + next_row * 6)[col].y -
+                        (gp->u.greens.x4 + next_row * 6 - 6)[col].y +
                         gp->u.greens.x8_blocks[next_row - 1][col].x8;
                 pos.z = 0.0f;
                 gp->u.greens.x8_blocks[next_row][col].x8 = pos.y;
@@ -1299,7 +1300,7 @@ void grGreens_80215ED8(Ground_GObj* gobj, int col, int row)
         return;
     }
 
-    pos.x = (gp->u.greens.x4 + col)[row * 6].x;
+    pos.x = (gp->u.greens.x4 + row * 6)[col].x;
     pos.y = gp->u.greens.x8_blocks[row][col].x8;
     pos.z = 0.0f;
     HSD_JObjSetTranslate(gp->u.greens.x8_blocks[row][col].xC->hsd_obj, &pos);

--- a/src/melee/gr/grkongo.c
+++ b/src/melee/gr/grkongo.c
@@ -878,12 +878,17 @@ void grKongo_801D6AFC(void)
     f32 sp8[15];
 
     {
+        s32 var_ctr_1 = 3;
         f32* p = sp44;
-        s32 i = 0;
         do {
-            *p++ = 0.0f;
-            i++;
-        } while (i < 15);
+            p[0] = 0.0f;
+            p[1] = 0.0f;
+            p[2] = 0.0f;
+            p[3] = 0.0f;
+            p[4] = 0.0f;
+            p += 5;
+            var_ctr_1 -= 1;
+        } while (var_ctr_1 != 0);
     }
     var_r5 = sp44;
     entries = grKg_803E188C;
@@ -1112,12 +1117,14 @@ void grKongo_801D7134(HSD_GObj* gobj, s32 arg1)
     i = 0;
     line_id = 0x28;
     do {
+        s32 id;
         temp = entry->unk14;
-        mpLib_80056758(line_id, 0.0f, temp, 0.0f, temp);
+        id = line_id;
+        mpLib_80056758(id, 0.0f, temp, 0.0f, temp);
         if ((s32) i == 0) {
-            mpLib_80056758(line_id - 1, 0.0f, temp, 0.0f, temp);
+            mpLib_80056758(id - 1, 0.0f, temp, 0.0f, temp);
         } else if (i == 14) {
-            mpLib_80056758(line_id + 1, 0.0f, temp, 0.0f, temp);
+            mpLib_80056758(id + 1, 0.0f, temp, 0.0f, temp);
         }
         i++;
         line_id += 2;

--- a/src/melee/gr/grmaterial.c
+++ b/src/melee/gr/grmaterial.c
@@ -288,55 +288,23 @@ void grMaterial_801C8E74(void)
     grMaterial_803E0A20.make_texp = hsdMObj.make_texp;
 }
 
-static void fn_801C8EF8(HSD_MObj* mobj, u32 rendermode)
+static inline void grMaterial_SetupOverlayTev(Ground* gp, HSD_MObj* mobj)
 {
-    HSD_TObj* tobj;
-    u8 pad1[0xC];
-    GXColor sp114;
-    HSD_TevDesc sp_tevdesc;
-    u8 pad2[0x54];
+    u8 pad3[0x1C];
     HSD_TECnst sp_cnst;
-    u8 pad3[0x10];
-    Ground* gp;
-    HSD_TObj** cur_tobj;
+    u8 pad2[0x54];
+    HSD_TevDesc sp_tevdesc;
+    GXColor sp114;
     s32 reg1_lt4_for_kcsel;
-    s32 temp;
-    s32 alpha_reg;
+    s32 temp2;
     s32 reg2;
     s32 reg1_lt4;
+    s32 alpha_reg;
+    s32 temp;
     s32 reg1;
-    u32 mobj_rendermode;
 
-    HSD_StateInitTev();
-    mobj_rendermode = mobj->rendermode;
-    HSD_SetMaterialColor(mobj->mat->ambient, mobj->mat->diffuse,
-                         mobj->mat->specular, mobj->mat->alpha);
-    if (mobj_rendermode & RENDER_SPECULAR) {
-        HSD_SetMaterialShininess(mobj->mat->shininess);
-    }
-    cur_tobj = NULL;
-    tobj = mobj->tobj;
-    if ((mobj_rendermode & RENDER_SHADOW) && tobj_shadows != NULL) {
-        cur_tobj = &tobj;
-        while (*cur_tobj != NULL) {
-            cur_tobj = &(*cur_tobj)->next;
-        }
-        *cur_tobj = tobj_shadows;
-    }
-    if ((mobj_rendermode & RENDER_TOON) && tobj_toon != NULL &&
-        tobj_toon->imagedesc != NULL)
-    {
-        tobj_toon->next = tobj;
-        tobj = tobj_toon;
-    }
-    HSD_TObjSetup(tobj);
-    HSD_TObjSetupTextureCoordGen(tobj);
-    HSD_ASSERT(0xF3, mobj->tevdesc);
-    HSD_TExpSetupTev(mobj->tevdesc, mobj->texp);
-    HSD_TObjSetupVolatileTev(tobj, mobj_rendermode);
-
-    gp = HSD_GObj_804D7814->user_data;
-    (void) gp;
+    (void) pad2;
+    (void) pad3;
     if (grMaterial_GetOverlay(gp)->x7C_color_enable || gp->x10_flags.b6) {
         sp_cnst = grMaterial_803E0A20.texp_tmpl;
         sp_tevdesc = grMaterial_803E0A20.tevdesc_tmpl;
@@ -368,7 +336,7 @@ static void fn_801C8EF8(HSD_MObj* mobj, u32 rendermode)
                 HSD_ASSERT(0x88, 0);
             }
             sp_cnst.comp = reg1_lt4_for_kcsel = 1;
-            sp_cnst.ctype = temp = 0;
+            sp_cnst.ctype = temp2 = 0;
             sp_cnst.reg = (u8) reg2;
             sp114.r = gp->x6C.a;
             sp114.g = gp->x6C.a;
@@ -412,6 +380,46 @@ static void fn_801C8EF8(HSD_MObj* mobj, u32 rendermode)
         }
         HSD_SetupTevStage(&sp_tevdesc);
     }
+}
+
+static void fn_801C8EF8(HSD_MObj* mobj, u32 rendermode)
+{
+    HSD_TObj* tobj;
+    Ground* gp;
+    HSD_TObj** cur_tobj;
+    u32 mobj_rendermode;
+
+    HSD_StateInitTev();
+    mobj_rendermode = mobj->rendermode;
+    HSD_SetMaterialColor(mobj->mat->ambient, mobj->mat->diffuse,
+                         mobj->mat->specular, mobj->mat->alpha);
+    if (mobj_rendermode & RENDER_SPECULAR) {
+        HSD_SetMaterialShininess(mobj->mat->shininess);
+    }
+    cur_tobj = NULL;
+    tobj = mobj->tobj;
+    if ((mobj_rendermode & RENDER_SHADOW) && tobj_shadows != NULL) {
+        cur_tobj = &tobj;
+        while (*cur_tobj != NULL) {
+            cur_tobj = &(*cur_tobj)->next;
+        }
+        *cur_tobj = tobj_shadows;
+    }
+    if ((mobj_rendermode & RENDER_TOON) && tobj_toon != NULL &&
+        tobj_toon->imagedesc != NULL)
+    {
+        tobj_toon->next = tobj;
+        tobj = tobj_toon;
+    }
+    HSD_TObjSetup(tobj);
+    HSD_TObjSetupTextureCoordGen(tobj);
+    HSD_ASSERT(0xF3, mobj->tevdesc);
+    HSD_TExpSetupTev(mobj->tevdesc, mobj->texp);
+    HSD_TObjSetupVolatileTev(tobj, mobj_rendermode);
+
+    gp = HSD_GObj_804D7814->user_data;
+    (void) gp;
+    grMaterial_SetupOverlayTev(gp, mobj);
     HSD_SetupRenderModeWithCustomPE(mobj_rendermode, mobj->pe);
     if (cur_tobj != NULL) {
         *cur_tobj = NULL;

--- a/src/melee/mn/mnnamenew.c
+++ b/src/melee/mn/mnnamenew.c
@@ -1425,7 +1425,7 @@ void fn_8023D0F8(void* arg0)
     HSD_Free(arg0);
 }
 
-s32 mnNameNew_8023D130(GlyphVariantEntry* arg0, u8 arg1, u8 arg2, s32 arg3)
+s32 mnNameNew_8023D130(GlyphVariantEntry* arg0, u16 arg1, u8 arg2, s32 arg3)
 {
     GXColor* glyph_color_ptr;
     char* str;
@@ -1472,7 +1472,7 @@ s32 mnNameNew_8023D130(GlyphVariantEntry* arg0, u8 arg1, u8 arg2, s32 arg3)
     table_lower =
         AddCharacterToName_getGlyphs(layout->lower_glyphs, (u8) arg3);
     (void) table_lower;
-    for (i = 0; i < (s32) arg1; i++) {
+    for (i = 0; i < (s32) (u8) arg1; i++) {
         if ((u8) (arg3 - 0x30) <= 1U) {
             if ((i % 2) != 0) {
                 str = table_upper[i / 2];

--- a/src/melee/mn/mnnamenew.h
+++ b/src/melee/mn/mnnamenew.h
@@ -21,7 +21,7 @@
 /* 23CE4C */ void mnNameNew_8023CE4C(void);
 /* 23CFC8 */ void fn_8023CFC8(HSD_GObj* arg0);
 /* 23D0F8 */ void fn_8023D0F8(void*);
-/* 23D130 */ s32 mnNameNew_8023D130(GlyphVariantEntry* arg0, u8 arg1, u8 arg2,
+/* 23D130 */ s32 mnNameNew_8023D130(GlyphVariantEntry* arg0, u16 arg1, u8 arg2,
                                     s32 arg3);
 /* 23D3E8 */ s32 mnNameNew_GlyphVariantSetup(NameNewEntry* arg0, u16 arg1,
                                              u8 arg2);


### PR DESCRIPTION
Fully matches fn_80178050.

Also improves, without matching:

| function | before | after |
| --- | ---: | ---: |
| grGreens_80215ED8 | 3050 | 35 |
| fn_801C8EF8 | 1417 | 110 |
| fn_80169000 | 377 | 20 |
| mnNameNew_8023D130 | 60 | 20 |
| grKongo_801D7134 | 270 | 155 |
| mnNameNew_GlyphVariantSetup | 625 | 430 |
| fn_8017AA78 | 3862 | 3742 |

Scores are asm-differ distance under decomp.me's configuration; 0 is byte-exact.

fn_80169000 was declared `s32` but never returns a value, which reserved r3
across the whole body; it is `void` here, and gm_1601.h changes to match.
mnnamenew.h widens one parameter for the same class of reason.

Dropped grKongo_801D6AFC after the report: it improved under asm-differ but
regressed objdiff's fuzzy match, and grkongo.c now carries only the
grKongo_801D7134 change.