### PR TITLE
Improve JPEG color conversion matching

### DIFF
--- a/src/sysdolphin/baselib/hsd_3B5C.c
+++ b/src/sysdolphin/baselib/hsd_3B5C.c
@@ -490,6 +490,7 @@ static inline s32 jpeg_clamp(f32 value)
 static inline void jpeg_store_rgb565(u16* out, s32 luminance, s32 cb, s32 cr)
 {
     f32 red_value, green_value, blue_value;
+    u8 green;
     struct {
         u8 red, green, blue;
     } pixel;
@@ -499,7 +500,8 @@ static inline void jpeg_store_rgb565(u16* out, s32 luminance, s32 cb, s32 cr)
 
     green_value =
         ((f32) luminance - (0.3441f * (f32) cb)) - (0.7139f * (f32) cr);
-    pixel.green = jpeg_clamp(green_value);
+    green = jpeg_clamp(green_value);
+    pixel.green = green;
 
     blue_value = (f32) ((f64) ((1.7718f * (f32) cb) + (f32) luminance) -
                         (0.0012 * (f64) cr));


### PR DESCRIPTION
Keep the clamped green-channel value in a separate temporary before assigning it to the RGB pixel. This improves `fn_803B6820` from 98.65145% to 98.81743%, with the instruction sequence and original 0xB0-byte frame preserved. The other five functions remain at 100%.

Adapted from @fjooord’s work in #3358. Register allocation differences remain, so the translation unit remains `Linkable`.

Validation: configured and built successfully, including the original DOL SHA-1 check.
