### PR TITLE
Fix some pointer math member accesses

### DIFF
--- a/src/melee/ef/efalt.c
+++ b/src/melee/ef/efalt.c
@@ -5,6 +5,7 @@
 
 #include "eflib.h"
 #include "types.h"
+#include <melee/ft/fighter.h>
 #include <sysdolphin/baselib/generator.h>
 #include <sysdolphin/baselib/gobj.h>
 #include <sysdolphin/baselib/jobj.h>
@@ -209,8 +210,7 @@ void* efAlt_Spawn(s32 gfx_id, HSD_GObj* gobj, va_list vlist_arg)
         break;
     }
     case 0x494: {
-        void* user_data;
-        HSD_JObj** jobj_ptr;
+        Fighter* fp;
         HSD_JObj* jobj;
         HSD_JObj* jobj_2;
         EF_Effect* effect_1;
@@ -219,10 +219,9 @@ void* efAlt_Spawn(s32 gfx_id, HSD_GObj* gobj, va_list vlist_arg)
         u16 effect_flags;
 
         effect_flags = 0x41;
-        user_data = gobj->user_data;
-        jobj_ptr = *(HSD_JObj***) ((u8*) user_data + 0x5E8);
-        jobj = jobj_ptr[0xB0];
-        jobj_2 = jobj_ptr[4];
+        fp = gobj->user_data;
+        jobj = fp->parts[FtPart_R3rdNa].joint;
+        jobj_2 = fp->parts[FtPart_TransN].joint;
         ret_obj = efLib_Create_AttachChild(0x1388U, gobj, jobj);
         if (ret_obj != NULL) {
             effect_1 = ret_obj;
@@ -235,14 +234,14 @@ void* efAlt_Spawn(s32 gfx_id, HSD_GObj* gobj, va_list vlist_arg)
                 effect_2 = (void*) effect_1->next;
                 effect_2->update = efLib_Cb_SetRotYAndTransition;
                 effect_2->lifetime = effect_flags;
-                effect_2->user_data = user_data;
+                effect_2->user_data = fp;
                 next_eff = (void*) efLib_Create_Attach(0x138AU, gobj, jobj_2);
                 effect_2->next = next_eff;
                 if (next_eff != NULL) {
                     effect_1 = (void*) effect_2->next;
                     effect_1->update = efLib_Cb_SetRotYAndTransition;
                     effect_1->lifetime = effect_flags;
-                    effect_1->user_data = user_data;
+                    effect_1->user_data = fp;
                 }
             }
         }

--- a/src/melee/ef/efalt.c
+++ b/src/melee/ef/efalt.c
@@ -5,7 +5,7 @@
 
 #include "eflib.h"
 #include "types.h"
-#include <melee/ft/fighter.h>
+#include <melee/ft/types.h>
 #include <sysdolphin/baselib/generator.h>
 #include <sysdolphin/baselib/gobj.h>
 #include <sysdolphin/baselib/jobj.h>

--- a/src/melee/gm/gm_1601.c
+++ b/src/melee/gm/gm_1601.c
@@ -2767,8 +2767,7 @@ s32 fn_8016588C(lbl_8046B6A0_24C_t* arg0, s32 arg1)
     } else {
         u16 a = arg0->x58[arg1].xA;
         return fn_8016588C_clamp(arg0->x58[arg1].x20 -
-                                 (arg0->x58[arg1].x24 - a) +
-                                 a * arg0->xC);
+                                 (arg0->x58[arg1].x24 - a) + a * arg0->xC);
     }
 }
 

--- a/src/melee/gm/gm_1601.c
+++ b/src/melee/gm/gm_1601.c
@@ -2768,7 +2768,7 @@ s32 fn_8016588C(lbl_8046B6A0_24C_t* arg0, s32 arg1)
         u16 a = arg0->x58[arg1].xA;
         return fn_8016588C_clamp(arg0->x58[arg1].x20 -
                                  (arg0->x58[arg1].x24 - a) +
-                                 a * (s8) arg0->xC);
+                                 a * arg0->xC);
     }
 }
 

--- a/src/melee/gm/gm_16F1.c
+++ b/src/melee/gm/gm_16F1.c
@@ -333,8 +333,7 @@ int fn_8016FAD4(struct lbl_8046B6A0_24C_t* rules, int kind, int flags,
     for (i = 0; i < 6; i++) {
         if (x58[i].x0 != 3) {
             u16 sd = x58[i].xA;
-            scores[i] =
-                x58[i].x20 - (x58[i].x24 - sd) + rules->xC * sd;
+            scores[i] = x58[i].x20 - (x58[i].x24 - sd) + rules->xC * sd;
         }
     }
 

--- a/src/melee/gm/gm_16F1.c
+++ b/src/melee/gm/gm_16F1.c
@@ -334,7 +334,7 @@ int fn_8016FAD4(struct lbl_8046B6A0_24C_t* rules, int kind, int flags,
         if (x58[i].x0 != 3) {
             u16 sd = x58[i].xA;
             scores[i] =
-                x58[i].x20 - (x58[i].x24 - sd) + *(s8*) &rules->xC * sd;
+                x58[i].x20 - (x58[i].x24 - sd) + rules->xC * sd;
         }
     }
 

--- a/src/melee/gm/gm_16F1.c
+++ b/src/melee/gm/gm_16F1.c
@@ -446,9 +446,9 @@ int fn_801701B8(void)
     return lbl_804D65A0.x0;
 }
 
-int fn_801701C0(void* arg0, int arg1, int arg2)
+int fn_801701C0(struct lbl_8046B6A0_24C_t* rules, int arg1, int arg2)
 {
-    struct lbl_8046B6A0_24C_t* rules = arg0;
+    u8* tmp;
     const struct lbl_803B7A60_t* zeroes = &lbl_803B7A60;
     u8* flags = rules->pad3F0;
     struct lbl_8046B6A0_24C_58_t* x58 = rules->x58;
@@ -471,8 +471,7 @@ int fn_801701C0(void* arg0, int arg1, int arg2)
         for (k = 0; k < 6; k++) {
             if (x58[k].x0 != 3) {
                 u16 xA = x58[k].xA;
-                scores[k] =
-                    (x58[k].x20 - (x58[k].x24 - xA)) + *(s8*) &rules->xC * xA;
+                scores[k] = (x58[k].x20 - (x58[k].x24 - xA)) + rules->xC * xA;
             }
         }
 
@@ -500,7 +499,7 @@ int fn_801701C0(void* arg0, int arg1, int arg2)
 
     switch (arg2) {
     case 0xD7:
-        if ((unsigned) fn_801701C0(arg0, arg1, 0xD9) != 0) {
+        if ((unsigned) fn_801701C0(rules, arg1, 0xD9) != 0) {
             return 0;
         }
         {
@@ -517,7 +516,7 @@ int fn_801701C0(void* arg0, int arg1, int arg2)
         return 0;
 
     case 0xD8:
-        if ((unsigned) fn_801701C0(arg0, arg1, 0xDA) != 0) {
+        if ((unsigned) fn_801701C0(rules, arg1, 0xDA) != 0) {
             return 0;
         }
         {
@@ -594,7 +593,7 @@ int fn_801701C0(void* arg0, int arg1, int arg2)
     }
 
     case 0xDC: {
-        if ((unsigned) fn_801701C0(arg0, arg1, 0xDB) == 0) {
+        if ((unsigned) fn_801701C0(rules, arg1, 0xDB) == 0) {
             {
                 int i;
                 for (i = 0; i < 4; i++) {
@@ -644,7 +643,7 @@ int fn_801701C0(void* arg0, int arg1, int arg2)
     }
 
     case 0xDE: {
-        if ((unsigned) fn_801701C0(arg0, arg1, 0xDD) == 0) {
+        if ((unsigned) fn_801701C0(rules, arg1, 0xDD) == 0) {
             {
                 int i;
                 for (i = 0; i < 4; i++) {
@@ -697,7 +696,7 @@ int fn_801701C0(void* arg0, int arg1, int arg2)
     }
 
     case 0xE0: {
-        if ((unsigned) fn_801701C0(arg0, arg1, 0xDF) == 0) {
+        if ((unsigned) fn_801701C0(rules, arg1, 0xDF) == 0) {
             {
                 int i;
                 for (i = 0; i < 4; i++) {
@@ -748,7 +747,7 @@ int fn_801701C0(void* arg0, int arg1, int arg2)
     }
 
     case 0xE2: {
-        if ((unsigned) fn_801701C0(arg0, arg1, 0xE1) == 0) {
+        if ((unsigned) fn_801701C0(rules, arg1, 0xE1) == 0) {
             {
                 int i;
                 for (i = 0; i < 4; i++) {
@@ -972,9 +971,8 @@ int fn_801701C0(void* arg0, int arg1, int arg2)
                     }
                 }
             }
-            if (!(((u8*) x58)[arg1 * sizeof(*x58) + 3] & 1) &&
-                rankings[arg1] == 0 && x58[arg1].x20 == 0)
-            {
+            tmp = &x58[arg1].x3;
+            if (!(*tmp & 1) && rankings[arg1] == 0 && x58[arg1].x20 == 0) {
                 return 1;
             }
         } else {
@@ -993,15 +991,13 @@ int fn_801701C0(void* arg0, int arg1, int arg2)
                         }
                     }
                 }
-                if (!(((u8*) x58)[arg1 * sizeof(*x58) + 3] & 1) &&
-                    x58[arg1].x5 == 0 && x58[arg1].x20 == 0)
-                {
+                tmp = &x58[arg1].x3;
+                if (!(*tmp & 1) && x58[arg1].x5 == 0 && x58[arg1].x20 == 0) {
                     return 1;
                 }
             } else {
-                if (!(((u8*) x58)[arg1 * sizeof(*x58) + 3] & 1) &&
-                    x58[arg1].x20 == 0)
-                {
+                tmp = &x58[arg1].x3;
+                if (!(*tmp & 1) && x58[arg1].x20 == 0) {
                     return 1;
                 }
             }

--- a/src/melee/gm/gm_16F1.h
+++ b/src/melee/gm/gm_16F1.h
@@ -31,7 +31,7 @@ struct lbl_804D65A8_t;
 /* 1701A0 */ UNK_RET gm_801701A0(UNK_PARAMS);
 /* 1701AC */ UNK_RET fn_801701AC(UNK_PARAMS);
 /* 1701B8 */ int fn_801701B8(void);
-/* 1701C0 */ int fn_801701C0(void*, int, int);
+/* 1701C0 */ int fn_801701C0(struct lbl_8046B6A0_24C_t*, int, int);
 /* 171A88 */ int fn_80171A88(void);
 /* 171AD4 */ UNK_RET fn_80171AD4(UNK_PARAMS);
 /* 171B00 */ bool fn_80171B00(int);

--- a/src/melee/gm/gmevent.c
+++ b/src/melee/gm/gmevent.c
@@ -636,7 +636,6 @@ void onExitVs(GameModeState* arg0)
     struct EventData* ev = &gmMainLib_804D3EE0->vs.unk_530;
     MatchExitInfo* exit = gm_GetGameModeStateExitData(arg0);
     u8 stage = ev->unk_535;
-    u8 b;
     u8 kind;
     s32 t;
 
@@ -677,8 +676,7 @@ void onExitVs(GameModeState* arg0)
     }
     ev->x3C += gm_80168940(&vs_exit_data[0].match_end);
     ev->x40 += (s32) exit->match_end.frame_count;
-    b = ((u8*) ev)[0xB];
-    if (((b >> 3) & 1) && ((b >> 5) & 1)) {
+    if (ev->xB_4 && ev->xB_2) {
         ev->x24 = vs_exit_data[0].match_end.player_standings[0].stocks;
         ev->x28 = vs_exit_data[0].match_end.player_standings[0].percent;
         ev->xB_2 = 0;
@@ -1558,7 +1556,7 @@ void gm_801BCC9C(HSD_GObj* arg0)
         mi = gmVs_GetController_0();
         if (ev3->xB_0) {
             var_r0 = 0;
-        } else if (((*(u8*) &mi->start >> 1U) & 1) && gm_8016AEEC() == 0 &&
+        } else if (mi->start.timer_enabled && gm_8016AEEC() == 0 &&
                    gm_8016AEFC() == 0x3B)
         {
             var_r0 = 1;
@@ -2605,7 +2603,6 @@ u8 gm_801BEBF8(u8 arg0)
     u8 i;
     struct gm_804D6900_t** array = gm_804D6900[0];
     struct gm_804D6900_t* entry;
-    u8* ptr;
 
     for (i = 0; i < 0x33; i++) {
         if (arg0 == table[i]) {
@@ -2618,8 +2615,7 @@ u8 gm_801BEBF8(u8 arg0)
         return ChKind_None;
     }
 
-    ptr = *(u8**) ((u8*) entry + 0x14);
-    return *ptr;
+    return entry->player_init[0]->c_kind;
 }
 
 UNK_T gm_801BEC54(void)

--- a/src/melee/gm/types.h
+++ b/src/melee/gm/types.h
@@ -424,7 +424,7 @@ struct lbl_8046B6A0_24C_t {
     u8 is_teams;
     u8 x7;
     u32 x8;
-    u8 xC;
+    s8 xC;
     u8 xD;
     u8 xE;
     u8 padF[0x16 - 0xF];


### PR DESCRIPTION
It's pretty easy to find these by grepping for `(u8*)` casts. We should use proper struct member accesses whenever possible, as accessing data by raw offsets breaks if the struct layout changes.