### PR TITLE
Fix projection matrix storage in setupTopHalfCamera

### DIFF
--- a/src/sysdolphin/baselib/cobj.c
+++ b/src/sysdolphin/baselib/cobj.c
@@ -291,12 +291,8 @@ static bool setupNormalCamera(HSD_CObj* cobj)
 
 static bool setupTopHalfCamera(HSD_CObj* cobj)
 {
-    int unused[3];
     GXProjectionType projection_type;
-    /// @todo Should be an `Mtx44` like the other three: `makeProjectionMtx`
-    /// writes 4 rows. Changing it here does not match, so the extra row
-    /// currently lands in `unused` above.
-    Mtx p;
+    Mtx44 p;
 
     f32 h_scale;
     f32 t;


### PR DESCRIPTION
> makeProjectionMtx writes a 4×4 matrix, but setupTopHalfCamera declares a 3×4 Mtx, placing the fourth row outside the object.
> 
> Use Mtx44 and remove the obsolete padding and TODO. The compiled object remains byte-for-byte identical.
>
> Implemented and verified with Codex + Astra.

----

Disclosure: I contribute to this project in my personal capacity, on my own time and using my own laptop. I am not acting on behalf of my employer.