### PR TITLE
Improve register allocation in fn_803B6820 and mnSnap_80257F24

### DIFF
--- a/src/melee/mn/mnsnap.c
+++ b/src/melee/mn/mnsnap.c
@@ -2588,6 +2588,8 @@ void mnSnap_80257F24(void)
     lb_8001CDB4();
     memzero(&mnSnap_804A0A10, sizeof(mnSnap_State));
 
+    /* Self-assignment: nudges MWCC register allocation, no behavior change. */
+    snap->select_jobj->u.dobj->mobj = snap->select_jobj->u.dobj->mobj;
     snap->state = zero;
     snap->timer = 6;
     snap->photo_count[0] = zero;
@@ -2706,8 +2708,8 @@ void mnSnap_80257F24(void)
     thumb_root_ptr = &snap->thumb_root;
     lb_80011E24(jobj, thumb_root_ptr, 0, 1, 7, 8, -1);
 
-    mnSnap_CreateThumbnails(snap, thumb_root_ptr, photo_joint, sub_animjoint,
-                            sub_matanim, sub_shapeanim);
+    mnSnap_CreateThumbnails(&mnSnap_804A0A10, thumb_root_ptr, photo_joint,
+                            sub_animjoint, sub_matanim, sub_shapeanim);
 
     /* Load page indicator */
     mnSnap_LoadPageIndicator(page_joint, snap, thumb_root_ptr, &jobj2);
@@ -2715,7 +2717,7 @@ void mnSnap_80257F24(void)
 
     /* Create 4 SIS text objects for thumbnail labels */
     for (i = 0; i < 4; i++) {
-        snap->thumb_labels[i] = HSD_SisLib_803A6754(0, 0);
+        mnSnap_804A0A10.thumb_labels[i] = HSD_SisLib_803A6754(0, 0);
     }
 
     /* Set text positions for 4 thumbnail labels */
@@ -2753,7 +2755,7 @@ void mnSnap_80257F24(void)
 
     /* Create 2 SIS text objects for camera counts */
     for (i = 0; i < 2; i++) {
-        snap->count_texts[i] = HSD_SisLib_803A6754(0, 0);
+        mnSnap_804A0A10.count_texts[i] = HSD_SisLib_803A6754(0, 0);
     }
 
     text = snap->count_texts[0];

--- a/src/sysdolphin/baselib/hsd_3B5C.c
+++ b/src/sysdolphin/baselib/hsd_3B5C.c
@@ -590,12 +590,14 @@ static void fn_803B6820(u8* dst, s32 x, s32 y, s32 width, s32 unused_height)
                                               (-((block / 2) << 5))) *
                                              4);
                         }
-                        (void) ((u8*) out != chroma);
-                        cr = ((JpegState*) chroma)->work.cr[0];
+                        (void) ((s64) ((u8*) out != chroma));
+                        cr = (cb = ((JpegState*) chroma)->work.cr[0]);
                         cb = ((JpegState*) chroma)->work.cb[0];
                         out_offset = ((block & 1) << 5) +
                                      (aligned_width * ((block & 2) << 2));
-                        jpeg_store_rgb565(out + out_offset, luminance, cb, cr);
+                        jpeg_store_rgb565(
+                            out + (out_offset & 0xFFFFFFFFFFFFFFFFu),
+                            luminance, cb, cr);
                     }
                     out += 1;
                     luma_offset += 4;


### PR DESCRIPTION
regalloc tweaks for the two remaining functions. neither matches yet, both
units stay Linkable.

fn_803B6820: 98.90% -> 99.05%. `cr = (cb = ...)` puts cb in r18 like the
target; the s64 cast and the `& ~0ull` mask move the other temps around.
what's left is a register permutation (r15/r16/r20).

mnSnap_80257F24: 97.79% -> 99.68%. accessing mnSnap_804A0A10 directly in the
thumbnail/label/count loops fixes both inlines in the second half; the
self-assignment after memzero compiles to nothing but fixes the stack frame.
what's left is the arg setup for the lbArchive_LoadSections call.

numbers are objdiff, didn't run the full build.
