### PR TITLE
gm_801B5ACC from 86.09% to 97.99%

### DIFF
--- a/src/melee/gm/gmallstar.c
+++ b/src/melee/gm/gmallstar.c
@@ -617,7 +617,6 @@ void gm_801B5ACC(GameModeState* arg0)
     u16 round;
     StartMeleeData* data;
     s32 i;
-    s32 next_count;
 
     PAD_STACK(24);
     chars[0] = 0x21;
@@ -649,26 +648,25 @@ void gm_801B5ACC(GameModeState* arg0)
     {
         UnkAllstarData* allstar = &gm_80473A18;
         AllstarRoundInfo* ri = &gm_803DEC4C[round];
-        s32 next_start;
 
         for (i = 0; i < (s32) ri->count; i++) {
             u8* slot_ptr;
             s32 slot;
+            u8* p;
             do {
                 slot = HSD_Randi(0x1A);
-                slot_ptr = &allstar->x76[slot];
-            } while ((s32) *slot_ptr != 0x21);
+                p = (u8*) allstar + slot;
+                slot_ptr = p + 0x76;
+            } while ((s32) p[0x76] != 0x21);
             *slot_ptr = gm_803DEBE8[i + ri->start].x3;
         }
 
-        next_count = (s32) ri[1].count;
-        next_start = (s32) ri[1].start;
-        for (i = 0; i < next_count; i++) {
-            allstar->_94[2 + i] = gm_803DEBE8[next_start + i].x3;
+        for (i = 0; i < (s32) (&gm_803DEC4C[round])[1].count; i++) {
+            gm_80473A18._94[2 + i] = gm_803DEBE8[(s32) (&gm_803DEC4C[round])[1].start + i].x3;
         }
 
-        allstar->_94[1] = (u8) next_count;
-        allstar->_94[0] = (u8) (round + 1);
+        gm_80473A18._94[1] = (u8) i;
+        gm_80473A18._94[0] = (u8) (round + 1);
         data->players[0].xC_b1 = 0;
         data->rules.x1_2 = 1;
         data->rules.x1_3 = 1;

--- a/src/melee/gm/gmallstar.c
+++ b/src/melee/gm/gmallstar.c
@@ -662,7 +662,8 @@ void gm_801B5ACC(GameModeState* arg0)
         }
 
         for (i = 0; i < (s32) (&gm_803DEC4C[round])[1].count; i++) {
-            gm_80473A18._94[2 + i] = gm_803DEBE8[(s32) (&gm_803DEC4C[round])[1].start + i].x3;
+            gm_80473A18._94[2 + i] =
+                gm_803DEBE8[(s32) (&gm_803DEC4C[round])[1].start + i].x3;
         }
 
         gm_80473A18._94[1] = (u8) i;


### PR DESCRIPTION
Brings `gm_801B5ACC` (gmallstar) from 86.09% to 97.99%. The instruction
multiset now matches retail exactly (259/259); the remaining rows are a
single callee-saved register ranking permutation (r26–r29 rotated).

Three compiler behaviors drove the rewrite:

- **Mixed address spelling.** MWCC keeps `&gm_80473A18` in a callee-saved
  register for the code that uses the `allstar` pointer (first loop, the
  `|= 0x80`, the `gm_801B5324` call) but re-materializes it with `lis/addi`
  wherever the global is named directly. Retail does both, so the second
  loop and its tail now use `gm_80473A18._94[...]` directly.
- **Runtime unroller needs a provably invariant bound.** A loop bound read
  through a pointer (`ri[1].count`) makes MWCC refuse to unroll ("Loop
  Upper Bound is Variant") and the function loses its 8x unrolled copy loop.
  A direct static-array read, `(&gm_803DEC4C[round])[1].count`, keeps it,
  and the `(s32)` sum on the body index is what strength-reduces into
  retail's walking `addi`s. `_94[1]` is stored from the loop counter.
- **Two live pointers in the slot search.** Retail reads `x76[slot]` with
  the constant on the load (`lbz 0x76(r3)`) and stores through a
  separately formed pointer (`stb 0(r4)`); `p = (u8*) allstar + slot` with
  `slot_ptr = p + 0x76` reproduces that.

No type or header changes — only the function body is touched, so this
should not collide with in-progress typing work on the TU.

Fable 5.1 solved this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
