### PR TITLE
if: improve stock callback frame and register allocation

### DIFF
--- a/src/melee/if/ifstock.c
+++ b/src/melee/if/ifstock.c
@@ -127,6 +127,9 @@ int ifStock_802F7EFC(int arg0, int arg1)
 
 void ifStock_802F8298(HSD_GObj* gobj)
 {
+    int palette_index;
+    HSD_JObj* count_jobj;
+    HSD_JObj* ones_jobj;
     struct IfStockUserData* user_data;
     HSD_JObj* jobj;
     struct ifStock_804A1378* stock;
@@ -182,13 +185,14 @@ void ifStock_802F8298(HSD_GObj* gobj)
             }
             HSD_JObjReqAnimAll(
                 jobj2, stock->x204[user_data->player].x0[(int) (i + 5)]);
+            palette_index = user_data->player;
             HSD_TObjReqAnimAll(jobj2->u.dobj->mobj->tobj,
-                               gm_80168BF8((user_data->player)));
+                               gm_80168BF8(palette_index));
             HSD_AObjSetRate(jobj2->u.dobj->mobj->tobj->aobj, 0.0f);
         }
     } else {
-        HSD_JObjClearFlagsAll((stock->player[user_data->player].x3C),
-                              JOBJ_HIDDEN);
+        count_jobj = stock->player[user_data->player].x3C;
+        HSD_JObjClearFlagsAll(count_jobj, JOBJ_HIDDEN);
         if (stock->player[user_data->player].stocks >= 10) {
             HSD_JObjReqAnimAll(stock->player[user_data->player].x44,
                                (stock->player[user_data->player].stocks / 10));
@@ -197,8 +201,8 @@ void ifStock_802F8298(HSD_GObj* gobj)
         } else {
             HSD_JObjReqAnimAll(stock->player[user_data->player].x44,
                                stock->player[user_data->player].stocks);
-            HSD_JObjSetFlagsAll((stock->player[user_data->player].x40),
-                                JOBJ_HIDDEN);
+            ones_jobj = stock->player[user_data->player].x40;
+            HSD_JObjSetFlagsAll(ones_jobj, JOBJ_HIDDEN);
         }
         for (i = 0; i < 5; i++) {
             jobj2 = stock->player[user_data->player].x4[i + 1];

--- a/src/melee/if/ifstock.c
+++ b/src/melee/if/ifstock.c
@@ -134,7 +134,7 @@ void ifStock_802F8298(HSD_GObj* gobj)
     int i;
     HSD_JObj* jobj2;
     Vec3 vecA, vecB, vecC, vecD;
-    unsigned char* anim_data;
+    struct IfStockData* anim_data;
     struct IfStockDataOffset* anim_base;
     user_data = gobj->user_data;
     jobj = gobj->hsd_obj;
@@ -222,13 +222,10 @@ void ifStock_802F8298(HSD_GObj* gobj)
             HSD_JObjClearFlagsAll(jobj2, JOBJ_HIDDEN);
             if (stock->x204[user_data->player].x0[(int) (i + 5)] <= 10) {
                 {
-                    unsigned char* data = stock->x204[user_data->player].x0;
-                    u32 anim_offset =
-                        0xC + (i - 5) * sizeof(struct IfStockStealAnim);
-                    lbVector_8000DE38(
-                        (float (*)[4]) &
-                            stock->x204[user_data->player].x0[anim_offset],
-                        &vecC, 0.1f * data[i + 5]);
+                    struct IfStockData* data =
+                        (struct IfStockData*) &stock->x204[user_data->player];
+                    lbVector_8000DE38((float (*)[4]) & data->anim[i - 5],
+                                      &vecC, 0.1f * data->x0[i + 5]);
                 }
                 HSD_JObjGetTranslation(stock->player[user_data->player].x4[0],
                                        &vecD);
@@ -239,14 +236,9 @@ void ifStock_802F8298(HSD_GObj* gobj)
                 anim_base =
                     (struct IfStockDataOffset*) ((struct IfStockData*) stock +
                                                  user_data->player);
-                anim_data = (unsigned char*) ++anim_base;
-                if (anim_data[i + 5] == 1) {
-                    vecC.x = ((struct IfStockStealAnim*) &anim_data
-                                  [0xC +
-                                   (int) (i * (int) sizeof(
-                                                  struct IfStockStealAnim)) -
-                                   5 * sizeof(struct IfStockStealAnim)])
-                                 ->start.x;
+                anim_data = (struct IfStockData*) ++anim_base;
+                if (anim_data->x0[i + 5] == 1) {
+                    vecC.x = anim_data->anim[i - 5].start.x;
                     vecC.y =
                         ((struct IfStockStealAnim*) &(
                              stock->x204)[user_data->player]
@@ -258,16 +250,8 @@ void ifStock_802F8298(HSD_GObj* gobj)
                                                 struct IfStockStealAnim))])
                             ->start.y;
                     efSync_Spawn(0x475, gobj, &vecC);
-                } else if (anim_data[i + 5] == 10) {
-                    {
-                        vecC.x =
-                            ((struct IfStockStealAnim*) &anim_data
-                                 [0xC +
-                                  (int) (i * (int) sizeof(
-                                                 struct IfStockStealAnim)) -
-                                  5 * sizeof(struct IfStockStealAnim)])
-                                ->end.x;
-                    }
+                } else if (anim_data->x0[i + 5] == 10) {
+                    vecC.x = anim_data->anim[i - 5].end.x;
                     vecC.y =
                         ((struct IfStockStealAnim*) &(
                              stock->x204)[user_data->player]

--- a/src/melee/if/ifstock.c
+++ b/src/melee/if/ifstock.c
@@ -298,14 +298,16 @@ void ifStock_802F8298(HSD_GObj* gobj)
                     vecC.x =
                         ((struct IfStockStealAnim*) &stock
                              ->x204[user_data->player]
-                             .x0[0xC + i * sizeof(struct IfStockStealAnim) -
-                                 5 * sizeof(struct IfStockStealAnim)])
+                             .x0[0xC +
+                                 i * (int) sizeof(struct IfStockStealAnim) -
+                                 5 * (int) sizeof(struct IfStockStealAnim)])
                             ->start.x;
                     vecC.y =
                         ((struct IfStockStealAnim*) &ifStock_802F8298_get_data(
                              stock)[user_data->player]
-                             .x0[0xC + i * sizeof(struct IfStockStealAnim) -
-                                 5 * sizeof(struct IfStockStealAnim)])
+                             .x0[0xC +
+                                 i * (int) sizeof(struct IfStockStealAnim) -
+                                 5 * (int) sizeof(struct IfStockStealAnim)])
                             ->start.y;
                     efSync_Spawn(0x475, gobj, &vecC);
                 } else if (stock->x204[user_data->player].x0[i + 5] == 10) {
@@ -316,15 +318,18 @@ void ifStock_802F8298(HSD_GObj* gobj)
                             ((struct IfStockStealAnim*) &data[user_data
                                                                   ->player]
                                  .x0[0xC +
-                                     i * sizeof(struct IfStockStealAnim) -
-                                     5 * sizeof(struct IfStockStealAnim)])
+                                     i * (int) sizeof(
+                                             struct IfStockStealAnim) -
+                                     5 * (int) sizeof(
+                                             struct IfStockStealAnim)])
                                 ->end.x;
                     }
                     vecC.y =
                         ((struct IfStockStealAnim*) &ifStock_802F8298_get_data(
                              stock)[user_data->player]
-                             .x0[0xC + i * sizeof(struct IfStockStealAnim) -
-                                 5 * sizeof(struct IfStockStealAnim)])
+                             .x0[0xC +
+                                 i * (int) sizeof(struct IfStockStealAnim) -
+                                 5 * (int) sizeof(struct IfStockStealAnim)])
                             ->end.y;
                     efSync_Spawn(0x476, gobj, &vecC);
                 }

--- a/src/melee/if/ifstock.c
+++ b/src/melee/if/ifstock.c
@@ -125,6 +125,11 @@ int ifStock_802F7EFC(int arg0, int arg1)
     return 0;
 }
 
+static inline struct IfStockUserData* ifStock_802F8298_get_data(HSD_GObj* gobj)
+{
+    return gobj->user_data;
+}
+
 void ifStock_802F8298(HSD_GObj* gobj)
 {
     int palette_index;
@@ -136,10 +141,11 @@ void ifStock_802F8298(HSD_GObj* gobj)
     HSD_JObj* jobj_anim;
     int i;
     HSD_JObj* jobj2;
+    HSD_JObj* steal_jobj;
     Vec3 vecA, vecB, vecC, vecD;
     struct IfStockData* anim_data;
     struct IfStockDataOffset* anim_base;
-    user_data = gobj->user_data;
+    user_data = ifStock_802F8298_get_data(gobj);
     jobj = gobj->hsd_obj;
     stock = &ifStock_804A1378;
     jobj_anim = jobj;
@@ -158,16 +164,18 @@ void ifStock_802F8298(HSD_GObj* gobj)
             if (i < stock->player[user_data->player].stocks) {
                 HSD_JObjClearFlagsAll(jobj2, JOBJ_HIDDEN);
                 {
-                    unsigned char* data = stock->x204[user_data->player].x0;
-                    if ((stock->x204[user_data->player].x0[2]) != 0) {
+                    unsigned char* data =
+                        ((struct IfStockData*) stock)[user_data->player].x0;
+                    if ((data += sizeof(struct IfStockDataOffset))[2] != 0) {
                         data[i + 5] = 0;
                     } else {
                         data[i + 5] = 10;
                     }
                 }
             } else {
-                unsigned char* data = stock->x204[user_data->player].x0;
-                if (stock->x204[user_data->player].x0[2] == 0) {
+                unsigned char* data =
+                    ((struct IfStockData*) stock)[user_data->player].x0;
+                if ((data += sizeof(struct IfStockDataOffset))[2] == 0) {
                     data[i + 5] = 10;
                 }
                 if ((stock->x204)[user_data->player].x0[(int) (i + 5)] == 0) {
@@ -219,11 +227,11 @@ void ifStock_802F8298(HSD_GObj* gobj)
         }
     }
     for (i = 5; i <= 6; i++) {
-        jobj2 = stock->player[user_data->player].x4[i + 1];
+        steal_jobj = stock->player[user_data->player].x4[i + 1];
         if ((stock->x204)[user_data->player].x0[(int) (i + 5)] == 0) {
-            HSD_JObjSetFlagsAll(jobj2, JOBJ_HIDDEN);
+            HSD_JObjSetFlagsAll(steal_jobj, JOBJ_HIDDEN);
         } else {
-            HSD_JObjClearFlagsAll(jobj2, JOBJ_HIDDEN);
+            HSD_JObjClearFlagsAll(steal_jobj, JOBJ_HIDDEN);
             if (stock->x204[user_data->player].x0[(int) (i + 5)] <= 10) {
                 {
                     struct IfStockData* data =
@@ -236,7 +244,7 @@ void ifStock_802F8298(HSD_GObj* gobj)
                 vecC.x -= vecD.x;
                 vecC.y -= vecD.y;
                 vecC.z -= vecD.z;
-                HSD_JObjSetTranslate(jobj2, &vecC);
+                HSD_JObjSetTranslate(steal_jobj, &vecC);
                 anim_base =
                     (struct IfStockDataOffset*) ((struct IfStockData*) stock +
                                                  user_data->player);
@@ -277,9 +285,9 @@ void ifStock_802F8298(HSD_GObj* gobj)
                      2] = 1;
             }
         }
-        HSD_TObjReqAnimAll(jobj2->u.dobj->mobj->tobj,
+        HSD_TObjReqAnimAll(steal_jobj->u.dobj->mobj->tobj,
                            gm_80168BF8(user_data->player));
-        HSD_AObjSetRate(jobj2->u.dobj->mobj->tobj->aobj, 0.0f);
+        HSD_AObjSetRate(steal_jobj->u.dobj->mobj->tobj->aobj, 0.0f);
     }
     HSD_JObjAnimAll(jobj_anim);
 }

--- a/src/melee/if/ifstock.c
+++ b/src/melee/if/ifstock.c
@@ -140,18 +140,6 @@ ifStock_802F8298_init(HSD_GObj* gobj, HSD_JObj** jobj,
     return GET_IFSTOCK(gobj);
 }
 
-static inline u8 ifStock_802F8298_get_flag(struct IfStockUserData* user_data,
-                                           struct ifStock_804A1378* stock)
-{
-    return stock->x204[user_data->player].x0[2];
-}
-
-static inline int
-ifStock_802F8298_get_player(struct IfStockUserData* user_data)
-{
-    return user_data->player;
-}
-
 static inline HSD_JObj*
 ifStock_802F8298_get_x3C(struct IfStockUserData* user_data,
                          struct ifStock_804A1378* stock)
@@ -200,7 +188,7 @@ void ifStock_802F8298(HSD_GObj* gobj)
                 HSD_JObjClearFlagsAll(jobj2, JOBJ_HIDDEN);
                 {
                     unsigned char* data = stock->x204[user_data->player].x0;
-                    if (ifStock_802F8298_get_flag(user_data, stock) != 0) {
+                    if (stock->x204[user_data->player].x0[2] != 0) {
                         data[i + 5] = 0;
                     } else {
                         data[i + 5] = 10;
@@ -230,9 +218,8 @@ void ifStock_802F8298(HSD_GObj* gobj)
             }
             HSD_JObjReqAnimAll(jobj2,
                                stock->x204[user_data->player].x0[i + 5]);
-            HSD_TObjReqAnimAll(
-                jobj2->u.dobj->mobj->tobj,
-                gm_80168BF8(ifStock_802F8298_get_player(user_data)));
+            HSD_TObjReqAnimAll(jobj2->u.dobj->mobj->tobj,
+                               gm_80168BF8(user_data->player));
             HSD_AObjSetRate(jobj2->u.dobj->mobj->tobj->aobj, 0.0f);
         }
     } else {

--- a/src/melee/if/ifstock.c
+++ b/src/melee/if/ifstock.c
@@ -125,51 +125,6 @@ int ifStock_802F7EFC(int arg0, int arg1)
     return 0;
 }
 
-static inline struct ifStock_804A1378_x204*
-ifStock_802F8298_get_data(struct ifStock_804A1378* stock)
-{
-    return stock->x204;
-}
-
-static inline struct IfStockUserData*
-ifStock_802F8298_init(HSD_GObj* gobj, HSD_JObj** jobj,
-                      struct ifStock_804A1378** stock)
-{
-    *jobj = gobj->hsd_obj;
-    *stock = &ifStock_804A1378;
-    return GET_IFSTOCK(gobj);
-}
-
-static inline HSD_JObj*
-ifStock_802F8298_get_x3C(struct IfStockUserData* user_data,
-                         struct ifStock_804A1378* stock)
-{
-    return stock->player[user_data->player].x3C;
-}
-
-static inline HSD_JObj*
-ifStock_802F8298_get_x40(struct IfStockUserData* user_data,
-                         struct ifStock_804A1378* stock)
-{
-    return stock->player[user_data->player].x40;
-}
-
-static inline void ifStock_802F8298_init_stocks(
-    HSD_GObj* gobj, struct ifStock_804A1378** stock, HSD_JObj** jobj,
-    struct IfStockUserData** user_data, HSD_JObj** jobj_anim)
-{
-    *user_data = ifStock_802F8298_init(gobj, jobj, stock);
-    *jobj_anim = *jobj;
-    (*stock)->player[(*user_data)->player].stocks =
-        Player_GetStocks((*user_data)->player);
-    if ((*stock)->player[(*user_data)->player].stocks > 99) {
-        (*stock)->player[(*user_data)->player].stocks = 99;
-    }
-    if ((*stock)->player[(*user_data)->player].stocks < 0) {
-        (*stock)->player[(*user_data)->player].stocks = 1;
-    }
-}
-
 void ifStock_802F8298(HSD_GObj* gobj)
 {
     struct IfStockUserData* user_data;
@@ -179,7 +134,20 @@ void ifStock_802F8298(HSD_GObj* gobj)
     int i;
     HSD_JObj* jobj2;
     Vec3 vecA, vecB, vecC, vecD;
-    ifStock_802F8298_init_stocks(gobj, &stock, &jobj, &user_data, &jobj_anim);
+    unsigned char* anim_data;
+    struct IfStockDataOffset* anim_base;
+    user_data = gobj->user_data;
+    jobj = gobj->hsd_obj;
+    stock = &ifStock_804A1378;
+    jobj_anim = jobj;
+    stock->player[user_data->player].stocks =
+        Player_GetStocks(user_data->player);
+    if (stock->player[user_data->player].stocks > 99) {
+        stock->player[user_data->player].stocks = 99;
+    }
+    if (stock->player[user_data->player].stocks < 0) {
+        stock->player[user_data->player].stocks = 1;
+    }
     if (stock->player[user_data->player].stocks <= 5) {
         HSD_JObjSetFlagsAll(stock->player[user_data->player].x3C, JOBJ_HIDDEN);
         for (i = 0; i < 5; i++) {
@@ -188,42 +156,38 @@ void ifStock_802F8298(HSD_GObj* gobj)
                 HSD_JObjClearFlagsAll(jobj2, JOBJ_HIDDEN);
                 {
                     unsigned char* data = stock->x204[user_data->player].x0;
-                    if (stock->x204[user_data->player].x0[2] != 0) {
+                    if ((stock->x204[user_data->player].x0[2]) != 0) {
                         data[i + 5] = 0;
                     } else {
                         data[i + 5] = 10;
                     }
                 }
             } else {
+                unsigned char* data = stock->x204[user_data->player].x0;
                 if (stock->x204[user_data->player].x0[2] == 0) {
-                    stock->x204[user_data->player].x0[i + 5] = 10;
+                    data[i + 5] = 10;
                 }
-                if (ifStock_802F8298_get_data(stock)[user_data->player]
-                        .x0[i + 5] == 0)
-                {
-                    HSD_JObjGetTranslation2(jobj, &vecA);
-                    HSD_JObjGetTranslation2(
+                if ((stock->x204)[user_data->player].x0[(int) (i + 5)] == 0) {
+                    HSD_JObjGetTranslation(jobj, &vecA);
+                    HSD_JObjGetTranslation(
                         stock->player[user_data->player].x4[i + 1], &vecB);
                     vecB.x += vecA.x;
                     vecB.y += vecA.y;
                     vecB.z += vecA.z;
                     efSync_Spawn(0x474, gobj, &vecB);
                 }
-                if (ifStock_802F8298_get_data(stock)[user_data->player]
-                        .x0[i + 5] < 10)
-                {
-                    ifStock_802F8298_get_data(stock)[user_data->player]
-                        .x0[i + 5] += 1;
+                if ((stock->x204)[user_data->player].x0[(int) (i + 5)] < 10) {
+                    (stock->x204)[user_data->player].x0[(int) (i + 5)] += 1;
                 }
             }
-            HSD_JObjReqAnimAll(jobj2,
-                               stock->x204[user_data->player].x0[i + 5]);
+            HSD_JObjReqAnimAll(
+                jobj2, stock->x204[user_data->player].x0[(int) (i + 5)]);
             HSD_TObjReqAnimAll(jobj2->u.dobj->mobj->tobj,
-                               gm_80168BF8(user_data->player));
+                               gm_80168BF8((user_data->player)));
             HSD_AObjSetRate(jobj2->u.dobj->mobj->tobj->aobj, 0.0f);
         }
     } else {
-        HSD_JObjClearFlagsAll(ifStock_802F8298_get_x3C(user_data, stock),
+        HSD_JObjClearFlagsAll((stock->player[user_data->player].x3C),
                               JOBJ_HIDDEN);
         if (stock->player[user_data->player].stocks >= 10) {
             HSD_JObjReqAnimAll(stock->player[user_data->player].x44,
@@ -233,20 +197,18 @@ void ifStock_802F8298(HSD_GObj* gobj)
         } else {
             HSD_JObjReqAnimAll(stock->player[user_data->player].x44,
                                stock->player[user_data->player].stocks);
-            HSD_JObjSetFlagsAll(ifStock_802F8298_get_x40(user_data, stock),
+            HSD_JObjSetFlagsAll((stock->player[user_data->player].x40),
                                 JOBJ_HIDDEN);
         }
         for (i = 0; i < 5; i++) {
             jobj2 = stock->player[user_data->player].x4[i + 1];
             if (i == 0) {
-                ifStock_802F8298_get_data(stock)[user_data->player].x0[i + 5] =
-                    0;
+                (stock->x204)[user_data->player].x0[(int) (i + 5)] = 0;
             } else {
-                ifStock_802F8298_get_data(stock)[user_data->player].x0[i + 5] =
-                    10;
+                (stock->x204)[user_data->player].x0[(int) (i + 5)] = 10;
             }
-            HSD_JObjReqAnimAll(jobj2,
-                               stock->x204[user_data->player].x0[i + 5]);
+            HSD_JObjReqAnimAll(
+                jobj2, stock->x204[user_data->player].x0[(int) (i + 5)]);
             HSD_TObjReqAnimAll(jobj2->u.dobj->mobj->tobj,
                                gm_80168BF8(user_data->player));
             HSD_AObjSetRate(jobj2->u.dobj->mobj->tobj->aobj, 0.0f);
@@ -254,12 +216,11 @@ void ifStock_802F8298(HSD_GObj* gobj)
     }
     for (i = 5; i <= 6; i++) {
         jobj2 = stock->player[user_data->player].x4[i + 1];
-        if (ifStock_802F8298_get_data(stock)[user_data->player].x0[i + 5] == 0)
-        {
+        if ((stock->x204)[user_data->player].x0[(int) (i + 5)] == 0) {
             HSD_JObjSetFlagsAll(jobj2, JOBJ_HIDDEN);
         } else {
             HSD_JObjClearFlagsAll(jobj2, JOBJ_HIDDEN);
-            if (stock->x204[user_data->player].x0[i + 5] <= 10) {
+            if (stock->x204[user_data->player].x0[(int) (i + 5)] <= 10) {
                 {
                     unsigned char* data = stock->x204[user_data->player].x0;
                     u32 anim_offset =
@@ -269,66 +230,63 @@ void ifStock_802F8298(HSD_GObj* gobj)
                             stock->x204[user_data->player].x0[anim_offset],
                         &vecC, 0.1f * data[i + 5]);
                 }
-                HSD_JObjGetTranslation2(stock->player[user_data->player].x4[0],
-                                        &vecD);
+                HSD_JObjGetTranslation(stock->player[user_data->player].x4[0],
+                                       &vecD);
                 vecC.x -= vecD.x;
                 vecC.y -= vecD.y;
                 vecC.z -= vecD.z;
-                if (jobj2 == NULL) {
-                    __assert("jobj.h", 916, "jobj");
-                }
-                jobj2->translate = vecC;
-                if (!(jobj2->flags & JOBJ_MTX_INDEP_SRT)) {
-                    HSD_JObjSetMtxDirty(jobj2);
-                }
-                if (stock->x204[user_data->player].x0[i + 5] == 1) {
-                    vecC.x =
-                        ((struct IfStockStealAnim*) &stock
-                             ->x204[user_data->player]
-                             .x0[0xC +
-                                 i * (int) sizeof(struct IfStockStealAnim) -
-                                 5 * (int) sizeof(struct IfStockStealAnim)])
-                            ->start.x;
+                HSD_JObjSetTranslate(jobj2, &vecC);
+                anim_base =
+                    (struct IfStockDataOffset*) ((struct IfStockData*) stock +
+                                                 user_data->player);
+                anim_data = (unsigned char*) ++anim_base;
+                if (anim_data[i + 5] == 1) {
+                    vecC.x = ((struct IfStockStealAnim*) &anim_data
+                                  [0xC +
+                                   (int) (i * (int) sizeof(
+                                                  struct IfStockStealAnim)) -
+                                   5 * sizeof(struct IfStockStealAnim)])
+                                 ->start.x;
                     vecC.y =
-                        ((struct IfStockStealAnim*) &ifStock_802F8298_get_data(
-                             stock)[user_data->player]
-                             .x0[0xC +
-                                 i * (int) sizeof(struct IfStockStealAnim) -
-                                 5 * (int) sizeof(struct IfStockStealAnim)])
+                        ((struct IfStockStealAnim*) &(
+                             stock->x204)[user_data->player]
+                             .x0[(int) (0xC +
+                                        (int) (i *
+                                               (int) sizeof(
+                                                   struct IfStockStealAnim)) -
+                                        5 * (int) sizeof(
+                                                struct IfStockStealAnim))])
                             ->start.y;
                     efSync_Spawn(0x475, gobj, &vecC);
-                } else if (stock->x204[user_data->player].x0[i + 5] == 10) {
+                } else if (anim_data[i + 5] == 10) {
                     {
-                        struct ifStock_804A1378_x204* data =
-                            ifStock_802F8298_get_data(stock);
                         vecC.x =
-                            ((struct IfStockStealAnim*) &data[user_data
-                                                                  ->player]
-                                 .x0[0xC +
-                                     i * (int) sizeof(
-                                             struct IfStockStealAnim) -
-                                     5 * (int) sizeof(
-                                             struct IfStockStealAnim)])
+                            ((struct IfStockStealAnim*) &anim_data
+                                 [0xC +
+                                  (int) (i * (int) sizeof(
+                                                 struct IfStockStealAnim)) -
+                                  5 * sizeof(struct IfStockStealAnim)])
                                 ->end.x;
                     }
                     vecC.y =
-                        ((struct IfStockStealAnim*) &ifStock_802F8298_get_data(
-                             stock)[user_data->player]
-                             .x0[0xC +
-                                 i * (int) sizeof(struct IfStockStealAnim) -
-                                 5 * (int) sizeof(struct IfStockStealAnim)])
+                        ((struct IfStockStealAnim*) &(
+                             stock->x204)[user_data->player]
+                             .x0[(int) (0xC +
+                                        (int) (i *
+                                               (int) sizeof(
+                                                   struct IfStockStealAnim)) -
+                                        5 * (int) sizeof(
+                                                struct IfStockStealAnim))])
                             ->end.y;
                     efSync_Spawn(0x476, gobj, &vecC);
                 }
-                ifStock_802F8298_get_data(stock)[user_data->player]
-                    .x0[i + 5]++;
+                (stock->x204)[user_data->player].x0[(int) (i + 5)]++;
             } else {
-                int count_index = i + 5;
-                stock->x204[user_data->player].x0[count_index] = 0;
-                ifStock_802F8298_get_data(
-                    stock)[ifStock_802F8298_get_data(stock)[user_data->player]
-                               .x0[i - 2]]
-                    .x0[2] = 1;
+                stock->x204[user_data->player].x0[(int) (i + 5)] = 0;
+                ((unsigned char*) stock->x204)
+                    [(stock->x204)[user_data->player].x0[(int) (i - 2)] *
+                         sizeof(struct ifStock_804A1378_x204) +
+                     2] = 1;
             }
         }
         HSD_TObjReqAnimAll(jobj2->u.dobj->mobj->tobj,


### PR DESCRIPTION
This improves `ifStock_802F8298` from 97.19068% to 99.745766%. The callback now has the target 136-byte frame, vector offsets, and saved-register allocation. It uses a direct typed user-data getter, a separate JObj local for the stock-steal loop, and named palette and digit-node arguments. Typed animation-array accesses recover the indexed X loads, while advancing the prefix pointer inside the flag condition preserves the target base-register reuse.

The remaining differences are temporary address registers and one commuted addition. `ifStock_802F98E8` remains at 99.57843%, and the other 26 functions in this file remain exact. The translation unit stays Linkable while both functions remain unmatched.

Validation: full configure/build passes; both callback comparisons and the complete translation-unit report were checked.
