### PR TITLE
Match ftCo_800A7AAC

### DIFF
--- a/src/melee/ft/chara/ftCommon/ftCo_0A01.c
+++ b/src/melee/ft/chara/ftCommon/ftCo_0A01.c
@@ -3698,6 +3698,31 @@ void ftCo_800A75DC(Fighter* fp0, Fighter* fp1)
     }
 }
 
+static inline s32 ftCo_800A7AAC_inline0(float x, float above, float below,
+                                        Vec3* floor_pos, int* line_id_ptr,
+                                        u32* flags, Vec3* floor_normal)
+{
+    int line_id;
+    s32 blocked = 0;
+    s32 result;
+    *line_id_ptr = -1;
+    result =
+        mpCheckFloor(x, above, x, below, 0.0f, floor_pos, line_id_ptr, flags,
+                     floor_normal, -1, -1, -1, NULL, (Fighter_GObj*) blocked);
+    if (result != 0) {
+        line_id = *line_id_ptr;
+        if (grBigBlue_801EF844(line_id) || grInishie1_801FCAAC(line_id) ||
+            grCorneria_801E2D90(line_id) || grVenom_80206D10(line_id))
+        {
+            blocked = 1;
+        }
+        if (blocked != 0) {
+            result = 0;
+        }
+    }
+    return result;
+}
+
 void ftCo_800A7AAC(Fighter* fp)
 {
     Fighter* partner;
@@ -3708,10 +3733,10 @@ void ftCo_800A7AAC(Fighter* fp)
     u32 flags;
     u8 _[0x18];
     Vec3 partner_pos;
+    u8 _2[4];
     f32 d;
 
     PAD_STACK(0xA);
-    PAD_STACK(8);
 
     partner = ftCo_800A589C(fp);
     if (partner == NULL) {
@@ -3719,27 +3744,12 @@ void ftCo_800A7AAC(Fighter* fp)
     }
     partner_pos = partner->cur_pos;
     if (partner->ground_or_air == GA_Air) {
-        s32 blocked;
         s32 result;
         mp_UnkStruct0* island;
         f32 below = partner_pos.y - 1000.0f;
         f32 above = 10.0f + partner_pos.y;
-        blocked = 0;
-        line_id = -1;
-        result = mpCheckFloor(partner_pos.x, above, partner_pos.x, below, 0.0f,
-                              &floor_pos, &line_id, &flags, &floor_normal, -1,
-                              -1, -1, NULL, (Fighter_GObj*) blocked);
-        if (result != 0) {
-            int line = line_id;
-            if (grBigBlue_801EF844(line) || grInishie1_801FCAAC(line) ||
-                grCorneria_801E2D90(line) || grVenom_80206D10(line))
-            {
-                blocked = 1;
-            }
-            if (blocked != 0) {
-                result = 0;
-            }
-        }
+        result = ftCo_800A7AAC_inline0(partner_pos.x, above, below, &floor_pos,
+                                       &line_id, &flags, &floor_normal);
         if (result != 0) {
             island = mpIsland_8005AB54(line_id);
             if (ftCo_800A2718(island) == 0) {


### PR DESCRIPTION
## Summary

- Extract the airborne floor query and blocked-stage filtering into a local inline helper.
- Replace diagnostic stack padding with a concrete local reservation.
- Match `ftCo_800A7AAC`.

## Verification

- `ftCo_800A7AAC`: 100.00% match
- `python configure.py && ninja`
- `clang-format`, `editorconfig-checker`, and `style-check`