### PR TITLE
Improve fn_803B6820 register allocation

### DIFF
--- a/src/sysdolphin/baselib/hsd_3B5C.c
+++ b/src/sysdolphin/baselib/hsd_3B5C.c
@@ -590,6 +590,7 @@ static void fn_803B6820(u8* dst, s32 x, s32 y, s32 width, s32 unused_height)
                                               (-((block / 2) << 5))) *
                                              4);
                         }
+                        (void) ((u8*) out != chroma);
                         cr = ((JpegState*) chroma)->work.cr[0];
                         cb = ((JpegState*) chroma)->work.cb[0];
                         out_offset = ((block & 1) << 5) +


### PR DESCRIPTION
Improves `fn_803B6820` from 98.83817% to 98.962654% by adding a discarded inequality between the output and chroma pointers. MWCC removes the comparison but changes register allocation in the color-conversion loop.

The function retains its 241 instructions and 176-byte stack frame. It remains unmatched, so `hsd_3B5C` stays Linkable.

Validation: full configured build and formatting checks pass.
