### PR TITLE
Fix snapshot .sdata2 constant order and improve initializer matching

### DIFF
--- a/src/melee/mn/mnsnap.c
+++ b/src/melee/mn/mnsnap.c
@@ -2500,6 +2500,11 @@ static inline void** mnSnap_GetMainShapeAnim(mnSnap_State* snap)
     return &snap->main_shapeanim;
 }
 
+static inline void** mnSnap_GetWarnAnimJoint(mnSnap_State* snap)
+{
+    return &snap->warn_animjoint;
+}
+
 /// Creates five thumbnail joints using the spacing between two markers.
 static inline void
 mnSnap_CreateThumbnails(mnSnap_State* snap, HSD_JObj** thumb_root_ptr,
@@ -2597,8 +2602,8 @@ void mnSnap_80257F24(void)
     }
     archive = mn_804D6BB8;
 
-    main_animjoint = &snap->main_animjoint;
     main_matanim = &snap->main_matanim;
+    main_animjoint = &snap->main_animjoint;
     main_shapeanim = &snap->main_shapeanim;
     csr_joint = &snap->csr_joint;
     csr_animjoint = &snap->csr_animjoint;
@@ -2636,7 +2641,7 @@ void mnSnap_80257F24(void)
         arrows_animjoint, "MenMainLoadSn_Top_animjoint", arrows_matanim,
         "MenMainLoadSn_Top_matanim_joint", arrows_shapeanim,
         "MenMainLoadSn_Top_shapeanim_joint", warn_joint,
-        "MenMainWarCmn_Top_joint", warn_animjoint,
+        "MenMainWarCmn_Top_joint", mnSnap_GetWarnAnimJoint(snap),
         "MenMainWarCmn_Top_animjoint", warn_matanim,
         "MenMainWarCmn_Top_matanim_joint", warn_shapeanim,
         "MenMainWarCmn_Top_shapeanim_joint\0\0\0\0\0\0", 0);

--- a/src/melee/mn/mnsnap.c
+++ b/src/melee/mn/mnsnap.c
@@ -633,6 +633,14 @@ void mnSnap_80254014(void)
 #pragma pop
 #endif
 
+/// @todo .sdata2 order hack
+#ifdef MUST_MATCH
+static void mnSnap_sdata2_order(void)
+{
+    (void) -6.9F;
+}
+#endif
+
 /// Configures the Yes/No dialog button positions based on language setting.
 void mnSnap_8025409C(s32 dlg_type)
 {
@@ -859,7 +867,7 @@ static UNINITIALIZED_RETURN(s32) mnSnap_8025441C(u64 buttons)
     }
 }
 
-static inline void mnSnap_InitDialogText(void)
+static void mnSnap_InitDialogText(void)
 {
     HSD_Text* t;
     if (mnSnap_804A0A10.dlg_text != NULL) {
@@ -2482,6 +2490,11 @@ static inline void mnSnap_InitPageText(HSD_Text** text)
     (*text)->pos_z = 17.0F;
 }
 
+static inline void** mnSnap_GetMainJoint(mnSnap_State* snap)
+{
+    return &snap->main_joint;
+}
+
 static inline void** mnSnap_GetMainShapeAnim(mnSnap_State* snap)
 {
     return &snap->main_shapeanim;
@@ -2608,8 +2621,8 @@ void mnSnap_80257F24(void)
     main_joint = &snap->main_joint;
 
     lbArchive_LoadSections(
-        archive, main_joint, "MenMainConSn_Top_joint", main_animjoint,
-        "MenMainConSn_Top_animjoint", main_matanim,
+        archive, mnSnap_GetMainJoint(snap), "MenMainConSn_Top_joint",
+        main_animjoint, "MenMainConSn_Top_animjoint", main_matanim,
         "MenMainConSn_Top_matanim_joint", mnSnap_GetMainShapeAnim(snap),
         "MenMainConSn_Top_shapeanim_joint", csr_joint,
         "MenMainSubSn_Top_joint", csr_animjoint, "MenMainSubSn_Top_animjoint",
@@ -2631,7 +2644,7 @@ void mnSnap_80257F24(void)
     /* Main GObj */
     gobj = GObj_Create(6, 7, 0x80);
     snap->main_gobj = gobj;
-    main_load = &snap->main_joint;
+    main_load = main_joint;
     jobj = HSD_JObjLoadJoint((HSD_Joint*) *main_load);
     HSD_GObjObject_80390A70(gobj, HSD_GObj_JObjKind, jobj);
     GObj_SetupGXLink(gobj, (GObj_RenderFunc) fn_80253DB4, 4, 0x80);


### PR DESCRIPTION
**This does not link `mnsnap`.** `mnSnap_80257F24` is still unmatched, so the TU stays non-linked and repo-wide progress numbers do not move. Whole-DOL totals are unchanged (Code 3877612/3882032 bytes, 19825/19828 functions, Data 100%).

What it does fix is the `.sdata2` constant pool, which takes two functions to 100%:

| symbol | before | after |
| --- | --- | --- |
| `mnSnap_8025409C` | 99.9213% | **100%** |
| `fn_802545C4` | 99.9860% | **100%** |
| `[.sdata2-0]` | 95.3947% | **100%** |
| `mnSnap_80257F24` | 97.6445% | 97.7991% |
| `[.sdata-0]` | 91.5254% | unchanged |

### Why

`.sdata2` entries are allocated in order of first use within the TU. The first reference to `-6.9F` was inside `fn_802545C4`, which placed it after `6.0F` and rotated the tail of the pool:

```
target:  ... 2.0  -6.9  -3.5  3.5  -2.9  23.0  440.0  10.0  0.03  6.0 ...
before:  ... 2.0  -3.5   3.5  6.0  -2.9  23.0  440.0  10.0  0.03  -6.9 ...
```

`mnSnap_8025409C` and `fn_802545C4` were **already byte-identical in code** — only their relocation offsets into the mis-ordered pool differed, which is why both jump straight to 100% once the pool is right and why the strict `matched_code` total does not move.

Two changes are needed together; either alone only gets `.sdata2` to 97.3684%:

- the standard guarded `.sdata2` order hack allocating `-6.9F` early, and
- `mnSnap_InitDialogText` forced out of line.

`static inline` does **not** work for the order hack here — the stub is dropped before it can allocate the constant, so it has to be `static`. The `#ifdef MUST_MATCH` guard is load-bearing rather than decorative: the lint job compiles with `-DLINT` and `-Werror` but *without* `-DMUST_MATCH`, so an unguarded never-called static would fail `-Wunused-function`.

### `mnSnap_80257F24`

Passing `&snap->main_joint` through an accessor at the `lbArchive_LoadSections` call site is worth +0.155 on its own (97.6445% → 97.7991%). `main_load` is switched to reuse the existing `main_joint` local so it does not become an assigned-but-never-read variable.

### Verification

Per-hunk attribution, each measured with a clean rebuild against the v1.02 DOL (A = order hack, B = out-of-line `InitDialogText`, C = accessor, D = `main_load` reuse):

| combo | `mnSnap_8025409C` | `fn_802545C4` | `mnSnap_80257F24` | `[.sdata2-0]` |
| --- | --- | --- | --- | --- |
| base | 99.9213 | 99.9860 | 97.6445 | 95.3947 |
| A | 100 | 99.9313 | 97.6368 | 97.3684 |
| B | 99.9213 | 99.9299 | 97.6368 | 97.3684 |
| C | 99.9213 | 99.9860 | **97.7991** | 95.3947 |
| D | 99.9213 | 99.9860 | 96.2148 | 95.3947 |
| AB | 100 | 100 | 97.6445 | **100** |
| ABCD | 100 | 100 | **97.7991** | **100** |

`ABC` and `ABCD` produce byte-identical objects, so D is codegen-neutral and kept only to avoid the dead local.

`[.sdata-0]` (91.5254%) is still open and is not addressed here — its 32-byte blob ends with a `"%d"` padded to 8 bytes that we currently emit as 3, but every way of padding it that I measured either regressed `mnSnap_80253964` or broke linked data, so I have left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
