### PR TITLE
Improve 3 functions, match 1

### DIFF
--- a/src/melee/gm/gm_16AE.c
+++ b/src/melee/gm/gm_16AE.c
@@ -293,7 +293,7 @@ void gm_8016B378(s8 arg0)
     gm_16AE_GetUnkData_0()->unk_18 = arg0;
 }
 
-void fn_8016B388(int arg0, s16 arg1)
+void fn_8016B388(int arg0, int arg1)
 {
     gm_16AE_GetUnkData_0()->FighterMatchInfo[arg0].x6 = arg1;
 }

--- a/src/melee/gm/gm_16AE.h
+++ b/src/melee/gm/gm_16AE.h
@@ -49,7 +49,7 @@
 /* 16B350 */ void gm_8016B350(int arg0);
 /* 16B364 */ void gm_8016B364(int arg0);
 /* 16B378 */ void gm_8016B378(s8 arg0);
-/* 16B388 */ void fn_8016B388(int arg0, s16 arg1);
+/* 16B388 */ void fn_8016B388(int arg0, int arg1);
 /* 16B3A0 */ bool gm_8016B3A0(void);
 /* 16B3D8 */ bool gm_8016B3D8(void);
 /* 16B41C */ bool gm_8016B41C(void);

--- a/src/melee/gm/gmallstar.c
+++ b/src/melee/gm/gmallstar.c
@@ -393,7 +393,7 @@ static inline void gm_801B5324_inline(s8* char_ids, gm_803DEBE8_t* opp_data,
     }
 }
 
-void gm_801B5324(UnkAllstarData* arg0, u8 arg1)
+void gm_801B5324(UnkAllstarData* arg0, s32 arg1)
 {
     s8 chars[3];
     u8 colors[3];

--- a/src/melee/gm/gmallstar.h
+++ b/src/melee/gm/gmallstar.h
@@ -3,7 +3,7 @@
 
 #include <melee/gm/forward.h>
 
-/* 1B5324 */ void gm_801B5324(UnkAllstarData*, u8);
+/* 1B5324 */ void gm_801B5324(UnkAllstarData*, s32);
 /* 1B5624 */ void gm_801B5624(GameModeState*);
 /* 1B59AC */ void gm_801B59AC(GameModeState*);
 /* 1B5AA8 */ void fn_801B5AA8(int);

--- a/src/melee/if/ifstock.c
+++ b/src/melee/if/ifstock.c
@@ -144,8 +144,8 @@ ifStock_802F8298_init(HSD_GObj* gobj, HSD_JObj** jobj,
     return GET_IFSTOCK(gobj);
 }
 
-static inline int ifStock_802F8298_get_flag(struct IfStockUserData* user_data,
-                                            struct ifStock_804A1378* stock)
+static inline u8 ifStock_802F8298_get_flag(struct IfStockUserData* user_data,
+                                           struct ifStock_804A1378* stock)
 {
     return stock->x204[user_data->player].x0[2];
 }

--- a/src/melee/mn/mnmainrule.c
+++ b/src/melee/mn/mnmainrule.c
@@ -1045,7 +1045,7 @@ void fn_802309F0(HSD_GObj* arg0)
     }
 }
 
-s32 mn_80230D18(struct mn_802307F8_t* arg0, HSD_JObj* arg1, s8 arg2)
+s32 mn_80230D18(struct mn_802307F8_t* arg0, HSD_JObj* arg1, int arg2)
 {
     GameRules* rules;
     s32 ret;

--- a/src/melee/mn/mnmainrule.h
+++ b/src/melee/mn/mnmainrule.h
@@ -44,7 +44,7 @@ struct mn_80231634_t {
 /* 2307F8 */ void mn_802307F8(struct mn_802307F8_t*, s32, s32);
 /* 2308F0 */ void mn_802308F0(HSD_GObj*, int, int);
 /* 2309F0 */ void fn_802309F0(HSD_GObj*);
-/* 230D18 */ s32 mn_80230D18(struct mn_802307F8_t*, HSD_JObj*, s8);
+/* 230D18 */ s32 mn_80230D18(struct mn_802307F8_t*, HSD_JObj*, int);
 /* 230E38 */ HSD_GObj* mn_80230E38(int);
 /* 231634 */ int mn_80231634(struct mn_80231634_t*);
 /* 23164C */ void mn_8023164C(void);


### PR DESCRIPTION
Fixes four integer type declarations that caused MWCC to emit width and
signedness conversions that retail does not have.

When an argument is passed to a parameter narrower than itself, MWCC emits a
conversion at the call site (`extsb`, `extsh`, `clrlwi`). When the declared type
is wide enough, no conversion is emitted. Retail's codegen therefore pins the
width of each parameter: a plain register copy where we emit a mask means the
declaration is too narrow, and a mask where we emit a plain copy means it is too
wide. This is the `s8`-is-usually-an-`int` case described in CONTRIBUTING.

- `gm_801B5324`: `arg1` widened to `s32`. The indirect call through `x54` now
  narrows its first argument as retail does. Matches.
- `fn_8016B388`: `arg1` widened to `int`, removing an `extsh` in the caller
  `fn_801891F4` (99.517 -> 99.786).
- `mn_80230D18`: `arg2` widened to `int`, removing an `extsb` in the caller
  `mn_80230E38` (99.843 -> 99.961).
- `ifStock_802F8298_get_flag`: return type changed to `u8`. The getter and a
  later direct read of the same byte are one common subexpression, so the
  getter's `int` was carried into a comparison that retail performs unsigned
  (`cmpwi` -> `cmplwi`), improving `ifStock_802F8298` (97.064 -> 97.191).

`gm_801B5324` is the one case where `s32` and `int` are not interchangeable: it
matches with `s32` and regresses with `int`.

Claude Opus 5 did the function matching work.
