### PR TITLE
mn: type mndiagram GObj callbacks

### DIFF
--- a/src/melee/mn/mndiagram.c
+++ b/src/melee/mn/mndiagram.c
@@ -841,8 +841,7 @@ void mnDiagram_PopupInputProc(HSD_GObj* gobj)
     if ((u32) input & MenuInput_Back) {
         sfxBack();
         HSD_GObjProc_RemoveProc(HSD_GObj_CurrentInvokedProc);
-        proc = HSD_GObj_SetupProc(
-            gobj, (void (*)(HSD_GObj*)) mnDiagram_InputProc, 0);
+        proc = HSD_GObj_SetupProc(gobj, mnDiagram_InputProc, 0);
         proc->flags_3 = HSD_GObj_804D783C;
         HSD_GObjFree(data->popup_gobj);
         data->popup_gobj = NULL;
@@ -1291,8 +1290,7 @@ void mnDiagram_InputProc(HSD_GObj* gobj)
         sfxForward();
         HSD_GObjProc_RemoveProc(HSD_GObj_CurrentInvokedProc);
         i = 0;
-        proc = HSD_GObj_SetupProc(
-            gobj, (void (*)(HSD_GObj*)) mnDiagram_PopupInputProc, i);
+        proc = HSD_GObj_SetupProc(gobj, mnDiagram_PopupInputProc, i);
         proc->flags_3 = HSD_GObj_804D783C;
         if (data->is_name_mode != 0) {
             col = mn_804A04F0.hovered_selection;
@@ -1624,9 +1622,9 @@ static inline Vec3* mnDiagram_PopupAnimProc_Inline(mnDiagram_AnimTable* arg0,
     return &arg0->points[arg1];
 }
 
-void mnDiagram_PopupAnimProc(void* arg0)
+void mnDiagram_PopupAnimProc(HSD_GObj* arg0)
 {
-    mnDiagram_PopupData* data = ((HSD_GObj*) arg0)->user_data;
+    mnDiagram_PopupData* data = arg0->user_data;
     HSD_Text* text;
     mnDiagram_AnimTable* tbl = GET_DIAGRAM_ANIM_TABLE();
     Vec3 pos;
@@ -1740,10 +1738,10 @@ static inline void mnDiagram_FormatPopupNumber(char* buf, u32 val)
     buf[digit_count] = *mnDiagram_804D4FA4;
 }
 
-void mnDiagram_CreatePopupTexts(void* arg0, s32 selkind_or_nametag_slot_id,
+void mnDiagram_CreatePopupTexts(HSD_GObj* arg0, s32 selkind_or_nametag_slot_id,
                                 s32 arg2, s32 use_nametag)
 {
-    mnDiagram_PopupData* data = ((HSD_GObj*) arg0)->user_data;
+    mnDiagram_PopupData* data = arg0->user_data;
     float new_var;
     Point3d pos;
     char buf[8];
@@ -1946,7 +1944,7 @@ void mnDiagram_CreatePopup(s32 arg0, s32 arg1, s32 use_nametag)
         lb_80011E24(jobj, &user_data->jobjs[i], i, -1);
     }
 
-    HSD_GObj_SetupProc(gobj, (void (*)(HSD_GObj*)) mnDiagram_PopupAnimProc, 0);
+    HSD_GObj_SetupProc(gobj, mnDiagram_PopupAnimProc, 0);
     mnDiagram_CreatePopupTexts(gobj, arg0, arg1, use_nametag);
 
     if (use_nametag != 0) {
@@ -1997,7 +1995,7 @@ static inline HSD_JObj* mnDiagram_GetJObjChild(HSD_JObj* jobj)
     return jobj->child;
 }
 
-void mnDiagram_ClearGrid(void* arg0)
+void mnDiagram_ClearGrid(HSD_GObj* arg0)
 {
     mnDiagram_MainOverlay* data = mnDiagram_GetUserData(arg0);
     HSD_JObj* child;
@@ -2305,7 +2303,7 @@ void mnDiagram_OnFrame(HSD_GObj* gobj)
     mnDiagram_UpdateScrollArrows(gobj);
 }
 
-void mnDiagram_DrawCellValue(void* arg0, u8 arg1, u8 arg2, int arg3)
+void mnDiagram_DrawCellValue(HSD_GObj* arg0, u8 arg1, u8 arg2, int arg3)
 {
     Diagram* data_alias;
     f32 row_offset_adj;
@@ -2326,7 +2324,7 @@ void mnDiagram_DrawCellValue(void* arg0, u8 arg1, u8 arg2, int arg3)
     u8 row = arg2;
     f32 y_offset;
 
-    data = ((HSD_GObj*) arg0)->user_data;
+    data = arg0->user_data;
     data_alias = data;
 
     jobj = data->jobjs[11];
@@ -2383,7 +2381,7 @@ static inline int mnDiagram_GetFighterPairKOs(u8 fighter, u8 opponent)
     return GetPersistentFighterData(kind)->fighter_kos[opponent];
 }
 
-void mnDiagram_DrawGridValues(void* arg0, s32 row_start, s32 col_start,
+void mnDiagram_DrawGridValues(HSD_GObj* arg0, s32 row_start, s32 col_start,
                               u8 arg3)
 {
     s32 name_col;
@@ -2501,9 +2499,9 @@ static inline void mnDiagram_TextSetPos(HSD_Text* text, f32 x, f32 y, f32 z)
     text->pos_z = z;
 }
 
-void mnDiagram_DrawNameHeaders(void* arg0, s32 arg1, s32 arg2)
+void mnDiagram_DrawNameHeaders(HSD_GObj* arg0, s32 arg1, s32 arg2)
 {
-    Diagram* data = ((HSD_GObj*) arg0)->user_data;
+    Diagram* data = arg0->user_data;
     u8* sorted = mnDiagram_FighterDisplayOrder;
     HSD_Text* row_text;
     u8 name_byte;
@@ -2607,7 +2605,7 @@ mnDiagram_LoadHeaderIcon(void** joint_data, int fighter_id, HSD_JObj** child)
     return jobj;
 }
 
-void mnDiagram_DrawFighterHeaders(void* arg0, int arg1, int arg2)
+void mnDiagram_DrawFighterHeaders(HSD_GObj* arg0, int arg1, int arg2)
 {
     HSD_JObj* col_ref;
     HSD_JObj* row_ref;
@@ -2837,7 +2835,7 @@ void mnDiagram_CreateScreen(u8 arg0)
         lb_80011E24(jobj, &user_data->jobjs[i], i, -1);
     }
 
-    HSD_GObj_SetupProc(gobj, (void (*)(HSD_GObj*)) mnDiagram_OnFrame, 0);
+    HSD_GObj_SetupProc(gobj, mnDiagram_OnFrame, 0);
 
     if (arg0 == 0) {
         anim_jobj = user_data->jobjs[1];
@@ -2953,7 +2951,6 @@ void mnDiagram_Init(u8 arg0, u8 arg1)
     mnDiagram_CreateScreen(mode_storage[0]);
 
     gobj = GObj_Create(0, 1, 0x80);
-    proc =
-        HSD_GObj_SetupProc(gobj, (void (*)(HSD_GObj*)) mnDiagram_InputProc, 0);
+    proc = HSD_GObj_SetupProc(gobj, mnDiagram_InputProc, 0);
     proc->flags_3 = HSD_GObj_804D783C;
 }

--- a/src/melee/mn/mndiagram.h
+++ b/src/melee/mn/mndiagram.h
@@ -37,23 +37,25 @@ mnDiagram_GetNamePlayTimeByFighter(int name_idx,
 /* 23FE30 */ void mnDiagram_PopupInputProc(HSD_GObj*);
 /* 23FED4 */ void mnDiagram_InputProc(HSD_GObj*);
 /* 240B18 */ void mnDiagram_PopupCleanup(void* arg0);
-/* 240B98 */ void mnDiagram_PopupAnimProc(void* arg0);
-/* 240D94 */ void mnDiagram_CreatePopupTexts(void* arg0, s32 arg1, s32 arg2,
-                                             s32 arg3);
+/* 240B98 */ void mnDiagram_PopupAnimProc(HSD_GObj* arg0);
+/* 240D94 */ void mnDiagram_CreatePopupTexts(HSD_GObj* arg0, s32 arg1,
+                                             s32 arg2, s32 arg3);
 /* 241310 */ void mnDiagram_CreatePopup(s32 arg0, s32 arg1, s32 arg2);
-/* 241668 */ void mnDiagram_ClearGrid(void* arg0);
+/* 241668 */ void mnDiagram_ClearGrid(HSD_GObj* arg0);
 /* 241730 */ void mnDiagram_RefreshGrid(HSD_GObj* arg0, int arg1, int arg2);
 /* 2417D0 */ void mnDiagram_UpdateScrollArrows(HSD_GObj* gobj);
 /* 241AE8 */ void mnDiagram_ExitAnimProc(HSD_GObj* gobj);
 /* 241B4C */ void mnDiagram_UpdateScrollArrowVisibility(void* gobj, int count);
 /* 241BF8 */ void mnDiagram_OnFrame(HSD_GObj* gobj);
-/* 241E78 */ void mnDiagram_DrawCellValue(void* arg0, u8 arg1, u8 arg2,
+/* 241E78 */ void mnDiagram_DrawCellValue(HSD_GObj* arg0, u8 arg1, u8 arg2,
                                           int arg3);
-/* 24227C */ void mnDiagram_DrawGridValues(void* arg0, s32 arg1, s32 arg2,
+/* 24227C */ void mnDiagram_DrawGridValues(HSD_GObj* arg0, s32 arg1, s32 arg2,
                                            u8 arg3);
-/* 2427B4 */ void mnDiagram_DrawNameHeaders(void* arg0, s32 arg1, s32 arg2);
+/* 2427B4 */ void mnDiagram_DrawNameHeaders(HSD_GObj* arg0, s32 arg1,
+                                            s32 arg2);
 /* 242B38 */ HSD_JObj* mnDiagram_CreateFighterIcon(int idx, int arg1);
-/* 242C0C */ void mnDiagram_DrawFighterHeaders(void* arg0, int arg1, int arg2);
+/* 242C0C */ void mnDiagram_DrawFighterHeaders(HSD_GObj* arg0, int arg1,
+                                               int arg2);
 /* 243038 */ void mnDiagram_CursorProc(HSD_GObj* gobj);
 /* 2433AC */ void mnDiagram_CreateCursor(void);
 /* 243434 */ void mnDiagram_CreateScreen(u8 arg0);


### PR DESCRIPTION
## Summary

- type mndiagram popup and grid helpers as `HSD_GObj*` where all callers pass game objects
- remove redundant object-pointer casts when accessing `user_data`
- remove redundant callback casts passed to `HSD_GObj_SetupProc`
- retain the `void*` cleanup callback because it receives the user-data allocation directly

## Verification

- `ninja`
- `python configure.py progress`
- 1130/1130 objects matching and linked
- rebuilt DOL SHA-1: `08e0bf20134dfcb260699671004527b2d6bb1a45`
- `git diff --check`
- `git clang-format --diff HEAD -- src/melee/mn/mndiagram.c src/melee/mn/mndiagram.h`