### PR TITLE
Use PAD_STACK for plain stack-padding locals in vi and sfx

### DIFF
--- a/src/melee/sfx/crowdsfx.c
+++ b/src/melee/sfx/crowdsfx.c
@@ -70,7 +70,7 @@ void un_80321AF4(HSD_GObj* gobj)
     s32 old_x24 = data->x24;
     s32 flag = 0;
     Vec3 pos;
-    char pad[12];
+    PAD_STACK(12);
 
     data->x24 = 0;
     cur = HSD_GObj_Entities->fighters;
@@ -278,7 +278,7 @@ bool un_8032201C(u32 arg0, s32 cat)
 {
     CrowdSFX_UnkStruct* data = un_804D7050;
     HSD_GObj* gobj;
-    char pad[16];
+    PAD_STACK(16);
 
     switch (cat) {
     case 3:
@@ -320,7 +320,7 @@ bool un_8032201C(u32 arg0, s32 cat)
 void un_80322178(int arg)
 {
     CrowdSFX_UnkStruct* data;
-    char pad[8];
+    PAD_STACK(8);
 
     switch (arg) {
     case 0:

--- a/src/melee/vi/vi0801.c
+++ b/src/melee/vi/vi0801.c
@@ -40,8 +40,8 @@ s32 un_80400128[23][2] = { { 1, 2 }, { 1, 3 }, { 1, 4 },  { 1, 5 },  { 1, 6 },
 static void vi0801_8031ED70(HSD_GObj* gobj, int unused)
 {
     GXColor* colors;
-    s32 zero;
-    s32 prio;
+
+    PAD_STACK(8);
 
     if (HSD_CObjSetCurrent(gobj->hsd_obj) != 0) {
         colors = &un_804D6FBC;

--- a/src/melee/vi/vi1101.c
+++ b/src/melee/vi/vi1101.c
@@ -60,7 +60,7 @@ void un_8031F294(s32 arg0, s32 arg1)
 {
     HSD_JObj* jobj;
     VecMtxPtr pmtx;
-    char pad[16];
+    PAD_STACK(16);
 
     Camera_80028B9C(6);
     lb_8000FCDC();
@@ -127,7 +127,7 @@ void fn_8031F548(HSD_GObj* gobj)
 
 static void fn_8031F56C(HSD_GObj* gobj, int unused)
 {
-    char pad[8];
+    PAD_STACK(8);
 
     lbShadow_8000F38C(0);
     vi_RunCamera(gobj, (u8*) &un_804D5B08, 0x281);

--- a/src/melee/vi/vi1201v1.c
+++ b/src/melee/vi/vi1201v1.c
@@ -122,7 +122,7 @@ void fn_8031FAA8(HSD_GObj* gobj)
 }
 void fn_8031FB90(HSD_GObj* gobj)
 {
-    char pad[8];
+    PAD_STACK(8);
     if (un_804D7000 != NULL) {
         lbShadow_8000F38C(0);
     }
@@ -281,7 +281,7 @@ void vi1201v1_Scene_OnEnter(void* arg)
     HSD_GObj* fog_gobj;
     HSD_LObj* lobj;
     HSD_GObj* light_gobj;
-    char pad[8];
+    PAD_STACK(8);
 
     un_804D6FFC = input[0];
     un_804D6FFD = input[1];

--- a/src/melee/vi/vi1201v2.c
+++ b/src/melee/vi/vi1201v2.c
@@ -75,7 +75,7 @@ void un_803204E4(HSD_GObj* gobj)
 
 void un_80320508(CharacterKind char_kind, int costume)
 {
-    char pad[16];
+    PAD_STACK(16);
 
     Camera_80028B9C(6);
     lb_8000FCDC();
@@ -103,7 +103,7 @@ void un_803205F4(void)
 {
     HSD_GObj* gobj;
     HSD_JObj* jobj;
-    char pad[16];
+    PAD_STACK(16);
 
     gobj = GObj_Create(0xE, 0xF, 0);
     jobj = HSD_JObjLoadJoint(un_804D7010->models[1]->joint);
@@ -132,7 +132,7 @@ void un_803205F4(void)
 void un_8032074C(HSD_GObj* gobj)
 {
     HSD_JObj* jobj = GET_JOBJ(gobj);
-    char pad[24];
+    PAD_STACK(24);
     HSD_JObjAnimAll(jobj);
     if (mn_8022F298(jobj) == 251.0F) {
         if (un_804D7030 != NULL) {
@@ -182,7 +182,7 @@ void un_803207C4(void)
 
 void un_803208F0(HSD_GObj* gobj)
 {
-    char pad[8];
+    PAD_STACK(8);
     lbShadow_8000F38C(0);
     vi_RunCamera(gobj, (u8*) &un_804D7028, 0x881);
 }


### PR DESCRIPTION
Part of #1242.

> Converts the plain stack-padding locals in `melee/vi` and `melee/sfx` to
> `PAD_STACK`, which carries `UNUSED` and so stops tripping
> `-Wunused-variable`. Those two modules had 18 such warnings; this clears 13
> of them.
>
> The remaining 5 are the `pad0..pad4` declarations in `un_8031D9F8`
> (`vi0501.c`), which are left alone deliberately: they sit ahead of the
> function's other locals, and folding them into the existing `PAD_STACK`
> moves the padding after those locals, which drops the function to 99.93%.
>
> Verified locally: `main.dol` still hashes to
> `08e0bf20134dfcb260699671004527b2d6bb1a45`, `objdiff-cli report changes`
> reports no functions broken, `pre-commit` passes, and clang confirms the
> count in those two modules goes from 18 to 5.
>
> For context on the rest of #1242: enabling `-Wunused-variable` and
> `-Wunused-but-set-variable` across the whole tree currently surfaces 2030
> warnings (1939 and 91 respectively) in 472 `.c` files, so this is one
> module-sized slice of that.