### PR TITLE
Improve RGB565 chroma row offset matching

### DIFF
--- a/src/sysdolphin/baselib/hsd_3B34.c
+++ b/src/sysdolphin/baselib/hsd_3B34.c
@@ -214,13 +214,15 @@ void hsd_803B3408(u8* image, s32 x, s32 y, s32 width, s32 height)
         src = (u16*) image + (image_offset + tile_y * stride);
         for (tile_x = 0; tile_x < 2; tile_x++) {
             s32 chroma_y;
+            s32 tile_offset = tile_y * 16 + tile_x * 2;
 
             for (chroma_y = 0; chroma_y < 4; chroma_y++) {
                 s32 dst_row;
                 s32 src_row;
+                s32 row_part;
 
-                dst_row = (chroma_y & 1) * 4 + (chroma_y & 2) * 16;
-                dst_row = (tile_y * 16 + tile_x * 2) + dst_row;
+                row_part = (chroma_y & 1) * 4;
+                dst_row = tile_offset + row_part + (chroma_y & 2) * 16;
                 src_row = (chroma_y & 1) * 32 + (chroma_y & 2) * stride;
 
                 for (chroma_x = 0; chroma_x < 4; chroma_x++) {


### PR DESCRIPTION
Improves `hsd_803B3408` from 98.7788% to 98.82488% by separating the invariant tile offset and low row term before combining the chroma destination offset. Both row additions now match their original operand order and registers.

The function remains unmatched. Its 868-byte size and 152-byte stack frame are unchanged, and the other seven functions in the translation unit remain 100% matched.

Validation: `python configure.py && ninja` passes; the full translation-unit comparison confirms the improvement without regressions.
