### PR TITLE
Match fn_80169000

### DIFF
--- a/src/melee/gm/gm_1601.c
+++ b/src/melee/gm/gm_1601.c
@@ -4149,11 +4149,9 @@ void fn_80169000(MatchEnd* arg0, u8* arg1)
     }
     /// @todo Matching tactic: reuse the loop index for the first copy to steer
     /// MWCC's instruction scheduling without changing the generated accesses.
-    i = 0;
-    hb[i] = handicaps[i];
-    hb[1] = handicaps[1];
-    hb[2] = handicaps[2];
-    hb[3] = handicaps[3];
+    for (i = 0; i < 4; i++) {
+        hb[i] = handicaps[i];
+    }
 }
 
 u8 gm_80169238(u8 ckind)

--- a/src/melee/gm/gm_1601.c
+++ b/src/melee/gm/gm_1601.c
@@ -4098,7 +4098,6 @@ void fn_80169000(MatchEnd* arg0, u8* arg1)
     u8* hb = arg1;
     s32 count;
     s32 i;
-    UNUSED u8 pad[8];
 
     count = 0;
     for (i = 0; i < 4; i++) {

--- a/src/melee/gm/gm_1601.c
+++ b/src/melee/gm/gm_1601.c
@@ -4147,7 +4147,10 @@ void fn_80169000(MatchEnd* arg0, u8* arg1)
             }
         }
     }
-    hb[0] = handicaps[0];
+    /// @todo Matching tactic: reuse the loop index for the first copy to steer
+    /// MWCC's instruction scheduling without changing the generated accesses.
+    i = 0;
+    hb[i] = handicaps[i];
     hb[1] = handicaps[1];
     hb[2] = handicaps[2];
     hb[3] = handicaps[3];


### PR DESCRIPTION
## Summary

- Match `fn_80169000` in `gm_1601.c`.
- Reuse the existing loop index for the first output copy to reproduce the original instruction schedule.

## Verification

- `fn_80169000`: instruction-identical
- Full GALE01 build passes
- Rebuilt `main.dol` matches the original SHA-1
- clang-format, EditorConfig, and source style checks pass