### PR TITLE
Improve hsd_803B3408 RGB565-to-JPEG conversion

### DIFF
--- a/src/sysdolphin/baselib/hsd_3B34.c
+++ b/src/sysdolphin/baselib/hsd_3B34.c
@@ -198,111 +198,80 @@ extern u16 lbl_8043169C[0xC];
 extern u8 lbl_804316B4[0xC];
 static s32 lbl_804D6398 = 3;
 
-static inline s32 hsd_803B3408_offset(s32 tile_stride, s32 y, s32 x)
-{
-    return ((x / 4) * 0x10) + ((y / 4) * tile_stride);
-}
-
 void hsd_803B3408(u8* image, s32 x, s32 y, s32 width, s32 height)
 {
-    JpegBlock* luma_block;
-    s32 tile_row_offset;
-    s32 chroma_row_base;
-    s32 luma_row_base;
-    s32 luma_offset;
-    s32 luma_row;
-    s32 luma_block_offset;
-    s32 tile_stride;
+    s32 chroma_x;
     s32 luma_y;
-    s32 block_count;
     s32 luma_x;
     s32 tile_y;
     s32 tile_x;
     u16 pixel;
     s32 pixel_index;
-    u16* pixel_ptr;
+    s32 image_offset;
+    s32 stride;
 
-    tile_row_offset = 0;
-    tile_stride = ((width + 0xF) / 16) << 6;
-    chroma_row_base = 0;
-    luma_row_base = 0;
+    stride = ((width + 0xF) / 16) << 6;
+    image_offset = ((x / 4) * 0x10) + ((y / 4) * stride);
     for (tile_y = 0; tile_y < 2; tile_y++) {
-        s32 chroma_block_offset;
         u16* src;
 
-        chroma_block_offset = chroma_row_base;
-        {
-            s32 image_offset = hsd_803B3408_offset(tile_stride, y, x);
-            src = (u16*) image + (image_offset + tile_row_offset);
-        }
-        for (tile_x = 0, luma_block_offset = 0; tile_x < 2; tile_x++) {
+        src = (u16*) image + (image_offset + tile_y * stride);
+        for (tile_x = 0; tile_x < 2; tile_x++) {
             s32 chroma_y;
 
             for (chroma_y = 0; chroma_y < 4; chroma_y++) {
-                s32 chroma_x;
+                s32 dst_row;
+                s32 src_row;
+
+                dst_row = (chroma_y & 1) * 4 + (chroma_y & 2) * 16;
+                dst_row = (tile_y * 16 + tile_x * 2) + dst_row;
+                src_row = (chroma_y & 1) * 32 + (chroma_y & 2) * stride;
 
                 for (chroma_x = 0; chroma_x < 4; chroma_x++) {
-                    f32 green;
-                    s32 chroma_x_offset;
-                    s32 red_chroma;
-                    s32 blue_chroma;
-                    u16 pixel;
-                    u16 pixel_again;
-                    JpegWork* chroma_work;
+                    s32 chroma_index;
+                    JpegWork* chroma_dest;
 
-                    chroma_x_offset = (chroma_x & 2) * 4;
-                    pixel_ptr =
-                        src +
-                        (((chroma_x & 1) * 2) +
-                         (chroma_x_offset + (((chroma_y & 1) * 0x20) +
-                                             ((chroma_y & 2) * tile_stride))));
-                    pixel = *pixel_ptr;
-                    red_chroma = (pixel >> 8U) & 0xF8;
-                    {
-                        s32 blue_shifted = pixel * 8;
-                        f32 green_value = (f32) ((pixel >> 3U) & 0xFC);
-                        blue_chroma = blue_shifted & 0xF8;
-                        green = green_value;
-                    }
-                    chroma_work =
-                        (JpegWork*) (HSD_804D2648_BUF +
-                                     (((chroma_x & 1) + chroma_x_offset +
-                                       (chroma_block_offset +
-                                        (((chroma_y & 1) * 4) +
-                                         ((chroma_y & 2) * 0x10)))) *
-                                      4));
-                    chroma_work->data.x518[0] =
-                        (s32) ((0.5f * (f32) blue_chroma) +
-                               ((-0.1687f * (f32) red_chroma) -
-                                (0.3313f * green)));
-                    pixel_again = *pixel_ptr;
-                    chroma_work->data.x618[0] =
-                        (s32) (((0.5f * (f32) ((pixel_again >> 8U) & 0xF8)) -
-                                (0.4187f *
-                                 (f32) ((pixel_again >> 3U) & 0xFC))) -
-                               (0.0813f * (f32) ((pixel_again * 8) & 0xF8)));
+                    pixel = src[(chroma_x & 1) * 2 +
+                                (((chroma_x & 2) * 4) + src_row)];
+                    chroma_index = (chroma_x & 2) * 4;
+                    chroma_index = (chroma_x & 1) + chroma_index;
+                    chroma_index += dst_row;
+                    chroma_dest =
+                        (JpegWork*) (HSD_804D2648_BUF + chroma_index * 4);
+                    chroma_dest->data.x518[0] =
+                        (s32) ((0.5f * (f32) ((pixel * 8) & 0xF8)) +
+                               ((-0.1687f * (f32) ((pixel >> 8U) & 0xF8)) -
+                                (0.3313f * (f32) ((pixel >> 3U) & 0xFC))));
+                    pixel = src[(chroma_x & 1) * 2 +
+                                (((chroma_x & 2) * 4) + src_row)];
+                    chroma_dest->data.x618[0] =
+                        (s32) (((0.5f * (f32) ((pixel >> 8U) & 0xF8)) -
+                                (0.4187f * (f32) ((pixel >> 3U) & 0xFC))) -
+                               (0.0813f * (f32) ((pixel * 8) & 0xF8)));
                 }
             }
             luma_y = 0;
-            luma_row = luma_row_base;
             for (; luma_y < 4; luma_y++) {
-                luma_offset = luma_row;
-                luma_offset <<= 3;
                 for (luma_x = 0; luma_x < 4; luma_x++) {
-                    pixel_index = 0;
-                    luma_block =
-                        (JpegBlock*) (HSD_804D2648_BUF +
-                                      ((luma_block_offset + luma_offset) * 4) +
-                                      0x118);
-                    for (block_count = 4; block_count != 0; block_count--) {
-                        s32 row_offset = (pixel_index & 2) * tile_stride;
+                    s32* luma_base;
+
+                    for (pixel_index = 0;
+                         luma_base =
+                             (s32*) (HSD_804D2648_BUF +
+                                     (tile_x * 4 +
+                                      ((tile_y * 4 + luma_y) * 8 + luma_x)) *
+                                         4 +
+                                     0x118),
+                        pixel_index != 4;
+                         pixel_index++)
+                    {
+                        s32 row_offset = (pixel_index & 2) * stride;
 
                         {
                             s32 column_offset = (pixel_index & 1) * 0x20;
                             pixel = src[column_offset + row_offset];
                         }
-                        pixel_index += 1;
-                        luma_block->data[0] =
+                        luma_base[pixel_index * 64] =
                             (s32) ((s32) ((0.114f *
                                            (f32) ((pixel * 8) & 0xF8)) +
                                           ((0.299f *
@@ -310,19 +279,11 @@ void hsd_803B3408(u8* image, s32 x, s32 y, s32 width, s32 height)
                                            (0.587f *
                                             (f32) ((pixel >> 3U) & 0xFC)))) -
                                    0x80);
-                        luma_block += 1;
                     }
                     src += 1;
-                    luma_offset += 1;
                 }
-                luma_row += 1;
             }
-            chroma_block_offset += 2;
-            luma_block_offset += 4;
         }
-        tile_row_offset += tile_stride;
-        chroma_row_base += 0x10;
-        luma_row_base += 4;
     }
 }
 


### PR DESCRIPTION
Improve `hsd_803B3408` from **88.76% to 98.78%** by simplifying tiled RGB565 addressing, sharing the chroma destination address, and expressing luma block traversal with an indexed loop. The function retains the target 868-byte size and 152-byte stack frame.

This is a progress update: the function remains unmatched, with chroma address grouping, register allocation, and luma setup ordering still to resolve.

Validation: GALE01 builds successfully. All seven neighboring functions retain their previous match percentages; `.data`, `.rodata`, `.sdata`, `.sdata2`, `extab`, and `extabindex` remain at 100% under data-value relocation comparison.
