### PR TITLE
Fix progress report paths when run outside the repository

### DIFF
--- a/tools/changes_fmt.py
+++ b/tools/changes_fmt.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python3
 
 from argparse import ArgumentParser
-import os
 import json
 from pathlib import Path
 from typing import Optional, Tuple
-
-script_dir = os.path.dirname(os.path.realpath(__file__))
-root_dir = os.path.abspath(os.path.join(script_dir, ".."))
-
 
 UNIT_KEYS_TO_DIFF = [
     "fuzzy_match_percent",
@@ -32,7 +27,6 @@ def format_float(value: float) -> str:
 
 
 def get_changes(changes_file: str) -> Tuple[list[Change], list[Change]]:
-    changes_file = os.path.relpath(changes_file, root_dir)
     with open(changes_file, "r") as f:
         changes_json = json.load(f)
 

--- a/tools/tests/test_changes_fmt.py
+++ b/tools/tests/test_changes_fmt.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Run with: python -m unittest discover -s tools/tests"""
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "tools" / "changes_fmt.py"
+
+
+class ChangesFmtTest(unittest.TestCase):
+    def test_report_paths(self):
+        with tempfile.TemporaryDirectory(prefix="changes fmt ") as directory:
+            caller = Path(directory)
+            report = caller / "report changes.json"
+            report.write_text(
+                json.dumps(
+                    {
+                        "from": {"matched_code_percent": 50.0},
+                        "to": {"matched_code_percent": 25.0},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            cases = [
+                (ROOT, report),
+                (caller, report),
+                (caller, Path(report.name)),
+            ]
+            for cwd, path in cases:
+                with self.subTest(cwd=cwd, path=path):
+                    result = subprocess.run(
+                        [sys.executable, str(SCRIPT), str(path)],
+                        cwd=cwd,
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertIn("Total | matched_code |", result.stdout)
+                    self.assertIn("50.00% ->  25.00%", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> AI-assisted summary: Open the supplied report path directly instead of rebasing it against the repository root. This fixes FileNotFoundError for both absolute and relative report paths when changes_fmt.py is invoked from another directory. Remove the unused path helpers and add CLI regression coverage, including paths containing spaces.
>
> Validation: `python -m unittest discover -s tools/tests` passes all three subcases on Windows with Python 3.13.1. Both external-directory cases failed before the fix; the repository-root case passed. `git diff --check` passes. No game source changes or full game build.